### PR TITLE
Fix job.py calling driver.kill before submit is done

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -625,7 +625,7 @@ async def test_signal_cancel_terminates_fm_dispatcher_with_scheduler_as_fallback
     assert isinstance(evaluator._evaluation_result.exception(), UserCancelled)
     assert (
         "Realization 0 was not killed gracefully by TERM message. "
-        "Killing it with the scheduler"
+        "Killing it with the driver"
     ) in caplog.text
 
 


### PR DESCRIPTION
**Issue**
Resolves #11779


**Approach**
This commit makes sure job.py does not call driver.kill if it is the middle of submitting a job, but rather waits for 5 seconds for it to finish. This should help with jobs being submitted to the cluster without Ert knowing about them.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
