### PR TITLE
Make everserver tolerate intermittent httpx glitches

### DIFF
--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -86,7 +86,7 @@ def mock_server(monkeypatch):
         response_mock = MagicMock()
         response_mock.json.return_value = {"status": status, "message": message}
         client_mock.get.return_value = response_mock
-        server_patch.session.return_value.__enter__.return_value = client_mock
+        server_patch.session.return_value = client_mock
         monkeypatch.setattr("everest.detached.everserver.StorageService", server_patch)
 
     yield func


### PR DESCRIPTION
There are rare occurences where a httpx.RemoteProtocolError is thrown on the client side when it is talking to a experiment server even on the same host.

With this patch, this exception is caught and ignored when it happens during normal status polling, since status polling is retried twice a second we can just wait and see if the next connection attempt is successful.

For failsafe reasons, the client is also recreated, as the reason for the glitch can be connected to this object as well. The client object keeps a connection pool, and the server may have decided to close some of the long-lived keep-alive connections to save resources. There is no builtin retry mechanism in httpx for this situation.

This unfortunately means that a the context manager goes away, as it will not support recreating itself on failure. In this commit, that affects the mocking of the service.

**Issue**
Resolves #11776 


**Approach**
Ignore and retry

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
