### PR TITLE
Skip some slow tests on mac_ci, may be due to a socket.getfqdn issue

### DIFF
--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -13,6 +13,7 @@ from ert.shared import find_available_socket
 from everest.config import ServerConfig
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 def test_create_connection_string():
     authtoken = "very_secret_token"
     sock = find_available_socket()
@@ -60,6 +61,7 @@ def test_that_service_can_be_started_with_existing_conn_info_json(tmp_path):
     StorageService.connect(project=tmp_path)
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 @patch("ert.services.StorageService.start_server")
 def test_that_service_can_be_started_with_missing_cert_in_conn_info_json(
     start_server_mock, tmp_path
@@ -111,6 +113,7 @@ def test_that_service_can_be_started_with_empty_json_content(
     start_server_mock.assert_called_once()
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 @pytest.mark.integration_test
 def test_storage_logging(change_to_tmpdir):
     """
@@ -140,6 +143,7 @@ def test_storage_logging(change_to_tmpdir):
     ), "Found duplicated log entries"
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 def test_certificate_generation(change_to_tmpdir):
     cert, key, pw = _generate_certificate(ServerConfig.get_certificate_dir("output"))
 
@@ -152,6 +156,7 @@ def test_certificate_generation(change_to_tmpdir):
     ctx.load_cert_chain(cert, key, pw)  # raise on error
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
     with patch(
         "ert.shared.get_machine_name",
@@ -170,6 +175,7 @@ def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
     ctx.load_cert_chain(cert, key, pw)  # raise on error
 
 
+@pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir):
     auth_token = "very_secret_token"
     sock = find_available_socket()


### PR DESCRIPTION
**Issue**
Some tests are very much slower on the mac runner than other machines, skip and investigate.

See https://github.com/equinor/ert/issues/11573


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
