### PR TITLE
Use an environment variable for skip_mac_ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,6 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       test-type: ${{ matrix.test-type }}
-      select-string: '"not skip_mac_ci"'
     secrets: inherit
 
   docs-ert:

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -7,13 +7,9 @@ on:
         type: string
       test-type:
         type: string
-      select-string:
-        type: string
-        default: '""'
-
 env:
   ERT_SHOW_BACKTRACE: 1
-  ERT_PYTEST_ARGS: '-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_main.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
+  ERT_PYTEST_ARGS: '--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_main.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'
   UV_FROZEN: true
   OMP_NUM_THREADS: 1
 
@@ -28,6 +24,9 @@ jobs:
         fetch-depth: 0
         submodules: true
         lfs: true
+
+    - if: ${{ inputs.os == 'macos-latest' }}
+      run: echo "ERT_TESTS_RUN_ON_MAC_CI=true" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/install_dependencies_qt
       with:
@@ -80,8 +79,8 @@ jobs:
         touch storage
         chmod 000 storage
         uv run just ert-unit-tests
-        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_docs.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-doc-tests
-        ERT_PYTEST_ARGS='-m ${{ inputs.select-string }} --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_mem.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-memory-tests
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_docs.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-doc-tests
+        ERT_PYTEST_ARGS='--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_mem.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable' uv run just ert-memory-tests
         chmod 700 storage
         rm storage
 

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -37,6 +37,9 @@ jobs:
         fetch-depth: 0
         filter: tree:0
 
+    - if: ${{ inputs.os == 'macos-latest' }}
+      run: echo "ERT_TESTS_RUN_ON_MAC_CI=true" >> "$GITHUB_ENV"
+
     - uses: ./.github/actions/install_dependencies_qt
       with:
         os: ${{ inputs.os }}
@@ -64,7 +67,7 @@ jobs:
     - name: Run Tests macOS
       if: ${{ inputs.test-type == 'test' && runner.os == 'macOS'}}
       run: |
-        ERT_PYTEST_ARGS='-n 3 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -m "not skip_mac_ci" -v' uv run just everest-tests
+        ERT_PYTEST_ARGS='-n 3 --cov=ert --cov=everest --cov=_ert --cov-report=xml:cov1.xml --junit-xml=junit.xml -o junit_family=legacy -v' uv run just everest-tests
 
     - name: Build Documentation
       if: inputs.test-type == 'doc'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,11 @@ def pytest_collection_modifyitems(config, items):
         ):
             item.add_marker(pytest.mark.skip("Requires eclipse"))
 
+    if os.environ.get("ERT_TESTS_RUN_ON_MAC_CI"):
+        for item in items:
+            if "skip_mac_ci" in item.keywords:
+                item.add_marker(pytest.mark.skip(reason="Skipped on mac ci"))
+
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
         skip_quick = pytest.mark.skip(


### PR DESCRIPTION
This avoids a problem where only the last `-m` option in pytest is selected, meaning we never skip on mac when the corresponding pytest command later sets `-m`.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
