### PR TITLE
[Backport version-14.6] Raise error for restart without time map or refcase

### DIFF
--- a/src/ert/config/observations.py
+++ b/src/ert/config/observations.py
@@ -311,6 +311,11 @@ class EnkfObs:
         summary_key = summary_dict.key
         value, std_dev = cls._make_value_and_std_dev(summary_dict)
 
+        if summary_dict.restart and not (time_map or has_refcase):
+            raise ObservationConfigError.with_context(
+                "Keyword 'RESTART' requires either TIME_MAP or REFCASE", context=obs_key
+            )
+
         try:
             if summary_dict.date is not None and not time_map:
                 # We special case when the user has provided date in SUMMARY_OBS

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2447,3 +2447,24 @@ def test_validation_error_on_invalid_design_matrix_parameter_name(
                 DESIGN_MATRIX {tmp_path}/my_design_matrix.xlsx
                 """
         )
+
+
+def test_that_time_map_or_refcase_is_present_if_restart_is_used_for_summary_observation():  # noqa E501
+    with pytest.raises(ConfigValidationError, match="either TIME_MAP or REFCASE"):
+        ErtConfig.from_dict(
+            {
+                "ECLBASE": "ECLIPSE_CASE",
+                "OBS_CONFIG": (
+                    "obsconf",
+                    """
+                    SUMMARY_OBSERVATION FOPR
+                    {
+                        KEY = FOPR;
+                        RESTART = 1;
+                        VALUE = 1.0;
+                        ERROR = 0.1;
+                    };
+                    """,
+                ),
+            }
+        )


### PR DESCRIPTION
Manual backport of this commit https://github.com/equinor/ert/commit/cb2cb64c017bc5aafff14c9df1ca48f801c47b2a.

Was not possible to cherry pick. The test did not work as intended when copied from commit as the parser would complain:

```Trace
    def match(self, text, pos):
        for mre in self._mres:
>           m = mre.match(text, pos)
                ^^^^^^^^^^^^^^^^^^^^
E           TypeError: expected string or bytes-like object, got 'list'

../../../.venv/lib/python3.13/site-packages/lark/lexer.py:389: TypeError
```
... so I rewrote it to a string format similar to another test in the same file..