### PR TITLE
Fix flaky openpbs test

### DIFF
--- a/tests/ert/unit_tests/scheduler/bin/qdel
+++ b/tests/ert/unit_tests/scheduler/bin/qdel
@@ -4,9 +4,23 @@ set -e
 jobdir="${PYTEST_TMP_PATH:-.}/mock_jobs"
 jobid=$1
 
-if ! [ -f "${jobdir}/${jobid}.pid" ]
+if ! [ -f "${jobdir}/${jobid}.name" ]
 then
     echo "No such job ${jobid}" >&2
+    exit 1
+fi
+
+timeout=2
+elapsed=0
+interval=0.1
+
+while [ ! -f "${jobdir}/${jobid}.pid" ] && [ $elapsed -lt $timeout ]; do
+    sleep $interval
+    elapsed=$(echo "$elapsed + $interval" | bc)
+done
+
+if [ ! -f "${jobdir}/${jobid}.pid" ]; then
+        echo "No such job ${jobid}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
**Issue**
Resolves #11841


**Approach**
Fix flaky test

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
