### PR TITLE
Make sure everserver logs reach attached azure logger

### DIFF
--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -61,11 +61,12 @@ def _configure_loggers(
             "class": "logging.FileHandler",
             "formatter": "default",
             "level": log_level,
-            "filename": path,
+            "filename": str(path),
         }
 
     logging_config = {
         "version": 1,
+        "disable_existing_loggers": False,
         "handlers": {
             "endpoint_log": make_handler_config(
                 detached_dir / "endpoint.log", logging_level
@@ -80,21 +81,21 @@ def _configure_loggers(
             EVERSERVER: {
                 "handlers": ["endpoint_log"],
                 "level": logging_level,
-                "propagate": False,
+                "propagate": True,
             },
             EVEREST: {
                 "handlers": ["everest_log"],
                 "level": logging_level,
-                "propagate": False,
+                "propagate": True,
             },
             "forward_models": {
                 "handlers": ["forward_models_log"],
                 "level": logging_level,
-                "propagate": False,
+                "propagate": True,
             },
             "ert.scheduler.job": {
                 "handlers": ["forward_models_log"],
-                "propagate": False,
+                "propagate": True,
                 "level": logging_level,
             },
         },

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -7,7 +7,7 @@ DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 
 EVEREST = "everest"
-EVERSERVER = "everserver"
+EVERSERVER = "everest.everserver"
 
 HOSTFILE_NAME = "storage_server.json"
 


### PR DESCRIPTION
**Issue**
Resolves #11626

**Approach**
~~(TODO: need to rebase this once the PR moving to `ErtPluginManager` is in)~~

Current logs from the `everserver` will not reach the Azure logs, this is most likely due to:
logs from children not being propagated to the root + `everserver` logs being filtered out due to the hook implementation in `fmu_site_configuration`. This PR attempts to fix that (i.e., changing the name of the logger to start with `everest`, alternatively we could also add `everserver` to the allowed modules in the hook implementation). 

A lot of logs might now end up in the Azure logs, not sure if we want all of them + a bit scared if I somehow introduce duplicate logs (due to the propagate True, I don't understand all this logging business at a low enough level I am afraid) or bloat due to third party loggers that are not reaching the root logger (due to `"disable_existing_loggers": False`). 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
