### PR TITLE
Improve feedback when storage_server.json is not writable

### DIFF
--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -112,8 +112,20 @@ def run_gui(args: Namespace, plugin_manager: ErtPluginManager | None = None) -> 
         if ens_path is None:
             return show_window()
 
-        with StorageService.init_service(project=os.path.abspath(ens_path)):
-            return show_window()
+        try:
+            with StorageService.init_service(project=os.path.abspath(ens_path)):
+                return show_window()
+        except PermissionError as pe:
+            print(f"Error: {pe}", file=sys.stderr)
+            print(
+                "Cannot start or connect to storage service due to permission issues.",
+                file=sys.stderr,
+            )
+            print(
+                "This is most likely due to another user starting ERT "
+                "with this storage.",
+                file=sys.stderr,
+            )
     return -1
 
 

--- a/src/ert/services/storage_service.py
+++ b/src/ert/services/storage_service.py
@@ -73,6 +73,12 @@ class StorageService(BaseService):
                 f"{type(e).__name__}: {e}, starting new service"
             )
             return cls.start_server(*args, **kwargs)
+        except PermissionError as pe:
+            logging.getLogger(__name__).error(
+                f"{type(pe).__name__}: {pe}, cannot connect to storage service "
+                f"due to permission issues."
+            )
+            raise pe
         return _Context(service)
 
     def fetch_url(self) -> str:


### PR DESCRIPTION
**Issue**
Resolves #11848 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
