### PR TITLE
Ensure copybutton is placed next to runpath

### DIFF
--- a/src/ert/gui/ertwidgets/copyablelabel.py
+++ b/src/ert/gui/ertwidgets/copyablelabel.py
@@ -82,3 +82,5 @@ class CopyableLabel(QHBoxLayout):
 
         self.addWidget(self.label)
         self.addWidget(self.copy_button, alignment=Qt.AlignmentFlag.AlignLeft)
+
+        self.setStretch(1, 1)


### PR DESCRIPTION
On TGX, the copy button was always placed at least 50% to the right due to evenly distributed spaces in the layout. This change will allow the copybutton section to stretch farther to the left such that the copybutton will be next to the runpath label.

Before change Linux:

<img width="1495" height="852" alt="image" src="https://github.com/user-attachments/assets/0a7b993c-4dac-40a4-a0a4-e68668fe4155" />

After change Linux:

<img width="1493" height="853" alt="image" src="https://github.com/user-attachments/assets/b9b07abc-a5e9-471b-bfa0-6a096a119b8d" />

Before change Mac:

<img width="1491" height="819" alt="image" src="https://github.com/user-attachments/assets/cf8fbbff-45f5-44da-8ad4-77275bece9e3" />

After change Mac:

<img width="1488" height="819" alt="image" src="https://github.com/user-attachments/assets/16976a6a-bf5d-496c-9a8b-ed48c063900a" />


**Issue**
Resolves #11839 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
