### PR TITLE
Change open_storage mode to 'r' where possible

### DIFF
--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -679,7 +679,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
             reals_rerun_option,
         )
 
-    with open_storage(ert_config.ens_path, mode="w") as storage:
+    with open_storage(ert_config.ens_path, mode="r") as storage:
         parameter_values = storage.get_ensemble(ensemble.id).load_parameters_numpy(
             "COEFFS", np.arange(num_realizations)
         )

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -27,7 +27,7 @@ def test_field_param_update_using_heat_equation_enif(
     symlinked_heat_equation_storage_enif,
 ):
     config = ErtConfig.from_file("config.ert")
-    with open_storage(config.ens_path, mode="w") as storage:
+    with open_storage(config.ens_path, mode="r") as storage:
         experiment = storage.get_experiment_by_name("enif")
         [prior, posterior] = experiment.ensembles
 
@@ -174,7 +174,7 @@ def test_field_param_update_using_heat_equation_enif_snapshot(
     symlinked_heat_equation_storage_enif, snapshot, request
 ):
     config = ErtConfig.from_file("config.ert")
-    with open_storage(config.ens_path, mode="w") as storage:
+    with open_storage(config.ens_path, mode="r") as storage:
         experiment = storage.get_experiment_by_name("enif")
         prior = experiment.get_ensemble_by_name("iter-0")
         posterior = experiment.get_ensemble_by_name("iter-1")
@@ -214,7 +214,7 @@ def test_field_param_update_using_heat_equation_enif_snapshot(
 
 def test_field_param_update_using_heat_equation(symlinked_heat_equation_storage_es):
     config = ErtConfig.from_file("config.ert")
-    with open_storage(config.ens_path, mode="w") as storage:
+    with open_storage(config.ens_path, mode="r") as storage:
         experiment = storage.get_experiment_by_name("es")
         prior = experiment.get_ensemble_by_name("iter-0")
         posterior = experiment.get_ensemble_by_name("iter-1")

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -294,7 +294,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
     esmda_has_run: ErtMainWindow, qtbot
 ):
     gui = esmda_has_run
-    open_storage(gui.ert_config.ens_path, mode="w")
+    open_storage(gui.ert_config.ens_path, mode="r")
     with StorageService.init_service(
         project=os.path.abspath(gui.ert_config.ens_path),
     ):
@@ -633,7 +633,7 @@ def test_that_gui_plotter_works_when_no_data(qtbot, monkeypatch, use_tmpdir):
     ert_config = ErtConfig.from_file(config_file)
     # Open up storage to create it, so that dark storage can be mounted onto it
     # Not creating will result in dark storage hanging/lagging
-    open_storage(ert_config.ens_path, mode="w")
+    open_storage(ert_config.ens_path, mode="r")
 
     with StorageService.init_service(
         project=os.path.abspath(ert_config.ens_path),
@@ -665,7 +665,7 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, use_tmpdir, monke
 
     # Open up storage to create it, so that dark storage can be mounted onto it
     # Not creating will result in dark storage hanging/lagging
-    open_storage("storage", mode="w")
+    open_storage("storage", mode="r")
 
     args_mock = Mock()
     args_mock.config = config_file

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -393,7 +393,7 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
     config = ErtConfig.from_file("poly_localization_0.ert")
 
     notifier = ErtNotifier()
-    with open_storage(config.ens_path, mode="w") as storage:
+    with open_storage(config.ens_path, mode="r") as storage:
         notifier.set_storage(str(storage.path))
 
         tool = ManageExperimentsPanel(

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -59,7 +59,7 @@ def plot_figure(
         args_mock.config = "config.ert"
 
     # For dark storage not to hang
-    open_storage(storage_config.ens_path, mode="w")
+    open_storage(storage_config.ens_path, mode="r")
     log_handler = GUILogHandler()
     with (
         StorageService.init_service(

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -71,7 +71,7 @@ def test_create_experiment(tmp_path):
 
 def test_that_loading_non_existing_experiment_throws(tmp_path):
     with (
-        open_storage(tmp_path, mode="w") as storage,
+        open_storage(tmp_path, mode="r") as storage,
         pytest.raises(
             KeyError, match="Experiment with name 'non-existing-experiment' not found"
         ),
@@ -1132,7 +1132,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
     def __init__(self) -> None:
         super().__init__()
         self.tmpdir = tempfile.mkdtemp(prefix="StatefulStorageTest")
-        self.storage = open_storage(self.tmpdir + "/storage/", "w")
+        self.storage = open_storage(self.tmpdir + "/storage/", mode="w")
         note(f"storage path is: {self.storage.path}")
         self.model: dict[UUID, Experiment] = {}
         assert list(self.storage.ensembles) == []


### PR DESCRIPTION
**Issue**
Resolves #11749 

This should fix the issue in the linked PR failure.  
`test_that_all_snake_oil_visualisations_matches_snapshot`
Making more tests open storage in read mode should reduce the number of tests trying to acquire locks on the storage. 

If this does not help. The next step would be to still symnlink but copy the storage in the tests that needs the storage in write mode.




**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
