### PR TITLE
Fix flaky test test_that_kill_before_submit_is_finished_works

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -1351,12 +1351,18 @@ async def test_that_kill_before_submit_is_finished_works(tmp_path, monkeypatch, 
 
     async def finished(iens: int, returncode: int):
         SIGTERM = 15
+        EXIT_CODE_KILLED_BY_OWNER = 130
         assert iens == 0
         # If the kill is issued before the job really starts, you will not
         # get SIGTERM but rather LSF_FAILED_JOB. Whether SIGNAL_OFFSET is
         # added or not depends on various shell configurations and is a
         # detail we do not want to track.
-        assert returncode in {SIGTERM, SIGNAL_OFFSET + SIGTERM, LSF_FAILED_JOB}
+        assert returncode in {
+            SIGTERM,
+            SIGNAL_OFFSET + SIGTERM,
+            LSF_FAILED_JOB,
+            EXIT_CODE_KILLED_BY_OWNER,
+        }
 
     await poll(driver, {0}, finished=finished)
     assert "ERROR" not in str(caplog.text)


### PR DESCRIPTION
**Issue**
Resolves #11547


**Approach**
This commit fixes the flaky test by adding the lsf exit code 130 (killed by user according to the lsf documentation) to the list of accepted exit codes in the test.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
