### PR TITLE
Exclude SCRIPT from words

### DIFF
--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -42,11 +42,13 @@ from .observations_generator import (
 )
 from .summary_generator import Date, Smspec, Unsmry, smspecs, summary_variables, unsmrys
 
+# Exclude SCRIPT because it is used as folder-name in
+# generate_files_and_dict
 words = st.text(
     min_size=4,
     max_size=8,
     alphabet=st.characters(min_codepoint=ord("A"), max_codepoint=ord("Z")),
-)
+).filter(lambda x: x != "SCRIPT")
 
 
 def touch(filename):


### PR DESCRIPTION
Test will fail if we set `words = st.just("SCRIPT")`

IsADirectoryError: [Errno 21] Is a directory: 'dirSCRIPT/SCRIPT'


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
