### PR TITLE
Fix color to ensemble sort order

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -49,6 +49,9 @@ class EnsembleSelectionWidget(QWidget):
     def get_selected_ensembles(self) -> list[EnsembleObject]:
         return self.__dndlist.get_checked_ensembles()
 
+    def get_selected_ensembles_indexes(self) -> list[int]:
+        return self.__dndlist.get_checked_indexes()
+
 
 class EnsembleSelectListWidget(QListWidget):
     ensembleSelectionListChanged = Signal()
@@ -87,6 +90,16 @@ class EnsembleSelectListWidget(QListWidget):
                 assert item is not None
                 if item.data(Qt.ItemDataRole.CheckStateRole):
                     yield item.data(Qt.ItemDataRole.UserRole)
+
+        return list(_iter())
+
+    def get_checked_indexes(self) -> list[int]:
+        def _iter() -> Iterator[int]:
+            for index in range(self._ensemble_count):
+                item = self.item(index)
+                assert item is not None
+                if item.data(Qt.ItemDataRole.CheckStateRole):
+                    yield index
 
         return list(_iter())
 

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -217,6 +217,9 @@ class PlotWindow(QMainWindow):
             selected_ensembles = (
                 self._ensemble_selection_widget.get_selected_ensembles()
             )
+            selected_ensembles_indexes = (
+                self._ensemble_selection_widget.get_selected_ensembles_indexes()
+            )
             ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame] = {}
             for ensemble in selected_ensembles:
                 try:
@@ -265,7 +268,9 @@ class PlotWindow(QMainWindow):
                 plot_widget.showLayerWidget.emit(False)
 
             plot_config = PlotConfig.createCopy(self._plot_customizer.getPlotConfig())
-            plot_context = PlotContext(plot_config, selected_ensembles, key, layer)
+            plot_context = PlotContext(
+                plot_config, selected_ensembles, selected_ensembles_indexes, key, layer
+            )
 
             # Check if key is a history key.
             # If it is it already has the data it needs

--- a/src/ert/gui/tools/plot/plottery/plot_config.py
+++ b/src/ert/gui/tools/plot/plottery/plot_config.py
@@ -88,6 +88,11 @@ class PlotConfig:
 
         self._std_dev_factor = 1  # sigma 1 is default std dev
 
+    def setCurrentColor(self, index: int) -> None:
+        self._current_color = self._line_color_cycle_colors[
+            index % len(self._line_color_cycle_colors)
+        ]
+
     def currentColor(self) -> tuple[str, float]:
         if self._current_color is None:
             return self.nextColor()

--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -30,12 +30,14 @@ class PlotContext:
         self,
         plot_config: PlotConfig,
         ensembles: list[EnsembleObject],
+        ensembles_index: list[int],
         key: str,
         layer: int | None = None,
     ) -> None:
         super().__init__()
         self._key = key
         self._ensembles = ensembles
+        self._ensembles_index = ensembles_index
         self._plot_config = plot_config
         self.history_data: DataFrame | None = None
         self._layer: int | None = layer
@@ -49,6 +51,9 @@ class PlotContext:
 
     def ensembles(self) -> list[EnsembleObject]:
         return self._ensembles
+
+    def ensembles_index(self) -> list[int]:
+        return self._ensembles_index
 
     def key(self) -> str:
         return self._key

--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -39,14 +39,16 @@ class EnsemblePlot:
         plot_context.x_axis = plot_context.DATE_AXIS
         draw_style = "steps-pre" if is_rate(plot_context.key()) else None
 
-        for ensemble, data in ensemble_to_data_map.items():
+        for (ensemble, data), index in zip(
+            ensemble_to_data_map.items(), plot_context.ensembles_index(), strict=False
+        ):
             data = data.T
 
             if not data.empty:
                 if data.index.inferred_type != "datetime64":
                     plot_context.deactivateDateSupport()
                     plot_context.x_axis = plot_context.INDEX_AXIS
-
+                config.setCurrentColor(index)
                 self._plotLines(
                     axes,
                     config,

--- a/tests/ert/unit_tests/gui/plottery/test_ensemble_plot.py
+++ b/tests/ert/unit_tests/gui/plottery/test_ensemble_plot.py
@@ -24,6 +24,7 @@ def plot_context(request):
             "ensemble_1", "id", False, "experiment_1", started_at="2012-12-10T00:00:00"
         )
     ]
+    context.ensembles_index.return_value = [1]
     context.key.return_value = request.param
     context.history_data = None
     context.plotConfig.return_value = PlotConfig(title="Ensemble Plot")


### PR DESCRIPTION
**Issue**
Intended to solve #11829, but abandoned


**Approach**
Added logic to fix plot color to ensemble order, including unselected ensembles. 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
