### PR TITLE
Remove parameter logging

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -237,14 +237,6 @@ class RunModel(BaseModelWithContextSupport, ABC):
             "run_model": self.name(),
             "num_realizations": self.runpath_config.num_realizations,
             "num_active_realizations": self.active_realizations.count(True),
-            "num_parameters": (
-                sum(
-                    len(param_config.parameter_keys)
-                    for param_config in self.parameter_configuration
-                )
-                if hasattr(self, "parameter_configuration")
-                else "NA"
-            ),
             "localization": getattr(
                 settings_dict.get("analysis_settings", {}), "localization", "NA"
             ),

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -1,9 +1,7 @@
 import asyncio
 import math
 import os
-import re
 import uuid
-from logging import Logger
 from pathlib import Path
 from queue import SimpleQueue
 from types import MethodType
@@ -12,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import ConfigDict
 
-from ert.config import ErtConfig, GenKwConfig, ModelConfig, QueueConfig
+from ert.config import ErtConfig, ModelConfig, QueueConfig
 from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
 from ert.run_models.run_model import RunModel, UserCancelled
@@ -597,25 +595,3 @@ def test_create_mask_from_failed_realizations_returns_initial_active_realization
     failed_realization_mask = brm._create_mask_from_failed_realizations()
 
     assert failed_realization_mask == initial_active_realizations
-
-
-# TODO remove this test?
-def test_run_model_logs_number_of_parameters(use_tmpdir):
-    parameters = GenKwConfig(
-        distribution={"name": "normal", "mean": 0, "std": 1},
-        name="parameter_configuration",
-        forward_init=False,
-        update=True,
-    )
-
-    rm = create_run_model(parameter_configuration=[parameters])
-
-    def mock_logging(_, log_str):
-        regex = r"'num_parameters': (\d+)"
-        match = re.search(regex, log_str)
-        num_param = int(match.group(1))
-
-        assert num_param == 1
-
-    with patch.object(Logger, "info", mock_logging):
-        rm.log_at_startup()


### PR DESCRIPTION
This logging only logs parameters detected in the parameter configuration. If paramters are defined in for example design matrix, this log will log 0 parameters.
Logging parameters from other steps and correlate them to this summary log does not sound easy or feasible, therefore will we remove logging of parameters from now.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
