### PR TITLE
Re-introduce missing timeout in monitor script

### DIFF
--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -74,7 +74,7 @@ def monitor_everest(options: argparse.Namespace) -> None:
 
     try:
         client = StorageService.session(
-            Path(ServerConfig.get_session_dir(config.output_dir))
+            Path(ServerConfig.get_session_dir(config.output_dir)), timeout=1
         )
         server_context = ServerConfig.get_server_context_from_conn_info(
             client.conn_info


### PR DESCRIPTION
We used to to a get with 1s timeout, after refactoring
 to checking with StorageService.session, the equivalent
 timeout was forgotten.

**Issue**
Resolves #11900 



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
