### PR TITLE
Describe history_source behavior in observations.rst

### DIFF
--- a/docs/ert/reference/configuration/observations.rst
+++ b/docs/ert/reference/configuration/observations.rst
@@ -140,6 +140,11 @@ In its simplest form, a history observation is created as follows::
 This will condition on ``WOPR`` in well P1 using a default observation
 error.
 
+By default, this will not extract the simulated values for the vector ``WOPR:P1``
+from :ref:`refcase`, but rather the corresponding history values: ``WOPRH:P1``
+(see `OPM Flow manual`_ table 11.4 "Fifth Character"). This can changed to
+fetch ``WOPR:P1`` instead with the :ref:`history_source` keyword.
+
 In general, a :term:`summary key` is given following the
 HISTORY_OBSERVATION keyword, e.g. to condition on variable VAR in well or group
 WGNAME, use::
@@ -438,3 +443,5 @@ So consider a setup like this::
 Here we see that the observation is active at report step 20, and we
 expect the forward model to create a file rft_BH67_20 in each
 realization directory.
+
+.. _OPM Flow manual: https://opm-project.org/wp-content/uploads/2023/06/OPM_Flow_Reference_Manual_2023-04_Rev-0_Reduced.pdf


### PR DESCRIPTION
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
