### PR TITLE
Deprecate the --new-run argument for everest

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -118,7 +118,8 @@ def _build_args_parser() -> argparse.ArgumentParser:
     arg_parser.add_argument(
         "--new-run",
         action="store_true",
-        help="Run the optimization even though results are already available",
+        help="DEPRECATED: This option is deprecated and has no effect. "
+        "Update your scripts accordingly.",
     )
     arg_parser.add_argument(
         "--gui",
@@ -132,7 +133,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
         "--show-all-jobs",
         action="store_true",
         help=(
-            "This option no longer has an effect, "
+            "DEPRECATED: This option no longer has an effect, "
             "and will be removed in a future version"
         ),
     )
@@ -157,10 +158,9 @@ async def run_everest(options: argparse.Namespace) -> None:
         options.config.output_dir
     )
 
-    if not options.new_run:
-        EverestStorage.check_for_deprecated_seba_storage(
-            options.config.optimization_output_dir
-        )
+    EverestStorage.check_for_deprecated_seba_storage(
+        options.config.optimization_output_dir
+    )
 
     server_state = everserver_status(everserver_status_path)
     try:
@@ -180,7 +180,7 @@ async def run_everest(options: argparse.Namespace) -> None:
             "To kill the running optimization use command:\n"
             f"  `everest kill {config_file}`"
         )
-    elif server_state["status"] == ExperimentState.never_run or options.new_run:
+    elif server_state["status"] == ExperimentState.never_run:
         config_dict = options.config.to_dict()
         logger.info("Running everest with the following config:")
         logger.info(json.dumps(config_dict, sort_keys=True, indent=2))

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -425,17 +425,10 @@ def report_on_previous_run(
     server_state = everserver_status(everserver_status_path)
     if server_state["status"] == ExperimentState.failed:
         error_msg = server_state["message"]
-        print(
-            f"Optimization run failed, with error: {error_msg}\n"
-            "To re-run optimization case use command:\n"
-            f"`  everest run --new-run {config_file}`\n"
-        )
+        print(f"Optimization run failed, with error: {error_msg}\n")
     else:
         print(
-            f"Optimization completed.\n"
-            "\nTo re-run the optimization use command:\n"
-            f"  `everest run --new-run {config_file}`\n"
-            f"Results are stored in {optimization_output_dir}"
+            f"Optimization completed.\nResults are stored in {optimization_output_dir}"
         )
 
 


### PR DESCRIPTION
**Issue**
Resolves #11910 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
