### PR TITLE
Allow more fine-grained subsystem tests

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -103,6 +103,15 @@ start_tests() {
     if [ "$CI_SUBSYSTEM_TEST" == "ert" ]; then
       just -f "${CI_SOURCE_ROOT}"/justfile ert-tests
       return $?
+    elif [ "$CI_SUBSYSTEM_TEST" == "ert-gui-tests" ]; then
+      just -f "${CI_SOURCE_ROOT}"/justfile ert-gui-tests
+      return $?
+    elif [ "$CI_SUBSYSTEM_TEST" == "ert-cli-tests" ]; then
+      just -f "${CI_SOURCE_ROOT}"/justfile ert-cli-tests
+      return $?
+    elif [ "$CI_SUBSYSTEM_TEST" == "ert-unit-tests" ]; then
+      just -f "${CI_SOURCE_ROOT}"/justfile ert-unit-tests
+      return $?
     elif [ "$CI_SUBSYSTEM_TEST" == "everest" ]; then
       just -f "${CI_SOURCE_ROOT}"/justfile everest-tests
       return $?


### PR DESCRIPTION
This makes it possible to split the "ert" subsystem tests into its three parts.

If the selected subsystem is 'ert', it will run the justfile line:
`      parallel -j4 ::: 'just ert-gui-tests' 'just ert-cli-tests' 'just ert-unit-tests'`
so we just add the possibility of running these three directly.

The subsystem "ert" is kept for backwards compatibility.

**Issue**
First step towards https://github.com/equinor/komodo-releases/issues/8174

**Approach**
Split.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
