### PR TITLE
Explicitly use local queue for math_func

### DIFF
--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -74,6 +74,10 @@ optimization:
   max_batch_num: 5
   speculative: true
 
+simulator:
+  queue_system:
+    name: local
+
 environment:
   log_level: info
   random_seed: 999

--- a/test-data/everest/math_func/config_minimal.yml
+++ b/test-data/everest/math_func/config_minimal.yml
@@ -33,6 +33,10 @@ model:
 forward_model:
   - distance3 --point-file point.json --target 0.5 0.5 0.5 --out distance
 
+simulator:
+  queue_system:
+    name: local
+
 environment:
   simulation_folder: sim_output
   log_level: info

--- a/test-data/everest/math_func/config_multiobj.yml
+++ b/test-data/everest/math_func/config_multiobj.yml
@@ -43,6 +43,10 @@ forward_model:
               --target -1.5 -1.5 0.5
               --out distance_q
 
+simulator:
+  queue_system:
+    name: local
+
 environment:
   simulation_folder: sim_output
   output_folder: everest_output_multiobj


### PR DESCRIPTION
Site-configs could set the queue to something else than local, but for something as simple as math_func, that is probably never a good idea.

**Issue**
Resolves developers constantly needing to constantly modify this file when fmu-site-configurations is installed in the venv.

**Approach**
:brain:

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
