### PR TITLE
Disable some tests on macOS

### DIFF
--- a/tests/ert/performance_tests/test_obs_and_responses_performance.py
+++ b/tests/ert/performance_tests/test_obs_and_responses_performance.py
@@ -1,5 +1,6 @@
 import datetime
 import random
+import sys
 from dataclasses import dataclass
 
 import memray
@@ -420,6 +421,9 @@ def setup_benchmark(tmp_path, request):
 
 
 @pytest.mark.memory_test
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Currently failing on mac"
+)
 def test_memory_performance_of_joining_observations_and_responses(
     setup_benchmark, tmp_path
 ):
@@ -518,6 +522,9 @@ def setup_es_benchmark(tmp_path, request):
 
 
 @pytest.mark.memory_test
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Currently failing on mac"
+)
 def test_memory_performance_of_doing_es_update(setup_es_benchmark, tmp_path):
     _, prior, posterior, gen_kw_names, expected_performance = setup_es_benchmark
     with memray.Tracker(tmp_path / "memray.bin"):
@@ -555,6 +562,9 @@ def test_speed_performance_of_doing_es_update(setup_es_benchmark, benchmark):
 
 
 @pytest.mark.memory_test
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Currently failing on mac"
+)
 def test_memory_performance_of_doing_enif_update(setup_es_benchmark, tmp_path):
     _, prior, posterior, gen_kw_names, expected_performance = setup_es_benchmark
     with memray.Tracker(tmp_path / "memray.bin"):

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import stat
+import sys
 import threading
 import warnings
 from datetime import datetime
@@ -904,6 +905,9 @@ def test_that_connection_errors_do_not_effect_final_result(
 
 
 @pytest.mark.usefixtures("copy_poly_case")
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"), reason="Currently failing on mac"
+)
 async def test_that_killed_ert_does_not_leave_storage_server_process():
     ert_subprocess = Popen(["ert", "gui", "poly.ert"])
     assert ert_subprocess.is_running()


### PR DESCRIPTION
Currently failing on mac, ref https://github.com/equinor/ert/actions/runs/18031826487/job/51310865467

ref #11548  Skip test_that_killed_ert_does_not_leave_storage_server_process on mac