### PR TITLE
Allow inline data in install_data

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -763,9 +763,10 @@ to read summary data from forward model, do:
         model = self.model
         if model and config_path:
             for install_data_cfg in install_data:
-                check_path_exists(
-                    install_data_cfg.source, config_path, model.realizations
-                )
+                if install_data_cfg.source is not None:
+                    check_path_exists(
+                        install_data_cfg.source, config_path, model.realizations
+                    )
 
         return self
 

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -1,25 +1,30 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 from textwrap import dedent
+from typing import Any
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
-class InstallDataConfig(BaseModel, extra="forbid"):
-    source: str = Field(
+class InstallDataConfig(BaseModel):
+    source: str | None = Field(
+        default=None,
         description=dedent(
             """
             Path to file or directory that needs to be copied or linked into the
             directory where the forward model executes.
             """
-        )
-    )  # existing path
+        ),
+    )
     target: str = Field(
         description=dedent(
             """
             Relative destination path to copy or link the given source to.
             """
         )
-    )  # path
+    )
     link: bool = Field(
         default=False,
         description=dedent(
@@ -28,6 +33,25 @@ class InstallDataConfig(BaseModel, extra="forbid"):
             if not set the source will be copied at the given target.
             """
         ),
+    )
+    data: dict[str, Any] | None = Field(
+        default=None,
+        description=dedent(
+            """
+            Data to be exported to the target file.
+
+            If provided, the data is exported to a JSON file. If `target` has no
+            `.json` extension, it is added.
+
+            The `data` and `source` fields are mutually exclusive.
+
+            If `data` is provided, `link` will be ignored.
+            """
+        ),
+    )
+
+    model_config = ConfigDict(
+        extra="forbid",
     )
 
     @field_validator("link", mode="before")
@@ -40,7 +64,29 @@ class InstallDataConfig(BaseModel, extra="forbid"):
         return link
 
     @model_validator(mode="after")
-    def validate_target(self) -> "InstallDataConfig":
-        if self.target in {".", "./"}:
+    def validate_target(self) -> InstallDataConfig:
+        if self.data is not None:
+            if self.source is not None:
+                raise ValueError("The data and source options are mutually exclusive.")
+            if self.target.strip() in {"", ".", "./"}:
+                raise ValueError("A target name must be provided with data.")
+
+            ext = Path(self.target).suffix.lower()
+            if ext not in {".json", ""}:
+                raise ValueError(f"Invalid target extension {ext} (.json expected).")
+
+            return self
+
+        if self.source is None:
+            raise ValueError("Either source or data must be provided.")
+
+        if self.target.strip() in {".", "./"}:
             self.target = Path(self.source).name
         return self
+
+    def inline_data_as_str(self) -> tuple[str, str]:
+        assert self.data is not None
+        return (
+            str(Path(self.target).with_suffix(".json")),
+            json.dumps(self.data, indent=2),
+        )

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -1,4 +1,5 @@
 import fileinput
+import re
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 from textwrap import dedent
@@ -108,7 +109,15 @@ def test_extra_key(min_config):
         ),
         (
             {"install_data": [{"source": None, "target": "not_relevant"}]},
-            "source\n  Input should be a valid string",
+            "Either source or data must be provided",
+        ),
+        (
+            {
+                "install_data": [
+                    {"source": "", "data": {"foo": 1}, "target": "not_relevant"}
+                ]
+            },
+            "The data and source options are mutually exclusive",
         ),
         (
             {"install_data": [{"source": ["a", "b"], "target": "not_relevant"}]},
@@ -179,7 +188,10 @@ def test_that_install_data_target_path_outside_runpath_is_invalid(
     Path.mkdir(Path("test_dir"))
     Path("test_dir/my_file").touch()
     min_config["install_data"] = [{"source": source, "target": target, "link": link}]
-    with pytest.raises(ValidationError, match="Target location outside of runpath"):
+    with pytest.raises(
+        ValidationError,
+        match=re.escape(f"Target location '{target}' is outside of the runpath."),
+    ):
         EverestConfig(**min_config)
 
 


### PR DESCRIPTION
**Issue**
Resolves #11895


**Approach**
Extends the `install_data` section of the Everest configuration with a `data` fields that is mutually exclusive with the `source` field. If present, the content of that field is used instead of a source file to generate the target file. Supported outputs are json and yaml. This feature is intended to replace the `wells` field in the configuration, which is to be deprecated. Since it is a generic mechanism, it will also be documented as a new feature.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
