### PR TITLE
Catch BaseException in ert_script.py

### DIFF
--- a/src/ert/config/ert_script.py
+++ b/src/ert/config/ert_script.py
@@ -159,7 +159,7 @@ class ErtScript:
         except UserWarning as uw:
             self.__failed = True
             return uw.args[0]
-        except Exception as e:
+        except BaseException as e:
             full_trace = "".join(traceback.format_exception(*sys.exc_info()))
             self.output_stack_trace(f"{e!s}\n{full_trace}")
             return None

--- a/tests/ert/unit_tests/workflow_runner/test_ert_script.py
+++ b/tests/ert/unit_tests/workflow_runner/test_ert_script.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ert import ErtScript
@@ -66,3 +68,13 @@ def test_empty_ert_script_raises_value_error():
 
     with pytest.raises(ValueError, match="does not contain an ErtScript"):
         _ = ErtScript.loadScriptFromFile("empty_script.py")
+
+
+def test_that_exits_in_ert_script_is_trapped():
+    class FailingScript(ErtScript):
+        def run(self, *arg):
+            sys.exit(-1)
+
+    failing = FailingScript()
+    failing.initializeAndRun([], [])
+    assert failing.hasFailed()


### PR DESCRIPTION
Exception catches everything but cases like system exits - which BaseException catches.

This caused some workflows to crash given system exit, producing a traceback instead of a short summary of what went wrong.

**Issue**
Resolves #11814 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
