### PR TITLE
Increase timeout for rapid-tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ pytest_args := env("ERT_PYTEST_ARGS", "--quiet")
 
 # execute rapid unittests
 rapid-tests:
-    OMP_NUM_THREADS=1 pytest -n auto --benchmark-disable --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky or memory_test or limit_memory)" --timeout=10
+    OMP_NUM_THREADS=1 pytest -n auto --benchmark-disable --dist loadgroup tests/ert/unit_tests tests/everest --hypothesis-profile=fast -m "not (integration_test or flaky or memory_test or limit_memory)" --timeout=20
 
 ert-gui-tests:
     pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui


### PR DESCRIPTION
Sometimes, especially if cache needs updating, the tests may take more than 10 seconds without being a problem.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
