### PR TITLE
Add deprecation message for FORWARD_MODEL DESIGN2PARAMS usage

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -1,7 +1,28 @@
 from functools import partial
-from typing import cast
+from typing import Any, cast
 
 from .deprecation_info import DeprecationInfo
+
+
+def make_forward_model_design2params_deprecation_message(line: list[Any]) -> str:
+    design_matrix_file = "<name_of_design_matrix_file.xlsx>"
+    design_sheet = "<name_of_design_sheet>"
+    defaults_sheet = "<name_of_defaults_sheet>"
+    arguments_dict = dict(line[1])
+
+    design_matrix_file = arguments_dict.get("<xls_filename>", design_matrix_file)
+    design_sheet = arguments_dict.get("<designsheet>", design_sheet)
+    defaults_sheet = arguments_dict.get("<defaultssheet>", defaults_sheet)
+
+    msg = (
+        f"FORWARD_MODEL DESIGN2PARAMS will be replaced with DESIGN_MATRIX. "
+        "Please change configuration line with FORWARD_MODEL DESIGN2PARAMS,\n"
+        "To this format:\n "
+        f"'DESIGN_MATRIX {design_matrix_file} DESIGN_SHEET:{design_sheet} "
+        f"DEFAULT_SHEET:{defaults_sheet}'"
+    )
+    return msg
+
 
 REPLACE_WITH_GEN_KW = [
     "RELPERM",
@@ -203,5 +224,10 @@ deprecated_keywords_list = [
         "configuration path if provided."
         "It has been replaced with the path to the directory containing the "
         "configuration file for the experiment.",
+    ),
+    DeprecationInfo(
+        keyword="FORWARD_MODEL",
+        message=make_forward_model_design2params_deprecation_message,
+        check=lambda line: line[0] == "DESIGN2PARAMS",
     ),
 ]


### PR DESCRIPTION
**Issue**
Resolves #11935 

**Approach**
Adding FORWARD_MODEL DESIGN2PARAMS to deprecation list

<img width="1442" height="472" alt="image" src="https://github.com/user-attachments/assets/cf0f62e3-6389-4cea-b566-6fce200bcb78" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
