### PR TITLE
Stop reading status from file in everest_script.py and monitor_script.py

### DIFF
--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -23,6 +23,7 @@ from ert.ensemble_evaluator import (
     FullSnapshotEvent,
     SnapshotUpdateEvent,
 )
+from ert.ensemble_evaluator.event import EndEvent
 from ert.logging import LOGGING_CONFIG
 from ert.plugins.plugin_manager import ErtPluginManager
 from ert.services import StorageService
@@ -214,6 +215,8 @@ class _DetachedMonitor:
                     self._clear_lines = 0
             if SIM_PROGRESS_ID in status:
                 match status[SIM_PROGRESS_ID]:
+                    case EndEvent(msg=msg):
+                        return
                     case FullSnapshotEvent(snapshot=snapshot, iteration=batch):
                         if snapshot is not None:
                             self._snapshots[batch] = snapshot
@@ -404,7 +407,9 @@ class _DetachedMonitor:
             print(colorama.Cursor.UP(), end=colorama.ansi.clear_line())
 
 
-def run_detached_monitor(server_context: tuple[str, str, tuple[str, str]]) -> None:
+def run_detached_monitor(
+    server_context: tuple[str, str, tuple[str, str]],
+) -> None:
     monitor = _DetachedMonitor()
     start_monitor(server_context, callback=monitor.update)
 

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -17,7 +17,6 @@ from websockets import ConnectionClosedError, ConnectionClosedOK
 from websockets.sync.client import connect
 
 from ert.dark_storage.client import Client
-from ert.ensemble_evaluator import EndEvent
 from ert.run_models.event import EverestBatchResultEvent, status_event_from_json
 from ert.scheduler import create_driver
 from ert.scheduler.driver import Driver, FailedSubmit
@@ -236,9 +235,7 @@ def start_monitor(
                 try:
                     message = websocket.recv(timeout=1.0)
                     event = status_event_from_json(message)
-                    if isinstance(event, EndEvent):
-                        print(event.msg)
-                    elif isinstance(event, EverestBatchResultEvent):
+                    if isinstance(event, EverestBatchResultEvent):
                         if event.result_type == "FunctionResult":
                             callback(
                                 {
@@ -261,8 +258,9 @@ def start_monitor(
                     logger.error("Error when processing event %s", exc_info=e)
 
                 time.sleep(polling_interval)
+
     except Exception:
-        logger.debug(traceback.format_exc())
+        logger.exception(traceback.format_exc())
 
 
 def update_everserver_status(

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -8,7 +8,6 @@ import pytest
 from ert.storage import open_storage
 from everest.bin.everest_script import everest_entry
 from everest.config import EverestConfig
-from everest.detached import ExperimentState
 
 
 @pytest.mark.xdist_group("math_func/config_minimal.yml")
@@ -32,11 +31,7 @@ def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
 @patch("everest.bin.everest_script.wait_for_server")
 @patch("everest.bin.everest_script.start_server")
 @patch("everest.bin.everest_script.start_experiment")
-@patch(
-    "everest.bin.everest_script.everserver_status",
-    return_value={"status": ExperimentState.never_run, "message": None},
-)
-def test_save_running_config(_, _1, _2, _3, _4, _5, _6, change_to_tmpdir):
+def test_save_running_config(_, _1, _2, _3, _4, _5, change_to_tmpdir):
     """Test everest detached, when an optimization has already run"""
 
     Path("config.yml").touch()


### PR DESCRIPTION
**Issue**
Resolves partly #11355


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
