### PR TITLE
Remove mark applied to a fixture

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -179,7 +179,6 @@ def copy_eightcells_test_data_to_tmp(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 def cached_example(pytestconfig):
     cache = pytestconfig.cache
 


### PR DESCRIPTION
This has no effect. Pytest yields the warning:
PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

**Issue**
Resolves 
```
================================================================================================== warnings summary ==================================================================================================
../../venv/lib64/python3.12/site-packages/_hypothesis_pytestplugin.py:450
  /data/venv/lib64/python3.12/site-packages/_hypothesis_pytestplugin.py:450: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    return _orig_call(self, function)

```


**Approach**
Do as pytest says. 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
