### PR TITLE
Fix OpenPBSDriver.kill() getting malformed input

### DIFF
--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -252,7 +252,7 @@ class OpenPBSDriver(Driver):
             return
 
         process_success, process_message = await self._execute_with_retry(
-            [str(self._qdel_cmd), " ".join(job_ids_to_kill)],
+            [str(self._qdel_cmd), *job_ids_to_kill],
             retry_codes=(QDEL_REQUEST_INVALID,),
             accept_codes=(QDEL_JOB_HAS_FINISHED,),
             total_attempts=self._max_pbs_cmd_attempts,


### PR DESCRIPTION

**Approach**
This commit fixes the issue where we get `qdel: illegally formed job identifier: 'job_1 job_2'` when killing jobs. This is fixed by not joining the list of job ids into a single argument

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
