### PR TITLE
Fix erroneous overwriting of everserver logging configuration

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -140,7 +140,7 @@ def _check_user(credentials: HTTPBasicCredentials) -> None:
 
 
 def _log(request: Request) -> None:
-    logging.getLogger(EVERSERVER).info(
+    logging.getLogger(EVERSERVER).debug(
         f"{request.scope['path']} entered from "
         f"{request.client.host if request.client else 'unknown host'} "
         f"with HTTP {request.method}"

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -207,9 +207,6 @@ def run_server(
     connection_info = _create_connection_info(sock, authtoken, config.ssl_certfile)
     server = Server(config, json.dumps(connection_info))
 
-    if args.logging_config:
-        with open(args.logging_config, encoding="utf-8") as fin:
-            logging.config.dictConfig(yaml.safe_load(fin))
     logger = logging.getLogger("ert.shared.storage.info")
     if args.verbose:
         handler = logging.StreamHandler(sys.stdout)
@@ -278,7 +275,7 @@ def main() -> None:
         "ssl_keyfile_password": key_pw,
         "ssl_version": ssl.PROTOCOL_TLS_SERVER,
     }
-    with open(STORAGE_LOG_CONFIG, encoding="utf-8") as conf_file:
+    with open(args.logging_config or STORAGE_LOG_CONFIG, encoding="utf-8") as conf_file:
         logging_conf = yaml.safe_load(conf_file)
         logging.config.dictConfig(logging_conf)
         config_args.update(log_config=logging_conf)

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -66,6 +66,9 @@ def _configure_loggers(
         },
         "loggers": {
             "root": {"handlers": ["endpoint_log"], "level": logging_level},
+            "uvicorn": {
+                "level": logging.WARNING,
+            },
             EVERSERVER: {
                 "handlers": ["endpoint_log"],
                 "level": logging_level,

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -70,9 +70,8 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     # Avoid cases where optimization finished before we get a chance to check that
     # the everest server has started
     if endpoint_logs:
-        assert (
-            "everserver INFO: /experiment_server/status entered from" in endpoint_logs
-        )
+        assert "everserver INFO: Everserver starting" in endpoint_logs
+        assert "everserver INFO: ExperimentRunner done" in endpoint_logs
 
 
 def test_that_cleanup_logging_is_idempotent(monkeypatch):


### PR DESCRIPTION
**Issue**
Resolves #11626


**Approach**
See commit messages.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
