### PR TITLE
Fix warning for which parameters are to be overwritten

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1004,7 +1004,7 @@ class ErtConfig(BaseModel):
             ]
             if overwrite_params:
                 ConfigWarning.warn(
-                    f"Parameters {dm_params} "
+                    f"Parameters {overwrite_params} "
                     "will be overridden by design matrix. This will cause "
                     "updates to be turned off for these parameters."
                 )


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11964


It should only contain the overlapping params now.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
