### PR TITLE
Move log messages in prior sampling according to actual behaviour

### DIFF
--- a/src/ert/sample_prior.py
+++ b/src/ert/sample_prior.py
@@ -37,16 +37,17 @@ def sample_prior(
         config_node = parameter_configs[parameter]
         if config_node.forward_init:
             continue
-        logger.info(
-            f"Sampling parameter {config_node.name} "
-            f"for realizations {active_realizations}"
-        )
+
         if isinstance(config_node, GenKwConfig):
             dataset: pl.DataFrame | None = None
             if (
                 config_node.input_source == DataSource.DESIGN_MATRIX
                 and design_matrix_df is not None
             ):
+                logger.info(
+                    f"Getting parameter {config_node.name} "
+                    f"from design matrix for realizations {active_realizations}"
+                )
                 cols = {"realization", config_node.name}
                 missing = cols - set(design_matrix_df.columns)
                 if missing:
@@ -59,6 +60,10 @@ def sample_prior(
                 if dataset.is_empty():
                     raise KeyError("Active realization mask is not in design matrix!")
             elif config_node.input_source == DataSource.SAMPLED:
+                logger.info(
+                    f"Sampling parameter {config_node.name} "
+                    f"for realizations {active_realizations}"
+                )
                 datasets = [
                     Ensemble.sample_parameter(
                         config_node,

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -13,7 +13,6 @@ import pytest
 
 from ert.cli.main import ErtCliError
 from ert.config import ConfigWarning, ErtConfig
-from ert.config.design_matrix import DESIGN_MATRIX_GROUP
 from ert.mode_definitions import (
     ENSEMBLE_EXPERIMENT_MODE,
     ENSEMBLE_SMOOTHER_MODE,
@@ -44,7 +43,10 @@ def test_run_poly_example_with_design_matrix(copy_poly_case_with_design_matrix, 
         "--experiment-name",
         "test-experiment",
     )
-    assert f"Sampling parameter {DESIGN_MATRIX_GROUP}" not in caplog.text
+
+    for param in ["a", "b", "c", "category"]:
+        assert f"Getting parameter {param} from design matrix" in caplog.text
+
     storage_path = ErtConfig.from_file("poly.ert").ens_path
     config_path = ErtConfig.from_file("poly.ert").config_path
     with open_storage(storage_path) as storage:


### PR DESCRIPTION
The current logging is confusing, it looked as if we were sampling everything

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
