### PR TITLE
Improve error message when FIELD and GRID sizes are mismatched

### DIFF
--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
     from ert.storage import Ensemble
 
 
+class InvalidParameterFile(Exception):
+    """
+    Raised when a parameter file does not fulfill its
+    format requirements.
+    """
+
+
 class ParameterCardinality(StrEnum):
     """
     multiple_configs_per_ensemble_dataset: multiple config instances per group, one

--- a/src/ert/field_utils/field_utils.py
+++ b/src/ert/field_utils/field_utils.py
@@ -111,26 +111,16 @@ def read_field(
             f'Could not read {field_path}. Unrecognized suffix "{file_extension}"'
         ) from err
 
-    try:
-        values: npt.NDArray[np.float32] | np.ma.MaskedArray[Any, np.dtype[np.float32]]
-        if file_format in ROFF_FORMATS:
-            values = import_roff(field_path, field_name)
-        elif file_format == FieldFileFormat.GRDECL:
-            values = import_grdecl(field_path, field_name, shape, dtype=np.float32)
-        elif file_format == FieldFileFormat.BGRDECL:
-            values = import_bgrdecl(field_path, field_name, shape)
-        else:
-            ext = path.suffix
-            raise ValueError(
-                f'Could not read {field_path}. Unrecognized suffix "{ext}"'
-            )
-    except ValueError as err:
-        msg = (
-            f"Error trying to read FIELD {field_path}. This might be due to "
-            "a mismatch between the dimensions of the grids and fields used with "
-            f"the GRID and FIELD keywords in the configuration. ({err})"
-        )
-        raise ValueError(msg) from err
+    values: npt.NDArray[np.float32] | np.ma.MaskedArray[Any, np.dtype[np.float32]]
+    if file_format in ROFF_FORMATS:
+        values = import_roff(field_path, field_name)
+    elif file_format == FieldFileFormat.GRDECL:
+        values = import_grdecl(field_path, field_name, shape, dtype=np.float32)
+    elif file_format == FieldFileFormat.BGRDECL:
+        values = import_bgrdecl(field_path, field_name, shape)
+    else:
+        ext = path.suffix
+        raise ValueError(f'Could not read {field_path}. Unrecognized suffix "{ext}"')
 
     return np.ma.MaskedArray(data=values, mask=mask, fill_value=np.nan)  # type: ignore
 


### PR DESCRIPTION
**Issue**
Resolves #11824 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

<img width="903" height="159" alt="image" src="https://github.com/user-attachments/assets/cc392a0b-017a-4d81-95c4-1d43fbb1fa94" />


## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
