### PR TITLE
Fix smoother_update runmodels not using active realizations

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -419,6 +419,7 @@ def smoother_update(
     rng: np.random.Generator | None = None,
     progress_callback: Callable[[AnalysisEvent], None] | None = None,
     global_scaling: float = 1.0,
+    active_realizations: list[bool] | None = None,
 ) -> SmootherSnapshot:
     if not progress_callback:
         progress_callback = noop_progress_callback
@@ -426,6 +427,8 @@ def smoother_update(
         rng = np.random.default_rng()
 
     ens_mask = prior_storage.get_realization_mask_with_responses()
+    if active_realizations:
+        ens_mask &= active_realizations
 
     smoother_snapshot = SmootherSnapshot(
         source_ensemble_name=prior_storage.name,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -78,6 +78,7 @@ class EnsembleSmoother(UpdateRunModel, InitialEnsembleRunModel):
                 prior.iteration,
                 prior.id,
             ),
+            active_realizations=self.active_realizations,
         )
 
     @classmethod

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -59,6 +59,7 @@ class ManualUpdate(UpdateRunModel):
                 prior.iteration,
                 prior.id,
             ),
+            active_realizations=self.active_realizations,
         )
 
     @classmethod

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -143,6 +143,7 @@ class MultipleDataAssimilation(UpdateRunModel, InitialEnsembleRunModel):
                 prior.iteration,
                 prior.id,
             ),
+            active_realizations=self.active_realizations,
         )
 
     @staticmethod

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -1169,6 +1169,8 @@ def test_gen_data_missing(storage, uniform_parameter, obs):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_update_subset_parameters(storage, uniform_parameter, obs):
+    ensemble_size = 12  # We only want to update 0-9
+    active_realizations = [True] * 10 + [False] * 2
     no_update_param = GenKwConfig(
         name="KEY_2",
         group="EXTRA_PARAMETER",
@@ -1183,7 +1185,7 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
     )
     prior = storage.create_ensemble(
         experiment,
-        ensemble_size=10,
+        ensemble_size=ensemble_size,
         iteration=0,
         name="prior",
     )
@@ -1239,6 +1241,7 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
         ["KEY_1"],
         ObservationSettings(),
         ESSettings(),
+        active_realizations=active_realizations,
     )
 
     assert (
@@ -1249,3 +1252,8 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
         prior.load_parameters("PARAMETER", 0).rows()
         != posterior_ens.load_parameters("PARAMETER", 0).rows()
     )
+    assert prior.ensemble_size == posterior_ens.ensemble_size
+    assert len(prior.load_parameters("PARAMETER")["realization"]) == ensemble_size
+    assert len(
+        posterior_ens.load_parameters("PARAMETER")["realization"]
+    ) == active_realizations.count(True)


### PR DESCRIPTION
**Issue**
Resolves #11955 


**Approach**
Fix smoother_update runmodels not using active realizations
This commit fixes the issue where all the run models using smoother_update would ignore the specified active realizations.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
