### PR TITLE
Change evaluator log message for fm_steps with missing status updates

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -537,7 +537,7 @@ class EnsembleEvaluator:
             ):
                 host_name = real_data.get("exec_hosts")
                 if host_name == "-":
-                    host_name = "localhost"
+                    host_name = "unknown"
                 if (
                     host_name
                     and real_id


### PR DESCRIPTION
**Issue**
Resolves unclear log message


**Approach**
This commit changes
`EnsembleEvaluator._log_forward_model_steps_with_missing_status_updates()` to log 'unknown' host instead of 'localhost' host, if exec_host is '-'.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
