### PR TITLE
Use pathlib for reading files

### DIFF
--- a/docs/everest/conf.py
+++ b/docs/everest/conf.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 from importlib import metadata
+from pathlib import Path
 
 from json_schema_for_humans.generate import generate_from_filename
 from json_schema_for_humans.generation_configuration import GenerationConfiguration
@@ -58,8 +59,7 @@ with open("config_schema.json", "w", encoding="utf-8") as fout:
 
 generate_from_filename("config_schema.json", "config_schema.html", config=config)
 
-with open("config_schema.html", encoding="utf-8") as fin:
-    data = fin.read()
+data = Path("config_schema.html").read_text(encoding="utf-8")
 data = data.replace("schema_doc.css", "_static/styles/furo.css")
 with open("config_schema.html", "w", encoding="utf-8") as fout:
     fout.write(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ select = [
 preview = true
 ignore = [
     "FURB103", # write-hole-file
-    "FURB101", # read-whole-file
     "G004",    # logging-f-string
     "PLW2901", # redefined-loop-name
     "PLR2004", # magic-value-comparison

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -3,6 +3,7 @@ import logging
 import os
 import socket
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
@@ -192,12 +193,11 @@ class File(Reporter):
             stderr_file = None
             if fm_step.std_err:
                 if os.path.exists(fm_step.std_err):
-                    with open(fm_step.std_err, encoding="utf-8") as error_file_handler:
-                        stderr = error_file_handler.read()
-                        if stderr:
-                            stderr_file = os.path.join(os.getcwd(), fm_step.std_err)
-                        else:
-                            stderr = f"Empty stderr from {fm_step.name()}\n"
+                    stderr = Path(fm_step.std_err).read_text(encoding="utf-8")
+                    if stderr:
+                        stderr_file = os.path.join(os.getcwd(), fm_step.std_err)
+                    else:
+                        stderr = f"Empty stderr from {fm_step.name()}\n"
                 else:
                     stderr = f"stderr: Could not find file: {fm_step.std_err}\n"
             else:

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -267,8 +267,7 @@ def create_forward_model_json(
 
 def check_non_utf_chars(file_path: str) -> None:
     try:
-        with open(file_path, encoding="utf-8") as f:
-            f.read()
+        Path(file_path).read_text(encoding="utf-8")
     except UnicodeDecodeError as e:
         error_words = str(e).split(" ")
         hex_str = error_words[error_words.index("byte") + 1]

--- a/src/ert/config/parsing/_read_file.py
+++ b/src/ert/config/parsing/_read_file.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from .config_errors import ConfigValidationError, ErrorInfo
 from .file_context_token import FileContextToken
@@ -7,8 +8,7 @@ from .file_context_token import FileContextToken
 def read_file(file: str, token: FileContextToken | None = None) -> str:
     file = os.path.normpath(os.path.abspath(file))
     try:
-        with open(file, encoding="utf-8") as f:
-            return f.read()
+        return Path(file).read_text(encoding="utf-8")
     except OSError as err:
         raise ConfigValidationError.with_context(str(err), token or file) from err
     except UnicodeDecodeError as e:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
 import traceback
 from collections import defaultdict
 from collections.abc import Iterable, MutableMapping, Sequence
 from contextlib import suppress
 from dataclasses import asdict
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -368,13 +368,11 @@ class Scheduler:
             dispatch_url=ee_uri,
             ee_token=ee_token,
         )
-        jobs_path = os.path.join(runpath, "jobs.json")
+        jobs_path = Path(runpath) / "jobs.json"
         try:
-            with open(jobs_path, "rb") as fp:
-                data = orjson.loads(fp.read())
-            with open(jobs_path, "wb") as fp:
-                data.update(asdict(jobs))
-                fp.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
+            data = orjson.loads(jobs_path.read_bytes())
+            data.update(asdict(jobs))
+            jobs_path.write_bytes(orjson.dumps(data, option=orjson.OPT_INDENT_2))
         except OSError as err:
             error_msg = f"Could not update jobs.json: {err}"
             self._jobs[iens].unschedule(error_msg)

--- a/src/ert/shared/_doc_utils/forward_model_documentation.py
+++ b/src/ert/shared/_doc_utils/forward_model_documentation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from docutils import nodes
@@ -34,8 +35,7 @@ class _ForwardModelDocumentation:
         )
 
         if self.job_config_file:
-            with open(self.job_config_file, encoding="utf-8") as fh:
-                job_config_text = fh.read()
+            job_config_text = Path(self.job_config_file).read_text(encoding="utf-8")
             job_config_text_node = nodes.literal_block(text=job_config_text)
             config_section_node.append(job_config_text_node)
 

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -127,9 +127,7 @@ def start_experiment(
 
 
 def extract_errors_from_file(path: str) -> list[str]:
-    with open(path, encoding="utf-8") as f:
-        content = f.read()
-    return re.findall(r"(Error \w+.*)", content)
+    return re.findall(r"(Error \w+.*)", Path(path).read_text(encoding="utf-8"))
 
 
 def wait_for_server(client: Client, timeout: int | float) -> None:

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -135,8 +135,7 @@ def test_that_non_existent_forward_init_surface_file_fails_gracefully(
 @pytest.mark.usefixtures("copy_snake_oil_field")
 def test_that_unopenable_observation_config_fails_gracefully():
     config_file_name = "snake_oil_field.ert"
-    with open(config_file_name, encoding="utf-8") as config_file_handler:
-        content_lines = config_file_handler.read().splitlines()
+    content_lines = Path(config_file_name).read_text(encoding="utf-8").splitlines()
     index_line_with_observation_config = next(
         index
         for index, line in enumerate(content_lines)

--- a/tests/ert/ui_tests/cli/test_shell.py
+++ b/tests/ert/ui_tests/cli/test_shell.py
@@ -1,5 +1,4 @@
-import os
-import os.path
+from pathlib import Path
 
 from .run_cli import run_cli_with_pm
 
@@ -12,9 +11,8 @@ def test_shell_scripts_integration(tmpdir):
     """
     with tmpdir.as_cwd():
         ert_config_fname = "test.ert"
-        with open(ert_config_fname, "w", encoding="utf-8") as file_h:
-            file_h.write(
-                """
+        Path(ert_config_fname).write_text(
+            """
 RUNPATH realization-<IENS>/iter-<ITER>
 JOBNAME TEST
 QUEUE_SYSTEM LOCAL
@@ -29,21 +27,23 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=mydir, <TO>=mydir2)
 FORWARD_MODEL DELETE_DIRECTORY(<DIRECTORY>=mydir)
 FORWARD_MODEL COPY_FILE(<FROM>=<CONFIG_PATH>/file.txt, <TO>=mydir3/copied.txt)
 FORWARD_MODEL MOVE_DIRECTORY(<FROM>=mydir3, <TO>=mydir4/mydir3)
-"""
-            )
+""",
+            encoding="utf-8",
+        )
 
-        with open("file.txt", "w", encoding="utf-8") as file_h:
-            file_h.write("something")
+        Path("file.txt").write_text("something", encoding="utf-8")
 
         run_cli_with_pm(["test_run", "--disable-monitoring", ert_config_fname])
 
-        with open("realization-0/iter-0/moved.txt", encoding="utf-8") as output_file:
-            assert output_file.read() == "something"
-        assert not os.path.exists("realization-0/iter-0/copied.txt")
-        assert not os.path.exists("realization-0/iter-0/copied2.txt")
-        assert os.path.exists("realization-0/iter-0/copied3.txt")
-        assert not os.path.exists("realization-0/iter-0/mydir")
-        assert os.path.exists("realization-0/iter-0/mydir2")
-        assert not os.path.exists("realization-0/iter-0/mydir3")
-        assert os.path.exists("realization-0/iter-0/mydir4/mydir3")
-        assert os.path.exists("realization-0/iter-0/mydir4/mydir3/copied.txt")
+        assert (
+            Path("realization-0/iter-0/moved.txt").read_text(encoding="utf-8")
+            == "something"
+        )
+        assert not Path("realization-0/iter-0/copied.txt").exists()
+        assert not Path("realization-0/iter-0/copied2.txt").exists()
+        assert Path("realization-0/iter-0/copied3.txt").exists()
+        assert not Path("realization-0/iter-0/mydir").exists()
+        assert Path("realization-0/iter-0/mydir2").exists()
+        assert not Path("realization-0/iter-0/mydir3").exists()
+        assert Path("realization-0/iter-0/mydir4/mydir3").exists()
+        assert Path("realization-0/iter-0/mydir4/mydir3/copied.txt").exists()

--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -260,15 +261,13 @@ def open_gui_with_docs_example(
     )
 
     if random_seed is not None:
-        with open(config_file, encoding="utf-8") as f:
-            original_content = f.read()
+        original_content = Path(config_file).read_text(encoding="utf-8")
 
         combined_content = (
             f"RANDOM_SEED {random_seed}\n" + original_content
         )  # Add fixed random seed to make the plots reproducible
 
-        with open(config_file, "w", encoding="utf-8") as f:
-            f.write(combined_content)
+        Path(config_file).write_text(combined_content, encoding="utf-8")
 
     gui_generator = open_gui_with_config(tmp_path / config_file)
     return next(gui_generator)

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -240,9 +241,9 @@ def test_add_logging_handle(tmpdir):
         pm = ErtPluginManager(plugins=[dummy_plugins])
         pm.add_logging_handle_to_root(logging.getLogger())
         logging.critical("I should write this to spam.log")  # noqa: LOG015
-        with open("spam.log", encoding="utf-8") as fin:
-            result = fin.read()
-        assert "I should write this to spam.log" in result
+        assert "I should write this to spam.log" in Path("spam.log").read_text(
+            encoding="utf-8"
+        )
 
 
 def test_add_span_processor():

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -107,19 +107,17 @@ def test_symlink():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_symlink2():
     os.makedirs("path")
-    with open("path/target", "w", encoding="utf-8") as f:
-        f.write("1234")
+    Path("path/target").write_text("1234", encoding="utf-8")
 
     symlink("path/target", "link")
     assert os.path.islink("link")
-    assert os.path.isfile("path/target")
+    assert Path("path/target").is_file()
 
     symlink("path/target", "link")
     assert os.path.islink("link")
-    assert os.path.isfile("path/target")
-    with open("link", encoding="utf-8") as f:
-        s = f.read()
-        assert s == "1234"
+    assert Path("path/target").is_file()
+
+    assert Path("link").read_text(encoding="utf-8") == "1234"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -213,55 +211,43 @@ def test_move_directory():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_file_into_folder_file_exists():
     mkdir("dst_folder")
-    with open("dst_folder/file", "w", encoding="utf-8") as f:
-        f.write("old")
 
-    with open("file", "w", encoding="utf-8") as f:
-        f.write("new")
-
-    with open("dst_folder/file", encoding="utf-8") as f:
-        content = f.read()
-        assert content == "old"
+    Path("dst_folder/file").write_text("old", encoding="utf-8")
+    Path("file").write_text("new", encoding="utf-8")
 
     move_file("file", "dst_folder")
-    with open("dst_folder/file", encoding="utf-8") as f:
-        content = f.read()
-        assert content == "new"
+    assert Path("dst_folder/file").read_text(encoding="utf-8") == "new"
 
-    assert not os.path.exists("file")
+    assert not Path("file").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_pathfile_into_folder():
     mkdir("dst_folder")
     mkdir("source1/source2/")
-    with open("source1/source2/file", "w", encoding="utf-8") as f:
-        f.write("stuff")
+    orig_file = Path("source1/source2/file")
+    orig_file.write_text("stuff", encoding="utf-8")
 
     move_file("source1/source2/file", "dst_folder")
-    with open("dst_folder/file", encoding="utf-8") as f:
-        content = f.read()
-        assert content == "stuff"
+    assert Path("dst_folder/file").read_text(encoding="utf-8") == "stuff"
 
-    assert not os.path.exists("source1/source2/file")
+    assert not orig_file.exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_pathfile_into_folder_file_exists():
     mkdir("dst_folder")
     mkdir("source1/source2/")
-    with open("source1/source2/file", "w", encoding="utf-8") as f:
-        f.write("stuff")
+    orig_file = Path("source1/source2/file")
 
-    with open("dst_folder/file", "w", encoding="utf-8") as f:
-        f.write("garbage")
+    orig_file.write_text("stuff", encoding="utf-8")
+
+    Path("dst_folder/file").write_text("garbage", encoding="utf-8")
 
     move_file("source1/source2/file", "dst_folder")
-    with open("dst_folder/file", encoding="utf-8") as f:
-        content = f.read()
-        assert content == "stuff"
+    assert Path("dst_folder/file").read_text(encoding="utf-8") == "stuff"
 
-    assert not os.path.exists("source1/source2/file")
+    assert not orig_file.exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/resources/test_templating.py
+++ b/tests/ert/unit_tests/resources/test_templating.py
@@ -156,12 +156,10 @@ def test_template_multiple_input():
 
     render_template(["second.json", "third.json"], "template", "out_file")
 
-    with open("out_file", encoding="utf-8") as parameter_file:
-        expected_output = (
-            "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
-        )
-
-        assert parameter_file.read() == expected_output
+    assert (
+        Path("out_file").read_text(encoding="utf-8")
+        == "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -189,12 +187,10 @@ def test_no_parameters_json():
         "out_file",
     )
 
-    with open("out_file", encoding="utf-8") as parameter_file:
-        expected_output = (
-            "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
-        )
-
-        assert parameter_file.read() == expected_output
+    assert (
+        Path("out_file").read_text(encoding="utf-8")
+        == "FILENAME\n" + "F1 1999.22\n" + "OTH 1400\n" + "OTH_TEST 3000.22"
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -226,9 +222,10 @@ def test_template_executable():
 
     subprocess.call(template_render_exec + params, shell=True, stdout=subprocess.PIPE)
 
-    with open("out_file", encoding="utf-8") as parameter_file:
-        expected_output = "FILENAME\n" + "F1 1999.22\n" + "F2 200"
-        assert parameter_file.read() == expected_output
+    assert (
+        Path("out_file").read_text(encoding="utf-8")
+        == "FILENAME\n" + "F1 1999.22\n" + "F2 200"
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/services/test_base_service.py
+++ b/tests/ert/unit_tests/services/test_base_service.py
@@ -158,8 +158,7 @@ time.sleep(10)  # Wait for the test to read the JSON file
 def test_json_created(server):
     server.fetch_conn_info()  # wait for it to start
 
-    with open("dummy_server.json", encoding="utf-8") as f:
-        assert f.read()
+    assert Path("dummy_server.json").read_text(encoding="utf-8")
 
 
 @pytest.mark.integration_test

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -670,9 +670,10 @@ def test_num_cpu_subst(append, numcpu, make_run_path):
     )
     make_run_path(config)
 
-    with open("simulations/realization-0/iter-0/jobs.json", encoding="utf-8") as f:
-        jobs = orjson.loads(f.read())
-        assert [str(numcpu)] == jobs["jobList"][0]["argList"]
+    jobs = orjson.loads(
+        Path("simulations/realization-0/iter-0/jobs.json").read_text(encoding="utf-8")
+    )
+    assert [str(numcpu)] == jobs["jobList"][0]["argList"]
 
 
 @pytest.mark.filterwarnings(
@@ -950,9 +951,8 @@ def test_when_manifest_files_are_written_loading_succeeds(storage, itr):
             if itr == 0
             else set()
         )
-        with open(manifest_path, encoding="utf-8") as f:
-            manifest = orjson.loads(f.read())
-            assert {run_path + "/" + f for f in manifest.values()} == expected_files
+        manifest = orjson.loads(manifest_path.read_text(encoding="utf-8"))
+        assert {run_path + "/" + f for f in manifest.values()} == expected_files
 
         # write files in manifest
         for file in expected_files:

--- a/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
+++ b/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
@@ -69,8 +69,7 @@ def test_run_external_job():
     assert runner.run(["test", "text"]) is None
     assert runner.stdoutdata() == "Hello World\n"
 
-    with open("test", encoding="utf-8") as f:
-        assert f.read() == "text"
+    assert Path("test").read_text(encoding="utf-8") == "text"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -188,11 +187,8 @@ def test_workflow_run():
 
     WorkflowRunner(workflow, fixtures={}).run_blocking()
 
-    with open("dump1", encoding="utf-8") as f:
-        assert f.read() == "dump_text_1"
-
-    with open("dump2", encoding="utf-8") as f:
-        assert f.read() == "dump_text_2"
+    assert Path("dump1").read_text(encoding="utf-8") == "dump_text_1"
+    assert Path("dump2").read_text(encoding="utf-8") == "dump_text_2"
 
 
 @pytest.mark.integration_test

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import jinja2
 import pytest
@@ -267,19 +268,18 @@ def test_user_specified_data_n_template(copy_math_func_test_data_to_tmp, test):
     run_model.run_experiment(evaluator_server_config)
 
     # The data should have been loaded and passed through template to file.
-    expected_file = os.path.join(
-        "everest_output",
-        "sim_output",
-        "batch_0",
-        "realization_0",
-        "perturbation_0",
-        "well_drill_constants.json",
+    expected_file = (
+        Path("everest_output")
+        / "sim_output"
+        / "batch_0"
+        / "realization_0"
+        / "perturbation_0"
+        / "well_drill_constants.json"
     )
-    assert os.path.isfile(expected_file)
+    assert expected_file.is_file()
 
     # Check expected contents of file
-    with open(expected_file, encoding="utf-8") as f:
-        contents = f.read()
+    contents = Path(expected_file).read_text(encoding="utf-8")
     assert contents == "VALUE1+VALUE2", (
         f'Expected contents: "VALUE1+VALUE2", found: {contents}'
     )


### PR DESCRIPTION
Enforced through ruff fule FURB101

$ ruff rule FURB101

Derived from the **refurb** linter.

This rule is in preview and is not stable. The `--preview` flag is required for use.

Checks for uses of `open` and `read` that can be replaced by `pathlib` methods, like `Path.read_text` and `Path.read_bytes`.

When reading the entire contents of a file into a variable, it's simpler and more concise to use `pathlib` methods like `Path.read_text` and `Path.read_bytes` instead of `open` and `read` calls via `with` statements.

**Issue**
Resolves ruff ignore statement in pyproject.toml

**Approach**
do-it


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
