### PR TITLE
Remove the default for perturbation_magnitude

### DIFF
--- a/src/everest/config/control_config.py
+++ b/src/everest/config/control_config.py
@@ -167,8 +167,7 @@ class ControlConfig(BaseModel):
             """
         ),
     )
-    perturbation_magnitude: float | None = Field(
-        default=None,
+    perturbation_magnitude: float = Field(
         description=dedent(
             """
             The magnitude of the perturbation of all control variables in the
@@ -177,6 +176,14 @@ class ControlConfig(BaseModel):
             This controls the magnitude of perturbations (e.g. the standard
             deviation in case of a normal distribution) of controls, used to
             approximate the gradient.
+
+            The interpretation of this field depends on the value of the
+            `perturbation_type` field:
+
+            - `absolute`: The given value is used as-is.
+            - `relative`: The perturbation magnitude is calculated by
+              multiplying the given by value by the difference between the `max`
+              and `min` fields.
 
             This default value can be overridden at the variable level.
             """

--- a/src/everest/config/control_variable_config.py
+++ b/src/everest/config/control_variable_config.py
@@ -98,6 +98,20 @@ class _ControlVariable(BaseModel):
             """
         ),
     )
+    perturbation_type: Literal["absolute", "relative"] = Field(
+        default="absolute",
+        description=dedent(
+            """
+            The perturbation type for the control group.
+
+            The `perturbation_type` keyword defines whether the perturbation
+            magnitude (`perturbation_magnitude`) should be treated as an
+            absolute value or as relative to the dynamic range of the controls.
+
+            Overrides the value of `perturbation_type` in the control group.
+            """
+        ),
+    )
     perturbation_magnitude: PositiveFloat | None = Field(
         default=None,
         description=dedent(
@@ -107,6 +121,14 @@ class _ControlVariable(BaseModel):
             This controls the magnitude of perturbations (e.g. the standard
             deviation in case of a normal distribution) of controls, used to
             approximate the gradient.
+
+            The interpretation of this field depends on the value of the
+            `perturbation_type` field:
+
+            - `absolute`: The given value is used as-is.
+            - `relative`: The perturbation magnitude is calculated by
+              multiplying the given by value by the difference between the `max`
+              and `min` fields.
 
             Overrides the value of `perturbation_magnitude` in the control group.
             """

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -1018,6 +1018,7 @@ to read summary data from forward model, do:
                     "name": "default_group",
                     "type": "generic_control",
                     "initial_guess": 0.5,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "default_name", "min": 0, "max": 1},
                     ],

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -23,22 +23,16 @@ def _parse_controls(
         "variable_count": len(controls.initial_guesses),
         "lower_bounds": controls.lower_bounds,
         "upper_bounds": controls.upper_bounds,
+        "perturbation_types": [
+            PerturbationType[perturbation_type.upper()]
+            for perturbation_type in controls.perturbation_types
+        ],
+        "perturbation_magnitudes": controls.perturbation_magnitudes,
         "mask": controls.enabled,
         "seed": random_seed,
+        "samplers": controls.sampler_indices,
     }
 
-    default_magnitude = (max(controls.upper_bounds) - min(controls.lower_bounds)) / 10.0
-    ropt_variables["perturbation_magnitudes"] = [
-        default_magnitude if perturbation_magnitude is None else perturbation_magnitude
-        for perturbation_magnitude in controls.perturbation_magnitudes
-    ]
-
-    ropt_variables["perturbation_types"] = [
-        PerturbationType[perturbation_type.upper()]
-        for perturbation_type in controls.perturbation_types
-    ]
-
-    ropt_variables["samplers"] = controls.sampler_indices
     ropt_samplers = [
         {}
         if sampler is None

--- a/test-data/everest/eightcells/everest/model/config.yml
+++ b/test-data/everest/eightcells/everest/model/config.yml
@@ -9,6 +9,7 @@ controls:
   -
     name: well_rate
     type: generic_control
+    perturbation_magnitude: 50
     variables:
       -
         name: OP1

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -261,6 +261,7 @@ def min_config():
         type: well_control
         min: 0
         max: 0.1
+        perturbation_magnitude: 0.01
         variables:
           - { name: test, initial_guess: 0.1 }
     objective_functions:

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -128,6 +128,7 @@ def test_that_duplicate_control_names_raise_error():
                     "type": "well_control",
                     "min": 0,
                     "max": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w00", "initial_guess": 0.06},
                     ],
@@ -137,6 +138,7 @@ def test_that_duplicate_control_names_raise_error():
                     "type": "well_control",
                     "min": 0,
                     "max": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w01", "initial_guess": 0.09},
                     ],
@@ -154,6 +156,7 @@ def test_that_dot_not_in_control_names():
                     "type": "well_control",
                     "min": 0,
                     "max": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w00", "initial_guess": 0.06},
                         {"name": "w01", "initial_guess": 0.09},
@@ -174,6 +177,7 @@ def test_that_scaled_range_is_valid_range():
                     "type": "well_control",
                     "min": 0,
                     "max": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "scaled_range": [2, 1],
                     "variables": [
                         {"name": "w00", "initial_guess": 0.06},
@@ -225,7 +229,12 @@ def test_that_invalid_control_initial_guess_outside_bounds(
     with pytest.raises(ValueError) as e:
         EverestConfig.with_defaults(
             controls=[
-                {"name": "group_0", "type": "well_control", "variables": variables}
+                {
+                    "name": "group_0",
+                    "type": "well_control",
+                    "perturbation_magnitude": 0.01,
+                    "variables": variables,
+                }
             ]
         )
 
@@ -278,6 +287,7 @@ def test_that_invalid_control_unique_entry(variables, unique_key):
                     "type": "well_control",
                     "max": 0,
                     "min": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "variables": variables,
                 }
             ]
@@ -294,6 +304,7 @@ def test_that_invalid_control_undefined_fields():
                 {
                     "name": "group_0",
                     "type": "well_control",
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w00"},
                     ],
@@ -313,6 +324,7 @@ def test_that_control_variables_index_is_defined_for_all_variables():
                     "type": "well_control",
                     "min": 0,
                     "max": 0.1,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w01", "initial_guess": 0.06, "index": 0},
                         {"name": "w00", "initial_guess": 0.09},
@@ -542,6 +554,7 @@ def test_install_data_with_invalid_templates(
                     "type": "well_control",
                     "min": 0,
                     "max": 1,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {
                             "name": "param_a",
@@ -999,6 +1012,7 @@ def test_load_file_with_errors(capsys):
         min: -1.0
         name: point
         type: yolo_control
+        perturbation_magnitude: 0.01
         variables:
         -   name: x
     install_jobs:
@@ -1034,7 +1048,7 @@ def test_load_file_with_errors(capsys):
         "unable to parse string as a number (type=float_parsing)"
     ) in captured.err
 
-    assert "line: 13, column: 14" in captured.err
+    assert "line: 14, column: 14" in captured.err
     assert "install_jobs -> 0 -> invalid" in captured.err
     assert "Extra inputs are not permitted (type=extra_forbidden)" in captured.err
 
@@ -1066,6 +1080,7 @@ def test_load_file_with_errors(capsys):
                     "name": "test",
                     "type": "generic_control",
                     "initial_guess": 0.5,
+                    "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "test", "min": 0, "max": 1},
                     ],
@@ -1230,6 +1245,7 @@ def test_that_nested_extra_types_are_validated_correctly(change_to_tmpdir):
             min: 0
             max: 1
             initial_guess: 0.5
+            perturbation_magnitude: 0.01
             variables:
                 - name: my_var
 
@@ -1248,7 +1264,7 @@ def test_that_nested_extra_types_are_validated_correctly(change_to_tmpdir):
         EverestConfig.load_file("everest_config.yml")
 
     assert "ctx" in err.value.errors[0]
-    assert err.value.errors[0]["ctx"] == {"line_number": 17}
+    assert err.value.errors[0]["ctx"] == {"line_number": 18}
     assert err.value.errors[0]["type"] == "extra_forbidden"
 
 

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -18,6 +18,7 @@ def test_that_duplicate_control_group_name_is_invalid(min_config):
         {
             "name": existing_name,
             "type": "generic_control",
+            "perturbation_magnitude": 0.01,
             "variables": [{"name": "var_b", "min": 0, "max": 1, "initial_guess": 0.9}],
         }
     )
@@ -66,6 +67,7 @@ def test_that_duplicate_control_variable_name_and_index_is_invalid():
             name="group",
             type="generic_control",
             initial_guess=0.5,
+            perturbation_magnitude=0.01,
             variables=[
                 ControlVariableConfig(name="w00", min=0, max=1, index=0),
                 ControlVariableConfig(name="w00", min=0, max=1, index=0),
@@ -85,6 +87,7 @@ def test_that_unmatched_weight_name_due_to_missing_index_is_invalid():
                     name="group",
                     type="generic_control",
                     initial_guess=0.5,
+                    perturbation_magnitude=0.01,
                     variables=[
                         ControlVariableConfig(name="w00", min=0, max=1, index=0),
                         ControlVariableConfig(name="w01", min=0, max=1, index=0),
@@ -111,6 +114,7 @@ def test_that_input_constraint_with_deprecated_indexed_name_format_warns():
                     name="group",
                     type="generic_control",
                     initial_guess=0.5,
+                    perturbation_magnitude=0.01,
                     variables=[
                         ControlVariableConfig(name="w00", min=0, max=1, index=0),
                         ControlVariableConfig(name="w01", min=0, max=1, index=0),
@@ -134,6 +138,7 @@ def test_that_control_variable_with_initial_guess_below_min_is_invalid():
         ControlConfig(
             name="my_control",
             type="well_control",
+            perturbation_magnitude=0.01,
             variables=[
                 ControlVariableConfig(name="w00", min=0.5, max=1.0, initial_guess=0.3)
             ],
@@ -145,6 +150,7 @@ def test_that_control_variable_with_initial_guess_above_max_is_invalid():
         ControlConfig(
             name="my_control",
             type="well_control",
+            perturbation_magnitude=0.01,
             variables=[
                 ControlVariableConfig(name="w00", min=0.5, max=1.0, initial_guess=1.3)
             ],

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -27,6 +27,7 @@ def test_discrete_optimizer(copy_math_func_test_data_to_tmp):
                 "max": 10,
                 "control_type": "integer",
                 "initial_guess": 0,
+                "perturbation_magnitude": 0.01,
                 "variables": [{"name": "x"}, {"name": "y"}],
             }
         ],

--- a/tests/everest/test_domain_transforms.py
+++ b/tests/everest/test_domain_transforms.py
@@ -17,6 +17,7 @@ def ever_config() -> EverestConfig:
                 "max": 1.0,
                 "scaled_range": [0.3, 0.7],
                 "initial_guess": 0.5,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "a"},
                     {"name": "b"},

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -41,6 +41,7 @@ def test_that_control_config_is_initialized_with_control_variables():
         "type": "generic_control",
         "min": 0,
         "max": 1,
+        "perturbation_magnitude": 0.01,
         "variables": [
             {
                 "name": "var1",
@@ -91,6 +92,7 @@ def test_that_get_output_dir_returns_same_for_old_and_new():
                 "type": "well_control",
                 "min": 0,
                 "max": 0.1,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "w00", "initial_guess": 0.0626},
                 ],
@@ -130,6 +132,7 @@ def test_that_invalid_keys_are_linted():
                 "inital_guss": "well_control",
                 "min": 0,
                 "max": 0.1,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "w00"},
                 ],
@@ -140,6 +143,7 @@ def test_that_invalid_keys_are_linted():
                 "initial_guess": "well_control",
                 "min": 0,
                 "max": 0.1,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "w00", "inital_guess": 0.0626},
                     {"name": "w01", "sampler": {"bakkend": "#DYSNEKTIC"}},
@@ -271,6 +275,7 @@ def test_that_log_level_property_is_consistent_with_environment_log_level():
                 "type": "well_control",
                 "min": 0,
                 "max": 0.1,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "w01", "initial_guess": 0.0626},
                 ],

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -14,6 +14,7 @@ def test_input_constraint_control_references(tmp_path, capsys, caplog, monkeypat
             "min": 0,
             "max": 1,
             "initial_guess": 0,
+            "perturbation_magnitude": 0.01,
             "variables": [
                 {"name": "x", "index": "0"},
                 {"name": "x", "index": "1"},

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -728,6 +728,7 @@ def test_that_summary_keys_default_to_expected_keys_according_to_wells(
         {
             "name": "well_rate",
             "type": "generic_control",
+            "perturbation_magnitude": 0.01,
             "variables": [
                 {
                     "name": "OP1",

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -19,6 +19,7 @@ def ever_config() -> EverestConfig:
                 "type": "generic_control",
                 "min": 0,
                 "max": 0.1,
+                "perturbation_magnitude": 0.01,
                 "variables": [
                     {"name": "a", "initial_guess": 0.01},
                     {

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -24,6 +24,7 @@ CONFIG = {
             "type": "well_control",
             "min": 0,
             "max": 1,
+            "perturbation_magnitude": 0.01,
             "variables": [
                 {"name": "PROD1", "initial_guess": 1},
                 {"name": "PROD2", "initial_guess": 0.9},

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -39,6 +39,7 @@ def test_read_file(tmp_path, monkeypatch):
         type: well_control
         min: 0
         max: 0.1
+        perturbation_magnitude: 0.01
         variables:
           - { name: test, initial_guess: 0.1 }
     objective_functions:


### PR DESCRIPTION
**Issue**
Resolves #9844


**Approach**
The default for the perturbation_magnitude would be wrong in case the relative perturbation type is selected. In addition, choosing a good default is non-trivial and current practice is to always set it manually. This PR makes this mandatory.

This will also require a fix in everest-models: https://github.com/equinor/everest-models/pull/184

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
