### PR TITLE
Add better validation for when saving pl.dataframe parameters

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -839,6 +839,24 @@ class LocalEnsemble(BaseMode):
 
         """
         if isinstance(dataset, pl.DataFrame):
+            if dataset.is_empty():
+                raise ValueError("Parameters dataframe is empty.")
+            allowed_cols = set(self.experiment.parameter_configuration) | {
+                "realization"
+            }
+            actual_cols = set(dataset.columns)
+            unexpected_cols = actual_cols - allowed_cols
+            if unexpected_cols:
+                raise KeyError(
+                    f"Columns {', '.join(sorted(unexpected_cols))}"
+                    " not in experiment parameters"
+                )
+            if "realization" not in dataset.columns:
+                raise KeyError(
+                    "DataFrame must contain a 'realization' column for"
+                    " saving scalar parameters"
+                )
+
             try:
                 # since all realizations are saved in a single parquet file,
                 # this makes sure that we only add / replace new data.


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11929


**Approach**
Just do it!
include extra tests.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
