### PR TITLE
Fix plotting of categorical histogram bar x ticks not in middle

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -163,8 +163,8 @@ def _plotCategoricalHistogram(
     counts = data.value_counts()
     freq = [counts.get(category, 0) for category in categories]
     pos = np.arange(len(categories))
-    width = 1.0
-    axes.set_xticks(pos + (width / 2.0))
+    width = 0.95
+    axes.set_xticks(pos)
     axes.set_xticklabels(categories)
 
     axes.bar(pos, freq, alpha=style.alpha, color=style.color, width=width)


### PR DESCRIPTION
**Issue**
Resolves #8687 


**Approach**
🔧 Fix plotting of categorical histogram bar x ticks not in middle

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
