### PR TITLE
Use assert_never for matches that should be exhaustive

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ exclude_also =
     if TYPE_CHECKING:
     ; Don't complain about overload type specifications, they aren't run:
     @(typing\.)?overload
+    assert_never

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-exclude_also =
+exclude_lines =
     ; Don't complain about code for type checking only
     if TYPE_CHECKING:
     ; Don't complain about overload type specifications, they aren't run:

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ exclude_lines =
     ; Don't complain about overload type specifications, they aren't run:
     @(typing\.)?overload
     assert_never
+    if sys.platform == "darwin":

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,6 @@ fixes:
     - "*/site-packages/::"
     - "/home/runner/work/ert/ert/::"
 comment:
-    # The code coverage is made up of 4 test runs so only after all coverage
+    # The code coverage is made up of several test runs so only after all coverage
     # reports have been uploaded will the comparison be sane
-    after_n_builds: 21
+    after_n_builds: 9

--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 
 import numpy as np
 import polars as pl
@@ -85,6 +85,8 @@ def create_observation_dataframes(
                             bool(ensemble_config.refcase),
                         )
                     )
+                case default:
+                    assert_never(default)
         except ObservationConfigError as err:
             config_errors.extend(err.errors)
 
@@ -119,6 +121,8 @@ def _handle_error_mode(
             return np.abs(values) * error
         case "RELMIN":
             return np.maximum(np.abs(values) * error, np.full(values.shape, error_min))
+        case default:
+            assert_never(default)
 
 
 def _handle_history_observation(

--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -13,10 +13,7 @@ import re
 from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 from enum import Enum, auto
-from typing import (
-    Any,
-    TypeVar,
-)
+from typing import Any, TypeVar, assert_never
 
 import numpy as np
 import numpy.typing as npt
@@ -134,6 +131,8 @@ def make_summary_key(
         case SummaryKeyType.NETWORK:
             (name,) = _check_if_missing("network", "WGNAMES", name)
             return f"{keyword}:{name}"
+        case default:
+            assert_never(default)
 
 
 __all__ = ["make_summary_key", "read_summary"]

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, no_type_check
+from typing import Any, assert_never, no_type_check
 
 from lark import Lark, Token, Transformer, UnexpectedCharacters, UnexpectedToken
 from lark.exceptions import VisitError
@@ -103,8 +103,8 @@ def parse_observations(content: str, filename: str) -> list[ObservationDict]:
                     f" (on line {e.line}: {unexpected_line}). "
                     f"Expected one of {allowed_chars}."
                 )
-            case _:
-                raise
+            case default, _:
+                assert_never(default)
 
         raise ObservationConfigError.from_info(
             ErrorInfo(

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from queue import SimpleQueue
-from typing import cast
+from typing import assert_never, cast
 
 import humanize
 from PyQt6.QtCore import QModelIndex, QSize, Qt, QThread, QTimer
@@ -641,6 +641,8 @@ class RunDialog(QFrame):
                 formatted_queue_system = "Torque/OpenPBS"
             case QueueSystem.SLURM:
                 formatted_queue_system = "Slurm"
+            case default:
+                assert_never(default)
         self.queue_system.setText(f"Queue system:\n{formatted_queue_system}")
 
     def hideEvent(self, event: QHideEvent | None) -> None:

--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from os import getuid
 from pwd import getpwuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_never
 
 from ert.config import QueueSystem
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 def create_driver(queue_options: QueueOptions) -> Driver:
-    match str(queue_options.name):
+    match queue_options.name:
         case QueueSystem.LOCAL:
             return LocalDriver()
         case QueueSystem.TORQUE:
@@ -33,9 +33,8 @@ def create_driver(queue_options: QueueOptions) -> Driver:
                     **queue_options.driver_options,
                 )
             )
-    raise NotImplementedError(
-        "Only LOCAL, SLURM, TORQUE and LSF drivers are implemented"
-    )
+        case default:
+            assert_never(default)
 
 
 __all__ = [

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -10,7 +10,7 @@ from collections import Counter
 from contextlib import suppress
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_never
 
 from lxml import etree
 from opentelemetry.trace import Status, StatusCode
@@ -434,6 +434,8 @@ class Job:
                 event = RealizationSuccess(real=str(self.iens))
                 self._end_time = time.time()
                 await self._scheduler.completed_jobs.put(self.iens)
+            case default:
+                assert_never(default)
 
         self.state = state
         if event is not None:


### PR DESCRIPTION
This uses assert_never to type-check that matches that should be exhaustive stay that way. Will also produce a runtime error when the match is not exhaustive.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
