### PR TITLE
made extparamconfig consistent with genkwconfig

### DIFF
--- a/src/ert/config/ext_param_config.py
+++ b/src/ert/config/ext_param_config.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import networkx as nx
-import numpy as np
-import xarray as xr
+import polars as pl
 
 from ert.substitutions import substitute_runpath_name
 
-from .parameter_config import ParameterConfig, ParameterMetadata
+from .gen_kw_config import DataSource, GenKwConfig
+from .parameter_config import ParameterMetadata
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -24,13 +24,25 @@ if TYPE_CHECKING:
     MutableDataType = MutableMapping[str, Number | MutableMapping[str, Number]]
 
 
-class ExtParamConfig(ParameterConfig):
+class ExtParamConfig(GenKwConfig):
     """Create an ExtParamConfig for @key with the given @input_keys
 
     @input_keys can be either a list of keys as strings or a dict with
     keys as strings and a list of suffixes for each key.
     If a list of strings is given, the order is preserved.
+    
+    This class extends GenKwConfig to use polars.DataFrame for scalar-like
+    parameters instead of xarray.Dataset, providing better integration with
+    ensemble-level data operations and storage.
     """
+
+    type: Literal["everest_parameters"] = "everest_parameters"  # type: ignore[assignment]
+    input_keys: list[str] = field(default_factory=list)
+    distribution: None = None  # type: ignore[assignment]  # ExtParamConfig doesn't use distributions
+    forward_init: bool = False
+    output_file: str = ""
+    update: bool = False
+    input_source: DataSource = DataSource.DESIGN_MATRIX  # External parameters come from design/optimization
 
     @property
     def parameter_keys(self) -> list[str]:
@@ -40,68 +52,82 @@ class ExtParamConfig(ParameterConfig):
     def metadata(self) -> list[ParameterMetadata]:
         return []
 
-    type: Literal["everest_parameters"] = "everest_parameters"
-    input_keys: list[str] = field(default_factory=list)
-    forward_init: bool = False
-    output_file: str = ""
-    forward_init_file: str = ""
-    update: bool = False
+    def __len__(self) -> int:
+        return len(self.input_keys)
 
     def read_from_runpath(
         self, run_path: Path, real_nr: int, iteration: int
-    ) -> xr.Dataset:
+    ) -> pl.DataFrame:
         raise NotImplementedError
 
     def write_to_runpath(
         self, run_path: Path, real_nr: int, ensemble: Ensemble
-    ) -> None:
+    ) -> dict[str, dict[str, float | str]]:
         file_path = run_path / substitute_runpath_name(
             self.output_file, real_nr, ensemble.iteration
         )
         Path.mkdir(file_path.parent, exist_ok=True, parents=True)
 
+        # Load parameters as polars DataFrame
+        df = ensemble.load_parameters(self.name, real_nr)
+        
+        assert isinstance(df, pl.DataFrame)
+        
+        # Build hierarchical data structure from DataFrame
         data: MutableDataType = {}
-        for da in ensemble.load_parameters(self.name, real_nr)["values"]:
-            assert isinstance(da, xr.DataArray)
-            name = str(da.names.values)
-            try:
-                outer, inner = name.split("\0")
-
+        for col in df.columns:
+            if col == "realization":
+                continue
+            value = df[col][0]
+            
+            # Handle nested structure with null byte separator
+            if "\0" in col:
+                outer, inner = col.split("\0")
                 if outer not in data:
                     data[outer] = {}
-                data[outer][inner] = float(da)  # type: ignore
-            except ValueError:
-                data[name] = float(da)
+                data[outer][inner] = float(value)  # type: ignore
+            else:
+                data[col] = float(value)
 
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(data, f)
+        
+        return {self.name: data}  # type: ignore
 
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
-        iens_active_index: npt.NDArray[np.int_],
-    ) -> Iterator[tuple[int, xr.Dataset]]:
-        for i, realization in enumerate(iens_active_index):
-            yield (
-                int(realization),
-                xr.Dataset(
-                    {
-                        "values": ("names", from_data[:, i]),
-                        "names": [
-                            x.split(f"{self.name}.")[1].replace(".", "\0")
-                            for x in self.parameter_keys
-                        ],
-                    }
-                ),
-            )
+        from_data: npt.NDArray[np.float64],  # type: ignore[name-defined]
+        iens_active_index: npt.NDArray[np.int_],  # type: ignore[name-defined]
+    ) -> Iterator[tuple[int | None, pl.DataFrame]]:
+        # Create column names with null byte separator for nested structure
+        column_names = [
+            x.split(f"{self.name}.")[1].replace(".", "\0")
+            if f"{self.name}." in x
+            else x
+            for x in self.parameter_keys
+        ]
+        
+        # Yield single DataFrame with all realizations (ensemble-level)
+        df_data = {"realization": iens_active_index}
+        for i, col_name in enumerate(column_names):
+            df_data[col_name] = pl.Series(from_data[i, :])
+        
+        yield (None, pl.DataFrame(df_data))
 
     def load_parameters(
-        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
-        raise NotImplementedError
+        self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]  # type: ignore[name-defined]
+    ) -> npt.NDArray[np.float64]:  # type: ignore[name-defined]
+        """Load parameters from ensemble as numpy array.
+        
+        Returns a 2D array where each column is a realization and each row
+        is a parameter value.
+        """
+        df = ensemble.load_parameters(self.name, realizations)
+        assert isinstance(df, pl.DataFrame)
+        return df.drop("realization").to_numpy().T.copy()
 
     def load_parameter_graph(self) -> nx.Graph[int]:
-        raise NotImplementedError
-
-    def __len__(self) -> int:
-        return len(self.input_keys)
+        """Return independence graph (no edges) since parameters are independent."""
+        graph_independence: nx.Graph[int] = nx.Graph()
+        graph_independence.add_nodes_from(range(len(self.input_keys)))
+        return graph_independence

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -868,13 +868,12 @@ def test_that_all_parameters_and_gen_data_consolidation_works(
             ensemble.save_everest_realization_info(everest_realization_info)
 
             for realization in range(num_realizations):
-                param_data = xr.Dataset(
+                # ExtParamConfig now uses polars DataFrame instead of xarray Dataset
+                param_data = pl.DataFrame(
                     {
-                        "values": (
-                            "names",
-                            np.array([realization] * len(param_keys)) + (batch / 10),
-                        ),
-                        "names": param_keys,
+                        "realization": [realization],
+                        "P1": [realization + (batch / 10)],
+                        "P2": [realization + (batch / 10)],
                     }
                 )
                 ensemble.save_parameters(param_data, "point", realization)


### PR DESCRIPTION
**Issue**
Resolves #12005 


**Approach**
Refactored `ExtParamConfig` to inherit from `GenKwConfig` and use `polars.DataFrame` instead of `xarray.Dataset` for storing parameter data. This change makes ExtParamConfig consistent with how scalar parameters (GenKwConfig) are handled, enabling better ensemble-level data operations and improved integration with the storage and migration logic.

**Key changes:**
- Changed `ExtParamConfig` to extend `GenKwConfig` instead of `ParameterConfig`
- Updated `create_storage_datasets()` to yield `polars.DataFrame` instead of `xarray.Dataset`
- Implemented `load_parameters()` method to work with DataFrames
- Implemented `load_parameter_graph()` to return an independence graph
- Updated `write_to_runpath()` to load parameters as DataFrame while maintaining JSON output format
- Updated test in `test_local_storage.py` to use DataFrame instead of Dataset


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
Suggested label: release-notes:improvement or release-notes:refactoring
-->