### PR TITLE
Use pathlib for writing to files

### DIFF
--- a/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
 import json
+from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
     coeffs = json.load(f)["COEFFS"]
@@ -11,5 +11,4 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(50)]
-with open("poly.out", "w", encoding="utf-8") as f:
-    f.write("\n".join(map(str, output)))
+Path("poly.out").write_text("\n".join(map(str, output)), encoding="utf-8")

--- a/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
 import json
+from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
     coeffs = json.load(f)["COEFFS"]
@@ -11,5 +11,4 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly.out", "w", encoding="utf-8") as f:
-    f.write("\n".join(map(str, output)))
+Path("poly.out").write_text("\n".join(map(str, output)), encoding="utf-8")

--- a/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
 import json
+from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
     coeffs = json.load(f)["COEFFS"]
@@ -11,5 +11,4 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly.out", "w", encoding="utf-8") as f:
-    f.write("\n".join(map(str, output)))
+Path("poly.out").write_text("\n".join(map(str, output)), encoding="utf-8")

--- a/docs/ert/getting_started/configuration/poly_new/with_simple_script/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_simple_script/poly_eval.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pathlib import Path
 
 coeffs = {"a": 1, "b": 2, "c": 3}
 
@@ -8,5 +9,4 @@ def evaluate(coeffs, x):
 
 
 output = [evaluate(coeffs, x) for x in range(10)]
-with open("poly.out", "w", encoding="utf-8") as f:
-    f.write("\n".join(map(str, output)))
+Path("poly.out").write_text("\n".join(map(str, output)), encoding="utf-8")

--- a/docs/everest/conf.py
+++ b/docs/everest/conf.py
@@ -61,8 +61,8 @@ generate_from_filename("config_schema.json", "config_schema.html", config=config
 
 data = Path("config_schema.html").read_text(encoding="utf-8")
 data = data.replace("schema_doc.css", "_static/styles/furo.css")
-with open("config_schema.html", "w", encoding="utf-8") as fout:
-    fout.write(data)
+Path("config_schema.html").write_text(data, encoding="utf-8")
+
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,6 @@ select = [
 ]
 preview = true
 ignore = [
-    "FURB103", # write-hole-file
     "G004",    # logging-f-string
     "PLW2901", # redefined-loop-name
     "PLR2004", # magic-value-comparison

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -220,11 +220,12 @@ class File(Reporter):
 
     @staticmethod
     def _dump_ok_file() -> None:
-        with open(OK_file, "w", encoding="utf-8") as f:
-            f.write(
-                f"All jobs complete {time.strftime(TIME_FORMAT, time.localtime())} \n"
-            )
+        Path(OK_file).write_text(
+            f"All jobs complete {time.strftime(TIME_FORMAT, time.localtime())} \n",
+            encoding="utf-8",
+        )
 
     def _dump_status_json(self) -> None:
-        with open(STATUS_json, "wb") as fp:
-            fp.write(orjson.dumps(self.status_dict, option=orjson.OPT_INDENT_2))
+        Path(STATUS_json).write_bytes(
+            orjson.dumps(self.status_dict, option=orjson.OPT_INDENT_2)
+        )

--- a/src/ert/resources/forward_models/template_render.py
+++ b/src/ert/resources/forward_models/template_render.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import os
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 import jinja2
@@ -105,8 +106,7 @@ def render_template(
     template = _load_template(template_file)
     data = _load_input(all_input_files)
 
-    with open(output_file, "w", encoding="utf-8") as fout:
-        fout.write(template.render(**data))
+    Path(output_file).write_text(template.render(**data), encoding="utf-8")
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -219,21 +219,17 @@ def create_run_path(
                 iens=run_arg.iens,
                 itr=ensemble.iteration,
             )
-            with open(run_path / "jobs.json", mode="wb") as fptr:
-                fptr.write(
-                    orjson.dumps(
-                        forward_model_output,
-                        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
-                    )
+            Path(run_path / "jobs.json").write_bytes(
+                orjson.dumps(
+                    forward_model_output,
+                    option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
                 )
+            )
             # Write MANIFEST file to runpath use to avoid NFS sync issues
             data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
-            with open(run_path / "manifest.json", mode="wb") as fptr:
-                fptr.write(
-                    orjson.dumps(
-                        data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2
-                    )
-                )
+            Path(run_path / "manifest.json").write_bytes(
+                orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2)
+            )
 
     runpaths.write_runpath_list(
         [ensemble.iteration], [real.iens for real in run_args if real.active]

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -14,6 +14,7 @@ import threading
 import time
 import warnings
 from base64 import b64encode
+from pathlib import Path
 from typing import Any
 
 import uvicorn
@@ -150,18 +151,16 @@ def _generate_certificate(cert_folder: str) -> tuple[str, str, bytes]:
     # Write certificate and key to disk
     makedirs_if_needed(cert_folder)
     cert_path = os.path.join(cert_folder, dns_name + ".crt")
-    with open(cert_path, "wb") as f:
-        f.write(cert.public_bytes(serialization.Encoding.PEM))
+    Path(cert_path).write_bytes(cert.public_bytes(serialization.Encoding.PEM))
     key_path = os.path.join(cert_folder, dns_name + ".key")
     pw = bytes(os.urandom(28))
-    with open(key_path, "wb") as f:
-        f.write(
-            key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.BestAvailableEncryption(pw),
-            )
+    Path(key_path).write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.BestAvailableEncryption(pw),
         )
+    )
     return cert_path, key_path, pw
 
 

--- a/src/ert/storage/migration/to10.py
+++ b/src/ert/storage/migration/to10.py
@@ -25,13 +25,15 @@ def migrate(path: Path) -> None:
         with open(experiment / "parameter.json", encoding="utf-8") as fin:
             parameters_json = json.load(fin)
 
-        with open(experiment / "parameter.json", "w", encoding="utf-8") as fout:
-            for param in parameters_json.values():
-                if param["_ert_kind"] == "GenKwConfig":
-                    param.pop("forward_init_file", None)
-                    param.pop("template_file", None)
-                    param.pop("output_file", None)
-            fout.write(json.dumps(parameters_json, indent=4))
+        for param in parameters_json.values():
+            if param["_ert_kind"] == "GenKwConfig":
+                param.pop("forward_init_file", None)
+                param.pop("template_file", None)
+                param.pop("output_file", None)
+        Path(experiment / "parameter.json").write_text(
+            json.dumps(parameters_json, indent=4), encoding="utf-8"
+        )
 
-        with open(experiment / "templates.json", "w", encoding="utf-8") as fout:
-            fout.write(json.dumps(templates_abs))
+        Path(experiment / "templates.json").write_text(
+            json.dumps(templates_abs), encoding="utf-8"
+        )

--- a/src/ert/storage/migration/to13.py
+++ b/src/ert/storage/migration/to13.py
@@ -109,8 +109,9 @@ def migrate_genkw(path: Path) -> None:
             parameters_json = json.load(fin)
 
         new_parameter_configs = migrate_gen_kw_param(parameters_json)
-        with open(experiment / "parameter.json", "w", encoding="utf-8") as fout:
-            fout.write(json.dumps(new_parameter_configs, indent=2))
+        Path(experiment / "parameter.json").write_text(
+            json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
+        )
 
         # migrate parquet files
         for ens in ensembles:

--- a/src/ert/storage/migration/to14.py
+++ b/src/ert/storage/migration/to14.py
@@ -34,8 +34,9 @@ def migrate_fields(path: Path) -> None:
             parameters_json = json.load(fin)
 
         new_parameter_configs = migrate_field_param(parameters_json)
-        with open(experiment / "parameter.json", "w", encoding="utf-8") as fout:
-            fout.write(json.dumps(new_parameter_configs, indent=2))
+        Path(experiment / "parameter.json").write_text(
+            json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
+        )
 
 
 def migrate(path: Path) -> None:

--- a/src/ert/storage/migration/to6.py
+++ b/src/ert/storage/migration/to6.py
@@ -9,30 +9,29 @@ def migrate(path: Path) -> None:
         with open(experiment / "parameter.json", encoding="utf-8") as fin:
             parameters_json = json.load(fin)
 
-        with open(experiment / "parameter.json", "w", encoding="utf-8") as fout:
-            for param in parameters_json.values():
-                if "transfer_function_definitions" in param:
-                    param["transform_function_definitions"] = param[
-                        "transfer_function_definitions"
-                    ]
-                    del param["transfer_function_definitions"]
+        for param in parameters_json.values():
+            if "transfer_function_definitions" in param:
+                param["transform_function_definitions"] = param[
+                    "transfer_function_definitions"
+                ]
+                del param["transfer_function_definitions"]
 
-                if "transform_function_definitions" in param:
-                    transform_function_definitions = []
-                    for tfd in param["transform_function_definitions"]:
-                        if isinstance(tfd, str):
-                            items = tfd.split()
-                            transform_function_definitions.append(
-                                {
-                                    "name": items[0],
-                                    "param_name": items[1],
-                                    "values": items[2:],
-                                }
-                            )
-                        elif isinstance(tfd, dict):
-                            transform_function_definitions.append(tfd)
+            if "transform_function_definitions" in param:
+                transform_function_definitions = []
+                for tfd in param["transform_function_definitions"]:
+                    if isinstance(tfd, str):
+                        items = tfd.split()
+                        transform_function_definitions.append(
+                            {
+                                "name": items[0],
+                                "param_name": items[1],
+                                "values": items[2:],
+                            }
+                        )
+                    elif isinstance(tfd, dict):
+                        transform_function_definitions.append(tfd)
 
-                    param["transform_function_definitions"] = (
-                        transform_function_definitions
-                    )
-            fout.write(json.dumps(parameters_json, indent=4))
+                param["transform_function_definitions"] = transform_function_definitions
+        Path(experiment / "parameter.json").write_text(
+            json.dumps(parameters_json, indent=4), encoding="utf-8"
+        )

--- a/test-data/ert/heat_equation/generate_files.py
+++ b/test-data/ert/heat_equation/generate_files.py
@@ -3,6 +3,7 @@ Contains code that was used to generate files expected by ert.
 """
 
 from collections.abc import Callable
+from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
@@ -139,8 +140,9 @@ if __name__ == "__main__":
         )
 
     for obs_time in obs_times:
-        with open(f"obs_{obs_time}.txt", "w", encoding="utf-8") as fobs:
-            df = d.iloc[d.index.get_level_values("k") == obs_time]
-            fobs.write(df.sort_index().to_csv(header=False, index=False, sep=" "))
+        df = d.iloc[d.index.get_level_values("k") == obs_time]
+        Path(f"obs_{obs_time}.txt").write_text(
+            df.sort_index().to_csv(header=False, index=False, sep=" "), encoding="utf-8"
+        )
 
     generate_priors()

--- a/test-data/ert/poly_example/poly_eval.py
+++ b/test-data/ert/poly_example/poly_eval.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+from pathlib import Path
 
 
 def _load_coeffs(filename):
@@ -14,5 +15,4 @@ def _evaluate(coeffs, x):
 if __name__ == "__main__":
     coeffs = _load_coeffs("parameters.json")
     output = [_evaluate(coeffs, x) for x in range(10)]
-    with open("poly.out", "w", encoding="utf-8") as f:
-        f.write("\n".join(map(str, output)))
+    Path("poly.out").write_text("\n".join(map(str, output)), encoding="utf-8")

--- a/test-data/ert/snake_oil/forward_models/snake_oil_diff.py
+++ b/test-data/ert/snake_oil/forward_models/snake_oil_diff.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from resdata.summary import Summary
 
 
 def writeDiff(filename, vector1, vector2):
-    with open(filename, "w", encoding="utf-8") as f:
-        f.writelines(
-            f"{node1 - node2:f}\n"
-            for node1, node2 in zip(vector1, vector2, strict=False)
-        )
+    Path(filename).write_text(
+        "\n".join(
+            f"{node1 - node2:f}" for node1, node2 in zip(vector1, vector2, strict=False)
+        ),
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/test-data/ert/snake_oil_field/forward_models/snake_oil_diff.py
+++ b/test-data/ert/snake_oil_field/forward_models/snake_oil_diff.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from resdata.summary import Summary
 
 
 def writeDiff(filename, vector1, vector2):
-    with open(filename, "w", encoding="utf-8") as f:
-        diff = vector1 - vector2
-        f.write("\n".join([str(itm) for itm in diff]))
+    diff = vector1 - vector2
+    Path(filename).write_text("\n".join([str(itm) for itm in diff]), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/test-data/everest/math_func/jobs/adv_dump_controls.py
+++ b/test-data/everest/math_func/jobs/adv_dump_controls.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 
 def main(argv):
@@ -20,8 +21,7 @@ def main(argv):
             out_file = "{}{}{}".format(
                 opts.out_prefix, f"{name}-{idx}", opts.out_suffix
             )
-            with open(out_file, "w", encoding="utf-8") as f:
-                f.write(f"{val:g} \n")
+            Path(out_file).write_text(f"{val:g} \n", encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/test-data/everest/math_func/jobs/discrete.py
+++ b/test-data/everest/math_func/jobs/discrete.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 
 def compute_func(x, y):
@@ -28,8 +29,8 @@ def main(argv):
     value = compute_func(*point)
 
     if options.out:
-        with open(options.out, "w", encoding="utf-8") as f:
-            f.write(f"{value:g} \n")
+        Path(options.out).write_text(f"{value:g} \n", encoding="utf-8")
+
     else:
         print(value)
 

--- a/test-data/everest/math_func/jobs/dump_controls.py
+++ b/test-data/everest/math_func/jobs/dump_controls.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 
 def main(argv):
@@ -17,8 +18,7 @@ def main(argv):
 
     for k, v in controls.items():
         out_file = f"{opts.out_prefix}{k}{opts.out_suffix}"
-        with open(out_file, "w", encoding="utf-8") as f:
-            f.write(f"{v:g} \n")
+        Path(out_file).write_text(f"{v:g} \n", encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -212,10 +212,9 @@ def copy_poly_case_with_design_matrix(copy_case):
             pl.DataFrame(design_dict),
             pl.DataFrame(default_list, orient="row"),
         )
-        with open("poly.ert", "w", encoding="utf-8") as fout:
-            fout.write(
-                dedent(
-                    f"""\
+        Path("poly.ert").write_text(
+            dedent(
+                f"""\
                     QUEUE_OPTION LOCAL MAX_RUNNING 2
                     RUNPATH poly_out/realization-<IENS>/iter-<ITER>
                     NUM_REALIZATIONS {num_realizations}
@@ -225,13 +224,13 @@ def copy_poly_case_with_design_matrix(copy_case):
                     INSTALL_JOB poly_eval POLY_EVAL
                     FORWARD_MODEL poly_eval
                     """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
 
-        with open("poly_eval.py", "w", encoding="utf-8") as f:
-            f.write(
-                dedent(
-                    """\
+        Path("poly_eval.py").write_text(
+            dedent(
+                """\
                     #!/usr/bin/env python
                     import json
 
@@ -248,8 +247,10 @@ def copy_poly_case_with_design_matrix(copy_case):
                         with open("poly.out", "w", encoding="utf-8") as f:
                             f.write("\\n".join(map(str, output)))
                     """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
+
         os.chmod(
             "poly_eval.py",
             os.stat("poly_eval.py").st_mode

--- a/tests/ert/performance_tests/performance_utils.py
+++ b/tests/ert/performance_tests/performance_utils.py
@@ -57,8 +57,7 @@ def write_summary_data(file, x_size, keywords, update_steps):
 def render_template(folder, template, target, **kwargs):
     output = template.render(kwargs)
     file = folder / target
-    with open(file, "w", encoding="utf-8") as f:
-        f.write(output)
+    Path(file).write_text(output, encoding="utf-8")
 
 
 def make_poly_example(folder, source, **kwargs):

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -227,9 +227,8 @@ def create_poly_with_field(field_dim: tuple[int, int, int], realisations: int):
     grid.to_file("MY_EGRID.EGRID", "egrid")
     del grid
 
-    with open("forward_model", "w", encoding="utf-8") as f:
-        f.write(
-            f"""#!/usr/bin/env python
+    Path("forward_model").write_text(
+        f"""#!/usr/bin/env python
 import numpy as np
 import os
 import resfo
@@ -245,38 +244,39 @@ if __name__ == "__main__":
     output = [float(a) * x**2 + float(b) * x + float(c) for x in range(10)]
     with open("gen_data_0.out", "w", encoding="utf-8") as f:
         f.write("\\n".join(map(str, output)))
-            """
-        )
+            """,
+        encoding="utf-8",
+    )
+
     os.chmod(
         "forward_model",
         os.stat("forward_model").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
     )
-    with open("POLY_EVAL", "w", encoding="utf-8") as fout:
-        fout.write("EXECUTABLE forward_model")
-    with open("observations", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """
+    Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
+    Path("observations").write_text(
+        dedent(
+            """
         GENERAL_OBSERVATION MY_OBS {
             DATA       = MY_RESPONSE;
             INDEX_LIST = 0,2,4,6,8;
             RESTART    = 0;
             OBS_FILE   = obs.txt;
         };"""
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("obs.txt", "w", encoding="utf-8") as fobs:
-        fobs.write(
-            dedent(
-                """
+    Path("obs.txt").write_text(
+        dedent(
+            """
         2.1457049781272213 0.6
         8.769219841380755 1.4
         12.388014786122742 3.0
         25.600464531354252 5.4
         42.35204755970952 8.6"""
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
 
 def run_poly():

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
@@ -86,16 +87,13 @@ def test_that_adaptive_localization_works_with_a_single_observation():
         OBS_FILE   = poly_obs_data.txt;
     };"""
 
-    with open("observations", "w", encoding="utf-8") as file:
-        file.write(content)
+    Path("observations").write_text(content, encoding="utf-8")
 
     content = "2.1457049781272213 0.6"
 
-    with open("poly_obs_data.txt", "w", encoding="utf-8") as file:
-        file.write(content)
+    Path("poly_obs_data.txt").write_text(content, encoding="utf-8")
 
-    with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
-        f.writelines(lines)
+    Path("poly_localization_0.ert").write_text("".join(lines), encoding="utf-8")
 
     _, _, _ = run_cli_ES_with_case("poly_localization_0.ert", "test_experiment")
 
@@ -103,9 +101,8 @@ def test_that_adaptive_localization_works_with_a_single_observation():
 @pytest.mark.timeout(600)
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_adaptive_localization_works_with_multiple_observations(snapshot):
-    with open("observations", "w", encoding="utf-8") as file:
-        file.write(
-            """GENERAL_OBSERVATION POLY_OBS {
+    Path("observations").write_text(
+        """GENERAL_OBSERVATION POLY_OBS {
         DATA       = POLY_RES;
         INDEX_LIST = 0,1,2,3,4;
         OBS_FILE   = poly_obs_data.txt;
@@ -120,12 +117,12 @@ def test_that_adaptive_localization_works_with_multiple_observations(snapshot):
         INDEX_LIST = 0,1,2,3,4;
         OBS_FILE   = poly_obs_data2.txt;
     };
-    """
-        )
+    """,
+        encoding="utf-8",
+    )
 
-    with open("poly_eval.py", "w", encoding="utf-8") as file:
-        file.write(
-            """#!/usr/bin/env python3
+    Path("poly_eval.py").write_text(
+        """#!/usr/bin/env python3
 import json
 
 
@@ -149,15 +146,15 @@ if __name__ == "__main__":
 
     with open("poly.out2", "w", encoding="utf-8") as f:
         f.write("\\n".join(map(str, [x*3 for x in output])))
-"""
-        )
+""",
+        encoding="utf-8",
+    )
 
     shutil.copy("poly_obs_data.txt", "poly_obs_data1.txt")
     shutil.copy("poly_obs_data.txt", "poly_obs_data2.txt")
 
-    with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
-        f.write(
-            """
+    Path("poly_localization_0.ert").write_text(
+        """
         QUEUE_SYSTEM LOCAL
 QUEUE_OPTION LOCAL MAX_RUNNING 2
 
@@ -182,8 +179,9 @@ ANALYSIS_SET_VAR STD_ENKF LOCALIZATION_CORRELATION_THRESHOLD 0.0
 
 ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE *
 ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
-"""
-        )
+""",
+        encoding="utf-8",
+    )
 
     expected_records = {
         ("*", "POLY_OBS", "0, 0"),

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -101,10 +101,9 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         pl.DataFrame(default_values, orient="row"),
     )
 
-    with open("poly.ert", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """\
+    Path("poly.ert").write_text(
+        dedent(
+            """\
                 QUEUE_OPTION LOCAL MAX_RUNNING 2
                 RUNPATH poly_out/realization-<IENS>/iter-<ITER>
                 NUM_REALIZATIONS 10
@@ -116,18 +115,18 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
     # This adds a dummy category parameter to COEFFS GENKW
     # which will be overridden by the design matrix catagorical entries
     with open("coeff_priors", "a", encoding="utf-8") as f:
         f.write("category UNIFORM 0 1")
 
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly_eval.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python
                 import json
 
@@ -144,20 +143,22 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
                     with open("poly.out", "w", encoding="utf-8") as f:
                         f.write("\\n".join(map(str, output)))
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("my_template", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("my_template").write_text(
+        dedent(
+            """\
                 a: <a>
                 b: <b>
                 c: <c>
                 category: <category>
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     os.chmod(
         "poly_eval.py",
         os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
@@ -226,10 +227,9 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
         pl.DataFrame([["g", 4]], orient="row"),
     )
 
-    with open("poly.ert", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """\
+    Path("poly.ert").write_text(
+        dedent(
+            """\
                 QUEUE_OPTION LOCAL MAX_RUNNING 2
                 RUNPATH poly_out/realization-<IENS>/iter-<ITER>
                 NUM_REALIZATIONS 10
@@ -240,13 +240,13 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly_eval.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python
                 import json
 
@@ -263,8 +263,10 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
                     with open("poly.out", "w", encoding="utf-8") as f:
                         f.write("\\n".join(map(str, output)))
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     os.chmod(
         "poly_eval.py",
         os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
@@ -314,10 +316,9 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
         ),
     )
 
-    with open("poly.ert", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly.ert").write_text(
+        dedent(
+            """\
                 QUEUE_OPTION LOCAL MAX_RUNNING 2
                 RUNPATH poly_out/realization-<IENS>/iter-<ITER>
                 OBS_CONFIG observations
@@ -330,13 +331,13 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
                 INSTALL_JOB poly_eval POLY_EVAL
                 FORWARD_MODEL poly_eval
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly_eval.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python3
                 import json
 
@@ -355,19 +356,18 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
                     with open("poly.out", "w", encoding="utf-8") as f:
                         f.write("\\n".join(map(str, output)))
                 """  # noqa: E501
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     os.chmod(
         "poly_eval.py",
         os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
     )
 
-    with open("coeff_priors_a", "w", encoding="utf-8") as f:
-        f.write("a UNIFORM 0 1")
-    with open("coeff_priors_b", "w", encoding="utf-8") as f:
-        f.write("b UNIFORM 0 2")
-    with open("coeff_priors_c", "w", encoding="utf-8") as f:
-        f.write("c UNIFORM 0 5")
+    Path("coeff_priors_a").write_text("a UNIFORM 0 1", encoding="utf-8")
+    Path("coeff_priors_b").write_text("b UNIFORM 0 2", encoding="utf-8")
+    Path("coeff_priors_c").write_text("c UNIFORM 0 5", encoding="utf-8")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=ConfigWarning)

--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -110,8 +110,7 @@ def test_that_surfaces_retain_their_order_when_loaded_and_saved_by_ert():
     };
     """
 
-    with open("observations/observations.txt", "w", encoding="utf-8") as file:
-        file.write(obs)
+    Path("observations/observations.txt").write_text(obs, encoding="utf-8")
 
     run_cli(
         ENSEMBLE_SMOOTHER_MODE,
@@ -174,10 +173,9 @@ def test_update_multiple_param():
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_reals_with_load_failure_in_prior_become_parent_failure_in_posterior():
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly_eval.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python
                 import numpy as np
                 import sys
@@ -203,8 +201,10 @@ def test_that_reals_with_load_failure_in_prior_become_parent_failure_in_posterio
                     with open("poly.out", "w", encoding="utf-8") as f:
                         f.write("\\n".join(map(str, output)))
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     os.chmod(
         "poly_eval.py",
         os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -473,16 +473,13 @@ def test_that_stop_on_fail_workflow_jobs_stop_ert(
     script_name = f"failing_script.{file_extension}"
     monkeypatch.setattr(_ert.threading, "_can_raise", False)
 
-    with open("failing_job", "w", encoding="utf-8") as f:
-        f.write(workflow_job_config_content)
+    Path("failing_job").write_text(workflow_job_config_content, encoding="utf-8")
 
-    with open(script_name, "w", encoding="utf-8") as s:
-        s.write(script_content)
+    Path(script_name).write_text(script_content, encoding="utf-8")
 
     os.chmod(script_name, os.stat(script_name).st_mode | 0o111)
 
-    with open("dump_failing_workflow", "w", encoding="utf-8") as f:
-        f.write("failjob")
+    Path("dump_failing_workflow").write_text("failjob", encoding="utf-8")
 
     with open("poly.ert", mode="a", encoding="utf-8") as fh:
         fh.write(

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -288,10 +288,9 @@ def test_parameter_update_with_inactive_cells_xtgeo_grdecl(tmpdir):
         grid.set_actnum(mask)
         grid.to_file("MY_EGRID.EGRID", "egrid")
 
-        with open("forward_model", "w", encoding="utf-8") as f:
-            f.write(
-                dedent(
-                    f"""#!/usr/bin/env python
+        Path("forward_model").write_text(
+            dedent(
+                f"""#!/usr/bin/env python
 import xtgeo
 import numpy as np
 import os
@@ -309,8 +308,10 @@ if __name__ == "__main__":
     with open("gen_data_0.out", "w", encoding="utf-8") as f:
         f.write("\\n".join(map(str, output)))
         """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
+
         os.chmod(
             "forward_model",
             os.stat("forward_model").st_mode
@@ -318,32 +319,31 @@ if __name__ == "__main__":
             | stat.S_IXGRP
             | stat.S_IXOTH,
         )
-        with open("POLY_EVAL", "w", encoding="utf-8") as fout:
-            fout.write("EXECUTABLE forward_model")
-        with open("observations", "w", encoding="utf-8") as fout:
-            fout.write(
-                dedent(
-                    """
+        Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
+        Path("observations").write_text(
+            dedent(
+                """
             GENERAL_OBSERVATION MY_OBS {
                 DATA       = MY_RESPONSE;
                 INDEX_LIST = 0,2,4,6,8;
                 RESTART    = 0;
                 OBS_FILE   = obs.txt;
             };"""
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
 
-        with open("obs.txt", "w", encoding="utf-8") as fobs:
-            fobs.write(
-                dedent(
-                    """
+        Path("obs.txt").write_text(
+            dedent(
+                """
             2.1457049781272213 0.6
             8.769219841380755 1.4
             12.388014786122742 3.0
             25.600464531354252 5.4
             42.35204755970952 8.6"""
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,

--- a/tests/ert/ui_tests/cli/test_parameter_sample_types.py
+++ b/tests/ert/ui_tests/cli/test_parameter_sample_types.py
@@ -1,5 +1,6 @@
 import os
 import stat
+from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
@@ -42,11 +43,10 @@ FORWARD_MODEL poly_eval
         )
         base_surface.to_file("surf.irap", fformat="irap_ascii")
 
-        with open("forward_model", "w", encoding="utf-8") as f:
-            f.write(
-                """#!/usr/bin/env python
+        Path("forward_model").write_text(
+            """#!/usr/bin/env python
 import os
-
+from pathlib import Path
 import xtgeo
 import numpy as np
 
@@ -69,10 +69,11 @@ if __name__ == "__main__":
 
     output = [a * x**2 + b * x + c for x in range(10)]
 
-    with open("gen_data_0.out", "w", encoding="utf-8") as f:
-        f.write("\\n".join(map(str, output)))
-        """
-            )
+    Path("gen_data_0.out").write_text("\\n".join(map(str, output)), encoding="utf-8")
+        """,
+            encoding="utf-8",
+        )
+
         os.chmod(
             "forward_model",
             os.stat("forward_model").st_mode
@@ -80,35 +81,33 @@ if __name__ == "__main__":
             | stat.S_IXGRP
             | stat.S_IXOTH,
         )
-        with open("POLY_EVAL", "w", encoding="utf-8") as fout:
-            fout.write("EXECUTABLE forward_model")
-        with open("observations", "w", encoding="utf-8") as fout:
-            fout.write(
-                dedent(
-                    """
+        Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
+        Path("observations").write_text(
+            dedent(
+                """
             GENERAL_OBSERVATION MY_OBS {
                 DATA       = MY_RESPONSE;
                 INDEX_LIST = 0,2,4,6,8;
                 RESTART    = 0;
                 OBS_FILE   = obs.txt;
             };"""
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
 
-        with open("obs.txt", "w", encoding="utf-8") as fobs:
-            fobs.write(
-                dedent(
-                    """
+        Path("obs.txt").write_text(
+            dedent(
+                """
             2.1457049781272213 0.6
             8.769219841380755 1.4
             12.388014786122742 3.0
             25.600464531354252 5.4
             42.35204755970952 8.6"""
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
 
-        with open("config.ert", "w", encoding="utf-8") as fh:
-            fh.writelines(config)
+        Path("config.ert").write_text(config, encoding="utf-8")
 
         run_cli(
             ENSEMBLE_SMOOTHER_MODE,

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -146,10 +146,9 @@ def _ensemble_experiment_run(
     ):
         mp.chdir(path)
         if failing_reals:
-            with open("poly_eval.py", "w", encoding="utf-8") as f:
-                f.write(
-                    dedent(
-                        """\
+            Path("poly_eval.py").write_text(
+                dedent(
+                    """\
                         #!/usr/bin/env python3
                         import os
                         import sys
@@ -170,8 +169,10 @@ def _ensemble_experiment_run(
                             with open("poly.out", "w", encoding="utf-8") as f:
                                 f.write("\\n".join(map(str, output)))
                         """
-                    )
-                )
+                ),
+                encoding="utf-8",
+            )
+
             os.chmod(
                 "poly_eval.py",
                 os.stat("poly_eval.py").st_mode

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -220,10 +220,12 @@ def test_that_the_run_workflow_tool_is_enabled_when_there_are_workflows(qapp, tm
 
     os.mkdir(tmp_path / "workflows")
 
-    with open(tmp_path / "workflows/MAGIC_PRINT", "w", encoding="utf-8") as f:
-        f.write("print_uber\n")
-    with open(tmp_path / "workflows/UBER_PRINT", "w", encoding="utf-8") as f:
-        f.write("EXECUTABLE ls\n")
+    Path(tmp_path / "workflows/MAGIC_PRINT").write_text(
+        "print_uber\n", encoding="utf-8"
+    )
+    Path(tmp_path / "workflows/UBER_PRINT").write_text(
+        "EXECUTABLE ls\n", encoding="utf-8"
+    )
 
     args = Mock()
     args.config = str(config_file)
@@ -559,17 +561,17 @@ def test_that_a_failing_job_shows_error_message_with_context(
     gui = opened_main_window_poly
 
     # break poly eval script so realz fail
-    with open("poly_eval.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("poly_eval.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python
 
                 if __name__ == "__main__":
                     raise RuntimeError('Argh')
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     os.chmod(
         "poly_eval.py",
         os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -1,5 +1,6 @@
 import datetime
 import shutil
+from pathlib import Path
 
 import numpy as np
 import polars as pl
@@ -303,9 +304,8 @@ def test_ensemble_view(
 
 @pytest.mark.usefixtures("copy_poly_case")
 def test_ensemble_observations_view(qtbot):
-    with open("observations", "w", encoding="utf-8") as file:
-        file.write(
-            """GENERAL_OBSERVATION POLY_OBS {
+    Path("observations").write_text(
+        """GENERAL_OBSERVATION POLY_OBS {
         DATA       = POLY_RES;
         INDEX_LIST = 0,1,2,3,4;
         OBS_FILE   = poly_obs_data.txt;
@@ -320,12 +320,12 @@ def test_ensemble_observations_view(qtbot):
         INDEX_LIST = 0,1,2,3,4;
         OBS_FILE   = poly_obs_data2.txt;
     };
-    """
-        )
+    """,
+        encoding="utf-8",
+    )
 
-    with open("poly_eval.py", "w", encoding="utf-8") as file:
-        file.write(
-            """#!/usr/bin/env python3
+    Path("poly_eval.py").write_text(
+        """#!/usr/bin/env python3
 import json
 
 
@@ -349,15 +349,15 @@ if __name__ == "__main__":
 
     with open("poly.out2", "w", encoding="utf-8") as f:
         f.write("\\n".join(map(str, [x*3 for x in output])))
-"""
-        )
+""",
+        encoding="utf-8",
+    )
 
     shutil.copy("poly_obs_data.txt", "poly_obs_data1.txt")
     shutil.copy("poly_obs_data.txt", "poly_obs_data2.txt")
 
-    with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
-        f.write(
-            """
+    Path("poly_localization_0.ert").write_text(
+        """
         QUEUE_SYSTEM LOCAL
 QUEUE_OPTION LOCAL MAX_RUNNING 2
 
@@ -382,8 +382,9 @@ ANALYSIS_SET_VAR STD_ENKF LOCALIZATION_CORRELATION_THRESHOLD 0.0
 
 ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE *
 ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
-"""
-        )
+""",
+        encoding="utf-8",
+    )
 
     prior_ens_id, _, _ = run_cli_ES_with_case(
         "poly_localization_0.ert", "test_experiment"

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 import stat
+from pathlib import Path
 from textwrap import dedent
 
 from PyQt6.QtCore import Qt, QTimer
@@ -22,10 +23,9 @@ def test_rerun_failed_all_realizations(opened_main_window_poly, qtbot):
     gui = opened_main_window_poly
 
     def write_poly_eval(failing_reals: bool):
-        with open("poly_eval.py", "w", encoding="utf-8") as f:
-            f.write(
-                dedent(
-                    f"""\
+        Path("poly_eval.py").write_text(
+            dedent(
+                f"""\
                     #!/usr/bin/env python
                     import numpy as np
                     import sys
@@ -47,8 +47,10 @@ def test_rerun_failed_all_realizations(opened_main_window_poly, qtbot):
                         with open("poly.out", "w", encoding="utf-8") as f:
                             f.write("\\n".join(map(str, output)))
                     """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
+
         os.chmod(
             "poly_eval.py",
             os.stat("poly_eval.py").st_mode
@@ -105,10 +107,9 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
     caplog.set_level(logging.INFO)
 
     def write_poly_eval(failing_reals: set[int]):
-        with open("poly_eval.py", "w", encoding="utf-8") as f:
-            f.write(
-                dedent(
-                    f"""\
+        Path("poly_eval.py").write_text(
+            dedent(
+                f"""\
                     #!/usr/bin/env python
                     import numpy as np
                     import sys
@@ -130,8 +131,10 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
                         with open("poly.out", "w", encoding="utf-8") as f:
                             f.write("\\n".join(map(str, output)))
                     """  # noqa: E501
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
+
         os.chmod(
             "poly_eval.py",
             os.stat("poly_eval.py").st_mode
@@ -272,10 +275,9 @@ def test_rerun_failed_realizations_evaluate_ensemble(
     gui = ensemble_experiment_has_run_no_failure
 
     def write_poly_eval(failing_reals: set[int]):
-        with open("poly_eval.py", "w", encoding="utf-8") as f:
-            f.write(
-                dedent(
-                    f"""\
+        Path("poly_eval.py").write_text(
+            dedent(
+                f"""\
                     #!/usr/bin/env python
                     import numpy as np
                     import sys
@@ -297,8 +299,10 @@ def test_rerun_failed_realizations_evaluate_ensemble(
                         with open("poly.out", "w", encoding="utf-8") as f:
                             f.write("\\n".join(map(str, output)))
                     """  # noqa: E501
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
+
         os.chmod(
             "poly_eval.py",
             os.stat("poly_eval.py").st_mode

--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -2,6 +2,7 @@ import os
 import stat
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock
 
@@ -27,10 +28,9 @@ from .conftest import get_child
 def _open_main_window(
     path,
 ) -> Generator[tuple[ErtMainWindow, Storage, ErtConfig], None, None]:
-    with open("forward_model.py", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("forward_model.py").write_text(
+        dedent(
+            """\
                 #!/usr/bin/env python3
                 import os
 
@@ -38,8 +38,10 @@ def _open_main_window(
                     if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:
                         raise ValueError()
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     os.chmod(
         "forward_model.py",
         os.stat("forward_model.py").st_mode
@@ -47,8 +49,8 @@ def _open_main_window(
         | stat.S_IXGRP
         | stat.S_IXOTH,
     )
-    with open("FORWARD_MODEL", "w", encoding="utf-8") as fout:
-        fout.write("EXECUTABLE forward_model.py")
+    Path("FORWARD_MODEL").write_text("EXECUTABLE forward_model.py", encoding="utf-8")
+
     config = dedent("""
     QUEUE_SYSTEM LOCAL
     QUEUE_OPTION LOCAL MAX_RUNNING 2

--- a/tests/ert/unit_tests/cli/test_cli_workflow.py
+++ b/tests/ert/unit_tests/cli/test_cli_workflow.py
@@ -1,5 +1,6 @@
 import os
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -11,8 +12,9 @@ from ert.plugins.plugin_manager import ErtPluginContext
 @pytest.mark.usefixtures("copy_poly_case")
 def test_executing_workflow(storage):
     with ErtPluginContext() as ctx:
-        with open("test_wf", "w", encoding="utf-8") as wf_file:
-            wf_file.write("CSV_EXPORT test_workflow_output.csv")
+        Path("test_wf").write_text(
+            "CSV_EXPORT test_workflow_output.csv", encoding="utf-8"
+        )
 
         config_file = "poly.ert"
         with open(config_file, "a", encoding="utf-8") as file_handle:

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -747,8 +747,9 @@ def config_generators(draw, use_eclbase=booleans):
             config_values.refcase_smspec.to_file(f"./refcase/{summary_basename}.SMSPEC")
             config_values.refcase_unsmry.to_file(f"./refcase/{summary_basename}.UNSMRY")
             config_values.egrid.to_file(config_values.grid_file, fformat="egrid")
-            with open(config_values.time_map[0], "w", encoding="utf-8") as fh:
-                fh.write(config_values.time_map[1])
+            Path(config_values.time_map[0]).write_text(
+                config_values.time_map[1], encoding="utf-8"
+            )
 
             if config_file_name is not None:
                 to_config_file(config_file_name, config_values)

--- a/tests/ert/unit_tests/config/parsing/test_lark_parser.py
+++ b/tests/ert/unit_tests/config/parsing/test_lark_parser.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -12,8 +13,7 @@ from ert.config.parsing import (
 
 
 def touch(filename):
-    with open(filename, "w", encoding="utf-8") as fh:
-        fh.write(" ")
+    Path(filename).write_text(" ", encoding="utf-8")
 
 
 def test_that_no_arguments_to_summary_raises_config_validation_error():
@@ -148,17 +148,15 @@ def test_that_cyclical_includes_raise_config_validation_error():
     test_include_file_name = "include.ert"
     test_include_contents = "JOBNAME included\nINCLUDE test.ert\n"
 
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     with pytest.raises(ConfigValidationError, match=r"Cyclical .*test.ert"):
         _ = parse(test_config_file_name, schema=init_user_config_schema())
 
     # Test self include raises cyclical include error
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_self_include)
+    Path(test_config_file_name).write_text(test_config_self_include, encoding="utf-8")
+
     with pytest.raises(ConfigValidationError, match=r"Cyclical .*test.ert->test.ert"):
         _ = parse(test_config_file_name, schema=init_user_config_schema())
 
@@ -226,8 +224,7 @@ def test_that_file_without_read_access_raises_config_validation_error(
         ConfigValidationError,
         match=f'{template_file}" is not readable; please check read access.',
     ):
-        with open(config_file_name, mode="w", encoding="utf-8") as file:
-            file.write(config_file_contents)
+        Path(config_file_name).write_text(config_file_contents, encoding="utf-8")
 
         _ = parse(config_file_name, schema=init_user_config_schema())
 
@@ -245,8 +242,7 @@ def test_not_executable_job_script_raises_config_validation_error():
          JOB_SCRIPT {script_name}
          """
     )
-    with open(config_file_name, mode="w", encoding="utf-8") as fh:
-        fh.write(config_file_contents)
+    Path(config_file_name).write_text(config_file_contents, encoding="utf-8")
     with pytest.raises(ConfigValidationError, match=f"not executable.*{script_name}"):
         _ = parse(config_file_name, schema=init_user_config_schema())
 
@@ -273,8 +269,8 @@ def test_not_executable_job_script_somewhere_in_PATH_raises_config_validation_er
          JOB_SCRIPT {script_name}
          """
     )
-    with open(config_file_name, mode="w", encoding="utf-8") as fh:
-        fh.write(config_file_contents)
+    Path(config_file_name).write_text(config_file_contents, encoding="utf-8")
+
     with pytest.raises(
         ConfigValidationError,
         match="Could not find executable",
@@ -316,8 +312,7 @@ def test_that_giving_non_executable_in_job_script_raises_config_validation_error
         JOB_SCRIPT  not-an-executable-anyone-would-have-on-their-laptop
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with pytest.raises(ConfigValidationError, match="executable"):
         _ = parse(test_config_file_name, schema=init_user_config_schema())

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -3,6 +3,7 @@ import logging
 import os
 import os.path
 import stat
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -540,20 +541,13 @@ def test_that_env_vars_with_surrounded_by_brackets_are_ommitted_from_Jobs_json(
     ],
 )
 def test_forward_model_job(job, forward_model, expected_args):
-    with open("job_file", "w", encoding="utf-8") as fout:
-        fout.write(job)
+    Path("job_file").write_text(job, encoding="utf-8")
 
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
-        # Write a minimal config file
-        fout.write(
-            dedent(
-                """
-        NUM_REALIZATIONS 1
-        """
-            )
-        )
-        fout.write("INSTALL_JOB job_name job_file\n")
-        fout.write(forward_model)
+    # Write a minimal config file
+    Path("config_file.ert").write_text(
+        "NUM_REALIZATIONS 1\nINSTALL_JOB job_name job_file\n" + forward_model,
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config_file.ert")
 
@@ -573,21 +567,23 @@ def test_forward_model_job(job, forward_model, expected_args):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_config_path_is_the_directory_of_the_main_ert_config():
     os.mkdir("jobdir")
-    with open("jobdir/job_file", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """
+    Path("jobdir/job_file").write_text(
+        dedent(
+            """
             EXECUTABLE echo
             ARGLIST <CONFIG_PATH>
             """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
-        # Write a minimal config file
-        fout.write("NUM_REALIZATIONS 1\n")
-        fout.write("INSTALL_JOB job_name jobdir/job_file\n")
-        fout.write("FORWARD_MODEL job_name")
+    # Write a minimal config file
+    Path("config_file.ert").write_text(
+        "NUM_REALIZATIONS 1\n"
+        "INSTALL_JOB job_name jobdir/job_file\n"
+        "FORWARD_MODEL job_name",
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config_file.ert")
     data = create_forward_model_json(
@@ -603,23 +599,25 @@ def test_that_config_path_is_the_directory_of_the_main_ert_config():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_private_over_global_args_gives_logging_message(caplog):
     caplog.set_level(logging.INFO)
-    with open("job_file", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """
+    Path("job_file").write_text(
+        dedent(
+            """
             EXECUTABLE echo
             ARGLIST <ARG>
             ARG_TYPE 0 STRING
             """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
-        # Write a minimal config file
-        fout.write("NUM_REALIZATIONS 1\n")
-        fout.write("DEFINE <ARG> A\n")
-        fout.write("INSTALL_JOB job_name job_file\n")
-        fout.write("FORWARD_MODEL job_name(<ARG>=B)")
+    # Write a minimal config file
+    Path("config_file.ert").write_text(
+        "NUM_REALIZATIONS 1\n"
+        "DEFINE <ARG> A\n"
+        "INSTALL_JOB job_name job_file\n"
+        "FORWARD_MODEL job_name(<ARG>=B)",
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config_file.ert")
     data = create_forward_model_json(
@@ -642,23 +640,25 @@ def test_that_private_over_global_args_does_not_give_logging_message_for_argpass
     caplog,
 ):
     caplog.set_level(logging.INFO)
-    with open("job_file", "w", encoding="utf-8") as fout:
-        fout.write(
-            dedent(
-                """
+    Path("job_file").write_text(
+        dedent(
+            """
             EXECUTABLE echo
             ARGLIST <ARG>
             ARG_TYPE 0 STRING
             """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
-        # Write a minimal config file
-        fout.write("NUM_REALIZATIONS 1\n")
-        fout.write("DEFINE <ARG> A\n")
-        fout.write("INSTALL_JOB job_name job_file\n")
-        fout.write("FORWARD_MODEL job_name(<ARG>=<ARG>)")
+    # Write a minimal config file
+    Path("config_file.ert").write_text(
+        "NUM_REALIZATIONS 1\n"
+        "DEFINE <ARG> A\n"
+        "INSTALL_JOB job_name job_file\n"
+        "FORWARD_MODEL job_name(<ARG>=<ARG>)",
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config_file.ert")
     data = create_forward_model_json(
@@ -699,8 +699,7 @@ def test_that_environment_variables_are_set_in_forward_model(
     monkeypatch, job, forward_model, expected_args
 ):
     monkeypatch.setenv("ENV", "env_value")
-    with open("job_file", "w", encoding="utf-8") as fout:
-        fout.write(job)
+    Path("job_file").write_text(job, encoding="utf-8")
 
     with open("config_file.ert", "w", encoding="utf-8") as fout:
         # Write a minimal config file

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -254,16 +254,11 @@ def test_that_parsing_workflows_gives_expected():
 
     os.mkdir("workflows")
 
-    with open("workflows/MAGIC_PRINT", "w", encoding="utf-8") as f:
-        f.write("print_uber\n")
-    with open("workflows/NO_PRINT", "w", encoding="utf-8") as f:
-        f.write("print_uber\n")
-    with open("workflows/SOME_PRINT", "w", encoding="utf-8") as f:
-        f.write("print_uber\n")
-    with open("workflows/UBER_PRINT", "w", encoding="utf-8") as f:
-        f.write("EXECUTABLE ls\n")
-    with open("workflows/HIDDEN_PRINT", "w", encoding="utf-8") as f:
-        f.write("EXECUTABLE ls\n")
+    Path("workflows/MAGIC_PRINT").write_text("print_uber\n", encoding="utf-8")
+    Path("workflows/NO_PRINT").write_text("print_uber\n", encoding="utf-8")
+    Path("workflows/SOME_PRINT").write_text("print_uber\n", encoding="utf-8")
+    Path("workflows/UBER_PRINT").write_text("EXECUTABLE ls\n", encoding="utf-8")
+    Path("workflows/HIDDEN_PRINT").write_text("EXECUTABLE ls\n", encoding="utf-8")
 
     ert_config = ErtConfig.from_dict(config_dict)
 
@@ -649,19 +644,19 @@ def test_that_job_definition_file_with_unexecutable_script_gives_validation_erro
     test_config_file_name = "test.ert"
     job_script_file = os.path.abspath("not_executable")
     job_name = "JOB_NAME"
-    with open(job_name, "w", encoding="utf-8") as fh:
-        fh.write(f"EXECUTABLE {job_script_file}\n")
-    with open(job_script_file, "w", encoding="utf-8") as fh:
-        fh.write("#!/bin/sh\n")
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+    Path(job_name).write_text(f"EXECUTABLE {job_script_file}\n", encoding="utf-8")
+    Path(job_script_file).write_text("#!/bin/sh\n", encoding="utf-8")
+
+    Path(test_config_file_name).write_text(
+        dedent(
+            f"""
                 NUM_REALIZATIONS  1
                 LOAD_WORKFLOW_JOB {job_name}
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
+
     with pytest.raises(
         expected_exception=ConfigValidationError,
     ):
@@ -700,33 +695,32 @@ def test_that_magic_strings_get_substituted_in_workflow():
     )
     script_file_path = os.path.join(os.getcwd(), "script")
     workflow_file_path = os.path.join(os.getcwd(), "workflow")
-    with open(script_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(script_file_contents)
-    with open(workflow_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(workflow_file_contents)
+    Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
+    Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
 
-    with open("script.py", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                """
+    Path("script.py").write_text(
+        dedent(
+            """
                 from ert import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass
                 """
-            )
-        )
-    with open("config.ert", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+        ),
+        encoding="utf-8",
+    )
+
+    Path("config.ert").write_text(
+        dedent(
+            f"""
                 NUM_REALIZATIONS 1
                 DEFINE <ZERO> 0
                 LOAD_WORKFLOW_JOB {script_file_path} script
                 LOAD_WORKFLOW {workflow_file_path}
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config.ert")
 
@@ -1101,8 +1095,7 @@ def test_that_workflows_with_errors_are_not_loaded():
         """
     )
 
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with pytest.warns(
         ConfigWarning,
@@ -1150,8 +1143,7 @@ def test_that_adding_a_workflow_twice_warns():
         """
     )
 
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with pytest.warns(
         ConfigWarning,
@@ -1186,8 +1178,7 @@ def test_that_failing_to_load_ert_script_with_errors_fails_gracefully(load_state
         """
     )
 
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with (
         pytest.warns(
@@ -1268,10 +1259,8 @@ def test_that_include_statements_work():
         JOBNAME included
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert ert_config.runpath_config.jobname_format_string == "included"
@@ -1299,12 +1288,9 @@ def test_that_included_files_uses_paths_relative_to_itself():
         EXECUTABLE echo
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
-    with open(test_fm_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_fm_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
+    Path(test_fm_file_name).write_text(test_fm_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert ert_config.installed_forward_model_steps["FM"].name == "FM"
@@ -1348,10 +1334,8 @@ def test_that_include_take_into_account_path():
     os.mkdir("dir")
     Path("dir/job1").write_text("EXECUTABLE echo\n", encoding="utf-8")
     Path("job2").write_text("EXECUTABLE ls\n", encoding="utf-8")
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert list(ert_config.installed_forward_model_steps.keys()) == [
@@ -1377,10 +1361,8 @@ def test_that_substitution_happens_for_include():
         """
     )
     os.mkdir("dir")
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert (
@@ -1407,10 +1389,8 @@ def test_that_defines_in_included_files_has_immediate_effect():
         """
     )
     os.mkdir("dir")
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
-    with open(test_include_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_include_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
+    Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
     assert "baz-<ITER>-<IENS>" in ert_config.runpath_config.runpath_format_string
@@ -1483,33 +1463,31 @@ def test_parsing_workflow_with_multiple_args():
     )
     script_file_path = os.path.join(os.getcwd(), "script")
     workflow_file_path = os.path.join(os.getcwd(), "workflow")
-    with open(script_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(script_file_contents)
-    with open(workflow_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(workflow_file_contents)
+    Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
+    Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
 
-    with open("script.py", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                """
+    Path("script.py").write_text(
+        dedent(
+            """
                 from ert import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass
                 """
-            )
-        )
-    with open("config.ert", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+        ),
+        encoding="utf-8",
+    )
+    Path("config.ert").write_text(
+        dedent(
+            f"""
                 NUM_REALIZATIONS 1
                 DEFINE <ZERO> 0
                 LOAD_WORKFLOW_JOB {script_file_path} script
                 LOAD_WORKFLOW {workflow_file_path}
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
     ert_config = ErtConfig.from_file("config.ert")
 
@@ -1541,8 +1519,9 @@ def test_no_warning_given_when_using_parameters_defined_by_ert_in_forward_model_
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_validate_no_logs_when_overwriting_with_same_value(caplog):
-    with open("step_file", "w", encoding="utf-8") as fout:
-        fout.write("EXECUTABLE echo\nARGLIST <VAR1> <VAR2> <VAR3>\n")
+    Path("step_file").write_text(
+        "EXECUTABLE echo\nARGLIST <VAR1> <VAR2> <VAR3>\n", encoding="utf-8"
+    )
 
     with caplog.at_level(logging.INFO):
         ert_config = ErtConfig.from_file_contents(
@@ -2017,30 +1996,26 @@ def test_parsing_define_within_workflow():
     workflow_file_path = os.path.join(os.getcwd(), "workflow")
     workflow2_file_path = os.path.join(os.getcwd(), "workflow2")
 
-    with open(script_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(script_file_contents)
+    Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
 
-    with open(workflow_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(workflow_file_contents)
+    Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
 
-    with open(workflow2_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write(workflow2_file_contents)
+    Path(workflow2_file_path).write_text(workflow2_file_contents, encoding="utf-8")
 
-    with open("script.py", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                """
+    Path("script.py").write_text(
+        dedent(
+            """
                 from ert import ErtScript
                 class Script(ErtScript):
                     def run(self, *args):
                         pass
                 """
-            )
-        )
-    with open("config.ert", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+        ),
+        encoding="utf-8",
+    )
+    Path("config.ert").write_text(
+        dedent(
+            f"""
                 NUM_REALIZATIONS 1
                 DEFINE <FOO> ertconfig_foo
                 DEFINE <FOO2> ertconfig_foo2
@@ -2048,8 +2023,9 @@ def test_parsing_define_within_workflow():
                 LOAD_WORKFLOW {workflow_file_path}
                 LOAD_WORKFLOW {workflow2_file_path}
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
     with pytest.warns(ConfigWarning, match="SCRIPT has no effect"):
         ert_config = ErtConfig.from_file("config.ert")
@@ -2248,20 +2224,19 @@ def test_run_template_raises_configvalidationerror_with_more_than_two_arguments(
 @pytest.fixture
 def setup_workflow_file():
     workflow_file_path = os.path.join(os.getcwd(), "workflow")
-    with open(workflow_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write("TEST_SCRIPT")
+    Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
 
-    with open("config.ert", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+    Path("config.ert").write_text(
+        dedent(
+            f"""
                     NUM_REALIZATIONS 1
 
                     LOAD_WORKFLOW {workflow_file_path} workflow_alias
                     HOOK_WORKFLOW workflow_alias PRE_EXPERIMENT
                     """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir", "setup_workflow_file")
@@ -2344,13 +2319,11 @@ def test_ert_script_hook_pre_experiment_essettings_fails():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_script_hook_valid_essettings_succeed():
     workflow_file_path = os.path.join(os.getcwd(), "workflow")
-    with open(workflow_file_path, mode="w", encoding="utf-8") as fh:
-        fh.write("TEST_SCRIPT")
+    Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
 
-    with open("config.ert", mode="w", encoding="utf-8") as fh:
-        fh.write(
-            dedent(
-                f"""
+    Path("config.ert").write_text(
+        dedent(
+            f"""
                 NUM_REALIZATIONS 1
 
                 LOAD_WORKFLOW {workflow_file_path} workflow_alias
@@ -2358,8 +2331,9 @@ def test_ert_script_hook_valid_essettings_succeed():
                 HOOK_WORKFLOW workflow_alias POST_UPDATE
                 HOOK_WORKFLOW workflow_alias PRE_FIRST_UPDATE
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
 
     class SomeScript(ErtScript):
         def run(self, es_settings: ESSettings):
@@ -2399,8 +2373,9 @@ def test_queue_options_are_joined_after_option_name():
 def test_validation_error_on_invalid_parameter_name(
     invalid_parameter_definition_name, tmp_path, caplog
 ):
-    with open(tmp_path / "coeffs_priors", mode="w", encoding="utf-8") as fh:
-        fh.write(invalid_parameter_definition_name)
+    Path(tmp_path / "coeffs_priors").write_text(
+        invalid_parameter_definition_name, encoding="utf-8"
+    )
     with pytest.raises(
         ConfigValidationError,
         match=(

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -28,8 +28,7 @@ from .config_dict_generator import config_generators
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_forward_model():
     name = "script.sh"
-    with open(name, "w", encoding="utf-8") as f:
-        f.write("This is a script")
+    Path(name).write_text("This is a script", encoding="utf-8")
     mode = os.stat(name).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
     os.chmod(name, stat.S_IMODE(mode))
@@ -59,8 +58,7 @@ def test_load_forward_model():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_load_forward_model_upgraded():
     name = "script.sh"
-    with open(name, "w", encoding="utf-8") as f:
-        f.write("This is a script")
+    Path(name).write_text("This is a script", encoding="utf-8")
     mode = os.stat(name).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
     os.chmod(name, stat.S_IMODE(mode))
@@ -381,8 +379,7 @@ def test_that_installing_two_forward_model_steps_with_the_same_name_warn():
         INSTALL_JOB job job
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with pytest.warns(ConfigWarning, match="Duplicate forward model step"):
         _ = ErtConfig.from_file(test_config_file_name)
@@ -400,8 +397,7 @@ def test_that_forward_model_substitution_does_not_warn_about_reaching_max_iterat
         FORWARD_MODEL ECLIPSE100(<VERSION>=2020.2)
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with ErtPluginContext() as ctx:
         ert_config = ErtConfig.with_plugins(ctx).from_file(test_config_file_name)
@@ -432,8 +428,7 @@ def test_that_installing_two_forward_model_steps_with_the_same_name_warn_with_di
         INSTALL_JOB job job
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with pytest.warns(ConfigWarning, match="Duplicate forward model step"):
         _ = ErtConfig.from_file(test_config_file_name)
@@ -471,8 +466,7 @@ def test_that_forward_model_with_different_token_kinds_are_added():
         FORWARD_MODEL job(<MESSAGE>=HELLO)
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     assert [
         (j.name, len(j.private_args))

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -481,8 +481,7 @@ def make_context_string(msg: str, filename: str) -> FileContextToken:
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_config_validation():
-    with open("template.txt", "w", encoding="utf-8") as f:
-        f.write("Hello")
+    Path("template.txt").write_text("Hello", encoding="utf-8")
 
     GenKwConfig.templates_from_config(
         [

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import ExitStack as does_not_raise
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import hypothesis.strategies as st
 import pytest
@@ -497,9 +498,10 @@ def test_that_error_must_be_greater_than_zero_in_general_observations(std):
 
 def test_that_all_errors_in_general_observations_must_be_greater_than_zero(tmpdir):
     with tmpdir.as_cwd():
-        with open("obs_data.txt", "w", encoding="utf-8") as fh:
-            # First error value will be 0
-            fh.writelines(f"{float(i)} {float(i)}\n" for i in range(5))
+        # First error value will be 0
+        Path("obs_data.txt").write_text(
+            "\n".join(f"{float(i)} {float(i)}" for i in range(5)), encoding="utf-8"
+        )
         with pytest.raises(
             ConfigValidationError, match=r"must be given a positive value|strictly > 0"
         ):
@@ -581,8 +583,9 @@ def test_that_having_no_refcase_but_history_observations_causes_exception():
 
 def test_that_index_list_is_read(tmpdir):
     with tmpdir.as_cwd():
-        with open("obs_data.txt", "w", encoding="utf-8") as fh:
-            fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
+        Path("obs_data.txt").write_text(
+            "\n".join(f"{float(i)} 0.1" for i in range(5)), encoding="utf-8"
+        )
         observations = make_observations(
             [
                 {
@@ -606,10 +609,10 @@ def test_that_invalid_time_map_file_raises_config_validation_error():
 
 def test_that_index_file_is_read(tmpdir):
     with tmpdir.as_cwd():
-        with open("obs_idx.txt", "w", encoding="utf-8") as fh:
-            fh.write("0\n2\n4\n6\n8")
-        with open("obs_data.txt", "w", encoding="utf-8") as fh:
-            fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
+        Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
+        Path("obs_data.txt").write_text(
+            "\n".join(f"{float(i)} 0.1\n" for i in range(5)), encoding="utf-8"
+        )
         observations = make_observations(
             [
                 {
@@ -674,10 +677,10 @@ def test_that_non_existent_time_map_file_is_invalid():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_general_observation_cannot_contain_both_value_and_obs_file():
-    with open("obs_idx.txt", "w", encoding="utf-8") as fh:
-        fh.write("0\n2\n4\n6\n8")
-    with open("obs_data.txt", "w", encoding="utf-8") as fh:
-        fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
+    Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
+    Path("obs_data.txt").write_text(
+        "\n".join(f"{float(i)} 0.1" for i in range(5)), encoding="utf-8"
+    )
     with pytest.raises(
         ConfigValidationError, match=r"cannot contain both VALUE.*OBS_FILE"
     ):
@@ -717,8 +720,7 @@ def test_that_general_observation_must_contain_either_value_or_obs_file():
 
 def test_that_non_numbers_in_obs_file_shows_informative_error_message(tmpdir):
     with tmpdir.as_cwd():
-        with open("obs_data.txt", "w", encoding="utf-8") as fh:
-            fh.write("not_an_int 0.1\n")
+        Path("obs_data.txt").write_text("not_an_int 0.1\n", encoding="utf-8")
         with pytest.raises(
             expected_exception=ConfigValidationError,
             match=r"Failed to read OBS_FILE obs_data.txt: could not convert"
@@ -784,8 +786,7 @@ def test_that_the_number_of_values_in_obs_file_must_be_even():
 
 def test_that_giving_both_index_file_and_index_list_raises_an_exception(tmpdir):
     with tmpdir.as_cwd():
-        with open("obs_idx.txt", "w", encoding="utf-8") as fh:
-            fh.write("0\n2\n4\n6\n8")
+        Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
         with pytest.raises(
             expected_exception=ConfigValidationError,
             match="both INDEX_FILE and INDEX_LIST",
@@ -1062,10 +1063,12 @@ def test_that_history_observations_values_are_fetched_from_refcase(
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_obs_file_must_have_the_same_number_of_lines_as_the_index_file():
-    with open("obs_idx.txt", "w", encoding="utf-8") as fh:
-        fh.write("0\n2\n4\n6")  # Should have 5 lines
-    with open("obs_data.txt", "w", encoding="utf-8") as fh:
-        fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
+    Path("obs_idx.txt").write_text(
+        "0\n2\n4\n6", encoding="utf-8"
+    )  # Should have 5 lines
+    Path("obs_data.txt").write_text(
+        "\n".join(f"{float(i)} 0.1" for i in range(5)), encoding="utf-8"
+    )
     with pytest.raises(ConfigValidationError, match="must be of equal length"):
         ErtConfig.from_dict(
             {

--- a/tests/ert/unit_tests/config/test_parser_error_collection.py
+++ b/tests/ert/unit_tests/config/test_parser_error_collection.py
@@ -4,6 +4,7 @@ import stat
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -742,8 +743,7 @@ def test_that_unicode_decode_error_is_localized_random_line_single_insert():
         before = lines[0:insertion_index]
         after = lines[insertion_index : len(lines)]
 
-        with open("test.ert", "w", encoding="utf-8") as f:
-            f.write("\n".join(before) + "\n")
+        Path("test.ert").write_text("\n".join(before) + "\n", encoding="utf-8")
 
         with open("test.ert", "ab") as f:
             f.write(b"\xff")

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import ExitStack as does_not_raise
+from pathlib import Path
 
 import pytest
 from hypothesis import given, strategies
@@ -18,8 +19,7 @@ def test_reading_non_existent_workflow_raises_config_error():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_failure_in_parsing_workflow_gives_config_validation_error():
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write("DEFINE\n")
+    Path("workflow").write_text("DEFINE\n", encoding="utf-8")
     with pytest.raises(
         ConfigValidationError, match=r"DEFINE must have .* arguments"
     ) as err:
@@ -29,8 +29,7 @@ def test_that_failure_in_parsing_workflow_gives_config_validation_error():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_substitution_happens_in_workflow():
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write("JOB <A> <B>\n")
+    Path("workflow").write_text("JOB <A> <B>\n", encoding="utf-8")
 
     job = ExecutableWorkflow(
         executable="echo",
@@ -75,8 +74,7 @@ def get_workflow_job(name):
     )
 )
 def test_that_multiple_workflow_jobs_are_ordered_correctly(order):
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write("\n".join(order))
+    Path("workflow").write_text("\n".join(order), encoding="utf-8")
 
     foo = get_workflow_job("foo")
     bar = get_workflow_job("bar")
@@ -97,19 +95,19 @@ def test_that_multiple_workflow_jobs_are_ordered_correctly(order):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write(
-            "\n".join(
-                [
-                    "DEFINE <A> 1",
-                    "foo <A>",
-                    "bar <A>",
-                    "DEFINE <A> 3",
-                    "foo <A>",
-                    "baz <A>",
-                ]
-            )
-        )
+    Path("workflow").write_text(
+        "\n".join(
+            [
+                "DEFINE <A> 1",
+                "foo <A>",
+                "bar <A>",
+                "DEFINE <A> 3",
+                "foo <A>",
+                "baz <A>",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     foo = get_workflow_job("foo")
     bar = get_workflow_job("bar")
@@ -132,15 +130,15 @@ def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_unknown_jobs_gives_error():
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write(
-            "\n".join(
-                [
-                    "boo <A>",
-                    "kingboo <A>",
-                ]
-            )
-        )
+    Path("workflow").write_text(
+        "\n".join(
+            [
+                "boo <A>",
+                "kingboo <A>",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     with pytest.raises(
         ConfigValidationError, match="Job with name: kingboo is not recognized"
@@ -176,8 +174,7 @@ def test_that_unknown_jobs_gives_error():
 )
 @pytest.mark.parametrize("min_args, max_args", [(1, 2), (None, None)])
 def test_args_validation(config, expectation, min_args, max_args):
-    with open("workflow", "w", encoding="utf-8") as f:
-        f.write(config)
+    Path("workflow").write_text(config, encoding="utf-8")
     if min_args is None and max_args is None:
         expectation = does_not_raise()
     with expectation:

--- a/tests/ert/unit_tests/config/test_workflow_jobs.py
+++ b/tests/ert/unit_tests/config/test_workflow_jobs.py
@@ -20,8 +20,9 @@ def test_that_ert_warns_on_duplicate_workflow_jobs(tmp_path):
     Relies on the internal workflow CAREFUL_COPY_FILE.
     """
     test_workflow_job = tmp_path / "CAREFUL_COPY_FILE"
-    with open(test_workflow_job, "w", encoding="utf-8") as fh:
-        fh.write("EXECUTABLE test_copy_duplicate.py")
+    Path(test_workflow_job).write_text(
+        "EXECUTABLE test_copy_duplicate.py", encoding="utf-8"
+    )
     test_workflow_job_executable = tmp_path / "test_copy_duplicate.py"
     Path(test_workflow_job_executable).touch(mode=0o755)
     test_config_file_name = tmp_path / "test.ert"
@@ -31,8 +32,7 @@ def test_that_ert_warns_on_duplicate_workflow_jobs(tmp_path):
         LOAD_WORKFLOW_JOB CAREFUL_COPY_FILE
         """
     )
-    with open(test_config_file_name, "w", encoding="utf-8") as fh:
-        fh.write(test_config_contents)
+    Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
 
     with (
         pytest.warns(
@@ -45,10 +45,9 @@ def test_that_ert_warns_on_duplicate_workflow_jobs(tmp_path):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_stop_on_fail_is_parsed_external():
-    with open("fail_job", "w+", encoding="utf-8") as f:
-        f.write("EXECUTABLE echo\n")
-        f.write("MIN_ARG 1\n")
-        f.write("STOP_ON_FAIL True\n")
+    Path("fail_job").write_text(
+        "EXECUTABLE echo\nMIN_ARG 1\nSTOP_ON_FAIL True\n", encoding="utf-8"
+    )
 
     job_internal = workflow_job_from_file(
         name="FAIL",

--- a/tests/ert/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/conftest.py
@@ -86,16 +86,16 @@ def make_ensemble(queue_config):
             forward_model_list = []
             for job_index in range(num_jobs):
                 forward_model_exec = Path(tmpdir) / f"ext_{job_index}.py"
-                with open(forward_model_exec, "w", encoding="utf-8") as f:
-                    f.write(
-                        "#!/usr/bin/env python\n"
-                        "import time\n"
-                        "\n"
-                        'if __name__ == "__main__":\n'
-                        f'    print("stdout from {job_index}")\n'
-                        f"    time.sleep({job_sleep})\n"
-                        f"    with open('status.txt', 'a', encoding='utf-8'): pass\n"
-                    )
+                forward_model_exec.write_text(
+                    "#!/usr/bin/env python\n"
+                    "import time\n"
+                    "\n"
+                    'if __name__ == "__main__":\n'
+                    f'    print("stdout from {job_index}")\n'
+                    f"    time.sleep({job_sleep})\n"
+                    f"    with open('status.txt', 'a', encoding='utf-8'): pass\n",
+                    encoding="utf-8",
+                )
                 mode = os.stat(forward_model_exec).st_mode
                 mode |= stat.S_IXUSR | stat.S_IXGRP
                 os.chmod(forward_model_exec, stat.S_IMODE(mode))
@@ -110,10 +110,9 @@ def make_ensemble(queue_config):
             realizations = []
             for iens in range(num_reals):
                 run_path = Path(tmpdir / f"real_{iens}")
-                os.mkdir(run_path)
-
-                with open(run_path / "jobs.json", "w", encoding="utf-8") as f:
-                    json.dump(
+                run_path.mkdir()
+                (run_path / "jobs.json").write_text(
+                    json.dumps(
                         {
                             "jobList": [
                                 _dump_forward_model(forward_model, index)
@@ -122,8 +121,9 @@ def make_ensemble(queue_config):
                                 )
                             ],
                         },
-                        f,
-                    )
+                    ),
+                    encoding="utf-8",
+                )
 
                 realizations.append(
                     ert.ensemble_evaluator.Realization(

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -7,6 +7,7 @@ import os
 import signal
 import stat
 import sys
+from pathlib import Path
 from subprocess import Popen
 from textwrap import dedent
 from threading import Lock
@@ -36,17 +37,17 @@ from tests.ert.utils import MockZMQServer, wait_until
 @pytest.mark.usefixtures("use_tmpdir")
 def test_terminate_steps():
     # Executes itself recursively and sleeps for 100 seconds
-    with open("dummy_executable", "w", encoding="utf-8") as f:
-        f.write(
-            """#!/usr/bin/env python
+    Path("dummy_executable").write_text(
+        """#!/usr/bin/env python
 import sys, os, time
 counter = eval(sys.argv[1])
 if counter > 0:
     os.fork()
     os.execv(sys.argv[0],[sys.argv[0], str(counter - 1) ])
 else:
-    time.sleep(100)"""
-        )
+    time.sleep(100)""",
+        encoding="utf-8",
+    )
 
     executable = os.path.realpath("dummy_executable")
     os.chmod("dummy_executable", stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
@@ -77,22 +78,23 @@ else:
         "ert_pid": "",
     }
 
-    with open(FORWARD_MODEL_DESCRIPTION_FILE, "w", encoding="utf-8") as f:
-        f.write(json.dumps(fm_description))
+    Path(FORWARD_MODEL_DESCRIPTION_FILE).write_text(
+        json.dumps(fm_description), encoding="utf-8"
+    )
 
     # macOS doesn't provide /usr/bin/setsid, so we roll our own
-    with open("setsid", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("setsid").write_text(
+        dedent(
+            """\
             #!/usr/bin/env python
             import os
             import sys
             os.setsid()
             os.execvp(sys.argv[1], sys.argv[1:])
             """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     os.chmod("setsid", 0o755)
 
     # (we wait for the process below)
@@ -124,13 +126,13 @@ def test_memory_profile_is_logged_as_csv(monkeypatch):
     fm_stepname = "do_nothing"
     scriptname = fm_stepname + ".py"
     fm_step_repeats = 3
-    with open(scriptname, "w", encoding="utf-8") as script:
-        script.write(
-            """#!/bin/sh
+    Path(scriptname).write_text(
+        """#!/bin/sh
         sleep 0.5
         exit 0
-        """
-        )
+        """,
+        encoding="utf-8",
+    )
     os.chmod(scriptname, stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
     forward_model_steps = {
         "jobList": [
@@ -143,8 +145,9 @@ def test_memory_profile_is_logged_as_csv(monkeypatch):
         * fm_step_repeats,
     }
 
-    with open(FORWARD_MODEL_DESCRIPTION_FILE, "w", encoding="utf-8") as f:
-        f.write(json.dumps(forward_model_steps))
+    Path(FORWARD_MODEL_DESCRIPTION_FILE).write_text(
+        json.dumps(forward_model_steps), encoding="utf-8"
+    )
 
     monkeypatch.setattr(
         _ert.forward_model_runner.runner.ForwardModelStep, "MEMORY_POLL_PERIOD", 0.1
@@ -161,14 +164,14 @@ def test_memory_profile_is_logged_as_csv(monkeypatch):
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 def test_fm_dispatch_run_subset_specified_as_parameter():
-    with open("dummy_executable", "w", encoding="utf-8") as f:
-        f.write(
-            "#!/usr/bin/env python\n"
-            "import sys, os\n"
-            'filename = "step_{}.out".format(sys.argv[1])\n'
-            'f = open(filename, "w", encoding="utf-8")\n'
-            "f.close()\n"
-        )
+    Path("dummy_executable").write_text(
+        "#!/usr/bin/env python\n"
+        "import sys, os\n"
+        'filename = "step_{}.out".format(sys.argv[1])\n'
+        'f = open(filename, "w", encoding="utf-8")\n'
+        "f.close()\n",
+        encoding="utf-8",
+    )
 
     executable = os.path.realpath("dummy_executable")
     os.chmod("dummy_executable", stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
@@ -233,22 +236,23 @@ def test_fm_dispatch_run_subset_specified_as_parameter():
         "ert_pid": "",
     }
 
-    with open(FORWARD_MODEL_DESCRIPTION_FILE, "w", encoding="utf-8") as f:
-        f.write(json.dumps(fm_description))
+    Path(FORWARD_MODEL_DESCRIPTION_FILE).write_text(
+        json.dumps(fm_description), encoding="utf-8"
+    )
 
     # macOS doesn't provide /usr/bin/setsid, so we roll our own
-    with open("setsid", "w", encoding="utf-8") as f:
-        f.write(
-            dedent(
-                """\
+    Path("setsid").write_text(
+        dedent(
+            """\
             #!/usr/bin/env python
             import os
             import sys
             os.setsid()
             os.execvp(sys.argv[1], sys.argv[1:])
             """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     os.chmod("setsid", 0o755)
 
     # (we wait for the process below)
@@ -414,12 +418,12 @@ def test_report_all_messages_drops_reporter_on_error():
 async def test_fm_dispatch_sends_exited_event_with_terminated_msg_on_sigterm(
     use_tmpdir,
 ):
-    with open("dummy_executable", "w", encoding="utf-8") as f:  # noqa: ASYNC230
-        f.write(
-            """#!/usr/bin/env python
+    Path("dummy_executable").write_text(
+        """#!/usr/bin/env python
 import time
-time.sleep(180)"""
-        )
+time.sleep(180)""",
+        encoding="utf-8",
+    )
 
     executable = os.path.realpath("dummy_executable")
     os.chmod("dummy_executable", stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
@@ -437,22 +441,23 @@ time.sleep(180)"""
             ],
         }
 
-        with open(FORWARD_MODEL_DESCRIPTION_FILE, "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(json.dumps(fm_description))
+        Path(FORWARD_MODEL_DESCRIPTION_FILE).write_text(
+            json.dumps(fm_description), encoding="utf-8"
+        )
 
         # macOS doesn't provide /usr/bin/setsid, so we roll our own
-        with open("setsid", "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(
-                dedent(
-                    """\
+        Path("setsid").write_text(
+            dedent(
+                """\
                 #!/usr/bin/env python
                 import os
                 import sys
                 os.setsid()
                 os.execvp(sys.argv[1], sys.argv[1:])
                 """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
         os.chmod("setsid", 0o755)
 
         fm_dispatch_process = Popen(  # noqa: ASYNC220
@@ -490,12 +495,12 @@ async def test_fm_dispatch_sends_exited_event_with_terminated_msg_on_terminate_m
     tmp_path,
 ):
     os.chdir(tmp_path)
-    with open("dummy_executable", "w", encoding="utf-8") as f:  # noqa: ASYNC230
-        f.write(
-            """#!/usr/bin/env python
+    Path("dummy_executable").write_text(
+        """#!/usr/bin/env python
 import time
-time.sleep(180)"""
-        )
+time.sleep(180)""",
+        encoding="utf-8",
+    )
 
     executable = os.path.realpath("dummy_executable")
     os.chmod("dummy_executable", stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
@@ -513,22 +518,23 @@ time.sleep(180)"""
             ],
         }
 
-        with open(FORWARD_MODEL_DESCRIPTION_FILE, "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(json.dumps(fm_description))
+        Path(FORWARD_MODEL_DESCRIPTION_FILE).write_text(
+            json.dumps(fm_description), encoding="utf-8"
+        )
 
         # macOS doesn't provide /usr/bin/setsid, so we roll our own
-        with open("setsid", "w", encoding="utf-8") as f:  # noqa: ASYNC230
-            f.write(
-                dedent(
-                    """\
+        Path("setsid").write_text(
+            dedent(
+                """\
                 #!/usr/bin/env python
                 import os
                 import sys
                 os.setsid()
                 os.execvp(sys.argv[1], sys.argv[1:])
                 """
-                )
-            )
+            ),
+            encoding="utf-8",
+        )
         os.chmod("setsid", 0o755)
 
         fm_dispatch_process = Popen(  # noqa: ASYNC220

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import stat
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -109,8 +110,7 @@ def test_when_forward_model_contains_multiple_steps_just_one_checksum_status_is_
             "argList": [fm_step_index],
         }
         fm_step_list.append(fm_step)
-    with open("manifest.json", "w", encoding="utf-8") as f:
-        json.dump(manifest, f)
+    Path("manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     fmr = ForwardModelRunner(create_jobs_json(fm_step_list))
 
@@ -134,8 +134,7 @@ def test_when_manifest_file_is_not_created_by_fm_runner_checksum_contains_error(
             "argList": ["not_test"],
         }
     )
-    with open("manifest.json", "w", encoding="utf-8") as f:
-        json.dump(manifest, f)
+    Path("manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     fmr = ForwardModelRunner(create_jobs_json(fm_step_list))
 
@@ -178,16 +177,16 @@ def test_run_multiple_fail_only_runs_one():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_env_var_available_inside_step_context():
-    with open("run_me.py", "w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+    Path("run_me.py").write_text(
+        textwrap.dedent(
+            """\
                 #!/usr/bin/env python
                 import os
                 assert os.environ["TEST_ENV"] == "123"
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     os.chmod("run_me.py", stat.S_IEXEC + stat.S_IREAD)
 
     step = forward_model_step_from_config_contents(
@@ -227,18 +226,18 @@ def test_env_var_available_inside_step_context():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_default_env_variables_available_inside_fm_step_context():
-    with open("run_me.py", "w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """\
+    Path("run_me.py").write_text(
+        textwrap.dedent(
+            """\
                 #!/usr/bin/env python
                 import os
                 assert os.environ["_ERT_ITERATION_NUMBER"] == "0"
                 assert os.environ["_ERT_REALIZATION_NUMBER"] == "0"
                 assert os.environ["_ERT_RUNPATH"] == "./"
                 """
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     os.chmod("run_me.py", stat.S_IEXEC + stat.S_IREAD)
 
     step = forward_model_step_from_config_contents(

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -46,10 +46,9 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
 def test_memory_usage_counts_grandchildren():
     scriptname = "recursive_memory_hog.py"
     blobsize = 1e7
-    with open(scriptname, "w", encoding="utf-8") as script:
-        script.write(
-            textwrap.dedent(
-                """\
+    pathlib.Path(scriptname).write_text(
+        textwrap.dedent(
+            """\
             #!/usr/bin/env python
             import os
             import sys
@@ -73,8 +72,9 @@ def test_memory_usage_counts_grandchildren():
                         ]
                         )
             time.sleep(3)"""  # Too low sleep will make the test faster but flaky
-            )
-        )
+        ),
+        encoding="utf-8",
+    )
     executable = os.path.realpath(scriptname)
     os.chmod(scriptname, stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -1,4 +1,5 @@
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pandas as pd
@@ -133,8 +134,7 @@ def run_dialog(qtbot: QtBot, use_tmpdir, mock_set_env_key, monkeypatch):
     monkeypatch.setattr(
         "ert.ensemble_evaluator.EnsembleEvaluator.BATCHING_INTERVAL", 0.01
     )
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1")
+    Path(config_file).write_text("NUM_REALIZATIONS 1", encoding="utf-8")
     args_mock = Mock()
     args_mock.config = config_file
     ert_config = ErtConfig.from_file(config_file)
@@ -606,8 +606,7 @@ def test_run_dialog_fm_label_show_correct_info(
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_exception_in_run_model_is_handled(qtbot: QtBot, use_tmpdir):
     config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1")
+    Path(config_file).write_text("NUM_REALIZATIONS 1", encoding="utf-8")
     args_mock = Mock()
     args_mock.config = config_file
 

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -74,15 +74,13 @@ def test_symlink():
     with pytest.raises(IOError, match="must exist"):
         symlink("target/does/not/exist", "link")
 
-    with open("target", "w", encoding="utf-8") as fileH:
-        fileH.write("target ...")
+    Path("target").write_text("target ...", encoding="utf-8")
 
     symlink("target", "link")
     assert os.path.islink("link")
     assert os.readlink("link") == "target"
 
-    with open("target2", "w", encoding="utf-8") as fileH:
-        fileH.write("target ...")
+    Path("target2").write_text("target ...", encoding="utf-8")
 
     with pytest.raises(IOError, match="File exists"):
         symlink("target2", "target")
@@ -122,8 +120,7 @@ def test_symlink2():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_mkdir():
-    with open("file", "w", encoding="utf-8") as f:
-        f.write("Hei")
+    Path("file").write_text("Hei", encoding="utf-8")
 
     with pytest.raises(OSError, match="File exists"):
         mkdir("file")
@@ -138,8 +135,7 @@ def test_mkdir():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_move_file():
-    with open("file", "w", encoding="utf-8") as f:
-        f.write("Hei")
+    Path("file").write_text("hei", encoding="utf-8")
 
     move_file("file", "file2")
     assert os.path.isfile("file2")
@@ -159,16 +155,14 @@ def test_move_file():
     with pytest.raises(OSError, match="not an existing file"):
         move_file("not_existing", "target")
 
-    with open("file2", "w", encoding="utf-8") as f:
-        f.write("123")
+    Path("file2").write_text("123", encoding="utf-8")
 
     move_file("file2", "path/file2")
     assert os.path.isfile("path/file2")
     assert not os.path.isfile("file2")
 
     mkdir("rms/ipl")
-    with open("global_variables.ipl", "w", encoding="utf-8") as f:
-        f.write("123")
+    Path("global_variables.ipl").write_text("123", encoding="utf-8")
 
     move_file("global_variables.ipl", "rms/ipl/global_variables.ipl")
 
@@ -286,8 +280,7 @@ def test_that_delete_non_existing_directory_is_silently_ignored(capsys):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_delete_directory_on_regular_file_fails():
-    with open("file", mode="w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("file").write_text("hei", encoding="utf-8")
 
     with pytest.raises(OSError, match="not a directory"):
         delete_directory("file")
@@ -296,15 +289,11 @@ def test_that_delete_directory_on_regular_file_fails():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_delete_directory_does_not_follow_symlinks():
     mkdir("link_target/subpath")
-    with open("link_target/link_file", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("link_target/link_file").write_text("hei", encoding="utf-8")
 
     mkdir("path/subpath")
-    with open("path/file", "w", encoding="utf-8") as f:
-        f.write("hei")
-
-    with open("path/subpath/file", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("path/file").write_text("hei", encoding="utf-8")
+    Path("path/subpath/file").write_text("hei", encoding="utf-8")
 
     symlink("../link_target", "path/link")
     delete_directory("path")
@@ -314,8 +303,7 @@ def test_that_delete_directory_does_not_follow_symlinks():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_delete_directory_on_a_symlink_to_file_fails():
-    with open("link_target", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("link_target").write_text("hei", encoding="utf-8")
     symlink("link_target", "link")
     with pytest.raises(IOError, match="is not a directory"):
         delete_directory("link")
@@ -326,8 +314,7 @@ def test_that_delete_directory_on_a_symlink_to_file_fails():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_delete_directory_on_a_symlink_to_a_directory_only_deletes_link():
     mkdir("link_target")
-    with open("link_target/file", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("link_target/file").write_text("hei", encoding="utf-8")
     symlink("link_target", "link")
     delete_directory("link")
     assert os.path.exists("link_target/file")
@@ -350,8 +337,7 @@ def test_that_delete_directory_on_a_symlink_to_a_directory_is_conditionally_igno
     altered as documented by this test.
     """
     mkdir("link_target")
-    with open("link_target/file", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("link_target/file").write_text("hei", encoding="utf-8")
     symlink("link_target", "link")
 
     with suppress(NotADirectoryError):
@@ -462,8 +448,7 @@ def test_copy_file():
     with pytest.raises(OSError, match="existing file"):
         copy_file("path", "target")
 
-    with open("file1", "w", encoding="utf-8") as f:
-        f.write("hei")
+    Path("file1").write_text("hei", encoding="utf-8")
 
     copy_file("file1", "file2")
     assert os.path.isfile("file2")
@@ -479,14 +464,12 @@ def test_copy_file():
 def test_copy_file2():
     mkdir("root/sub/path")
 
-    with open("file", "w", encoding="utf-8") as f:
-        f.write("Hei ...")
+    Path("file").write_text("Hei ...", encoding="utf-8")
 
     copy_file("file", "root/sub/path/file")
-    assert os.path.isfile("root/sub/path/file")
+    assert Path("root/sub/path/file").read_text(encoding="utf-8") == "Hei ..."
 
-    with open("file2", "w", encoding="utf-8") as f:
-        f.write("Hei ...")
+    Path("file2").write_text("Hei ...", encoding="utf-8")
 
     with pushd("root/sub/path"):
         copy_file("../../../file2")
@@ -497,11 +480,9 @@ def test_copy_file2():
 def test_copy_file3():
     mkdir("rms/output")
 
-    with open("file.txt", "w", encoding="utf-8") as f:
-        f.write("Hei")
-
+    Path("file.txt").write_text("Hei", encoding="utf-8")
     copy_file("file.txt", "rms/output/")
-    assert os.path.isfile("rms/output/file.txt")
+    assert Path("rms/output/file.txt").read_text(encoding="utf-8") == "Hei"
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -522,17 +503,13 @@ def test_copy_when_target_is_none_in_same_directory():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_careful_copy_file():
-    with open("file1", "w", encoding="utf-8") as f:
-        f.write("hei")
-    with open("file2", "w", encoding="utf-8") as f:
-        f.write("hallo")
-
+    Path("file1").write_text("hei", encoding="utf-8")
+    Path("file2").write_text("hallo", encoding="utf-8")
     careful_copy_file("file1", "file2")
-    with open("file2", encoding="utf-8") as f:
-        assert f.readline() == "hallo"
+    assert Path("file2").read_text(encoding="utf-8") == "hallo"
 
     print(careful_copy_file("file1", "file3"))
-    assert os.path.isfile("file3")
+    assert Path("file3").is_file()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -563,8 +540,7 @@ def test_careful_copy_when_target_is_none_does_not_touch_existing():
 @pytest.fixture
 def minimal_case(tmpdir):
     with tmpdir.as_cwd():
-        with open("config.ert", "w", encoding="utf-8") as fout:
-            fout.write("NUM_REALIZATIONS 1")
+        Path("config.ert").write_text("NUM_REALIZATIONS 1", encoding="utf-8")
         yield
 
 

--- a/tests/ert/unit_tests/services/test_base_service.py
+++ b/tests/ert/unit_tests/services/test_base_service.py
@@ -270,21 +270,19 @@ def test_local_exec_args_multi():
 def test_cleanup_service_files(tmpdir):
     with tmpdir.as_cwd():
         storage_service_name = "storage"
-        storage_service_file = f"{storage_service_name}_server.json"
-        with open(storage_service_file, "w", encoding="utf-8") as f:
-            f.write("storage_service info")
-        assert Path(storage_service_file).exists()
+        storage_service_file = Path(f"{storage_service_name}_server.json")
+        storage_service_file.write_text("storage_service info", encoding="utf-8")
+        assert storage_service_file.exists()
         SERVICE_CONF_PATHS.add(tmpdir / storage_service_file)
 
         webviz_service_name = "webviz-ert"
-        webviz_service_file = f"{webviz_service_name}_server.json"
-        with open(webviz_service_file, "w", encoding="utf-8") as f:
-            f.write("webviz-ert info")
-        assert Path(webviz_service_file).exists()
+        webviz_service_file = Path(f"{webviz_service_name}_server.json")
+        webviz_service_file.write_text("webviz-ert info", encoding="utf-8")
+        assert webviz_service_file.exists()
         SERVICE_CONF_PATHS.add(tmpdir / webviz_service_file)
 
         with pytest.raises(OSError):
             cleanup_service_files(signum=99, frame=None)
 
-        assert not Path(storage_service_file).exists()
-        assert not Path(webviz_service_file).exists()
+        assert not storage_service_file.exists()
+        assert not webviz_service_file.exists()

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -174,12 +174,15 @@ def test_load_forward_model_gen_data(setup_case):
 
     prior_ensemble = setup_case(config_text)
     run_path = Path("simulations/realization-0/iter-0/")
-    with open(run_path / "response_0.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "2", "3"]))
-    with open(run_path / "response_1.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["4", "5", "5"]))
-    with open(run_path / "response_0.out_active", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "0", "1"]))
+    (run_path / "response_0.out").write_text(
+        "\n".join(["1", "2", "3"]), encoding="utf-8"
+    )
+    (run_path / "response_1.out").write_text(
+        "\n".join(["4", "5", "5"]), encoding="utf-8"
+    )
+    (run_path / "response_0.out_active").write_text(
+        "\n".join(["1", "0", "1"]), encoding="utf-8"
+    )
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("gen_data", (0,))
@@ -197,10 +200,8 @@ def test_single_valued_gen_data_with_active_info_is_loaded(setup_case):
     prior_ensemble = setup_case(config_text)
 
     run_path = Path("simulations/realization-0/iter-0/")
-    with open(run_path / "response_0.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1"]))
-    with open(run_path / "response_0.out_active", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1"]))
+    (run_path / "response_0.out").write_text("\n".join(["1"]), encoding="utf-8")
+    (run_path / "response_0.out_active").write_text("\n".join(["1"]), encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -217,10 +218,8 @@ def test_that_all_deactivated_values_are_loaded(setup_case):
     prior_ensemble = setup_case(config_text)
 
     run_path = Path("simulations/realization-0/iter-0/")
-    with open(run_path / "response_0.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["-1"]))
-    with open(run_path / "response_0.out_active", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["0"]))
+    (run_path / "response_0.out").write_text("\n".join(["-1"]), encoding="utf-8")
+    (run_path / "response_0.out_active").write_text("\n".join(["0"]), encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     response = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -259,10 +258,10 @@ def test_loading_gen_data_without_restart(storage, run_args):
         runpaths=Runpaths.from_config(ert_config),
     )
     run_path = Path("simulations/realization-0/iter-0/")
-    with open(run_path / "response.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "2", "3"]))
-    with open(run_path / "response.out_active", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "0", "1"]))
+    (run_path / "response.out").write_text("\n".join(["1", "2", "3"]), encoding="utf-8")
+    (run_path / "response.out_active").write_text(
+        "\n".join(["1", "0", "1"]), encoding="utf-8"
+    )
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -331,10 +330,10 @@ def test_loading_from_any_available_iter(storage, run_args, itr):
         runpaths=Runpaths.from_config(ert_config),
     )
     run_path = Path(f"simulations/realization-0/iter-{itr if itr is not None else 0}/")
-    with open(run_path / "response.out", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "2", "3"]))
-    with open(run_path / "response.out_active", "w", encoding="utf-8") as fout:
-        fout.write("\n".join(["1", "0", "1"]))
+    (run_path / "response.out").write_text("\n".join(["1", "2", "3"]), encoding="utf-8")
+    (run_path / "response.out_active").write_text(
+        "\n".join(["1", "0", "1"]), encoding="utf-8"
+    )
 
     run_path_format = str(
         Path(

--- a/tests/ert/unit_tests/workflow_runner/test_ert_script.py
+++ b/tests/ert/unit_tests/workflow_runner/test_ert_script.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -47,24 +48,25 @@ def test_ert_script_from_file():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_script_with_syntax_error_raises_value_error():
-    with open("syntax_error_script.py", "w", encoding="utf-8") as f:
-        f.write("from ert not_legal_syntax ErtScript\n")
+    Path("syntax_error_script.py").write_text(
+        "from ert not_legal_syntax ErtScript\n", encoding="utf-8"
+    )
     with pytest.raises(ValueError, match=r"ErtScript .*.py contains syntax error"):
         _ = ErtScript.loadScriptFromFile("syntax_error_script.py")
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_script_with_import_error_raises_value_error():
-    with open("import_error_script.py", "w", encoding="utf-8") as f:
-        f.write("from ert import DoesNotExist\n")
+    Path("import_error_script.py").write_text(
+        "from ert import DoesNotExist\n", encoding="utf-8"
+    )
     with pytest.raises(ValueError, match="cannot import name 'DoesNotExist'"):
         _ = ErtScript.loadScriptFromFile("import_error_script.py")
 
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_empty_ert_script_raises_value_error():
-    with open("empty_script.py", "w", encoding="utf-8") as f:
-        f.write("from ert import ErtScript\n")
+    Path("empty_script.py").write_text("from ert import ErtScript\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="does not contain an ErtScript"):
         _ = ErtScript.loadScriptFromFile("empty_script.py")

--- a/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
+++ b/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
@@ -114,8 +114,7 @@ def test_run_internal_script():
 @pytest.mark.filterwarnings("ignore:.*Deprecated keywords, SCRIPT and INTERNAL")
 def test_deprecated_keywords(config, expected_result, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    with open("test_job", "w", encoding="utf-8") as f:
-        f.write("\n".join(config))
+    Path("test_job").write_text("\n".join(config), encoding="utf-8")
     Path("script.py").write_text(
         dedent("""
     from ert import ErtScript
@@ -330,8 +329,7 @@ def test_workflow_stops_with_stopping_job():
     with open("dump_failing_job", "a", encoding="utf-8") as f:
         f.write("STOP_ON_FAIL True")
 
-    with open("dump_failing_workflow", "w", encoding="utf-8") as f:
-        f.write("DUMP")
+    Path("dump_failing_workflow").write_text("DUMP", encoding="utf-8")
 
     job_failing_dump = workflow_job_from_file("dump_failing_job")
     assert job_failing_dump.stop_on_fail

--- a/tests/ert/unit_tests/workflow_runner/workflow_common.py
+++ b/tests/ert/unit_tests/workflow_runner/workflow_common.py
@@ -1,32 +1,34 @@
 import os
 import stat
+from pathlib import Path
 
 
 class WorkflowCommon:
     @staticmethod
     def createExternalDumpJob():
-        with open("dump_job", "w", encoding="utf-8") as f:
-            f.write("EXECUTABLE dump.py\n")
-            f.write("MIN_ARG 2\n")
-            f.write("MAX_ARG 2\n")
-            f.write("ARG_TYPE 0 STRING\n")
+        Path("dump_job").write_text(
+            "EXECUTABLE dump.py\nMIN_ARG 2\nMAX_ARG 2\nARG_TYPE 0 STRING\n",
+            encoding="utf-8",
+        )
 
-        with open("dump_failing_job", "w", encoding="utf-8") as f:
-            f.write("EXECUTABLE dump_failing.py\n")
+        Path("dump_failing_job").write_text(
+            "EXECUTABLE dump_failing.py\n", encoding="utf-8"
+        )
 
-        with open("dump.py", "w", encoding="utf-8") as f:
-            f.write("#!/usr/bin/env python\n")
-            f.write("import sys\n")
-            f.write("f = open('%s' % sys.argv[1], 'w')\n")
-            f.write("f.write('%s' % sys.argv[2])\n")
-            f.write("f.close()\n")
-            f.write('print("Hello World")')
+        Path("dump.py").write_text(
+            "#!/usr/bin/env python\n"
+            "import sys\n"
+            "f = open('%s' % sys.argv[1], 'w')\n"
+            "f.write('%s' % sys.argv[2])\n"
+            "f.close()\n"
+            'print("Hello World")',
+            encoding="utf-8",
+        )
 
-        with open("dump_failing.py", "w", encoding="utf-8") as f:
-            f.write("#!/usr/bin/env python\n")
-            f.write('print("Hello Failing")\n')
-            f.write("raise Exception")
-
+        Path("dump_failing.py").write_text(
+            '#!/usr/bin/env python\nprint("Hello Failing")\nraise Exception',
+            encoding="utf-8",
+        )
         st = os.stat("dump.py")
         os.chmod(
             "dump.py", st.st_mode | stat.S_IEXEC
@@ -34,84 +36,93 @@ class WorkflowCommon:
         st = os.stat("dump_failing.py")
         os.chmod("dump_failing.py", st.st_mode | stat.S_IEXEC)
 
-        with open("dump_workflow", "w", encoding="utf-8") as f:
-            f.write("DUMP dump1 dump_text_1\n")
-            f.write("DUMP dump2 dump_<PARAM>_2\n")
+        Path("dump_workflow").write_text(
+            "DUMP dump1 dump_text_1\nDUMP dump2 dump_<PARAM>_2\n", encoding="utf-8"
+        )
 
     @staticmethod
     def createErtScriptsJob():
-        with open("subtract_script.py", "w", encoding="utf-8") as f:
-            f.write("from ert import ErtScript\n")
-            f.write("class SubtractScript(ErtScript):\n")
-            f.write("    def run(self, *argv):\n")
-            f.write("        return argv[0] - argv[1]\n")
+        Path("subtract_script.py").write_text(
+            "from ert import ErtScript\n"
+            "class SubtractScript(ErtScript):\n"
+            "    def run(self, *argv):\n"
+            "        return argv[0] - argv[1]\n",
+            encoding="utf-8",
+        )
 
-        with open("subtract_script_job", "w", encoding="utf-8") as f:
-            f.write("INTERNAL True\n")
-            f.write("SCRIPT subtract_script.py\n")
-            f.write("MIN_ARG 2\n")
-            f.write("MAX_ARG 2\n")
-            f.write("ARG_TYPE 0 FLOAT\n")
-            f.write("ARG_TYPE 1 FLOAT\n")
+        Path("subtract_script_job").write_text(
+            "INTERNAL True\n"
+            "SCRIPT subtract_script.py\n"
+            "MIN_ARG 2\n"
+            "MAX_ARG 2\n"
+            "ARG_TYPE 0 FLOAT\n"
+            "ARG_TYPE 1 FLOAT\n",
+            encoding="utf-8",
+        )
 
     @staticmethod
     def createWaitJob():
-        with open("wait_job.py", "w", encoding="utf-8") as f:
-            f.write("from ert import ErtScript\n")
-            f.write("import time\n")
-            f.write("\n")
-            f.write("class WaitScript(ErtScript):\n")
-            f.write("    def dump(self, filename, content):\n")
-            f.write("        with open(filename, 'w') as f:\n")
-            f.write("            f.write(content)\n")
-            f.write("\n")
-            f.write("    def run(self, *argv):\n")
-            f.write("        number, wait_time = argv\n")
-            f.write("        self.dump('wait_started_%d' % number, 'text')\n")
-            f.write("        start = time.time()\n")
-            f.write("        diff = 0\n")
-            f.write("        while not self.isCancelled() and diff < wait_time: \n")
-            f.write("           time.sleep(0.2)\n")
-            f.write("           diff = time.time() - start\n")
-            f.write("\n")
-            f.write("        if self.isCancelled():\n")
-            f.write("            self.dump('wait_cancelled_%d' % number, 'text')\n")
-            f.write("        else:\n")
-            f.write("            self.dump('wait_finished_%d' % number, 'text')\n")
-            f.write("\n")
-            f.write("        return None\n")
+        Path("wait_job.py").write_text(
+            "import time\n"
+            "from pathlib import Path\n"
+            "\n"
+            "from ert import ErtScript\n"
+            "\n"
+            "class WaitScript(ErtScript):\n"
+            "    def dump(self, filename, content):\n"
+            "        Path(filename).write_text(content, encoding='utf-8')\n"
+            "\n"
+            "    def run(self, *argv):\n"
+            "        number, wait_time = argv\n"
+            "        self.dump('wait_started_%d' % number, 'text')\n"
+            "        start = time.time()\n"
+            "        diff = 0\n"
+            "        while not self.isCancelled() and diff < wait_time: \n"
+            "           time.sleep(0.2)\n"
+            "           diff = time.time() - start\n"
+            "        if self.isCancelled():\n"
+            "            self.dump('wait_cancelled_%d' % number, 'text')\n"
+            "        else:\n"
+            "            self.dump('wait_finished_%d' % number, 'text')\n"
+            "        return None\n",
+            encoding="utf-8",
+        )
 
-        with open("external_wait_job.sh", "w", encoding="utf-8") as f:
-            f.write("#!/usr/bin/env bash\n")
-            f.write('echo "text" > wait_started_$1\n')
-            f.write("sleep $2\n")
-            f.write('echo "text" > wait_finished_$1\n')
+        Path("external_wait_job.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            'echo "text" > wait_started_$1\n'
+            "sleep $2\n"
+            'echo "text" > wait_finished_$1\n',
+            encoding="utf-8",
+        )
 
         st = os.stat("external_wait_job.sh")
         os.chmod(
             "external_wait_job.sh", st.st_mode | stat.S_IEXEC
         )  # | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 
-        with open("wait_job", "w", encoding="utf-8") as f:
-            f.write("INTERNAL True\n")
-            f.write("SCRIPT wait_job.py\n")
-            f.write("MIN_ARG 2\n")
-            f.write("MAX_ARG 2\n")
-            f.write("ARG_TYPE 0 INT\n")
-            f.write("ARG_TYPE 1 INT\n")
+        Path("wait_job").write_text(
+            "INTERNAL True\n"
+            "SCRIPT wait_job.py\n"
+            "MIN_ARG 2\n"
+            "MAX_ARG 2\n"
+            "ARG_TYPE 0 INT\n"
+            "ARG_TYPE 1 INT\n",
+            encoding="utf-8",
+        )
 
-        with open("external_wait_job", "w", encoding="utf-8") as f:
-            f.write("EXECUTABLE external_wait_job.sh\n")
-            f.write("MIN_ARG 2\n")
-            f.write("MAX_ARG 2\n")
-            f.write("ARG_TYPE 0 INT\n")
-            f.write("ARG_TYPE 1 INT\n")
+        Path("external_wait_job").write_text(
+            "EXECUTABLE external_wait_job.sh\n"
+            "MIN_ARG 2\n"
+            "MAX_ARG 2\n"
+            "ARG_TYPE 0 INT\n"
+            "ARG_TYPE 1 INT\n",
+            encoding="utf-8",
+        )
 
-        with open("wait_workflow", "w", encoding="utf-8") as f:
-            f.write("WAIT 0 1\n")
-            f.write("WAIT 1 10\n")
-            f.write("WAIT 2 1\n")
-
-        with open("fast_wait_workflow", "w", encoding="utf-8") as f:
-            f.write("WAIT 0 1\n")
-            f.write("EXTERNAL_WAIT 1 1\n")
+        Path("wait_workflow").write_text(
+            "WAIT 0 1\nWAIT 1 10\nWAIT 2 1\n", encoding="utf-8"
+        )
+        Path("fast_wait_workflow").write_text(
+            "WAIT 0 1\nEXTERNAL_WAIT 1 1\n", encoding="utf-8"
+        )

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -486,9 +486,8 @@ def test_that_install_data_allows_runpath_root_as_target(
     target, link, change_to_tmpdir
 ):
     data = {"source": "relative/path_<GEO_ID>", "target": target, "link": link}
-    os.makedirs("config_dir/relative/path_0")
-    with open("config_dir/test.yml", "w", encoding="utf-8") as f:
-        f.write(" ")
+    Path("config_dir/relative/path_0").mkdir(parents=True)
+    Path("config_dir/test.yml").write_text(" ", encoding="utf-8")
     config = EverestConfig.with_defaults(
         install_data=[data],
         config_path=Path("config_dir/test.yml"),
@@ -577,9 +576,8 @@ def test_that_install_data_source_exists(change_to_tmpdir):
         "source": "relative/path",
         "target": "xxx",
     }
-    os.makedirs("config_dir")
-    with open("config_dir/test.yml", "w", encoding="utf-8") as f:
-        f.write(" ")
+    Path("config_dir").mkdir()
+    Path("config_dir/test.yml").write_text(" ", encoding="utf-8")
 
     with pytest.raises(ValueError, match="No such file or directory"):
         EverestConfig.with_defaults(
@@ -587,7 +585,7 @@ def test_that_install_data_source_exists(change_to_tmpdir):
             config_path=Path("config_dir/test.yml"),
         )
 
-    os.makedirs("config_dir/relative/path")
+    Path("config_dir/relative/path").mkdir(parents=True)
     EverestConfig.with_defaults(
         install_data=[data],
         config_path=Path("config_dir/test.yml"),
@@ -637,9 +635,8 @@ def test_that_install_data_with_inline_data_generates_a_file(
 def test_that_non_existing_install_job_errors_deprecated(
     install_keyword, change_to_tmpdir
 ):
-    os.makedirs("config_dir")
-    with open("config_dir/test.yml", "w", encoding="utf-8") as f:
-        f.write(" ")
+    Path("config_dir").mkdir()
+    Path("config_dir/test.yml").write_text(" ", encoding="utf-8")
     with pytest.warns(
         ConfigWarning, match=f"`{install_keyword}: source` is deprecated"
     ):
@@ -944,9 +941,8 @@ def test_that_install_templates_must_have_unique_names(change_to_tmpdir):
 
 
 def test_that_install_template_template_must_be_existing_file(change_to_tmpdir):
-    os.makedirs("config_dir")
-    with open("config_dir/test.yml", "w", encoding="utf-8") as f:
-        f.write(" ")
+    Path("config_dir").mkdir()
+    Path("config_dir/test.yml").write_text(" ", encoding="utf-8")
     with pytest.raises(ValueError, match=r"No.*file.*hello.*No.*file.*hey"):
         EverestConfig.with_defaults(
             install_templates=[
@@ -1028,8 +1024,7 @@ def test_load_file_with_errors(capsys):
     -   name: distance
 """)
 
-    with open("config_minimal_error.yml", "w", encoding="utf-8") as file:
-        file.write(content)
+    Path("config_minimal_error.yml").write_text(content, encoding="utf-8")
 
     with pytest.raises(SystemExit):
         parser = ArgumentParser(prog="test")

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -357,17 +357,17 @@ async def test_starting_not_in_folder(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PATH", f".:{os.environ['PATH']}")
     everserver_path = Path("everserver")
-    with open(everserver_path, "w", encoding="utf-8") as file:  # noqa: ASYNC230
-        file.write(
-            """#!/usr/bin/env python
+    everserver_path.write_text(
+        """#!/usr/bin/env python
 import sys
 from pathlib import Path
 if __name__ == "__main__":
     config_path = sys.argv[2]
     if not Path(config_path).exists():
         raise ValueError(f"config_path ({config_path}) does not exist")
-"""
-        )
+""",
+        encoding="utf-8",
+    )
     everserver_path.chmod(everserver_path.stat().st_mode | stat.S_IEXEC)
     makedirs_if_needed(everest_config.output_dir, roll_if_exists=True)
     driver = await start_server(everest_config, logging_level=logging.DEBUG)

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -70,8 +70,7 @@ template_render = import_from_location(
 
 def test_render_invalid(change_to_tmpdir):
     template_file = "well_drill_info.tmpl"
-    with open(template_file, "w", encoding="utf-8") as fp:
-        fp.write(WELL_DRILL_TMPL)
+    Path(template_file).write_text(WELL_DRILL_TMPL, encoding="utf-8")
 
     render = template_render.render_template
 
@@ -100,8 +99,7 @@ def test_render_invalid(change_to_tmpdir):
 
 def test_render(change_to_tmpdir):
     template_file = "well_drill_info.tmpl"
-    with open(template_file, "w", encoding="utf-8") as fp:
-        fp.write(WELL_DRILL_TMPL)
+    Path(template_file).write_text(WELL_DRILL_TMPL, encoding="utf-8")
 
     render = template_render.render_template
 
@@ -134,8 +132,7 @@ def test_render(change_to_tmpdir):
 
 def test_render_multiple_input(change_to_tmpdir):
     template_file = "dual_input.tmpl"
-    with open(template_file, "w", encoding="utf-8") as fp:
-        fp.write(DUAL_INPUT_TMPL)
+    Path(template_file).write_text(DUAL_INPUT_TMPL, encoding="utf-8")
 
     render = template_render.render_template
 
@@ -152,22 +149,16 @@ def test_render_multiple_input(change_to_tmpdir):
     wells_out = "sub_folder/wells.out"
     render((wells_north_in, wells_south_in), template_file, wells_out)
 
-    with open(wells_out, encoding="utf-8") as fin:
-        output = fin.readlines()
-
-    assert output == ["0.2 vs 0.8"]
+    assert Path(wells_out).read_text(encoding="utf-8").splitlines() == ["0.2 vs 0.8"]
 
 
 @pytest.mark.integration_test
 def test_install_template(change_to_tmpdir):
-    with open("config.yml", "w", encoding="utf-8") as fp:
-        YAML(typ="safe", pure=True).dump(CONFIG, fp)
-    template_file = "well_drill_info.tmpl"
-    with open(template_file, "w", encoding="utf-8") as fp:
-        fp.write(WELL_DRILL_TMPL)
-    template_file = "the_optimal_template.tmpl"
-    with open(template_file, "w", encoding="utf-8") as fp:
-        fp.write(THE_OPTIMAL_TEMPLATE_TMPL)
+    YAML(typ="safe", pure=True).dump(CONFIG, Path("config.yml"))
+    Path("well_drill_info.tmpl").write_text(WELL_DRILL_TMPL, encoding="utf-8")
+    Path("the_optimal_template.tmpl").write_text(
+        THE_OPTIMAL_TEMPLATE_TMPL, encoding="utf-8"
+    )
     config = EverestConfig.load_file("config.yml")
     with ErtPluginContext() as runtime_plugins:
         run_model = EverestRunModel.create(config, runtime_plugins=runtime_plugins)
@@ -189,8 +180,7 @@ def test_well_order_template(change_to_tmpdir):
     }
 
     data_file = "well_order.json"
-    with open(data_file, "w", encoding="utf-8") as fout:
-        json.dump(well_order, fout)
+    Path(data_file).write_text(json.dumps(well_order), encoding="utf-8")
 
     output_file = "well_order_list.json"
     template_render.render_template(
@@ -199,8 +189,7 @@ def test_well_order_template(change_to_tmpdir):
         output_file,
     )
 
-    with open(output_file, encoding="utf-8") as fin:
-        order = json.load(fin)
+    order = json.loads(Path(output_file).read_text(encoding="utf-8"))
 
     assert len(well_order) == len(order)
     for idx in range(len(order) - 1):
@@ -221,13 +210,14 @@ def test_user_specified_data_n_template(copy_math_func_test_data_to_tmp, test):
 
     # Write out some constants to a yaml file; doing it here, so config
     # test (TestRepoConfigs) doesn't try to lint this yaml file.
-    yaml = YAML(typ="safe", pure=True)
-    with open("my_constants.yml", "w", encoding="utf-8") as f:
-        yaml.dump({"CONST1": "VALUE1", "CONST2": "VALUE2"}, f)
+    YAML(typ="safe", pure=True).dump(
+        {"CONST1": "VALUE1", "CONST2": "VALUE2"}, Path("my_constants.yml")
+    )
 
     # Write out the template to which takes the constants above
-    with open("my_constants.tmpl", "w", encoding="utf-8") as f:
-        f.write("{{ my_constants.CONST1 }}+{{ my_constants.CONST2 }}")
+    Path("my_constants.tmpl").write_text(
+        "{{ my_constants.CONST1 }}+{{ my_constants.CONST2 }}", encoding="utf-8"
+    )
 
     # Modify the minimal config with template and constants
     updated_config_dict = config.to_dict()

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -22,20 +22,19 @@ EIGHTCELLS_DATA = relpath(
 
 
 def test_get_values(change_to_tmpdir):
-    exp_dir = "the_config_directory"
+    exp_dir = Path("the_config_directory")
     exp_file = "the_config_file"
     rel_out_dir = "the_output_directory"
     abs_out_dir = "/the_output_directory"
-    os.makedirs(exp_dir)
-    with open(os.path.join(exp_dir, exp_file), "w", encoding="utf-8") as f:
-        f.write(" ")
+    exp_dir.mkdir()
+    (exp_dir / exp_file).write_text(" ", encoding="utf-8")
 
     config = EverestConfig.with_defaults(
         environment={
             "output_folder": abs_out_dir,
             "simulation_folder": "simulation_folder",
         },
-        config_path=Path(os.path.join(exp_dir, exp_file)),
+        config_path=exp_dir / exp_file,
     )
 
     config.environment.output_folder = rel_out_dir
@@ -109,8 +108,7 @@ def test_get_everserver_status_path():
     return_value={"status": ExperimentState.failed, "message": "mock error"},
 )
 def test_report_on_previous_run(_, change_to_tmpdir):
-    with open("config_file", "w", encoding="utf-8") as f:
-        f.write(" ")
+    Path("config_file").write_text(" ", encoding="utf-8")
     config = EverestConfig.with_defaults(config_path="config_file")
     with capture_streams() as (out, _):
         report_on_previous_run(


### PR DESCRIPTION
Solves and enforces ruff rule FURB103

`$ ruff rule FURB103
`
Derived from the **refurb** linter.

This rule is in preview and is not stable. The `--preview` flag is required for use.

Checks for uses of `open` and `write` that can be replaced by `pathlib` methods, like `Path.write_text` and `Path.write_bytes`.

When writing a single string to a file, it's simpler and more concise to use `pathlib` methods like `Path.write_text` and `Path.write_bytes` instead of `open` and `write` calls via `with` statements.

**Issue**
Resolves ruff rule FURB103


**Approach**
`nvim` registers

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
