### PR TITLE
Skip recreating ensemble directory in storage

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -946,7 +946,7 @@ class LocalEnsemble(BaseMode):
             )
 
         output_path = self._realization_dir(realization)
-        Path.mkdir(output_path, parents=True, exist_ok=True)
+        Path(output_path).mkdir(exist_ok=True)
 
         self._storage._to_parquet_transaction(
             output_path / f"{response_type}.parquet", data


### PR DESCRIPTION
When writing errors.json (or responses) we should not recreate the ensemble directory in storage if it does not exist. Then the user has probably deleted it manually while Ert is running, and whatever happens is undefined behaviour.

**Issue**
Resolves #12025

**Approach**
Restrict the `mkdir`.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
