### PR TITLE
Solve test failure when interacting with plugins

### DIFF
--- a/tests/everest/test_everest_initialization.py
+++ b/tests/everest/test_everest_initialization.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -18,15 +16,6 @@ def test_no_config_init():
 
 
 def test_site_config_with_substitutions(monkeypatch, change_to_tmpdir):
-    # set up siteconfig
-    test_site_config = Path("test_site_config.ert")
-    test_site_config.write_text(
-        dedent("""
-        SETENV HOW_MANY_CPU <NUM_CPU>
-        """),
-        encoding="utf-8",
-    )
-
     def runtime_plugins_with_cpu_override(**kwargs):
         return ErtRuntimePlugins(
             **(


### PR DESCRIPTION
**Issue**
Resolves 
```
FAILED tests/everest/test_everest_initialization.py::test_site_config_with_substitutions - pydantic_core._pydantic_core.ValidationError: 1 validation error for ErtRuntimePlugins
queue_options
  Input tag '<MagicMock name='ErtRuntimePlugins.model_validate().queue_options.name' id='139649766029776'>' found using 'name' does not match any of the expected tags: <QueueSystem.LSF: 'lsf'>, <QueueSystem.TORQUE: 'torque'>, <QueueSystem.SLURM: 'slurm'>, <QueueSystem.LOCAL: 'local'> [type=union_tag_invalid, input_value=<MagicMock name='ErtRunti...s' id='139648873380496'>, input_type=MagicMock]

```
**Approach**
Avoid queue_options

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
