### PR TITLE
Reverse zorder in ensemble plot

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -38,7 +38,7 @@ class EnsemblePlot:
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.DATE_AXIS
         draw_style = "steps-pre" if is_rate(plot_context.key()) else None
-
+        zorder = 0
         for ensemble, data in ensemble_to_data_map.items():
             data = data.T
 
@@ -53,7 +53,9 @@ class EnsemblePlot:
                     data,
                     f"{ensemble.experiment_name} : {ensemble.name}",
                     draw_style,
+                    zorder=zorder,
                 )
+                zorder -= 1
                 config.nextColor()
 
         plotObservations(observation_data, plot_context, axes)
@@ -75,6 +77,7 @@ class EnsemblePlot:
         data: pd.DataFrame,
         ensemble_label: str,
         draw_style: str | None = None,
+        zorder: float = 1,
     ) -> None:
         style = plot_config.defaultStyle()
 
@@ -91,6 +94,7 @@ class EnsemblePlot:
             linestyle=style.line_style,
             markersize=style.size,
             drawstyle=draw_style,
+            zorder=zorder,
         )
 
         if len(lines) > 0:


### PR DESCRIPTION
In commit c580f1dd0c00a1050a6838500980607f304ad930 reversed chronologically sorting of ensembles was added in the  EnsembleSelectionWidget. This affected the drawing order of iterations, making the newer iterations hide the older iterations when using the default sorting order. This commit remedies this by reversing the zorder of plots, so that the first ensembles in the selection list will be drawn on top of the later ensembles.

Before this commit:
<img width="1498" height="825" alt="image" src="https://github.com/user-attachments/assets/f6b3b3f9-53a8-4dfd-b082-88cccdde21e4" />

With this commit:
<img width="1497" height="823" alt="image" src="https://github.com/user-attachments/assets/7943ac49-9e56-4f4b-b2a5-eeb262d1b76b" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
