### PR TITLE
Make ISO timestamps safe for filenames

### DIFF
--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -19,6 +19,7 @@ from _ert.forward_model_runner.reporting.message import (
     ProcessTreeStatus,
 )
 from _ert.forward_model_runner.runner import ForwardModelRunner
+from _ert.utils import file_safe_timestamp
 
 if TYPE_CHECKING:
     from ert.config.forward_model_step import ForwardModelJSON
@@ -81,10 +82,10 @@ def _setup_logging(directory: str = "logs") -> None:
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    filename = (
-        f"forward-model-runner-log-{datetime.now().isoformat(timespec='minutes')}.txt"
-    )
-    csv_filename = f"memory-profile-{datetime.now().isoformat(timespec='minutes')}.csv"
+    timestamp = file_safe_timestamp(datetime.now().isoformat(timespec="minutes"))
+
+    filename = f"forward-model-runner-log-{timestamp}.txt"
+    csv_filename = f"memory-profile-{timestamp}.csv"
 
     handler = logging.FileHandler(filename=directory + "/" + filename)
     handler.setFormatter(formatter)

--- a/src/_ert/utils.py
+++ b/src/_ert/utils.py
@@ -1,0 +1,12 @@
+def file_safe_timestamp(timestamp: str) -> str:
+    """
+    Convert an ISO timestamp string to a file-safe version
+
+    Keeps the date in the extended format (YYYY-MM-DD) and converts the time
+    to the basic format (HHMMSS) by removing colons. This mix is not strictly
+    ISO 8601 compliant, but it can still be parsed.
+
+    Example:
+    2025-10-10T14:30:00 -> 2025-10-10T143000
+    """
+    return str(timestamp).replace(":", "")

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
+from _ert.utils import file_safe_timestamp
+
 LOGGING_CONFIG = pathlib.Path(__file__).parent.resolve() / "logger.conf"
 STORAGE_LOG_CONFIG = pathlib.Path(__file__).parent.resolve() / "storage_log.conf"
 
@@ -34,7 +36,8 @@ _FORMATS = _FORMATS_ANSI if os.isatty(sys.stderr.fileno()) else _FORMATS_NO_COLO
 
 class TimestampedFileHandler(logging.FileHandler):
     def __init__(self, filename: str, *args: Any, **kwargs: Any) -> None:
-        timestamp = f"{datetime.now().isoformat(timespec='minutes')}"
+        timestamp = file_safe_timestamp(datetime.now().isoformat(timespec="minutes"))
+
         filename, extension = os.path.splitext(filename)
 
         if "config_filename" in kwargs:

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from _ert.utils import file_safe_timestamp
 from ert.config import (
     ExtParamConfig,
     Field,
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 def _backup_if_existing(path: Path) -> None:
     if not path.exists():
         return
-    timestamp = datetime.now(UTC).isoformat(timespec="seconds")
+    timestamp = file_safe_timestamp(datetime.now(UTC).isoformat(timespec="seconds"))
     new_path = path.parent / f"{path.name}_backup_{timestamp}"
     path.rename(new_path)
 

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -8,6 +8,7 @@ try:
     from ert.shared.version import version as ert_version
 except ImportError:
     ert_version = "0.0.0"
+from _ert.utils import file_safe_timestamp
 from everest.strings import EVEREST
 
 
@@ -37,6 +38,7 @@ def warn_user_that_runpath_is_nonempty() -> None:
 
 def _roll_dir(old_name: str) -> None:
     old_name = os.path.realpath(old_name)
-    new_name = f"{old_name}__{datetime.now(UTC).isoformat()}"
+    timestamp = file_safe_timestamp(datetime.now(UTC).isoformat())
+    new_name = f"{old_name}__{timestamp}"
     os.rename(old_name, new_name)
     logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")


### PR DESCRIPTION
**Issue**
Resolves [#12016](https://github.com/equinor/ert/issues/12016)


**Approach**  
Create `file_safe_timestamp` function to make ISO timestamps safe for filenames by replacing ":".


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
