### PR TITLE
Fix file removal delay

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -299,9 +299,7 @@ class LocalStorage(BaseMode):
 
     def _release_lock(self) -> None:
         self._lock.release()
-
-        if (self.path / "storage.lock").exists():
-            (self.path / "storage.lock").unlink()
+        (self.path / "storage.lock").unlink(missing_ok=True)
 
     @require_write
     def create_experiment(


### PR DESCRIPTION
**Issue**
Resolves [#12041](https://github.com/equinor/ert/issues/12041)

**Approach**
Safely remove storage.lock to prevent errors.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
