### PR TITLE
Increase waiting time in screenshot tests

### DIFF
--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -124,7 +124,7 @@ def run_experiment(qtbot, experiment_mode, gui, click_done=True):
         # The Run dialog opens, click show details and wait until done appears
         # then click it
         run_dialog = wait_for_child(gui, qtbot, RunDialog, timeout=10000)
-        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=200000)
+        qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=600000)
         qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
         # Assert that the number of boxes in the detailed view is


### PR DESCRIPTION
Increase waiting time in screenshot tests to avoid timeout during CI runs 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
