### PR TITLE
Remove custom escaping for fmstep args

### DIFF
--- a/src/ert/config/forward_model_step.py
+++ b/src/ert/config/forward_model_step.py
@@ -185,13 +185,6 @@ class ForwardModelStep:
             )
 
     def __post_init__(self) -> None:
-        # We unescape backslash here to keep backwards compatability ie. If
-        # the arglist contains a '\n' we interpret it as a newline.
-        self.arglist = [
-            s.encode("utf-8", "backslashreplace").decode("unicode_escape")
-            for s in self.arglist
-        ]
-
         self.environment.update(ForwardModelStep.default_env)
 
         if self.stdout_file is None:

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -192,7 +192,7 @@ def test_forward_model_arglist_with_weird_characters():
     assert forward_model.environment == forward_model.default_env
     assert forward_model.arglist == [
         "-i",
-        "s/^RUNSPEC.*/|RUNSPEC\nNOSIM/",
+        "s/^RUNSPEC.*/|RUNSPEC\\nNOSIM/",
         "<ECLBASE>.DATA",
     ]
 


### PR DESCRIPTION
Likely not needed? Goes in with https://github.com/equinor/semeio/pull/786