### PR TITLE
Const parameters will be marked as not updatable

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -121,7 +121,7 @@ class GenKwConfig(ParameterConfig):
         gen_kw_key = cast(str, config_list[0])
 
         options = cast(dict[str, str], config_list[-1])
-        positional_args = cast(list[str], config_list[:-1])
+        positional_args = cast(list[str | list[str]], config_list[:-1])
         errors = []
         update_parameter = str_to_bool(options.get("UPDATE", "TRUE"))
         if _get_abs_path(options.get("INIT_FILES")):
@@ -186,7 +186,7 @@ class GenKwConfig(ParameterConfig):
                         params[0], params[1], params[2:]
                     ),
                     forward_init=False,
-                    update=update_parameter,
+                    update="CONST" not in params and update_parameter,
                 )
                 for params in distributions_spec
             ]

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -791,3 +791,23 @@ def test_genkw_raises_config_validation_error_from_pydantic_validation_error_giv
     ]
     with pytest.raises(ConfigValidationError):
         GenKwConfig.from_config_list(config_list)
+
+
+def test_that_const_keyword_sets_update_to_false(tmpdir):
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        JOBNAME my_name%d
+        NUM_REALIZATIONS 1
+        GEN_KW CONST_TEST prior.txt UPDATE:TRUE
+        """
+        )
+        with open("config.ert", "w", encoding="utf-8") as fh:
+            fh.writelines(config)
+        with open("prior.txt", "w", encoding="utf-8") as fh:
+            fh.writelines("CONST_TEST CONST 1")
+
+        ert_config = ErtConfig.from_file("config.ert")
+
+        gen_kw_config = ert_config.ensemble_config.parameter_configs["CONST_TEST"]
+        assert gen_kw_config.update is False


### PR DESCRIPTION
**Issue**
Resolves #7074 


**Approach**
Force update to be false for const parameters 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
