### PR TITLE
Use QtAgg for matplotlib instead of Qt5Agg

### DIFF
--- a/src/ert/gui/__init__.py
+++ b/src/ert/gui/__init__.py
@@ -15,7 +15,7 @@ def headless() -> bool:
 if headless():
     mpl.use("Agg")
 else:
-    mpl.use("Qt5Agg")
+    mpl.use("QtAgg")
 
 
 def is_high_contrast_mode() -> bool:


### PR DESCRIPTION
Using Qt5Agg is discouraged. QtAgg should be able to select among available Qt versions automatically 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
