### PR TITLE
Adjust comments on ExceptionGroup handling

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -519,7 +519,7 @@ class EverestConfig(BaseModelWithContextSupport):
                         "The auto_scale option in the optimization section and the "
                         f"scale options in the {key} section are mutually exclusive."
                     )
-            if len(errors) > 0:
+            if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
                 raise ValueError(errors)
         return self
 
@@ -569,7 +569,7 @@ class EverestConfig(BaseModelWithContextSupport):
             if job_name not in installed_jobs_name:
                 errors.append(f"unknown job {job_name}")
 
-        if len(errors) > 0:  # Note: python3.11 ExceptionGroup will solve this nicely
+        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
             raise ValueError(errors)
         return self
 
@@ -648,7 +648,7 @@ class EverestConfig(BaseModelWithContextSupport):
             errors.extend(_check_jobs(self.install_jobs))
         if self.install_workflow_jobs is not None:
             errors.extend(_check_jobs(self.install_workflow_jobs))
-        if len(errors) > 0:  # Note: python3.11 ExceptionGroup will solve this nicely
+        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
             raise ValueError(errors)
         return self
 
@@ -667,7 +667,7 @@ class EverestConfig(BaseModelWithContextSupport):
                 if job_name not in installed_jobs_name:
                     errors.append(f"unknown workflow job {job_name}")
 
-        if len(errors) > 0:  # Note: python3.11 ExceptionGroup will solve this nicely
+        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
             raise ValueError(errors)
         return self
 
@@ -730,7 +730,7 @@ to read summary data from forward model, do:
             except ValueError as e:
                 errors.append(str(e))
 
-        if len(errors) > 0:
+        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
             raise ValueError(errors)
 
         return self
@@ -834,7 +834,7 @@ to read summary data from forward model, do:
                         f"control_name.variable_name.variable_index"
                     )
 
-        if len(errors) > 0:  # Note: python3.11 ExceptionGroup will solve this nicely
+        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
             raise ValueError(errors)
 
         return self


### PR DESCRIPTION
**Issue**
Resolves #11970

**Approach**
These comments suggest to use `ExceptionGroup` within pydantic validators. However, that is currently not supported by pydantic. Best practice seems to be to collect error messages and raise a single `ValueError`, as we are doing now.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
