### PR TITLE
Remove unused property from ErtConfig

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -715,9 +715,6 @@ class ErtConfig(BaseModel):
     runpath_file: Path = Path(DEFAULT_RUNPATH_FILE)
 
     ert_templates: list[tuple[str, str]] = Field(default_factory=list)
-    installed_forward_model_steps: dict[str, ForwardModelStep] = Field(
-        default_factory=dict
-    )
 
     forward_model_steps: list[ForwardModelStep] = Field(default_factory=list)
     runpath_config: ModelConfig = Field(default_factory=ModelConfig)
@@ -1074,7 +1071,6 @@ class ErtConfig(BaseModel):
                 hooked_workflows=hooked_workflows,
                 runpath_file=Path(runpath_file),
                 ert_templates=read_templates(config_dict),
-                installed_forward_model_steps=installed_forward_model_steps,
                 forward_model_steps=cls._create_list_of_forward_model_steps_to_run(
                     installed_forward_model_steps,
                     substitutions,

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1224,6 +1224,7 @@ def test_that_included_files_uses_paths_relative_to_itself():
         """
         NUM_REALIZATIONS 1
         INCLUDE includes/install_jobs.ert
+        FORWARD_MODEL FM
         """
     )
     os.mkdir("includes")
@@ -1244,7 +1245,7 @@ def test_that_included_files_uses_paths_relative_to_itself():
     Path(test_fm_file_name).write_text(test_fm_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
-    assert ert_config.installed_forward_model_steps["FM"].name == "FM"
+    assert ert_config.forward_model_steps[0].name == "FM"
 
 
 @pytest.mark.parametrize("val, expected", [("TrUe", True), ("FaLsE", False)])
@@ -1273,6 +1274,8 @@ def test_that_include_take_into_account_path():
         NUM_REALIZATIONS  1
         INCLUDE dir/include.ert
         INSTALL_JOB job2 job2
+        FORWARD_MODEL job1
+        FORWARD_MODEL job2
         """
     )
     test_include_file_name = "dir/include.ert"
@@ -1289,7 +1292,7 @@ def test_that_include_take_into_account_path():
     Path(test_include_file_name).write_text(test_include_contents, encoding="utf-8")
 
     ert_config = ErtConfig.from_file(test_config_file_name)
-    assert list(ert_config.installed_forward_model_steps.keys()) == [
+    assert [i.name for i in ert_config.forward_model_steps] == [
         "job1",
         "job2",
     ]

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -544,16 +544,16 @@ def minimal_case(tmpdir):
         yield
 
 
-def test_shell_script_fmstep_availability(minimal_case):
-    ert_config = ErtConfig.with_plugins(get_site_plugins()).from_file("config.ert")
+def test_shell_script_fmstep_availability():
+    plugins = get_site_plugins()
     fm_shell_jobs = {}
-    for fm_step in ert_config.installed_forward_model_steps.values():
+    for fm_step in plugins.installed_forward_model_steps.values():
         exe = fm_step.executable
         if "shell_scripts" in exe:
             fm_shell_jobs[fm_step.name.upper()] = Path(exe).resolve()
 
     wf_shell_jobs = {}
-    for wf_name, wf in ert_config.workflow_jobs.items():
+    for wf_name, wf in plugins.installed_workflow_jobs.items():
         if isinstance(wf, ExecutableWorkflow) and "shell_scripts" in wf.executable:
             wf_shell_jobs[wf_name] = Path(wf.executable).resolve()
 


### PR DESCRIPTION
Some cleanup after previous refactor.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
