### PR TITLE
Replace deprecated model_fields method

### DIFF
--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -58,7 +58,7 @@ class ParameterConfig(BaseModel):
     @model_validator(mode="after")
     def log_parameters_on_instantiation(self) -> ParameterConfig:
         specified_parameters = self.model_fields_set
-        defaulted_parameters = set(self.model_fields.keys()) - specified_parameters
+        defaulted_parameters = set(self.model_dump().keys()) - specified_parameters
         msg = (
             f"Attributes for {type(self).__name__} with input values:\n"
             f"{specified_parameters}\n"


### PR DESCRIPTION
This is not what failed, but the warning is visible in:
https://github.com/equinor/komodo-releases/actions/runs/18623391566/job/53098181243


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
