### PR TITLE
Change logger name in experiment server to match context

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -38,7 +38,7 @@ from everest.detached.everserver import (
     ExperimentStatus,
 )
 from everest.strings import (
-    EVERSERVER,
+    EXPERIMENT_SERVER,
     OPT_FAILURE_ALL_REALIZATIONS,
     OPT_FAILURE_REALIZATIONS,
     EverEndpoints,
@@ -115,7 +115,7 @@ def _get_optimization_status(
             status_ = ExperimentState.failed
             messages = _failed_realizations_messages(events, exit_code)
             for msg in messages:
-                logging.getLogger(EVERSERVER).error(msg)
+                logging.getLogger(EXPERIMENT_SERVER).error(msg)
             return status_, "\n".join(messages)
         case _:
             return ExperimentState.completed, "Optimization completed."
@@ -143,7 +143,7 @@ def _check_user(credentials: HTTPBasicCredentials) -> None:
 
 
 def _log(request: Request) -> None:
-    logging.getLogger(EVERSERVER).debug(
+    logging.getLogger(EXPERIMENT_SERVER).debug(
         f"{request.scope['path']} entered from "
         f"{request.client.host if request.client else 'unknown host'} "
         f"with HTTP {request.method}"
@@ -210,7 +210,7 @@ async def start_experiment(
                 status=ExperimentState.failed,
                 message=f"Could not start experiment: {e!s}",
             )
-            logging.getLogger(EVERSERVER).exception(e)
+            logging.getLogger(EXPERIMENT_SERVER).exception(e)
             return Response(f"Could not start experiment: {e!s}", status_code=501)
     return Response("Everest experiment is running")
 
@@ -258,9 +258,9 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             if isinstance(event, EndEvent):
                 break
     except Exception as e:
-        logging.getLogger(EVERSERVER).exception(str(e))
+        logging.getLogger(EXPERIMENT_SERVER).exception(str(e))
     finally:
-        logging.getLogger(EVERSERVER).info(
+        logging.getLogger(EXPERIMENT_SERVER).info(
             f"Subscriber {subscriber_id} done. Closing websocket"
         )
         # Give some time for subscribers to get events
@@ -348,15 +348,15 @@ class ExperimentRunner:
                 status=exp_status,
             )
         except UserCancelled as e:
-            logging.getLogger(EVERSERVER).info(f"User cancelled: {e}")
+            logging.getLogger(EXPERIMENT_SERVER).info(f"User cancelled: {e}")
         except Exception as e:
-            logging.getLogger(EVERSERVER).exception(e)
+            logging.getLogger(EXPERIMENT_SERVER).exception(e)
             shared_data.status = ExperimentStatus(
                 message=f"Exception: {e}\n{traceback.format_exc()}",
                 status=ExperimentState.failed,
             )
         finally:
-            logging.getLogger(EVERSERVER).info(
+            logging.getLogger(EXPERIMENT_SERVER).info(
                 f"ExperimentRunner done. Items left in queue: {status_queue.qsize()}"
             )
 

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -27,6 +27,7 @@ from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
     EVEREST,
     EVERSERVER,
+    EXPERIMENT_SERVER,
     OPTIMIZATION_LOG_DIR,
 )
 from everest.util import makedirs_if_needed, version_info
@@ -63,6 +64,11 @@ def _configure_loggers(
                 "level": logging.WARNING,
             },
             EVERSERVER: {
+                "handlers": ["endpoint_log"],
+                "level": logging_level,
+                "propagate": False,
+            },
+            EXPERIMENT_SERVER: {
                 "handlers": ["endpoint_log"],
                 "level": logging_level,
                 "propagate": False,

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -8,6 +8,7 @@ DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 
 EVEREST = "everest"
 EVERSERVER = "everserver"
+EXPERIMENT_SERVER = "experiment_server"
 
 HOSTFILE_NAME = "storage_server.json"
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -71,7 +71,7 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     # the everest server has started
     if endpoint_logs:
         assert "everserver INFO: Everserver starting" in endpoint_logs
-        assert "everserver INFO: ExperimentRunner done" in endpoint_logs
+        assert "experiment_server INFO: ExperimentRunner done" in endpoint_logs
 
 
 def test_that_cleanup_logging_is_idempotent(monkeypatch):


### PR DESCRIPTION
**Issue**
Resolves #11854 

Just adding EXPERIMENT_SERVER, since as understood from the existing epic, EVERSERVER is going to be nuked soon.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
