### PR TITLE
Improve invalid dataset type error message

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -803,6 +803,11 @@ class LocalEnsemble(BaseMode):
         Saves the provided dataset under a parameter group and realization index(es)
 
         """
+        assert isinstance(dataset, (xr.Dataset | pl.DataFrame)), (
+            f"Dataset must be either an xarray Dataset or polars Dataframe, "
+            f"was '{type(dataset).__name__}'"
+        )
+
         if isinstance(dataset, pl.DataFrame):
             if dataset.is_empty():
                 raise ValueError("Parameters dataframe is empty.")

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -21,6 +21,7 @@ from hypothesis import assume, given, note, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule
 from pandas import DataFrame, ExcelWriter
+from pydantic import BaseModel
 
 from ert.config import (
     DesignMatrix,
@@ -42,8 +43,8 @@ from ert.storage import (
     RealizationStorageState,
     open_storage,
 )
-from ert.storage.local_storage import _LOCAL_STORAGE_VERSION
-from ert.storage.mode import ModeError
+from ert.storage.local_storage import _LOCAL_STORAGE_VERSION, LocalStorage
+from ert.storage.mode import Mode, ModeError
 from tests.ert.unit_tests.config.egrid_generator import egrids
 from tests.ert.unit_tests.config.summary_generator import summaries, summary_variables
 
@@ -123,6 +124,26 @@ def test_that_saving_empty_responses_fails_nicely(tmp_path):
             ),
         ):
             ensemble.save_response("RESPONSE", empty_data, 0)
+
+
+def test_that_local_ensemble_save_parameter_raises_value_error_given_xr_array_dataset(
+    monkeypatch,
+):
+    # Mock storage interactions
+    monkeypatch.setattr(Path, "read_text", lambda *args, **kwargs: None)
+    monkeypatch.setattr(BaseModel, "model_validate_json", lambda _: True)
+    monkeypatch.setattr(LocalStorage, "_save_index", lambda _: None)
+
+    # Create read only storage but pretend it's write to avoid lock files
+    local_storage = LocalStorage(path=Path(""), mode=Mode.READ)
+    local_ensemble = LocalEnsemble(storage=local_storage, path=Path(""), mode=Mode.READ)
+    monkeypatch.setattr(LocalEnsemble, "can_write", lambda _: True)
+
+    expected_error_msg = (
+        r"Dataset must be either an xarray Dataset or polars Dataframe, was 'ndarray'"
+    )
+    with pytest.raises(AssertionError, match=expected_error_msg):
+        local_ensemble.save_parameters(dataset=np.array([]), group="", realization=None)
 
 
 def test_that_saving_response_updates_configs(tmp_path):


### PR DESCRIPTION
**Issue**
Resolves #11849 

Is this the solution you had in mind, @dafeda ?
Raising a Value Error will still create a Traceback in the error message, but that is how most of these edge cases are handled.

Is this a realistic bug for a user to run into?

<img width="1136" height="763" alt="image" src="https://github.com/user-attachments/assets/a3c2cc9a-37ae-421c-9a3a-989b6acdd802" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
