### PR TITLE
Rerun marginal flaky test on failure

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -201,6 +201,7 @@ async def test_that_max_submit_is_not_reached_on_success(realization, mock_drive
 
 @pytest.mark.integration_test
 @pytest.mark.timeout(10)
+@pytest.mark.flaky(rerun=3)
 async def test_max_runtime(realization, mock_driver, caplog):
     wait_started = asyncio.Event()
 


### PR DESCRIPTION
Observed once to not go through

**Issue**
Resolves https://github.com/equinor/komodo-releases/actions/runs/18702531396/job/53334583114


**Approach**
♻️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
