### PR TITLE
Remove SETENV ert dict dependency

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -424,21 +424,6 @@ class EverestRunModel(RunModel):
             for key, val in plugin_env_vars.items():
                 env_vars[key] = substituter.substitute(val)
 
-        for key, val in config_dict.get("SETENV", []):
-            if key in env_vars:
-                message = (
-                    f"Overriding environment variable: {key}, "
-                    f"old value: {env_vars[key]}, new value: {val}"
-                )
-
-                if key in plugin_env_vars:
-                    site_value = plugin_env_vars
-                    message += f", site configuration value: {site_value}"
-
-                logger.warning(message)
-
-            env_vars[key] = substituter.substitute(val)
-
         delete_run_path: bool = (
             everest_config.simulator is not None
             and everest_config.simulator.delete_run_path


### PR DESCRIPTION
**Issue**
Resolves #11954 

As far as I can see we currently didn't have the capability to set environment variables in this way (`config_dict[SETENV]` is always empty as far as I understand, nothing is mapped to it in `everest_to_ert_config_dict()`). If we want this functionality without using the intermidiary ert config_dict, we would have to add a section in the EverestConfig where we can specify environment variable mapping. Is there a use-case for this? Since as it looks to me, this wasn't even possible up until today.

**(note: auto-squash & merge is turned on)**


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
