### PR TITLE
Fix error handling in local_storage

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -625,17 +625,17 @@ class LocalStorage(BaseMode):
 def _storage_version(path: Path) -> int:
     if not path.exists():
         return _LOCAL_STORAGE_VERSION
+    if not (path / "index.json").exists():
+        if _is_block_storage(path):
+            return 0
+        else:
+            raise FileNotFoundError(path / "index.json")
     try:
         return int(
             json.loads((path / "index.json").read_text(encoding="utf-8"))["version"]
         )
     except KeyError as exc:
         raise NotImplementedError("Incompatible ERT Local Storage") from exc
-    except FileNotFoundError:
-        if _is_block_storage(path):
-            return 0
-        else:
-            raise
 
 
 _migration_ert_config: ErtConfig | None = None


### PR DESCRIPTION
Solves a failing test that got merged in by accident through e4178ddec017ee0a4f5ce026e77b27c7d6dd5dec

**Issue**
Resolves test failure on `main`


**Approach**
Rethink error handling as `open()` raises a FileNotFoundError while `notexistingpath.read_text()` returns `None`.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
