### PR TITLE
Have fm_dispatch remove event reporter after it shuts down

### DIFF
--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -137,6 +137,7 @@ class Event(Reporter):
                 return
             except ClientConnectionError as exc:
                 logger.error(f"Failed to send event: {exc}")
+                self._reporter_exception = exc
                 return
             except queue.Empty:
                 await asyncio.sleep(0)


### PR DESCRIPTION
**Issue**
Resolves **pew** **pew** 🔫  


**Approach**
If the event reporter's publisher zmq client gets a ClientConnectionError, it exits and no more messages are attempted delivered. The event_reporter.report(...) method is however still being called, and this causes a new log message `Event ... scheduled for delivery` every time. There is some
logic in fm_dispatch already to remove faulty reporters, and this commit makes the event reporter hit that code path.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
