### PR TITLE
Initialize workflow jobs in EverestRunModel

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -387,13 +387,11 @@ def workflow_jobs_from_dict(
 
 
 def create_and_hook_workflows(
-    content_dict: ConfigDict,
+    hook_workflow_info: list[tuple[str, HookRuntime]],
+    workflow_info: list[tuple[str, str]],
     workflow_jobs: dict[str, WorkflowJob],
     substitutions: dict[str, str],
 ) -> tuple[dict[str, Workflow], defaultdict[HookRuntime, list[Workflow]]]:
-    hook_workflow_info = content_dict.get(ConfigKeys.HOOK_WORKFLOW, [])
-    workflow_info = content_dict.get(ConfigKeys.LOAD_WORKFLOW, [])
-
     workflows = {}
     hooked_workflows = defaultdict(list)
 
@@ -496,7 +494,10 @@ def workflows_from_dict(
         dict(copy.copy(installed_workflows)) if installed_workflows else {},
     )
     workflows, hooked_workflows = create_and_hook_workflows(
-        content_dict, workflow_jobs, substitutions
+        content_dict.get(ConfigKeys.HOOK_WORKFLOW, []),
+        content_dict.get(ConfigKeys.LOAD_WORKFLOW, []),
+        workflow_jobs,
+        substitutions,
     )
     return workflow_jobs, workflows, hooked_workflows
 


### PR DESCRIPTION
**Issue**
Resolves #11952


**Approach**
- Removes the code that populated the generated ert config with workflow job information from `everest_to_ert_config_dict`.
- Adjust `create_and_hook_workflows` in `ert.config` to accept lists of hook and workflow tuples, rather then an ert config.
- Create the hooked workflows in EverestRunModel directly without passing information via the ert config.
- Adjust existing tests to make sure that no behavior was changed.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
