### PR TITLE
Avoid buggy version of PyQT6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "python-multipart", # extra dependency for fastapi
     "pyyaml",
     "pyzmq",
-    "pyqt6",
+    "pyqt6!=6.10.0",
     "requests",
     "resfo",
     "ropt-dakota>=0.24,<0.25",

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,7 @@ requires-dist = [
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">2" },
-    { name = "pyqt6" },
+    { name = "pyqt6", specifier = "!=6.10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">6" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-benchmark", marker = "extra == 'dev'" },


### PR DESCRIPTION
When not pinned, a pip install of ert pulls down pyqt6==6.10.0 and gives the error:

        ...
        user_defaults
                  self.builder.apply_user_defaults(tool)
                File /tmp/pip-build-env-c28ui_ep/overlay/lib/python3.11/site-packages/pyqtbuild/builder.py, line 49, in apply_user_defaults
                  raise PyProjectOptionException('qmake',
              sipbuild.pyproject.PyProjectOptionException
              [end of output]

**Issue**
Resolves install failure


**Approach**
⏬ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
