### PR TITLE
Fix plotter offering to select uninitialized ensembles

### DIFF
--- a/src/ert/dark_storage/endpoints/ensembles.py
+++ b/src/ert/dark_storage/endpoints/ensembles.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -38,4 +39,7 @@ def get_ensemble(
             "started_at": ensemble.started_at,
         },
         size=ensemble.ensemble_size,
+        realization_storage_states=Counter(
+            state for states in ensemble.get_ensemble_state() for state in states
+        ),
     )

--- a/src/ert/dark_storage/json_schema/ensemble.py
+++ b/src/ert/dark_storage/json_schema/ensemble.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from ert.storage.realization_storage_state import RealizationStorageState
+
 
 class _Ensemble(BaseModel):
     size: int
@@ -19,3 +21,4 @@ class EnsembleOut(_Ensemble):
     id: UUID
     experiment_id: UUID | None = None
     userdata: Mapping[str, Any]
+    realization_storage_states: Mapping[RealizationStorageState, int] | None = None

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -87,29 +87,47 @@ def mocked_requests_get(*args, **kwargs):
 
     ensemble = {
         "/ensembles/ens_id_1": {
-            "name": "ensemble_1",
-            "experiment_name": "experiment",
-            "started_at": "2012-12-10T00:00:00",
+            "userdata": {
+                "name": "ensemble_1",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T00:00:00",
+            }
         },
         "/ensembles/ens_id_2": {
-            "name": ".ensemble_2",
-            "experiment_name": "experiment",
-            "started_at": "2012-12-10T01:00:00",
+            "userdata": {
+                "name": ".ensemble_2",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T01:00:00",
+            }
         },
         "/ensembles/ens_id_3": {
-            "name": "default_0",
-            "experiment_name": "experiment",
-            "started_at": "2012-12-10T02:00:00",
+            "userdata": {
+                "name": "default_0",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T02:00:00",
+            }
         },
         "/ensembles/ens_id_4": {
-            "name": "default_1",
-            "experiment_name": "experiment",
-            "started_at": "2012-12-10T03:00:00",
+            "userdata": {
+                "name": "default_1",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T03:00:00",
+            }
         },
         "/ensembles/ens_id_5": {
-            "name": "default_manyobs",
-            "experiment_name": "experiment",
-            "started_at": "2012-12-10T04:00:00",
+            "userdata": {
+                "name": "default_manyobs",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T04:00:00",
+            }
+        },
+        "/ensembles/ens_id_uninitialized": {
+            "userdata": {
+                "name": "uninitialized_ensemble",
+                "experiment_name": "experiment",
+                "started_at": "2012-12-10T04:00:00",
+            },
+            "realization_storage_states": {"UNDEFINED": 1},
         },
     }
 
@@ -316,6 +334,7 @@ def mocked_requests_get(*args, **kwargs):
                 "ens_id_3",
                 "ens_id_4",
                 "ens_id_5",
+                "ens_id_uninitialized",
             ],
             "parameters": {
                 "default": [
@@ -379,7 +398,7 @@ def mocked_requests_get(*args, **kwargs):
     ]
 
     if args[0] in ensemble:
-        return MockResponse({"userdata": ensemble[args[0]]}, 200)
+        return MockResponse(ensemble[args[0]], 200)
     elif args[0] in observations:
         return MockResponse(
             observations[args[0]],

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -114,10 +114,11 @@ def test_case_structure(api):
         "default_0",
         "default_1",
         "default_manyobs",
+        "uninitialized_ensemble",
     ]
 
     assert ensembles == expected
-    assert hidden_case == [".ensemble_2"]
+    assert hidden_case == [".ensemble_2", "uninitialized_ensemble"]
 
 
 def test_can_load_data_and_observations(api):


### PR DESCRIPTION
**Issue**
Resolves #12075


**Approach**
This commit adds an extra field to the ensemble object returned from the dark storage api - `realization_storage_states`. The value of this new field is a map between RealizationStorageStates and the number of realizations in the ensemble with this RealizationStorageState. We then use this to hide uninitialized ensembles from the ensemble selector in the plotter.
Example: '{"realization_storage_states": {
    "UNDEFINED": 6,
    "PARAMETERS_LOADED": 94
}}'



The dark storage endpoint now returns this object: 
```
{
  "size": 100,
  "active_realizations": [],
  "id": "d056f89d-99fd-421c-b34e-8f117e69d9e6",
  "experiment_id": "43ca3156-4dbc-43f7-ab08-8332e2dd55cf",
  "userdata": {
    "name": "ensemble",
    "experiment_name": "new_experiment",
    "started_at": "2025-10-23T09:55:17.473356"
  },
  "realization_storage_states": {
    "UNDEFINED": 6,
    "PARAMETERS_LOADED": 94
  }
}
```

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
