### PR TITLE
Fix selecting a key in PlotWindow fetches same data multiple times

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -387,8 +387,6 @@ class PlotWindow(QMainWindow):
             self._central_tab.setTabEnabled(
                 self._central_tab.indexOf(plot_widget), plot_widget in available_widgets
             )
-        self._central_tab.currentChanged.connect(self.currentTabChanged)
-
         current_widget = self._central_tab.currentWidget()
 
         if 0 < self._prev_key_dimensionality != key_def.dimensionality:
@@ -403,6 +401,7 @@ class PlotWindow(QMainWindow):
             self._current_tab_index = -1
 
         self._central_tab.setCurrentWidget(current_widget)
+        self._central_tab.currentChanged.connect(self.currentTabChanged)
         self._prev_tab_widget_index = self._central_tab.currentIndex()
         self._prev_key_dimensionality = key_def.dimensionality
         self.updatePlot()


### PR DESCRIPTION
**Issue**
Resolves #12104


**Approach**
This commit fixes the issue by fixing the order of disconnecting/connecting the currentTabChanged signal in the `keySelected(...) method of PlotWindow. Before, we reconnected the signal before setting the widget manually, and this caused the signal to emit, and updating the plot twice.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
