### PR TITLE
Change LOGNORMAL warning and error validators

### DIFF
--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -260,37 +260,34 @@ def test_gen_kw_distribution_errors(tmpdir, distribution, mean, std, error):
             GenKwConfig.from_config_list(config_list)
 
 
-@pytest.mark.parametrize(
-    "param_name, values, expected_warning",
-    [
-        (
-            "LOGNORMAL",
-            ["700", "300"],  # high mean, high stdev
-            "LOGNORMAL distribution: Too large values for mean.*",
-        ),
-        (
-            "LOGNORMAL",
-            ["800", "1"],  # high mean, low stdev
-            "LOGNORMAL distribution: Too large values for mean.*",
-        ),
-        (
-            "LOGNORMAL",
-            ["1", "300"],  # low mean, high stdev
-            "LOGNORMAL distribution: Too large values for mean.*",
-        ),
-    ],
-)
-def test_that_high_mean_stddev_lognormal_gives_warning(
-    param_name, values, expected_warning
-):
+def test_that_high_mean_stddev_lognormal_gives_warning():
+    mean_log = 4
+    stdev_log = 4
+    expected_warning = r"Expectation value of the lognormal distribution is.*"
     with pytest.warns(
         ConfigWarning,
         match=expected_warning,
     ) as _:
         GenKwConfig(
             name="KEY1",
-            distribution={"name": "lognormal", "mean": values[0], "std": values[1]},
+            distribution={"name": "lognormal", "mean": mean_log, "std": stdev_log},
         )
+
+
+def test_that_very_high_mean_stddev_lognormal_gives_error(tmpdir):
+    mean_log = 3000
+    stdev_log = 10
+    expected_error = r"Expectation value of the lognormal distribution is too large!.*"
+    config_list = [
+        "COEFFS",
+        ["coeff_priors", f"MYVARIABLE LOGNORMAL {mean_log} {stdev_log}"],
+        {},
+    ]
+    with pytest.raises(
+        ConfigValidationError,
+        match=expected_error,
+    ):
+        GenKwConfig.from_config_list(config_list)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If the expected value overflows, raise config error
Set a limit on the expected value, and warn if expected value is over

**Issue**
Resolves #12068 

**Approach**
If the expected value overflows, raise config error
Set a limit on the expected value, and warn if expected value is over

The limit is suggested by Oddvar
<img width="1007" height="492" alt="image" src="https://github.com/user-attachments/assets/c427e657-940e-431f-b354-c6e744b000a6" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
