### PR TITLE
Avoid plotter if plot api versions differ

### DIFF
--- a/src/ert/dark_storage/common.py
+++ b/src/ert/dark_storage/common.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import re
+from importlib import metadata
 
 from ert.dark_storage.exceptions import InternalServerError
 from ert.storage import (
@@ -28,3 +30,11 @@ def get_storage() -> Storage:
             raise InternalServerError("Error accessing storage") from None
     _storage.refresh()
     return _storage
+
+
+def get_storage_api_version() -> str:
+    major = minor = "0"
+    match = re.match(r"(\d+)\.(\d+)", metadata.version("ert"))
+    if match:
+        major, minor = match.groups()
+    return f"{major}.{minor}"

--- a/src/ert/dark_storage/endpoints/__init__.py
+++ b/src/ert/dark_storage/endpoints/__init__.py
@@ -8,6 +8,7 @@ from .observations import router as observations_router
 from .parameters import router as parameters_router
 from .responses import router as responses_router
 from .updates import router as updates_router
+from .version import router as version_router
 
 router = APIRouter()
 router.include_router(experiments_router)
@@ -18,3 +19,4 @@ router.include_router(misfits_router)
 router.include_router(parameters_router)
 router.include_router(responses_router)
 router.include_router(experiment_server_router)
+router.include_router(version_router)

--- a/src/ert/dark_storage/endpoints/version.py
+++ b/src/ert/dark_storage/endpoints/version.py
@@ -1,0 +1,16 @@
+import logging
+
+from fastapi import APIRouter, Body, Depends
+
+from ert.dark_storage.common import get_storage, get_storage_api_version
+
+router = APIRouter(tags=["version"])
+logger = logging.getLogger(__name__)
+
+DEFAULT_STORAGE = Depends(get_storage)
+DEFAULT_BODY = Body(...)
+
+
+@router.get("/version")
+def get_version() -> str:
+    return get_storage_api_version()

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -81,8 +81,7 @@ class SidebarToolButton(QToolButton):
         if event:
             if event.button() == Qt.MouseButton.RightButton:
                 self.right_clicked.emit()
-            else:
-                super().mousePressEvent(event)
+            super().mousePressEvent(event)
 
 
 class ErtMainWindow(QMainWindow):

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -53,6 +53,19 @@ class PlotApi:
         self._all_ensembles: list[EnsembleObject] | None = None
         self._timeout = 120
 
+    @property
+    def api_version(self) -> str:
+        with StorageService.session(project=self.ens_path) as client:
+            try:
+                response = client.get("/version", timeout=self._timeout)
+                self._check_response(response)
+                api_version = str(response.json())
+            except Exception as exc:
+                logger.exception(exc)
+                raise exc
+            else:
+                return api_version
+
     @staticmethod
     def escape(s: str) -> str:
         return quote(quote(s, safe=""))

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -1,10 +1,13 @@
 import io
 import json
+import re
 
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from requests import Response
+
+from ert.dark_storage.common import get_storage_api_version
 
 
 @pytest.mark.integration_test
@@ -15,6 +18,20 @@ def test_get_experiment(poly_example_tmp_dir, dark_storage_client):
     assert "ensemble_ids" in answer_json[0]
     assert len(answer_json[0]["ensemble_ids"]) == 2
     assert "name" in answer_json[0]
+
+
+@pytest.mark.integration_test
+def test_get_storage_api_version(poly_example_tmp_dir, dark_storage_client):
+    resp: Response = dark_storage_client.get("/version")
+    answer_json = resp.json()
+
+    assert answer_json == get_storage_api_version()
+
+    version_pattern = r"^\d+\.\d+$"
+
+    assert re.match(version_pattern, answer_json), (
+        f"Version format is invalid: {answer_json}"
+    )
 
 
 @pytest.mark.integration_test

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -1,8 +1,11 @@
+from unittest.mock import MagicMock
+
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QPushButton
+from PyQt6.QtWidgets import QApplication, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
 
-from ert.gui.tools.plot.plot_window import create_error_dialog
+from ert.gui.tools.plot.plot_window import PlotWindow, create_error_dialog
+from ert.services import StorageService
 
 
 def test_pressing_copy_button_in_error_dialog(qtbot: QtBot):
@@ -13,3 +16,23 @@ def test_pressing_copy_button_in_error_dialog(qtbot: QtBot):
         qd.findChild(QPushButton, name="copy_button"), Qt.MouseButton.LeftButton
     )
     assert QApplication.clipboard().text() == "world"
+
+
+def test_warning_is_visible_on_incompatible_plot_api_version(
+    qtbot: QtBot, tmp_path, monkeypatch, use_tmpdir
+):
+    mock_get_data = MagicMock()
+    mock_get_data.return_value = "0.2"
+    monkeypatch.setattr(
+        "ert.gui.tools.plot.plot_api.PlotApi.api_version", mock_get_data
+    )
+
+    with StorageService.init_service(project=tmp_path):
+        pw = PlotWindow("", tmp_path, None)
+        qtbot.addWidget(pw)
+        pw.show()
+
+        label = pw.findChild(QLabel, name="plot_api_warning_label")
+        assert label
+        assert label.isVisible()
+        assert label.text().startswith("<b>Plot API version mismatch detected")


### PR DESCRIPTION
**Issue**
Resolves #12037 

⚠️ Note that I conducted recording altering the comparison function from `!=` to `==`, hence identical versions reported incompatible.

**Updated 2025-10-29:**
<img width="593" height="454" alt="Screenshot 2025-10-29 at 10 30 34" src="https://github.com/user-attachments/assets/2f82ed0f-3c5d-4308-a570-db752d17cf4d" />

https://github.com/user-attachments/assets/00da80dd-3d41-4d91-a48b-704bc736a25e

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
