### PR TITLE
Add scm fallback version for dependabot to work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,8 @@ timeout = 360
 
 [tool.setuptools_scm]
 write_to = "src/ert/shared/version.py"
+# Fallback needed due to https://github.com/dependabot/dependabot-core/issues/12340
+fallback_version = "0.0.0"
 
 [tool.ruff]
 src = ["src"]


### PR DESCRIPTION
See https://github.com/equinor/ert/network/updates/1136563587 and https://github.com/dependabot/dependabot-core/issues/12340


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
