### PR TITLE
Remove unneeded "ensemble size" number argument to panels

### DIFF
--- a/src/ert/gui/simulation/evaluate_ensemble_panel.py
+++ b/src/ert/gui/simulation/evaluate_ensemble_panel.py
@@ -32,9 +32,7 @@ class Arguments:
 
 
 class EvaluateEnsemblePanel(ExperimentConfigPanel):
-    def __init__(
-        self, ensemble_size: int, run_path: str, notifier: ErtNotifier
-    ) -> None:
+    def __init__(self, run_path: str, notifier: ErtNotifier) -> None:
         self.notifier = notifier
         super().__init__(EvaluateEnsemble)
         self.setObjectName("Evaluate_parameters_panel")
@@ -49,8 +47,14 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
-        number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+        ensemble_size = 0
+        if self._ensemble_selector.selected_ensemble:
+            ensemble_size = self._ensemble_selector.selected_ensemble.ensemble_size
+
+        self._number_of_realizations_label = QLabel(f"<b>{ensemble_size}</b>")
+        layout.addRow(
+            QLabel("Number of realizations:"), self._number_of_realizations_label
+        )
 
         self._active_realizations_field = StringBox(
             ActiveRealizationsModel(ensemble_size, show_default=False),  # type: ignore
@@ -58,7 +62,6 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         )
         self._realizations_validator = EnsembleRealizationsArgument(
             lambda: self._ensemble_selector.selected_ensemble,
-            max_value=ensemble_size,
             required_realization_storage_states=[
                 RealizationStorageState.PARAMETERS_LOADED
             ],
@@ -106,6 +109,9 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
                 if not any(mask):
                     mask = parameters
                 self._active_realizations_field.model.setValueFromMask(mask)  # type: ignore
+                self._number_of_realizations_label.setText(
+                    f"<b>{ensemble.ensemble_size}</b>"
+                )
         except OSError as err:
             logger.error(str(err))
             Suggestor(

--- a/src/ert/gui/simulation/experiment_panel.py
+++ b/src/ert/gui/simulation/experiment_panel.py
@@ -158,7 +158,6 @@ class ExperimentPanel(QWidget):
             True,
         )
 
-        ensemble_size = config.ensemble_size
         active_realizations = config.active_realizations
         config_num_realization = config.runpath_config.num_realizations
         self.addExperimentConfigPanel(
@@ -173,7 +172,7 @@ class ExperimentPanel(QWidget):
             True,
         )
         self.addExperimentConfigPanel(
-            EvaluateEnsemblePanel(ensemble_size, run_path, notifier),
+            EvaluateEnsemblePanel(run_path, notifier),
             True,
         )
 
@@ -215,7 +214,7 @@ class ExperimentPanel(QWidget):
             experiment_type_valid,
         )
         self.addExperimentConfigPanel(
-            ManualUpdatePanel(ensemble_size, run_path, notifier, analysis_config),
+            ManualUpdatePanel(run_path, notifier, analysis_config),
             experiment_type_valid,
         )
 

--- a/src/ert/gui/simulation/manual_update_panel.py
+++ b/src/ert/gui/simulation/manual_update_panel.py
@@ -39,7 +39,6 @@ class Arguments:
 class ManualUpdatePanel(ExperimentConfigPanel):
     def __init__(
         self,
-        ensemble_size: int,
         run_path: str,
         notifier: ErtNotifier,
         analysis_config: AnalysisConfig,
@@ -126,7 +125,6 @@ class ManualUpdatePanel(ExperimentConfigPanel):
                 self._active_realizations_field.setValidator(
                     EnsembleRealizationsArgument(
                         lambda: ensemble,
-                        max_value=ensemble.ensemble_size,
                         required_realization_storage_states=[
                             RealizationStorageState.PARAMETERS_LOADED,
                             RealizationStorageState.RESPONSES_LOADED,

--- a/src/ert/gui/simulation/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/simulation/multiple_data_assimilation_panel.py
@@ -137,7 +137,6 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._ensemble_selector = EnsembleSelector(notifier)
         self._previous_ensemble_realizations_validator = EnsembleRealizationsArgument(
             lambda: self._ensemble_selector.selected_ensemble,
-            max_value=len(active_realizations),
             required_realization_storage_states=[
                 RealizationStorageState.RESPONSES_LOADED
             ],

--- a/src/ert/validation/ensemble_realizations_argument.py
+++ b/src/ert/validation/ensemble_realizations_argument.py
@@ -17,11 +17,13 @@ class EnsembleRealizationsArgument(RangeStringArgument):
     def __init__(
         self,
         ensemble: Callable[[], Union["Ensemble", None]],
-        max_value: int | None,
         required_realization_storage_states: Iterable["RealizationStorageState"],
         **kwargs: bool,
     ) -> None:
-        super().__init__(max_value, **kwargs)
+        ens = ensemble()
+        size = ens.ensemble_size if ens is not None else None
+        super().__init__(size, **kwargs)
+
         self.__ensemble_getter = ensemble
         self._required_realization_storage_states: Iterable[RealizationStorageState] = (
             required_realization_storage_states

--- a/tests/ert/unit_tests/gui/simulation/test_manual_update.py
+++ b/tests/ert/unit_tests/gui/simulation/test_manual_update.py
@@ -23,7 +23,6 @@ def test_that_active_realizations_selector_validates_with_ensemble_size_from_pri
     """
     notifier = ErtNotifier()
     notifier._storage = MockStorage()
-    config_ensemble_size = 2
     notifier._storage._setup_mocked_run(
         "mock_ensemble0",
         "mock_experiment0",
@@ -51,7 +50,6 @@ def test_that_active_realizations_selector_validates_with_ensemble_size_from_pri
         ],
     )
     panel = ManualUpdatePanel(
-        ensemble_size=config_ensemble_size,
         analysis_config=AnalysisConfig(minimum_required_realizations=1),
         run_path="",
         notifier=notifier,
@@ -112,7 +110,6 @@ def test_that_manual_update_ensemble_selector_only_shows_ensembles_with_data(
     """
     notifier = ErtNotifier()
     notifier._storage = MockStorage()
-    config_ensemble_size = 2
     notifier._storage._setup_mocked_run(
         "mock_ensemble_no_data",
         "mock_experiment2",
@@ -120,7 +117,6 @@ def test_that_manual_update_ensemble_selector_only_shows_ensembles_with_data(
     )
 
     panel = ManualUpdatePanel(
-        ensemble_size=config_ensemble_size,
         analysis_config=AnalysisConfig(minimum_required_realizations=1),
         run_path="",
         notifier=notifier,


### PR DESCRIPTION
**Issue**
Resolves #12059 

**Approach**
Removing the "ensemble_size" from evaluate_ensemble_panel and manual_update_panel.
Some other changes were needed to get the size from elsewhere.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
