### PR TITLE
Add `flow` and `eclipseXXX` to built-in forward models

### DIFF
--- a/docs/everest/forward_models/builtin.rst
+++ b/docs/everest/forward_models/builtin.rst
@@ -41,34 +41,173 @@ This will produce an output file with the content:
     This is written in my file together with my_value
 
 
-.. _eclipse100:
+.. _built_in_reservoir_simulators:
 
-Eclipse simulator
------------------
+Reservoir simulators (Flow & Eclipse)
+-------------------------------------
 
-.. code-block:: bash
+Everest supports built-in forward model steps for running common reservoir simulators
+in optimization workflows related to subsurface activities.
+This includes **OPM Flow**, **Eclipse100**, and **Eclipse300**.
 
-  eclipse100 <eclbase> --version <version_number>
+.. note::
 
-Running eclipse with parallel option
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Everest does not include the simulators themselves. Any use of simulators **OPM Flow**,
+    **Eclipse100**, or **Eclipse300**, requires respective installation of that simulator
+    available in your environment. Everest interfaces with these simulators but does not
+    bundle or install them. Ensure they are accessible via your system's ``$PATH``
+    or configured appropriately in your environment.
 
-It is possible to run eclipse with multiple CPUs on clusters. This requires the eclipse data file to have the
-parallel option and the everest config needs to specify the number of CPUs per node:
+Supported simulator jobs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify the following simulator jobs in your Everest configuration:
+
+- ``flow`` — runs OPM Flow.
+- ``eclipse100`` — runs Eclipse 100 (i.e., ``eclipse``).
+- ``eclipse300`` — runs Eclipse 300 (i.e., ``e300``).
+
+All three map internally to the same reservoir simulator runner, but differ in how
+arguments are interpreted and which simulator is launched.
+
+.. _flow:
+
+Flow usage
+~~~~~~~~~~
+
+Everest will run the Flow simulator using either the ``flow`` binary or a wrapper script
+called ``flowrun``, depending on what is available in the user's environment (``$PATH``).
+
+- If ``flowrun`` is found, it takes precedence and enables additional features such as:
+
+  - version selection (``--version``)
+  - parallel execution (``--np``, ``--threads``)
+  - default flags (e.g., ``--enable-esmry=true``)
+
+- If only ``flow`` is available, Everest will invoke it directly with the provided arguments.
+
+You can check which binary is used by running ``which flowrun`` or ``which flow`` in your terminal.
+
+Single-threaded Flow example
+""""""""""""""""""""""""""""
 
 .. code-block:: yaml
 
-  simulator:
-    cores_per_realization: x
+   forward_model:
+     - job: flow r{{ eclbase }}
+       results:
+         file_name: r{{ eclbase }}
+         type: summary
 
-where x is an int giving the number of cores. The eclipse100 forward model also needs to be given the argument to use
-multiple cores:
+Multi-process and multi-threaded Flow example
+"""""""""""""""""""""""""""""""""""""""""""""
 
-.. code-block:: bash
+.. code-block:: yaml
 
-  eclipse100 <eclbase> --version <version_number> --num-cpu x
+   forward_model:
+     - job: flow r{{ eclbase }} --np 8 --threads 4 --version stable
+       results:
+         file_name: r{{ eclbase }}
+         type: summary
+         keys: ["FOPR", "WOPR"]
 
-where x is the number of cores.
+This runs Flow with 8 MPI ranks, each using 4 OpenMP threads. The version ``stable`` is selected
+(if supported by the wrapper). Additional Flow arguments can be passed as needed.
+
+Manual MPI launch (without flowrun wrapper)
+"""""""""""""""""""""""""""""""""""""""""""
+
+If your environment does **not** include a ``flowrun`` wrapper, Everest will invoke the ``flow`` binary directly.
+In this case, Everest does **not** insert ``mpirun`` or manage parallel execution.
+You must handle MPI launching manually by including ``mpirun`` in the job line and install ``mpirun``
+as a custom forward model job in Everest via the ``install_jobs`` section.
+
+.. code-block:: yaml
+
+   install_jobs:
+     -
+       name: mpirun
+       executable: /usr/bin/mpirun
+
+   forward_model:
+     - job: mpirun -np 8 flow r{{ eclbase }}.DATA --threads-per-process=4
+       results:
+         file_name: r{{ eclbase }}
+         type: summary
+         keys: ["FOPR", "WOPR"]
+
+This example:
+
+- Installs ``mpirun`` as a custom job in Everest
+  - NOTE: executable (path) should point to the ``mpirun`` binary in your environment (check ``which mpirun``)
+- Launches Flow with ``mpirun -np 8`` (8 MPI ranks)
+- Sets 4 OpenMP threads per rank using Flow's native flag ``--threads-per-process=4``
+- Assumes ``mpirun`` and ``flow`` are available in the environment
+
+.. _eclipse100:
+.. _eclipse300:
+
+Eclipse100 and Eclipse300 usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run Eclipse100, use the following syntax:
+
+.. code-block:: yaml
+
+   forward_model:
+     - job: eclipse100 r{{ eclbase }} --version 2020.2
+       results:
+         file_name: r{{ eclbase }}
+         type: summary
+         keys: ["FOPR", "WOPR"]
+
+Required and optional arguments:
+
+- ``--version <VERSION>``: **Required** for Eclipse jobs. Specifies the simulator version.
+- ``-i / --ignore-errors``: Continue even if the simulator returns an error.
+- ``--summary-conversion``: Enables summary conversion (only available for Eclipse).
+
+To run Eclipse300, please use the following syntax:
+
+.. code-block:: yaml
+
+   forward_model:
+     - job: eclipse300 r{{ eclbase }} --version 2021.1 --summary-conversion
+       results:
+         file_name: r{{ eclbase }}
+         type: summary
+         keys: ["FOPT", "FWPT"]
+
+These arguments are passed to the simulator runner and used to construct the command:
+
+.. code-block:: text
+
+   eclrun -v 2021.1 e300 <deckfile> --summary-conversion yes
+
+The deck file is automatically resolved from the base name (e.g., ``r{{ eclbase }}.DATA``).
+
+Running Eclipse in parallel
+"""""""""""""""""""""""""""
+
+To run Eclipse simulators (``eclipse``, ``e300``) in parallel, you must include the ``PARALLEL`` keyword in the ``RUNSPEC`` section of your simulation deck.
+The number of MPI processes is determined internally by Eclipse based on the deck configuration, not by command-line options (i.e., ``--np``).
+If ``PARALLEL`` is missing, the simulation runs in serial mode regardless of ``--np``.
+
+While Eclipse determines parallelism internally, the job scheduler (e.g., SLURM, LSF) may allocate resources based on
+``cores_per_node``, (see the example below). This affects how many MPI ranks are launched if the runner
+or wrapper respects the allocation. However, Eclipse itself still relies on the deck configuration
+to determine actual parallel behavior.
+
+.. code-block:: yaml
+
+    simulator:
+      cores_per_node: 16
+
+    forward_model:
+      - job: eclipse300 r{{ eclbase }} --version 2021.1
+        results:
+          file_name: r{{ eclbase }}
+          type: summary
 
 Everest usage example
 ~~~~~~~~~~~~~~~~~~~~~
@@ -388,7 +527,7 @@ where ``"--"`` marks the beginning of a comment line and will be ignored by the 
 
 
 Other template examples
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 The `jinja2 <https://jinja.palletsprojects.com/>`_ templating language is supported by
 the schedule merge job, and can be used to write the templates.
 Below a few default examples can be found:


### PR DESCRIPTION
**Issue**
Resolves #12108 
Resolves #12109 

**Approach**
~~For now places the built-in forward models related to reservoir simulation in the main built-in forward models file. Not sure if this is the right place. Also don't fully understand the `eclrun` and its arguments. The old docs are surely wrong, at least what it seems to me, since `--num-cpu` or `-n` doesn't seem to be passed to `ecl_runcommand` (and hence unused?).~~

Information should be correct, still not entirely sure about the place of these simulator descriptions, they are built-in forward models, so I guess it's OK (somehow it seems like a jump from `Template rendering` and then more at the end of the page). Feel free to suggest something else.

_NOTE: I have to probably rebase (and potentially add review comments) so I haven't squashed my commits yet._

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
