### PR TITLE
Avoid queue_options from plugins when testing

### DIFF
--- a/tests/everest/test_everest_run_model.py
+++ b/tests/everest/test_everest_run_model.py
@@ -23,6 +23,7 @@ def create_runmodel(min_config: dict, monkeypatch: pytest.MonkeyPatch) -> Callab
         queue_system: dict[str, str | int | bool | float],
     ) -> EverestRunModel:
         with ErtPluginContext() as runtime_plugins:
+            runtime_plugins.queue_options = None
             return EverestRunModel.create(
                 EverestConfig(
                     **(min_config | {"simulator": {"queue_system": queue_system}})


### PR DESCRIPTION
Otherwise the plugins can fail the tests

**Issue**
Resolves Komodo bleeding test failure


**Approach**
Modify the plugin context directly in the test. This object is pr now not a singleton object but that might change later?

The `no_plugin` fixture did not help, as it does not patch the correct places for this test. Considered the proposed change as fine as a fix to the `no_plugins` fixture.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
