### PR TITLE
Reword realization_memory doc for Everest

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 from abc import abstractmethod
+from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -60,11 +61,26 @@ class QueueOptions(
     num_cpu: pydantic.NonNegativeInt = 1
     realization_memory: pydantic.NonNegativeInt = Field(
         default=0,
-        description="""When set, a job is only allowed to use realization_memory
-        of memory.
+        description=dedent("""
+        Amount of memory to set aside for a forward model.
 
-        realization_memory may be an integer value, indicating the number of bytes, or a
-        string consisting of a number followed by a unit. The unit indicates the
+        This information is propagated to the queue system as the amount of memory
+        to reserve/book for a realization to complete. It is up to the configuration
+        of the queuing system how to treat this information, but usually it will
+        stop more realizations being assigned to a compute node if the compute nodes
+        memory is already fully booked.
+
+        Setting this number lower than the peak memory consumption of each
+        realization puts the realization at risk of being killed in an out-of-memory
+        situation. Setting this number higher than needed will give longer wait
+        times in the queue.
+
+        For the local queue system, this keyword has no effect. In that scenario,
+        you can use `max_running`  to choke the memory consumption.
+        scheduling of compute jobs.
+
+        `realization_memory` may be an integer value, indicating the number of bytes, or
+        a string consisting of a number followed by a unit. The unit indicates the
         multiplier that is applied, and must start with one of these characters:
 
         * b, B: bytes
@@ -77,9 +93,7 @@ class QueueOptions(
         Spaces between the number and the unit are ignored, and so are any
         characters after the first. For example: 2g, 2G, and 2 GB all resolve
         to the same value: 2 gigabytes, equaling 2 * 1024**3 bytes.
-
-        If not set, or set to zero, the allowed amount of memory is unlimited.
-        """,
+        """),
     )
     job_script: str = shutil.which("fm_dispatch.py") or "fm_dispatch.py"
     project_code: str | None = None

--- a/src/everest/config/simulator_config.py
+++ b/src/everest/config/simulator_config.py
@@ -75,9 +75,22 @@ class SimulatorConfig(BaseModelWithContextSupport, extra="forbid"):
         default=None,
         description=dedent(
             """
-            Maximum allowed memory usage of a forward model.
+            Amount of memory to set aside for a forward model.
 
-            When set, a job is only allowed to use `max_memory` of memory.
+            This information is propagated to the queue system as the amount of memory
+            to reserve/book for a realization to complete. It is up to the configuration
+            of the queuing system how to treat this information, but usually it will
+            stop more realizations being assigned to a compute node if the compute nodes
+            memory is already fully booked.
+
+            Setting this number lower than the peak memory consumption of each
+            realization puts the realization at risk of being killed in an out-of-memory
+            situation. Setting this number higher than needed will give longer wait
+            times in the queue.
+
+            For the local queue system, this keyword has no effect. In that scenario,
+            you can use `max_running`  to choke the memory consumption.
+            scheduling of compute jobs.
 
             `max_memory` may be an integer value, indicating the number of
             bytes, or a string consisting of a number followed by a unit. The
@@ -94,9 +107,6 @@ class SimulatorConfig(BaseModelWithContextSupport, extra="forbid"):
             Spaces between the number and the unit are ignored, and so are any
             characters after the first. For example: 2g, 2G, and 2 GB all
             resolve to the same value: 2 gigabytes, equaling 2 * 1024**3 bytes.
-
-            If not set, or a set to zero, the allowed amount of memory is
-            unlimited.
             """
         ),
     )


### PR DESCRIPTION
Text copied from Ert documentation, which describes correctly how this parameter is used.

This commit shows duplication of parameter names, deprecating one of them is scheduled for a future commit.

Also fix indentation issue with a call to dedent()

**Issue**
Resolves erroneous docs.

**Approach**
Copy from ert docs.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
