### PR TITLE
Error on ambigous spec of max_memory and realization_memory

### DIFF
--- a/src/everest/simulator/everest_to_ert.py
+++ b/src/everest/simulator/everest_to_ert.py
@@ -72,11 +72,6 @@ def _extract_simulator(ever_config: EverestConfig, ert_config: dict[str, Any]) -
     if max_runtime is not None:
         ert_config[ErtConfigKeys.MAX_RUNTIME] = max_runtime or 0
 
-    # Maximum amount of memory (REALIZATION_MEMORY) a forward model is allowed to use
-    max_memory = ever_simulation.max_memory
-    if max_memory is not None:
-        ert_config[ErtConfigKeys.REALIZATION_MEMORY] = max_memory or 0
-
     # Number of cores reserved on queue nodes (NUM_CPU)
     if (num_fm_cpu := ever_simulation.cores_per_node) is not None:
         if (

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -473,77 +473,6 @@ def test_passthrough_explicit_summary_keys(change_to_tmpdir):
     assert set(custom_sum_keys).issubset(set(smry_config.keys))
 
 
-@pytest.mark.usefixtures("no_plugins")
-@pytest.mark.parametrize(
-    "max_memory",
-    [
-        None,
-        0,
-        1,
-        "0",
-        "1",
-        "1b",
-        "1k",
-        "1m",
-        "1g",
-        "1t",
-        "1p",
-        "1G",
-        "1 G",
-        "1Gb",
-        "1 Gb",
-    ],
-)
-def test_that_max_memory_is_valid(max_memory) -> None:
-    EverestConfig.with_defaults(simulator={"max_memory": max_memory})
-
-
-@pytest.mark.usefixtures("no_plugins")
-@pytest.mark.parametrize(
-    "max_memory",
-    [-1, "-1", "-1G", "-1 G", "-1Gb"],
-)
-def test_that_negative_max_memory_fails(max_memory) -> None:
-    with pytest.raises(
-        ValidationError, match=f"Negative memory does not make sense in {max_memory}"
-    ):
-        EverestConfig.with_defaults(simulator={"max_memory": max_memory})
-
-
-@pytest.mark.usefixtures("no_plugins")
-@pytest.mark.parametrize(
-    "max_memory, exception_message",
-    [
-        ("1x", "Unknown memory unit"),
-        ("1 x", "Unknown memory unit"),
-        ("1 xy", "Unknown memory unit"),
-        ("foo", "Invalid memory string: foo"),
-    ],
-)
-def test_that_invalid_max_memory_fails(max_memory, exception_message) -> None:
-    with pytest.raises(ValidationError, match=exception_message):
-        EverestConfig.with_defaults(simulator={"max_memory": max_memory})
-
-
-@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
-@pytest.mark.parametrize(
-    "max_memory",
-    [0, 1, "0", "1", "1b", "1k", "1m", "1g", "1t", "1p", "1G", "1 G", "1Gb", "1 Gb"],
-)
-def test_that_max_memory_is_passed_to_ert_unchanged(
-    change_to_tmpdir, max_memory
-) -> None:
-    ever_config = EverestConfig.with_defaults(simulator={"max_memory": max_memory})
-    config_dict = everest_to_ert_config_dict(ever_config)
-    assert config_dict[ErtConfigKeys.REALIZATION_MEMORY] == str(max_memory)
-
-
-def test_that_max_memory_none_is_not_passed_to_ert(change_to_tmpdir) -> None:
-    ever_config = EverestConfig.with_defaults()
-    config_dict = everest_to_ert_config_dict(ever_config)
-    assert ErtConfigKeys.REALIZATION_MEMORY not in config_dict
-
-
 def test_that_resubmit_limit_is_set(change_to_tmpdir) -> None:
     ever_config = EverestConfig.with_defaults(simulator={"resubmit_limit": 0})
     config_dict = everest_to_ert_config_dict(ever_config)
@@ -551,34 +480,6 @@ def test_that_resubmit_limit_is_set(change_to_tmpdir) -> None:
 
 
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
-@pytest.mark.parametrize(
-    "max_memory, realization_memory",
-    [(None, 0), (999, 999), ("1Gb", 1073741824), (0, 0)],
-)
-def test_that_max_memory_is_passed_to_realization_memory(
-    change_to_tmpdir, max_memory, realization_memory
-) -> None:
-    config = EverestConfig.with_defaults(simulator={"max_memory": max_memory})
-    assert config.simulator.queue_system.realization_memory == realization_memory
-
-
-@pytest.mark.usefixtures("no_plugins")
-@pytest.mark.parametrize(
-    "max_memory, realization_memory, expected",
-    [(None, 0, 0), (0, 0, 0), (111, 999, 999), (55, 0, 55)],
-)
-def test_that_max_memory_does_not_overwrite_realization_memory(
-    change_to_tmpdir, max_memory, realization_memory, expected
-) -> None:
-    config = EverestConfig.with_defaults(
-        simulator={
-            "max_memory": max_memory,
-            "queue_system": {"name": "local", "realization_memory": realization_memory},
-        }
-    )
-    assert config.simulator.queue_system.realization_memory == expected
-
-
 @pytest.mark.parametrize(
     "realization_memory, expected",
     [


### PR DESCRIPTION
If the user specified something impossible, setting max_memory to a different value than realization_memory, realization_memory would silently take precedence. This is now changed to give a config validation error (unless the values are actually equal).

The configuration parsing is also moved from everest_to_ert into the pydantic setup, prompting a move of the test functions from test_res_initialization.py to test_config_validation. The memory tests for max_memory and realization_memory has also been slightly consolidated.

**Issue**
Resolves #12192 


**Approach**
Pydantic

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
