### PR TITLE
Remove no_plugins fixture

### DIFF
--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -6,7 +6,6 @@ import tempfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from copy import deepcopy
-from functools import partial
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
@@ -14,7 +13,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-import ert
 from ert.base_model_context import use_runtime_plugins
 from ert.config.queue_config import LocalQueueOptions, LsfQueueOptions
 from ert.ensemble_evaluator import EvaluatorServerConfig
@@ -290,15 +288,5 @@ def use_site_configurations_with_lsf_queue_options():
             "ert.plugins.plugin_manager.ErtRuntimePlugins",
             ErtRuntimePluginsWithLSFQueueOptions,
         ),
-    ):
-        yield
-
-
-@pytest.fixture()
-def no_plugins():
-    patched_plugin_manager = partial(ert.plugins.ErtPluginManager, plugins=[])
-
-    with (
-        patch("ert.plugins.ErtPluginManager", patched_plugin_manager),
     ):
         yield

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1464,7 +1464,7 @@ def test_that_max_memory_is_valid(max_memory) -> None:
     everest_config_with_defaults(simulator={"max_memory": max_memory})
 
 
-@pytest.mark.usefixtures("no_plugins")
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 @pytest.mark.parametrize(
     "max_memory",
     [-1, "-1", "-1G", "-1 G", "-1Gb"],

--- a/tests/everest/test_everest_run_model.py
+++ b/tests/everest/test_everest_run_model.py
@@ -347,13 +347,13 @@ def test_that_max_memory_is_passed_to_ert_unchanged(
     )
 
 
-@pytest.mark.usefixtures("no_plugins")
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 def test_that_max_memory_none_is_not_passed_to_ert(create_runmodel) -> None:
     runmodel = create_runmodel()
     assert runmodel.queue_config.queue_options.realization_memory == 0
 
 
-@pytest.mark.usefixtures("no_plugins")
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 def test_that_resubmit_limit_is_set(create_runmodel) -> None:
     runmodel = create_runmodel(simulator={"resubmit_limit": 2})
     assert runmodel.queue_config.max_submit == 3


### PR DESCRIPTION
EverestRunModel.create requires some site installed forward models to always be installed. Therefore it is better to only override queue options.
