### PR TITLE
Specify google style docstrings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,6 +121,7 @@ Reject commits that bundle unrelated changes (e.g., test addition + API rename +
 ## 4. Documentation
 
 - Avoid trivial docstrings that restate the obvious (`get_count()` does not need “Return count”).
+- Docstrings should follow the google style guide.
 - Remove commented-out code blocks; if something is temporarily disabled, use version control (or explain in commit message) rather than comments.
 - For user-facing changes (new features, changed behaviors, configuration adjustments), ensure an `.rst` file under `docs/` is added or updated:
   - Include usage examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,3 +194,8 @@ noise in the review process.
   * rebase onto base branch if necessary,
   * squash whatever still needs squashing, and
   * [fast-forward](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history) merge.
+
+## Docstrings
+
+Avoid adding trivial documentation but where warranted, docstrings should follow the
+[google style guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).


### PR DESCRIPTION
Specifies that we use google docstrings both to copilot review and in CONTRIBUTING.md.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
