### PR TITLE
Assert dtype is float32 in enif update

### DIFF
--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -37,6 +37,7 @@ def test_field_param_update_using_heat_equation_enif(
         assert len(prior_result.z) == param_config.nz
 
         posterior_result = posterior.load_parameters("COND")["values"]
+        assert posterior_result.dtype == np.float32
         prior_covariance = np.cov(
             prior_result.values.reshape(
                 prior.ensemble_size, param_config.nx * param_config.ny * param_config.nz
@@ -366,6 +367,7 @@ if __name__ == "__main__":
             # check the shape of internal data used in the update
             assert prior_result.shape == (5, NCOL, NROW, NLAY)
             assert posterior_result.shape == (5, NCOL, NROW, NLAY)
+            assert posterior_result.dtype == np.float32
 
             # Only assert on the first three rows, as there are only three parameters,
             # a, b and c, the rest have no correlation to the results.
@@ -504,6 +506,7 @@ def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc
         param_config = config.ensemble_config.parameter_configs["COND"]
         prior_result = new_prior.load_parameters("COND")["values"]
         posterior_result = new_posterior.load_parameters("COND")["values"]
+        assert posterior_result.dtype == np.float32
 
         # Make sure parameters with zero variance are not updated.
         assert (


### PR DESCRIPTION
**Issue**
Resolves #11510 


**Approach**
Not able to reproduce. Adding more asserts to avoid regressions.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
