### PR TITLE
Defer loading of ertscript workflows

### DIFF
--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -63,6 +63,7 @@ from .workflow_fixtures import (
     fixtures_per_hook,
 )
 from .workflow_job import (
+    BaseErtScriptWorkflow,
     ErtScriptWorkflow,
     ExecutableWorkflow,
     WorkflowJob,
@@ -72,6 +73,7 @@ from .workflow_job import (
 __all__ = [
     "AnalysisConfig",
     "AnalysisModule",
+    "BaseErtScriptWorkflow",
     "ConfigValidationError",
     "ConfigWarning",
     "DataSource",

--- a/src/ert/gui/tools/plugins/plugin.py
+++ b/src/ert/gui/tools/plugins/plugin.py
@@ -24,7 +24,7 @@ class Plugin:
         self.__description = script.getDescription()
 
     def __loadPlugin(self) -> ErtPlugin:
-        script_obj = self.__workflow_job.ert_script
+        script_obj = self.__workflow_job.load_ert_script_class()
         script = script_obj()
         assert isinstance(script, ErtPlugin)
         return script

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -393,7 +393,7 @@ def get_site_plugins(
     )
 
     for _, job_path in installable_workflow_jobs.items():
-        wf_job = workflow_job_from_file(job_path)
+        wf_job = workflow_job_from_file(job_path, origin="site")
         all_workflow_jobs[wf_job.name] = wf_job
 
     for fm_step_subclass in plugin_manager.forward_model_steps:

--- a/src/ert/workflow_runner.py
+++ b/src/ert/workflow_runner.py
@@ -7,6 +7,7 @@ from typing import Any, Self
 
 from ert import ErtScript
 from ert.config import (
+    BaseErtScriptWorkflow,
     ErtScriptWorkflow,
     ExternalErtScript,
     Workflow,
@@ -43,8 +44,9 @@ class WorkflowJobRunner:
                 f"{self.job.max_args} arguments, {len(arguments)} given."
             )
 
-        if isinstance(self.job, ErtScriptWorkflow):
-            self.__script = self.job.ert_script()
+        if isinstance(self.job, BaseErtScriptWorkflow):
+            ert_script_class = self.job.load_ert_script_class()
+            self.__script = ert_script_class()
             # We let stop on fail either from class or config take precedence
             self.stop_on_fail = self.job.stop_on_fail or self.__script.stop_on_fail
 

--- a/src/everest/config/install_job_config.py
+++ b/src/everest/config/install_job_config.py
@@ -90,7 +90,9 @@ class InstallWorkflowJobConfig(InstallJobConfig):
         else:
             assert self.source is not None
             workflow = workflow_job_from_file(
-                config_file=str(Path(config_directory) / self.source), name=self.name
+                config_file=str(Path(config_directory) / self.source),
+                name=self.name,
+                origin="user",
             )
             if not isinstance(workflow, ExecutableWorkflow):
                 raise ValueError(f"Workflow must be an executable: {self.source}")

--- a/tests/ert/unit_tests/config/test_workflow_jobs.py
+++ b/tests/ert/unit_tests/config/test_workflow_jobs.py
@@ -3,14 +3,21 @@ from textwrap import dedent
 
 import pytest
 
-from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
-from ert.config.workflow_job import workflow_job_from_file
-from ert.plugins import get_site_plugins
+from ert import ErtScript
+from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, Workflow
+from ert.config.workflow_job import (
+    ErtScriptWorkflow,
+    UserInstalledErtScriptWorkflow,
+    workflow_job_from_file,
+)
+from ert.plugins import ErtRuntimePlugins, get_site_plugins
+from ert.storage import Storage
 
 
 def test_reading_non_existent_workflow_job_raises_config_error():
     with pytest.raises(ConfigValidationError, match="No such file or directory"):
-        workflow_job_from_file("/tmp/does_not_exist")
+        workflow_job_from_file("/tmp/does_not_exist", origin="user")
 
 
 def test_that_ert_warns_on_duplicate_workflow_jobs(tmp_path):
@@ -49,8 +56,178 @@ def test_stop_on_fail_is_parsed_external():
     )
 
     job_internal = workflow_job_from_file(
-        name="FAIL",
-        config_file="fail_job",
+        name="FAIL", config_file="fail_job", origin="user"
     )
 
     assert job_internal.stop_on_fail
+
+
+def test_that_site_ertscript_is_serialized_to_name_and_deserialized_from_plugins():
+    class SomeScript(ErtScript):
+        def run(self, storage: Storage):
+            pass
+
+    workflow_job = ErtScriptWorkflow(
+        name="SOME_SITE_INSTALLED_WFJOB",
+        ert_script=SomeScript,
+    )
+
+    with use_runtime_plugins(
+        ErtRuntimePlugins(
+            installed_workflow_jobs={
+                "SOME_SITE_INSTALLED_WFJOB": ErtScriptWorkflow(
+                    name="SOME_SITE_INSTALLED_WFJOB",
+                    ert_script=SomeScript,
+                ),
+            }
+        )
+    ):
+        workflow_job_json = workflow_job.model_dump(mode="json", exclude_unset=True)
+        assert workflow_job_json == {
+            "name": "SOME_SITE_INSTALLED_WFJOB",
+            "type": "site_installed",
+        }
+
+        assert (
+            ErtScriptWorkflow.model_validate(workflow_job_json).ert_script == SomeScript
+        )
+
+    class RevisedErtScript(ErtScript):
+        def run(self, storage: Storage):
+            pass
+
+    with use_runtime_plugins(
+        ErtRuntimePlugins(
+            installed_workflow_jobs={
+                "SOME_SITE_INSTALLED_WFJOB": ErtScriptWorkflow(
+                    name="SOME_SITE_INSTALLED_WFJOB",
+                    ert_script=RevisedErtScript,
+                ),
+            }
+        )
+    ):
+        # Expect it to lookup revised ertscript from site plugins via name
+        assert (
+            ErtScriptWorkflow.model_validate(workflow_job_json).ert_script
+            == RevisedErtScript
+        )
+
+
+def test_that_user_installed_ertscript_serializes_as_source_and_loads_class_on_demand(
+    use_tmpdir,
+):
+    Path("script.py").write_text(
+        """
+from ert import ErtScript
+from ert.storage import Storage
+
+class SomeScript(ErtScript):
+    def run(self, storage: Storage):
+        return 'i am here'
+    """,
+        encoding="utf-8",
+    )
+
+    wfjob = UserInstalledErtScriptWorkflow(
+        name="Script1",
+        source="script.py",
+    )
+
+    script_class = wfjob.load_ert_script_class()
+    script_instance = script_class()
+    assert script_instance.run(storage=None) == "i am here"
+
+    # Expect only reference stored, i.e., name
+    serialized_json = wfjob.model_dump(mode="json", exclude_unset=True)
+    assert serialized_json == {
+        "name": "Script1",
+        "source": "script.py",
+    }
+
+    # Expect it to have the class resolved again
+    assert (
+        UserInstalledErtScriptWorkflow.model_validate(serialized_json)
+        .load_ert_script_class()()
+        .run(storage=None)
+        == "i am here"
+    )
+
+
+def test_that_site_and_user_installed_fm_steps_are_serialized_differently(use_tmpdir):
+    Path("USER_EXECUTABLE_JOB_FILE").write_text(
+        "EXECUTABLE echo",
+        encoding="utf-8",
+    )
+
+    Path("script.py").write_text(
+        """
+from ert import ErtScript
+from ert.storage import Storage
+
+class SomeScript(ErtScript):
+    def run(self, storage: Storage):
+        return 'i am here'
+    """,
+        encoding="utf-8",
+    )
+
+    Path("USER_ERTSCRIPT_JOB_FILE").write_text(
+        """
+        INTERNAL True
+        SCRIPT script.py
+""",
+        encoding="utf-8",
+    )
+
+    Path("DUMMY_WORKFLOW_FILE").write_text(
+        """
+        USR_INSTALLED_EXECUTABLE_JOB
+        SITE_INSTALLED_JOB
+        USR_INSTALLED_ERTSCRIPT_JOB
+    """,
+        encoding="utf-8",
+    )
+
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS 1
+        LOAD_WORKFLOW_JOB USER_EXECUTABLE_JOB_FILE USR_INSTALLED_EXECUTABLE_JOB
+        LOAD_WORKFLOW_JOB USER_ERTSCRIPT_JOB_FILE USR_INSTALLED_ERTSCRIPT_JOB
+        LOAD_WORKFLOW DUMMY_WORKFLOW_FILE DUMMY_WORKFLOW
+        HOOK_WORKFLOW DUMMY_WORKFLOW POST_EXPERIMENT
+        """
+    )
+    Path("config.ert").write_text(test_config_contents, encoding="utf-8")
+
+    class SiteWorkflowJobScript(ErtScript):
+        def run(self, storage: Storage):
+            pass
+
+    site_plugins = ErtRuntimePlugins(
+        installed_workflow_jobs={
+            "SITE_INSTALLED_JOB": ErtScriptWorkflow(
+                name="SITE_INSTALLED_JOB",
+                ert_script=SiteWorkflowJobScript,
+            )
+        }
+    )
+    ert_config = ErtConfig.with_plugins(site_plugins).from_file("config.ert")
+    workflow = ert_config.workflows["DUMMY_WORKFLOW"]
+    workflow_jobs = [wfj[0] for wfj in workflow.cmd_list]
+    assert [job.type for job in workflow_jobs] == [
+        "user_installed_executable",
+        "site_installed",
+        "user_installed_ertscript",
+    ]
+    [user_executable_wf, site_wf, user_ertscript_wf] = workflow_jobs
+    assert user_executable_wf.name == "USR_INSTALLED_EXECUTABLE_JOB"
+    assert user_executable_wf.executable == "echo"
+
+    assert site_wf.name == "SITE_INSTALLED_JOB"
+    assert site_wf.ert_script == SiteWorkflowJobScript
+
+    assert user_ertscript_wf.name == "USR_INSTALLED_ERTSCRIPT_JOB"
+    assert user_ertscript_wf.source == str(Path("script.py").resolve())
+
+    with use_runtime_plugins(site_plugins):
+        assert Workflow(**workflow.model_dump(mode="json")) == workflow

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -848,7 +848,7 @@ def test_that_dumped_esmda_matches_snapshot(
 def executable_workflow_job():
     return ExecutableWorkflow(
         name="exec_wf_name",
-        type="executable",
+        type="user_installed_executable",
         min_args=4,
         max_args=3,
         arg_types=[
@@ -868,7 +868,7 @@ def executable_workflow_job():
 def ertscript_workflow_job():
     return ErtScriptWorkflow(
         name="the_ertscript_wf_name",
-        type="ert_script",
+        type="site_installed",
         min_args=1,
         max_args=1,
         arg_types=[SchemaItemType.STRING],
@@ -929,7 +929,11 @@ def test_that_ertscript_wf_job_deserialization_raises_error_if_uninstalled(
                 }
             )
         ),
-        pytest.raises(KeyError, match="Did not find installed workflow job"),
+        pytest.raises(
+            KeyError,
+            match=f"Expected workflow job {ertscript_workflow_job.name}"
+            " to be installed",
+        ),
     ):
         deserialized_workflow_job = ErtScriptWorkflow.model_validate(serialized_job)
         assert deserialized_workflow_job == ertscript_workflow_job


### PR DESCRIPTION
Towards https://github.com/equinor/ert/pull/11513
Background: Workflow jobs come either site-installed plugins, or user-installed workflow jobs. Site-installed workflow jobs do not need serialization, as they can be resolved from site plugins by name. User installed workflow jobs do need to store a reference to the workflow script iself.
