### PR TITLE
Ensure user queue options name is also dumped

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -359,10 +359,15 @@ class EverestRunModel(RunModel):
         )
 
         simulator_config = everest_config.simulator
-        queue_options_from_everconfig = {"name": "local"} | (
-            simulator_config.queue_system.model_dump(exclude_unset=True)
-            if simulator_config.queue_system is not None
-            else {}
+        queue_options_from_everconfig: dict[str, Any] = (
+            {"name": "local"}
+            if simulator_config.queue_system is None
+            else (
+                simulator_config.queue_system.model_dump(exclude_unset=True)
+                | {
+                    "name": simulator_config.queue_system.name,
+                }
+            )
         )
 
         if simulator_config.max_memory is not None:


### PR DESCRIPTION
Obscurely behaves differently on cluster machines with python3.11 and pydantic2.12.3. Locally on MacOS with same pydantic and python, it did not. i.e., simulator_config.queue_system.model_dump(exclude_unset=True) included name locally, but not on the cluster machines.
