### PR TITLE
Split InstallJobConfig by usage

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -12,6 +12,7 @@ from typing import (
     Any,
     Optional,
     Self,
+    TypeVar,
     no_type_check,
 )
 
@@ -60,7 +61,11 @@ from .forward_model_config import (
 )
 from .input_constraint_config import InputConstraintConfig
 from .install_data_config import InstallDataConfig
-from .install_job_config import InstallJobConfig
+from .install_job_config import (
+    InstallForwardModelStepConfig,
+    InstallJobConfig,
+    InstallWorkflowJobConfig,
+)
 from .model_config import ModelConfig
 from .objective_function_config import ObjectiveFunctionConfig
 from .optimization_config import OptimizationConfig
@@ -160,6 +165,9 @@ def _find_loc(loc: tuple[int | str, ...] | None, file_content: list[str]) -> int
         if str(loc[0]) in line:
             return index + 1
     return None
+
+
+InstallJobConfigSubclass = TypeVar("InstallJobConfigSubclass", bound=InstallJobConfig)
 
 
 class EverestConfig(BaseModelWithContextSupport):
@@ -363,7 +371,7 @@ class EverestConfig(BaseModelWithContextSupport):
             """
         ),
     )
-    install_jobs: list[InstallJobConfig] = Field(
+    install_jobs: list[InstallForwardModelStepConfig] = Field(
         default_factory=list,
         description=dedent(
             """
@@ -375,7 +383,7 @@ class EverestConfig(BaseModelWithContextSupport):
         ),
         validate_default=True,
     )
-    install_workflow_jobs: list[InstallJobConfig] = Field(
+    install_workflow_jobs: list[InstallWorkflowJobConfig] = Field(
         default_factory=list,
         description=dedent(
             """
@@ -622,7 +630,7 @@ class EverestConfig(BaseModelWithContextSupport):
 
     @model_validator(mode="after")
     def validate_job_executables(self) -> Self:  # pylint: disable=E0213
-        def _check_jobs(jobs: list[InstallJobConfig]) -> list[str]:
+        def _check_jobs(jobs: list[InstallJobConfigSubclass]) -> list[str]:
             errors = []
             for job in jobs:
                 if job.executable is None:

--- a/src/everest/config/install_job_config.py
+++ b/src/everest/config/install_job_config.py
@@ -55,6 +55,8 @@ class InstallJobConfig(BaseModel, extra="forbid"):
             raise ValueError(f"No such file or directory: {self.source}")
         return self
 
+
+class InstallForwardModelStepConfig(InstallJobConfig):
     def to_ert_forward_model_step(self, config_directory: str) -> ForwardModelStep:
         if self.executable is not None:
             executable = Path(self.executable)
@@ -71,6 +73,8 @@ class InstallJobConfig(BaseModel, extra="forbid"):
                 name=self.name,
             )
 
+
+class InstallWorkflowJobConfig(InstallJobConfig):
     def to_ert_executable_workflow(self, config_directory: str) -> ExecutableWorkflow:
         if self.executable is not None:
             executable = Path(self.executable)

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -15,7 +15,7 @@ from everest.util.forward_models import (
     parse_forward_model_file,
 )
 
-from .install_job_config import InstallJobConfig
+from .install_job_config import InstallForwardModelStepConfig
 
 _VARIABLE_ERROR_MESSAGE = (
     "Variable {name} must define {variable_type} value either"
@@ -297,7 +297,7 @@ def check_writeable_path(path_source: str, config_path: Path) -> None:
 
 
 def validate_forward_model_configs(
-    forward_model: list[str], install_jobs: list[InstallJobConfig]
+    forward_model: list[str], install_jobs: list[InstallForwardModelStepConfig]
 ) -> None:
     if not forward_model:
         return

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -24,8 +24,9 @@ from ert.dark_storage.client import ConnInfo
 from ert.plugins import ErtRuntimePlugins
 from ert.scheduler.event import FinishedEvent
 from ert.services import StorageService
-from everest.config import EverestConfig, InstallJobConfig
+from everest.config import EverestConfig
 from everest.config.forward_model_config import ForwardModelStepConfig
+from everest.config.install_job_config import InstallForwardModelStepConfig
 from everest.config.server_config import ServerConfig
 from everest.config.simulator_config import SimulatorConfig
 from everest.detached import (
@@ -49,7 +50,7 @@ async def test_https_requests(change_to_tmpdir):
     everest_config = everest_config_with_defaults(config_path="./config.yml")
     everest_config.forward_model.append(ForwardModelStepConfig(job="sleep 5"))
     everest_config.install_jobs.append(
-        InstallJobConfig(name="sleep", executable=f"{which('sleep')}")
+        InstallForwardModelStepConfig(name="sleep", executable=f"{which('sleep')}")
     )
     # start_server() loads config based on config_path, so we need to actually
     # overwrite it

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -11,7 +11,7 @@ from everest.config import (
     ServerConfig,
 )
 from everest.config.forward_model_config import ForwardModelStepConfig
-from everest.config.install_job_config import InstallJobConfig
+from everest.config.install_job_config import InstallForwardModelStepConfig
 
 
 @pytest.mark.skip_mac_ci
@@ -33,7 +33,9 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
         ForwardModelStepConfig(job="toggle_failure --fail perturbation_1")
     )
     everest_config.install_jobs.append(
-        InstallJobConfig(name="toggle_failure", source="jobs/FAIL_SIMULATION")
+        InstallForwardModelStepConfig(
+            name="toggle_failure", source="jobs/FAIL_SIMULATION"
+        )
     )
     everest_config.optimization.min_pert_success = 1
     everest_config.optimization.max_iterations = 1


### PR DESCRIPTION
It is currently used for both forward model steps and workflows, disjoint by having `.to_ert_forward_model_step` and `.to_ert_executable_workflow`, making this distinction early makes it more clear what the intent of the config is.

