### PR TITLE
Revert "Use all interfaces when finding the private IP"

### DIFF
--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -1,10 +1,8 @@
-import ipaddress
 import logging
 import random
 import socket
 from functools import lru_cache
 
-import psutil
 from dns import exception, resolver, reversename
 
 
@@ -137,31 +135,20 @@ def get_family(host: str) -> socket.AddressFamily:
         return socket.AF_INET6
 
 
+# See https://stackoverflow.com/a/28950776
 def get_ip_address() -> str:
-    """
-    Get the first private IPv4 address of the current machine on the LAN.
-    Returns the private IP, public IP if no private is found,
-    or loopback as a last resort.
-
-    Returns:
-        str: The selected IP address as a string.
-    """
-    loopback = ""
-    public = ""
-    interfaces = psutil.net_if_addrs()
-    for addresses in interfaces.values():
-        for address in addresses:
-            if address.family.name == "AF_INET":
-                ip = address.address
-                if ipaddress.ip_address(ip).is_loopback:
-                    loopback = ip
-                elif ipaddress.ip_address(ip).is_private:
-                    return ip
-                else:
-                    public = ip
-
-    if public or loopback:
-        return public or loopback  # returns first non-None value
-    else:
-        logger.warning("Cannot determine ip-address. Falling back to 127.0.0.1")
-        return "127.0.0.1"
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.settimeout(0)
+            # try pinging a reserved, internal address in order
+            # to determine IP representing the default route
+            s.connect(("10.255.255.255", 1))
+            address = s.getsockname()[0]
+        finally:
+            s.close()
+    except BaseException:
+        logger.warning("Cannot determine ip-address. Falling back to localhost.")
+        address = "127.0.0.1"
+    logger.debug(f"ip-address: {address}")
+    return address

--- a/tests/ert/unit_tests/shared/test_net_utils.py
+++ b/tests/ert/unit_tests/shared/test_net_utils.py
@@ -1,12 +1,11 @@
 import contextlib
 import socket
 import threading
-from unittest.mock import MagicMock, patch
 
 import psutil
 import pytest
 
-from ert.shared import find_available_socket, get_ip_address, get_machine_name
+from ert.shared import find_available_socket, get_machine_name
 from ert.shared.net_utils import (
     NoPortsInRangeException,
     get_family,
@@ -292,50 +291,3 @@ def test_socket_can_not_rebind_immediately_after_close_if_used(unused_tcp_port):
     # Immediately trying to bind to the same port fails
     with pytest.raises(NoPortsInRangeException):
         find_available_socket(port_range=port_range, host="127.0.0.1")
-
-
-# Helper to create psutil-like address objects
-class FakeAddr:
-    def __init__(self, address, family_name="AF_INET") -> None:
-        self.address = address
-        self.family = MagicMock()
-        self.family.name = family_name
-
-
-test_cases = [
-    pytest.param({}, "127.0.0.1", id="no_ipv4_addresses_disconnected"),
-    pytest.param(
-        {"lo": [FakeAddr("127.0.0.1")], "eth0": [FakeAddr("192.168.1.10")]},
-        "192.168.1.10",
-        id="private_and_loopback_interface",
-    ),
-    pytest.param(
-        {"lo": [FakeAddr("127.0.0.1")], "eth0": [FakeAddr("8.8.8.8")]},
-        "8.8.8.8",
-        id="public_and_loopback_interface",
-    ),
-    pytest.param(
-        {"eth0": [FakeAddr("192.168.1.10")], "eth1": [FakeAddr("8.8.8.8")]},
-        "192.168.1.10",
-        id="private_and_public_interface",
-    ),
-    pytest.param(
-        {"eth0": [FakeAddr("8.8.8.8")]}, "8.8.8.8", id="only_public_interface"
-    ),
-    pytest.param(
-        {"eth0": [FakeAddr("10.0.0.5")], "eth1": [FakeAddr("8.8.8.8")]},
-        "10.0.0.5",
-        id="private_10_x_x_x_and_public_interface",
-    ),
-    pytest.param(
-        {"eth0": [FakeAddr("172.16.5.10")], "eth1": [FakeAddr("8.8.8.8")]},
-        "172.16.5.10",
-        id="private_172_16_x_x_and_public_interface",
-    ),
-]
-
-
-@pytest.mark.parametrize("mock_psutils_if_addrs,expected", test_cases)
-def test_get_ip_address(mock_psutils_if_addrs, expected):
-    with patch("psutil.net_if_addrs", return_value=mock_psutils_if_addrs):
-        assert get_ip_address() == expected


### PR DESCRIPTION
This reverts commit 26203ad8e1377cf10e5420ce3cc4fd3511726273.

Fails in Equinor

**Issue**
Resolves #12234


**Approach**
Revert commit


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
