### PR TITLE
Serialize only name and args of site-installed forward model steps

### DIFF
--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -23,6 +23,9 @@ from .forward_model_step import (
     ForwardModelStepPlugin,
     ForwardModelStepValidationError,
     ForwardModelStepWarning,
+    SiteInstalledForwardModelStep,
+    SiteOrUserForwardModelStep,
+    UserInstalledForwardModelStep,
 )
 from .gen_data_config import GenDataConfig
 from .gen_kw_config import DataSource, GenKwConfig, PriorDict
@@ -127,8 +130,11 @@ __all__ = [
     "QueueSystem",
     "ResponseConfig",
     "ResponseMetadata",
+    "SiteInstalledForwardModelStep",
+    "SiteOrUserForwardModelStep",
     "SummaryConfig",
     "SurfaceConfig",
+    "UserInstalledForwardModelStep",
     "WarningInfo",
     "Workflow",
     "WorkflowConfigs",

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -36,6 +36,9 @@ from .forward_model_step import (
     ForwardModelStepJSON,
     ForwardModelStepValidationError,
     ForwardModelStepWarning,
+    SiteInstalledForwardModelStep,
+    SiteOrUserForwardModelStep,
+    UserInstalledForwardModelStep,
 )
 from .gen_data_config import GenDataConfig
 from .gen_kw_config import GenKwConfig
@@ -518,18 +521,16 @@ def workflows_from_dict(
 
 def installed_forward_model_steps_from_dict(
     config_dict: ConfigDict,
-) -> dict[str, ForwardModelStep]:
+) -> dict[str, UserInstalledForwardModelStep]:
     errors: list[ErrorInfo | ConfigValidationError] = []
-    fm_steps: dict[str, ForwardModelStep] = {}
+    fm_steps: dict[str, UserInstalledForwardModelStep] = {}
     for name, (fm_step_config_file, config_contents) in config_dict.get(
         ConfigKeys.INSTALL_JOB, []
     ):
         fm_step_config_file = path.abspath(fm_step_config_file)
         try:
             new_fm_step = forward_model_step_from_config_contents(
-                config_contents,
-                name=name,
-                config_file=fm_step_config_file,
+                config_contents, name=name, config_file=fm_step_config_file
             )
         except ConfigValidationError as e:
             errors.append(e)
@@ -720,7 +721,7 @@ class ErtConfig(BaseModel):
 
     ert_templates: list[tuple[str, str]] = Field(default_factory=list)
 
-    forward_model_steps: list[ForwardModelStep] = Field(default_factory=list)
+    forward_model_steps: list[SiteOrUserForwardModelStep] = Field(default_factory=list)
     runpath_config: ModelConfig = Field(default_factory=ModelConfig)
     user_config_file: str = "no_config"
     config_path: str = Field(init=False, default="")
@@ -817,7 +818,7 @@ class ErtConfig(BaseModel):
     def with_plugins(runtime_plugins: ErtRuntimePlugins) -> type[ErtConfig]:
         class ErtConfigWithPlugins(ErtConfig):
             PREINSTALLED_FORWARD_MODEL_STEPS: ClassVar[
-                Mapping[str, ForwardModelStep]
+                Mapping[str, SiteInstalledForwardModelStep]
             ] = runtime_plugins.installed_forward_model_steps
             PREINSTALLED_WORKFLOWS = dict(runtime_plugins.installed_workflow_jobs)
             ENV_PR_FM_STEP: ClassVar[dict[str, dict[str, Any]]] = (
@@ -1365,8 +1366,10 @@ def uppercase_subkeys_and_stringify_subvalues(
 
 
 def forward_model_step_from_config_contents(
-    config_contents: str, config_file: str, name: str | None = None
-) -> ForwardModelStep:
+    config_contents: str,
+    config_file: str,
+    name: str | None = None,
+) -> UserInstalledForwardModelStep:
     if name is None:
         name = os.path.basename(config_file)
 
@@ -1390,7 +1393,7 @@ def forward_model_step_from_config_contents(
     environment = {k: v for [k, v] in content_dict.get("ENV", [])}
     default_mapping = {k: v for [k, v] in content_dict.get("DEFAULT", [])}
 
-    return ForwardModelStep(
+    return UserInstalledForwardModelStep(
         name=name,
         executable=content_dict["EXECUTABLE"],
         stdin_file=content_dict.get("STDIN"),

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -12,12 +12,12 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from ert.config import (
-    ForwardModelStep,
     ForwardModelStepDocumentation,
     ForwardModelStepPlugin,
     KnownQueueOptions,
     LegacyWorkflowConfigs,
     LocalQueueOptions,
+    SiteInstalledForwardModelStep,
     WorkflowConfigs,
     WorkflowJob,
     workflow_job_from_file,
@@ -328,7 +328,7 @@ class ErtPluginManager(pluggy.PluginManager):
 
 
 class ErtRuntimePlugins(BaseModel):
-    installed_forward_model_steps: Mapping[str, ForwardModelStep] = Field(
+    installed_forward_model_steps: Mapping[str, SiteInstalledForwardModelStep] = Field(
         default_factory=dict
     )
     installed_workflow_jobs: Mapping[str, WorkflowJob] = Field(default_factory=dict)

--- a/src/everest/config/forward_model_config.py
+++ b/src/everest/config/forward_model_config.py
@@ -9,7 +9,9 @@ from pydantic import (
 )
 
 from ert.base_model_context import BaseModelWithContextSupport
-from ert.config import ForwardModelStep
+from ert.config import (
+    SiteOrUserForwardModelStep,
+)
 
 
 class ForwardModelResult(BaseModelWithContextSupport):
@@ -74,8 +76,8 @@ class ForwardModelStepConfig(BaseModelWithContextSupport):
         return values
 
     def to_ert_forward_model_step(
-        self, installed_fm_steps: dict[str, ForwardModelStep]
-    ) -> ForwardModelStep:
+        self, installed_fm_steps: dict[str, SiteOrUserForwardModelStep]
+    ) -> SiteOrUserForwardModelStep:
         fm_name, *arglist = self.job.split()
         match fm_name:
             # All three reservoir simulator fm_steps map to

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -9,7 +9,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from ert.config import ForwardModelStep
+from ert.config.forward_model_step import (
+    SiteOrUserForwardModelStep,
+)
 
 
 def _is_dir_all_model(source: str, model_realizations: list[int]) -> bool:
@@ -126,8 +128,8 @@ class InstallDataConfig(BaseModel):
         config_directory: str,
         output_directory: str,
         model_realizations: list[int],
-        installed_fm_steps: dict[str, ForwardModelStep],
-    ) -> ForwardModelStep:
+        installed_fm_steps: dict[str, SiteOrUserForwardModelStep],
+    ) -> SiteOrUserForwardModelStep:
         target = self.target
 
         def _missing_fm_msg(fm_name: str) -> str:

--- a/src/everest/config/install_job_config.py
+++ b/src/everest/config/install_job_config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from ert.config import (
     ExecutableWorkflow,
-    ForwardModelStep,
+    UserInstalledForwardModelStep,
     forward_model_step_from_config_contents,
     workflow_job_from_file,
 )
@@ -57,12 +57,16 @@ class InstallJobConfig(BaseModel, extra="forbid"):
 
 
 class InstallForwardModelStepConfig(InstallJobConfig):
-    def to_ert_forward_model_step(self, config_directory: str) -> ForwardModelStep:
+    def to_ert_forward_model_step(
+        self, config_directory: str
+    ) -> UserInstalledForwardModelStep:
         if self.executable is not None:
             executable = Path(self.executable)
             if not executable.is_absolute():
                 executable = Path(config_directory) / executable
-            return ForwardModelStep(name=self.name, executable=str(executable))
+            return UserInstalledForwardModelStep(
+                name=self.name, executable=str(executable)
+            )
         else:
             assert (
                 self.source is not None

--- a/src/everest/config/install_template_config.py
+++ b/src/everest/config/install_template_config.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 
 from pydantic import BaseModel, Field
 
-from ert.config import ForwardModelStep
+from ert.config import SiteOrUserForwardModelStep
 from everest.strings import EVEREST
 
 
@@ -38,9 +38,9 @@ class InstallTemplateConfig(BaseModel, extra="forbid"):
     def to_ert_forward_model_step(
         self,
         control_names: list[str],
-        installed_fm_steps: dict[str, ForwardModelStep],
+        installed_fm_steps: dict[str, SiteOrUserForwardModelStep],
         well_path: str,
-    ) -> ForwardModelStep:
+    ) -> SiteOrUserForwardModelStep:
         fm_step_instance = copy.deepcopy(installed_fm_steps.get("template_render"))
         if fm_step_instance is None:
             raise KeyError(

--- a/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import pytest
 
 from ert.config import ConfigWarning, ErtConfig
-from ert.config.forward_model_step import ForwardModelStep
+from ert.config.forward_model_step import (
+    UserInstalledForwardModelStep,
+)
 from ert.config.parsing.config_schema_deprecations import (
     JUST_REMOVE_KEYWORDS,
     REPLACE_WITH_GEN_KW,
@@ -207,7 +209,7 @@ def test_that_a_deprecation_message_is_shown_for_use_of_the_job_prefix_queue_opt
 
 def test_that_forward_model_design2params_is_deprecated():
     # Create a mock DESIGN2PARAMS forward model step, since it is not installed
-    mock_design2params_step = ForwardModelStep(
+    mock_design2params_step = UserInstalledForwardModelStep(
         name="DESIGN2PARAMS",
         executable="design2params",
     )
@@ -232,7 +234,7 @@ def test_that_forward_model_design2params_is_deprecated():
 
 def test_that_forward_model_design_kw_is_deprecated():
     # Create a mock DESIGN_KW forward model step, since it is not installed
-    mock_design_kw_step = ForwardModelStep(
+    mock_design_kw_step = UserInstalledForwardModelStep(
         name="DESIGN_KW",
         executable="design_kw",
     )

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -29,7 +29,10 @@ from ert.config import (
     QueueSystem,
 )
 from ert.config.ert_config import _split_string_into_sections, create_forward_model_json
-from ert.config.forward_model_step import ForwardModelStep, ForwardModelStepPlugin
+from ert.config.forward_model_step import (
+    ForwardModelStepPlugin,
+    SiteInstalledForwardModelStep,
+)
 from ert.config.parsing import ConfigKeys, ConfigWarning
 from ert.config.parsing.context_values import (
     ContextBool,
@@ -2010,7 +2013,7 @@ def test_design2params_also_validates_design_matrix(tmp_path, caplog, monkeypatc
         ),
         pl.DataFrame([["b", 1], ["c", 2]], orient="row"),
     )
-    mock_design2params = ForwardModelStep(
+    mock_design2params = SiteInstalledForwardModelStep(
         name="DESIGN2PARAMS",
         executable="/usr/bin/env",
         arglist=["<IENS>", "<xls_filename>", "<designsheet>", "<defaultssheet>"],
@@ -2049,7 +2052,7 @@ def test_two_design2params_validates_design_matrix_merging(
         pl.DataFrame({"REAL": [1, 2], "numbers": [99, 98]}),
         pl.DataFrame(),
     )
-    mock_design2params = ForwardModelStep(
+    mock_design2params = SiteInstalledForwardModelStep(
         name="DESIGN2PARAMS",
         executable="/usr/bin/env",
         arglist=["<IENS>", "<xls_filename>", "<designsheet>", "<defaultssheet>"],
@@ -2107,7 +2110,7 @@ def test_three_design2params_validates_design_matrix_merging(
         pl.DataFrame({"REAL": [1, 2], "numbers": [99, 98]}),
         pl.DataFrame(),
     )
-    mock_design2params = ForwardModelStep(
+    mock_design2params = SiteInstalledForwardModelStep(
         name="DESIGN2PARAMS",
         executable="/usr/bin/env",
         arglist=["<IENS>", "<xls_filename>", "<designsheet>", "<defaultssheet>"],

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -8,7 +8,9 @@ from textwrap import dedent
 
 import pytest
 from hypothesis import given, settings
+from pydantic import TypeAdapter
 
+from ert.base_model_context import use_runtime_plugins
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
 from ert.config.ert_config import (
     create_forward_model_json,
@@ -18,6 +20,8 @@ from ert.config.forward_model_step import (
     ForwardModelStepJSON,
     ForwardModelStepPlugin,
     ForwardModelStepValidationError,
+    SiteInstalledForwardModelStep,
+    SiteOrUserForwardModelStep,
 )
 from ert.config.parsing import SchemaItemType
 from ert.plugins import ErtRuntimePlugins, get_site_plugins
@@ -37,10 +41,7 @@ def test_load_forward_model():
         STDERR null
         EXECUTABLE script.sh
         """
-    fm_step = forward_model_step_from_config_contents(
-        contents,
-        "CONFIG",
-    )
+    fm_step = forward_model_step_from_config_contents(contents, "CONFIG")
     assert fm_step.name == "CONFIG"
     assert fm_step.stdout_file is None
     assert fm_step.stderr_file is None
@@ -52,7 +53,7 @@ def test_load_forward_model():
 
     fm_step = forward_model_step_from_config_contents(contents, "CONFIG", name="Step")
     assert fm_step.name == "Step"
-    assert repr(fm_step).startswith("ForwardModelStep(")
+    assert repr(fm_step).startswith("UserInstalledForwardModelStep(")
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -1056,4 +1057,151 @@ def test_that_all_required_keywords_in_forward_model_are_validated():
            INSTALL_JOB step step
            FORWARD_MODEL step
            """
+        )
+
+
+def test_that_site_fm_step_serializes_as_reference_to_site_plugin(use_tmpdir):
+    class SiteForwardModel(ForwardModelStepPlugin):
+        def __init__(self) -> None:
+            super().__init__(
+                name="SITE_FM",
+                command=["echo", "helloworld", "<ONE>", "<TWO>"],
+            )
+
+    with use_runtime_plugins(
+        ErtRuntimePlugins(installed_forward_model_steps={"SITE_FM": SiteForwardModel()})
+    ):
+        site_fm = SiteForwardModel()
+        # PS: It is missing private args, this must be added by mutation
+        # as it is the current practice in ert config
+        site_fm.private_args = {"ONE": 1, "TWO": "2"}
+
+        serialized_fm_step = site_fm.model_dump(mode="json")
+        assert serialized_fm_step == {
+            "name": "SITE_FM",
+            "type": "site_installed",
+            "private_args": {"ONE": 1, "TWO": "2"},
+        }
+
+
+def test_that_site_fm_step_deserialization_is_overwritten_by_site_installed_fmsteps(
+    use_tmpdir,
+):
+    custom_echo_path = Path("custom_echo.sh")
+    custom_echo_path.write_text("#!/bin/bash\necho hello", encoding="utf-8")
+    custom_echo_path.chmod(custom_echo_path.stat().st_mode | stat.S_IEXEC)
+
+    class SomeUpdatedForwardModel(ForwardModelStepPlugin):
+        def __init__(self) -> None:
+            super().__init__(
+                name="SITE_FM",
+                command=["custom_echo.sh", "helloworld", "<hello>", "<hi>", "<noop>"],
+            )
+
+    with use_runtime_plugins(
+        ErtRuntimePlugins(
+            installed_forward_model_steps={"SITE_FM": SomeUpdatedForwardModel()}
+        )
+    ):
+        site_fm_with_updated_executable = TypeAdapter(
+            SiteOrUserForwardModelStep
+        ).validate_python(
+            {
+                "name": "SITE_FM",
+                "type": "site_installed",
+                "private_args": {"hello": "hi", "hi": "2"},
+            }
+        )
+
+        assert isinstance(
+            site_fm_with_updated_executable, SiteInstalledForwardModelStep
+        )
+        assert site_fm_with_updated_executable.executable == "custom_echo.sh"
+        assert site_fm_with_updated_executable.private_args == {
+            "hello": "hi",
+            "hi": "2",
+        }
+
+
+def test_that_user_fm_step_retains_executable_and_private_args_when_serialized(
+    use_tmpdir,
+):
+    Path("fm_step").write_text("EXECUTABLE echo\nARGLIST ARG1 ARG2", encoding="utf-8")
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS 1
+        INSTALL_JOB user_fm fm_step
+        FORWARD_MODEL user_fm(ARG1=<arg1>,ARG2=<arg2>)
+        """
+    )
+    Path("config.ert").write_text(test_config_contents, encoding="utf-8")
+
+    ert_config = ErtConfig.from_file("config.ert")
+    user_fm = ert_config.forward_model_steps[0]
+    assert user_fm.type == "user_installed"
+    assert user_fm.executable == "echo"
+    assert user_fm.arglist == ["ARG1", "ARG2"]
+    assert user_fm.private_args == {"ARG1": "<arg1>", "ARG2": "<arg2>"}
+    assert (
+        TypeAdapter(SiteOrUserForwardModelStep).validate_python(user_fm.model_dump())
+        == user_fm
+    )
+
+
+def test_that_fm_step_serializes_name_and_private_args_only_for_site_and_full_for_user(
+    use_tmpdir,
+):
+    Path("fm_step").write_text(
+        "EXECUTABLE echo\nARGLIST ONE TWO THREE", encoding="utf-8"
+    )
+    test_config_contents = dedent(
+        """
+        NUM_REALIZATIONS 1
+        INSTALL_JOB users_fm fm_step
+        FORWARD_MODEL users_fm(ONE=1,TWO=2,THREE=3)
+        FORWARD_MODEL SITE_INSTALLED_FM(ONE=1,TWO=2,THREE=3)
+        """
+    )
+    Path("config.ert").write_text(test_config_contents, encoding="utf-8")
+
+    class SiteForwardModel(ForwardModelStepPlugin):
+        def __init__(self) -> None:
+            super().__init__(
+                name="SITE_INSTALLED_FM",
+                command=["echo", "hello_from_site", "<ONE>", "<TWO>", "<THREE>"],
+            )
+
+    site_plugins = ErtRuntimePlugins(
+        installed_forward_model_steps={"SITE_INSTALLED_FM": SiteForwardModel()}
+    )
+    ert_config = ErtConfig.with_plugins(site_plugins).from_file("config.ert")
+    [user_fm, site_fm] = ert_config.forward_model_steps
+    assert user_fm.type == "user_installed"
+    assert site_fm.model_dump() == {
+        "type": "site_installed",
+        "name": "SITE_INSTALLED_FM",
+        "private_args": {"ONE": "1", "TWO": "2", "THREE": "3"},
+    }
+
+    assert user_fm.private_args == {"ONE": "1", "TWO": "2", "THREE": "3"}
+    assert user_fm.private_args == site_fm.private_args
+
+
+def test_that_deserializing_site_forward_model_without_site_plugins_raises_error():
+    with pytest.raises(KeyError, match="Trying to find site-installed forward model"):
+        SiteInstalledForwardModelStep.model_validate(
+            {"type": "site_installed", "name": "queue pool's closed"}
+        )
+
+
+def test_that_deserializing_site_forward_model_step_not_in_plugins_raises_error():
+    with (
+        pytest.raises(
+            KeyError,
+            match=r"Expected forward model step queue pool",
+        ),
+        use_runtime_plugins(ErtRuntimePlugins(installed_forward_model_steps={})),
+    ):
+        SiteInstalledForwardModelStep.model_validate(
+            {"type": "site_installed", "name": "queue pool's closed"}
         )


### PR DESCRIPTION
Pre-work for https://github.com/equinor/ert/pull/11513
Motivation is to not have a serialized runmodel be locked to the executable at that time. If the forward model step is from a plugin, it should upon serialization, store a reference to its plugin. If the plugin changes/updates, so should the forward model step.

Example serialization of site-installed forward model:
```
{
     "type": "site_installed",
     "name": "SITE_INSTALLED_FM",
}
```

(instead of the entire jobs.json dump)

PS: Some external plugin FM steps are still using legacy format (STEA for example) (config file for forward model, hence the `origin` arg of `forward_model_step_from_config_contents`. 