### PR TITLE
Remove unnecessary exclude_defaults for usr queue options

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -288,7 +288,7 @@ class RunModel(BaseModelWithContextSupport, ABC):
             else {}
         )
         usr_queue_options_dict = queue_config.queue_options.model_dump(
-            exclude_unset=True, exclude_defaults=True
+            exclude_unset=True
         )
 
         site_queue_system = str(


### PR DESCRIPTION
They should be excluded from site config, but not from user config.

**Issue**
Resolves https://github.com/equinor/ert/issues/12222
