### PR TITLE
Remove outdated doc about not supporting split summaries

### DIFF
--- a/docs/ert/reference/glossary.rst
+++ b/docs/ert/reference/glossary.rst
@@ -92,10 +92,7 @@ It is not about being correct, it is about being relevant and coherent.
 
     summary files
         The result of running a reservoir simulator is a number of time vectors
-        which are written to summary files. Ert only supports unified summary
-        files which comes in a pair of files with extension ".UNSMRY" and
-        ".SMSPEC" (or ".FUNSMRY" and ".FSMSPEC" when using formatted output).
-        See `OPM Flow manual`_ section F for details.
+        which are written to summary files. See `OPM Flow manual`_ section F for details.
 
     summary key
         A summary key is a colon separated list of the required properties


### PR DESCRIPTION
We now support split summaries through resfo-utilities


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
