### PR TITLE
Mark some heat equation tests as integration tests

### DIFF
--- a/tests/ert/unit_tests/dark_storage/test_parameters.py
+++ b/tests/ert/unit_tests/dark_storage/test_parameters.py
@@ -1,8 +1,11 @@
+import pytest
+
 from ert.config import ErtConfig
 from ert.dark_storage.endpoints.parameters import data_for_parameter
 from ert.storage import open_storage
 
 
+@pytest.mark.integration_test
 def test_that_asking_for_non_existent_key_doesnt_raise(
     symlinked_heat_equation_storage_es,
 ):
@@ -14,6 +17,7 @@ def test_that_asking_for_non_existent_key_doesnt_raise(
         assert df.empty
 
 
+@pytest.mark.integration_test
 def test_that_asking_for_existing_key_without_group_returns_empty(
     symlinked_heat_equation_storage_es,
 ):
@@ -25,6 +29,7 @@ def test_that_asking_for_existing_key_without_group_returns_empty(
         assert df.empty
 
 
+@pytest.mark.integration_test
 def test_that_asking_for_existing_key_with_group_returns_data(
     symlinked_heat_equation_storage_es,
 ):


### PR DESCRIPTION
slow if heat eq is not cached already

