### PR TITLE
Speed up ensemble_evaluator tests

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -68,6 +68,7 @@ class EventSentinel:
 
 class EnsembleEvaluator:
     BATCHING_INTERVAL = 0.5
+    DEFAULT_SLEEP_PERIOD = 0.1
 
     def __init__(
         self,
@@ -191,7 +192,7 @@ class EnsembleEvaluator:
                 await self._signal_cancel()
                 logger.debug("Run model cancelled - during evaluation - cancel sent")
                 self._end_event.clear()
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(self.DEFAULT_SLEEP_PERIOD)
 
     async def _send_terminate_message_to_dispatchers(self) -> None:
         event = TERMINATE_MSG
@@ -264,7 +265,7 @@ class EnsembleEvaluator:
                     batch.append((function, event))
                     self._events.task_done()
                 except asyncio.QueueEmpty:
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(self.DEFAULT_SLEEP_PERIOD)
                     continue
             self._complete_batch.set()
             await self._batch_processing_queue.put(batch)
@@ -416,7 +417,7 @@ class EnsembleEvaluator:
             while True:
                 if self._evaluation_result.done():
                     break
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(self.DEFAULT_SLEEP_PERIOD)
             logger.debug("Async server exiting.")
         finally:
             try:


### PR DESCRIPTION
**Approach**
Decrease sleep period and polling waiting. 

(Screenshot of new behavior in GUI if applicable)

Before:
```
4.55s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_scheduler_as_fallback
2.03s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_terminate_message
1.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.81s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_snapshot_on_resubmit_is_cleared
0.51s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.50s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_process_event_buffer-processing_task]
0.50s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_batch_events_into_buffer-dispatcher_task]
0.50s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_sends_terminate_message_to_dispatchers
0.40s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_snapshot_on_resubmit_is_cleared
0.40s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_to_hang
0.10s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_to_hang
0.09s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_overspent_cpu_is_logged
0.02s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_log_forward_model_steps_with_missing_status_updates
0.01s setup    tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_terminate_message
0.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_fails_evaluator_raises_exception[_batch_events_into_buffer-Batcher failed!]
0.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_sends_terminate_message_to_dispatchers
0.01s setup    tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_to_hang

(37 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================================================================================================================================================================================================================== 18 passed in 11.65s ===========================================================================================================================================================================================================================
```
After
```
0.82s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_terminate_message
0.51s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_process_event_buffer-processing_task]
0.50s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_when_task_prematurely_ends_raises_exception[_batch_events_into_buffer-dispatcher_task]
0.40s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_to_hang
0.26s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_scheduler_as_fallback
0.21s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.21s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_snapshot_on_resubmit_is_cleared
0.08s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_overspent_cpu_is_logged
0.05s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_does_not_cause_evaluator_dispatcher_communication_to_hang
0.05s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_snapshot_on_resubmit_is_cleared
0.05s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.05s teardown tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_sends_terminate_message_to_dispatchers
0.02s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_log_forward_model_steps_with_missing_status_updates
0.01s setup    tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_signal_cancel_terminates_fm_dispatcher_with_terminate_message
0.01s setup    tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_restarted_jobs_do_not_have_error_msgs
0.01s call     tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py::test_queue_config_properties_propagated_to_scheduler_from_ensemble

(38 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================================================================================================================================================================================================================== 18 passed in 3.40s ============================================================================================================================================================================================================================

```

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
