### PR TITLE
Clear run_dialog warnings when rerunning failed experiments

### DIFF
--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -633,6 +633,7 @@ class RunDialog(QFrame):
         if result == QMessageBox.StandardButton.Ok:
             self.rerun_button.setEnabled(False)
             self.kill_button.setEnabled(True)
+            self.post_simulation_warnings.clear()
             self._is_rerunning_failed_realizations = True
             self.rerun_failed_realizations_experiment.emit()
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -968,3 +968,21 @@ def test_that_file_dialog_close_when_run_dialog_hidden(qtbot: QtBot, run_dialog)
             assert file_dialog.isVisible()
             run_dialog.setVisible(False)
             assert not file_dialog.isVisible()
+
+
+def test_that_run_dialog_clears_warnings_when_rerun(qtbot, monkeypatch):
+    run_dialog = RunDialog(
+        title="test",
+        run_model_api=MagicMock(),
+        event_queue=MagicMock(),
+        notifier=MagicMock(),
+    )
+    assert len(run_dialog.post_simulation_warnings) == 0
+    run_dialog.post_simulation_warnings.append("warning")
+    assert len(run_dialog.post_simulation_warnings) > 0
+
+    monkeypatch.setattr(
+        QMessageBox, "exec", value=lambda _: QMessageBox.StandardButton.Ok
+    )
+    run_dialog.rerun_failed_realizations()
+    assert len(run_dialog.post_simulation_warnings) == 0


### PR DESCRIPTION
This fixes a bug where warnings are accumulated between reruns. This would flood the Suggestor box and give warnings which are not relevant to the current run.

This change will clear the list of warnings should the user click rerun failed experiments.

**Issue**
Resolves #12289 

Before:

https://github.com/user-attachments/assets/11d03c2f-e79d-4a06-ab39-054d82d39497


After:


https://github.com/user-attachments/assets/d17def1a-60a3-45ef-b12b-d5f0a8619e7d



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
