### PR TITLE
Remove installable_jobs hook for fmsteps

### DIFF
--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -44,25 +44,14 @@ A plugin is created with the `ert.plugin` decorator and the function name descri
 
 Forward models
 ~~~~~~~~~~~~~~
-To install forward model steps that you want to have available in ERT you can either
-use the simplified :code:`installable_jobs` function name, or
-:code:`installable_forward_model_steps` which gives a lot more control.
-The individual steps in a forward model were previously called "jobs" in Ert,
-and this is still partly present in the source code.
+To install forward model steps that you want to have available in ERT you can use
+:code:`installable_forward_model_steps`.
 
 .. code-block:: python
 
     from typing import Optional
 
     import ert
-
-
-    @ert.plugin(name="my_plugin")
-    def installable_jobs() -> dict[str, str]:
-        return {
-            "job_name": "/path/to/workflow.config"
-        }
-
 
     class MyForwardModel(ert.ForwardModelStepPlugin):
         def __init__(self):
@@ -104,11 +93,6 @@ throw ``ForwardModelStepValidationError`` to indicate that the configuration of 
 forward model step is invalid (which ert then handles gracefully and presents nicely
 to the user). If you want to show a warning in cases where the configuration cannot be
 validated pre-experiment, you can use the ``ForwardModelStepWarning.warn(...)`` method.
-
-To provide documentation for a forward model step given with
-``installable_jobs``, use the :code:`job_documentation` name. If you are the
-plugin that provided the step with the name :code:`step_name`, then you respond
-with the documentation as specified, else respond with :code:`None`.
 
 .. code-block:: python
 

--- a/src/ert/plugins/__init__.py
+++ b/src/ert/plugins/__init__.py
@@ -25,7 +25,6 @@ def plugin(name: str) -> Callable[[Callable[P, Any]], Callable[P, Any]]:
             if (
                 func.__name__
                 in {
-                    "installable_jobs",
                     "job_documentation",
                     "installable_workflow_jobs",
                     "help_links",

--- a/src/ert/plugins/hook_specifications/__init__.py
+++ b/src/ert/plugins/hook_specifications/__init__.py
@@ -5,7 +5,6 @@ from .forward_model_steps import (
 from .help_resources import help_links
 from .jobs import (
     ertscript_workflow,
-    installable_jobs,
     installable_workflow_jobs,
     job_documentation,
     legacy_ertscript_workflow,
@@ -20,7 +19,6 @@ __all__ = [
     "forward_model_configuration",
     "help_links",
     "installable_forward_model_steps",
-    "installable_jobs",
     "installable_workflow_jobs",
     "job_documentation",
     "legacy_ertscript_workflow",

--- a/src/ert/plugins/hook_specifications/jobs.py
+++ b/src/ert/plugins/hook_specifications/jobs.py
@@ -10,15 +10,6 @@ if TYPE_CHECKING:
 
 
 @no_type_check
-@hook_specification
-def installable_jobs() -> PluginResponse[dict[str, str]]:
-    """
-    :return: dict with job names as keys and path to config as value
-    :rtype: PluginResponse with data as dict[str,str]
-    """
-
-
-@no_type_check
 @hook_specification(firstresult=True)
 def job_documentation(job_name: str) -> PluginResponse[dict[str, str] | None]:
     """

--- a/src/ert/shared/_doc_utils/ert_jobs.py
+++ b/src/ert/shared/_doc_utils/ert_jobs.py
@@ -180,10 +180,7 @@ class _ErtDocumentation(SphinxDirective):
 
 class ErtForwardModelDocumentation(_ErtDocumentation):
     pm = ErtPluginManager()
-    _JOBS: ClassVar[dict[str, Any]] = {
-        **pm.get_documentation_for_jobs(),
-        **pm.get_documentation_for_forward_model_steps(),
-    }
+    _JOBS: ClassVar[dict[str, Any]] = pm.get_documentation_for_forward_model_steps()
 
     def run(self) -> list[nodes.section]:
         return self._generate_job_documentation_without_title(

--- a/tests/ert/unit_tests/plugins/dummy_plugins.py
+++ b/tests/ert/unit_tests/plugins/dummy_plugins.py
@@ -17,11 +17,6 @@ def forward_model_configuration():
 
 
 @plugin(name="dummy")
-def installable_jobs():
-    return {"job1": "dummy/path/job1", "job2": "dummy/path/job2"}
-
-
-@plugin(name="dummy")
 def installable_workflow_jobs():
     return {"wf_job1": "dummy/path/wf_job1", "wf_job2": "dummy/path/wf_job2"}
 

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -29,8 +29,6 @@ def test_with_plugins():
     }
     assert pm.get_forward_model_configuration() == {"FLOW": {"mpipath": "/foo"}}
 
-    assert pm.get_installable_jobs()["job1"] == "dummy/path/job1"
-    assert pm.get_installable_jobs()["job2"] == "dummy/path/job2"
     assert pm._get_config_workflow_jobs()["wf_job1"] == "dummy/path/wf_job1"
     assert pm._get_config_workflow_jobs()["wf_job2"] == "dummy/path/wf_job2"
 
@@ -181,26 +179,6 @@ def test_fm_config_with_wrong_keytype():
 
     with pytest.raises(TypeError, match="foo did not provide dict"):
         ErtPluginManager(plugins=[SomePlugin]).get_forward_model_configuration()
-
-
-def test_job_documentation():
-    pm = ErtPluginManager(plugins=[dummy_plugins])
-    expected = {
-        "job1": {
-            "config_file": "dummy/path/job1",
-            "source_package": "dummy",
-            "source_function_name": "installable_jobs",
-            "description": "job description",
-            "examples": "example 1 and example 2",
-            "category": "test.category.for.job",
-        },
-        "job2": {
-            "config_file": "dummy/path/job2",
-            "source_package": "dummy",
-            "source_function_name": "installable_jobs",
-        },
-    }
-    assert pm.get_documentation_for_jobs() == expected
 
 
 def test_workflows_merge(monkeypatch):


### PR DESCRIPTION
Since https://github.com/equinor/scout/issues/1290 is now resolved, we can remove this. All external plugins should now use installable_forward_model_steps hook instead. 
