### PR TITLE
Fix criteria check for <2 active realizations

### DIFF
--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -299,7 +299,7 @@ def _setup_ensemble_smoother(
 ) -> EnsembleSmoother:
     active_realizations = _get_and_validate_active_realizations_list(args, config)
     validate_minimum_realizations(config, active_realizations)
-    if len(active_realizations) < 2:
+    if sum(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
         )
@@ -346,7 +346,7 @@ def _setup_ensemble_information_filter(
 ) -> EnsembleInformationFilter:
     active_realizations = _get_and_validate_active_realizations_list(args, config)
     validate_minimum_realizations(config, active_realizations)
-    if len(active_realizations) < 2:
+    if sum(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
         )
@@ -412,7 +412,7 @@ def _setup_multiple_data_assimilation(
     restart_run, prior_ensemble = _determine_restart_info(args)
     active_realizations = _get_and_validate_active_realizations_list(args, config)
     validate_minimum_realizations(config, active_realizations)
-    if len(active_realizations) < 2:
+    if sum(active_realizations) < 2:
         raise ConfigValidationError(
             "Number of active realizations must be at least 2 for an update step"
         )


### PR DESCRIPTION
**Issue**
Resolves #12176 
Resolves #12297

Single test run before:

https://github.com/user-attachments/assets/f078a3e3-eb1d-4154-b0b5-3d42280a05ab

Single test run after:

https://github.com/user-attachments/assets/b5b7cbcf-6153-49fc-b2b5-b9ad2d1f0a91

Ensemble experiment before:

https://github.com/user-attachments/assets/f9f8551c-e550-4197-a90f-dcbd5acbaea9

Ensemble experiment after:

https://github.com/user-attachments/assets/b35e22b2-dfe2-44f6-8480-bd4c5f64549d


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
