### PR TITLE
Use setuptools_scm 'version_file' instead of 'write_to'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ session_timeout = 1800
 timeout_func_only = true # Do not apply timeout to fixtures which can be slow but cached
 
 [tool.setuptools_scm]
-write_to = "src/ert/shared/version.py"
+version_file = "src/ert/shared/version.py"
 # Fallback needed due to https://github.com/dependabot/dependabot-core/issues/12340
 fallback_version = "0.0.0"
 


### PR DESCRIPTION
See: https://setuptools-scm.readthedocs.io/en/latest/config/

```
write_to: Pathlike[str] | Path | None = None
(deprecated) legacy option to create a version file relative to the scm root it's broken for usage from a sdist and fixing it would be a fatal breaking change, use version_file instead.
```

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
