### PR TITLE
Make parameters in different design matrix instances unique

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -99,24 +99,17 @@ class DesignMatrix:
         common_keys = set(
             self.design_matrix_df.select(pl.exclude("realization")).columns
         ) & set(dm_other.design_matrix_df.columns)
-        non_identical_cols = set()
         if common_keys:
-            for key in common_keys:
-                if not self.design_matrix_df.select(key).equals(
-                    dm_other.design_matrix_df.select(key)
-                ):
-                    non_identical_cols.add(key)
-            if non_identical_cols:
-                errors.append(
-                    ErrorInfo(
-                        f"Design Matrices '{self.xls_filename.name} "
-                        f"({self.design_sheet} {self.default_sheet or ''})' and "
-                        f"'{dm_other.xls_filename.name} ({dm_other.design_sheet} "
-                        f"{dm_other.default_sheet or ''})' "
-                        "contains non identical columns with the same name: "
-                        f"{non_identical_cols}!"
-                    )
+            errors.append(
+                ErrorInfo(
+                    f"Design Matrices '{self.xls_filename.name} "
+                    f"({self.design_sheet} {self.default_sheet or ''})' and "
+                    f"'{dm_other.xls_filename.name} ({dm_other.design_sheet} "
+                    f"{dm_other.default_sheet or ''})' "
+                    "contains columns with the same name: "
+                    f"{common_keys}!"
                 )
+            )
 
         if errors:
             raise ConfigValidationError.from_collected(errors)
@@ -125,9 +118,7 @@ class DesignMatrix:
             self.design_matrix_df = pl.concat(
                 [
                     self.design_matrix_df,
-                    dm_other.design_matrix_df.select(
-                        pl.exclude([*list(common_keys), "realization"])
-                    ),
+                    dm_other.design_matrix_df.select(pl.exclude(["realization"])),
                 ],
                 how="horizontal",
             )

--- a/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
+++ b/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
@@ -27,27 +27,14 @@ from tests.ert.conftest import _create_design_matrix
         pytest.param(
             pl.DataFrame(
                 {
-                    "a": [1, 2, 3],
-                    "c": [9, 10, 11.1],
-                    "d": [0, 2, 0],
-                },
-                strict=False,
-            ),
-            pl.DataFrame([["e", 1]], orient="row"),
-            "",
-            id="ok_merge_with_identical_columns",
-        ),
-        pytest.param(
-            pl.DataFrame(
-                {
                     "REAL": [0, 1, 2],
                     "a": [1, 2, 4],
                 }
             ),
             pl.DataFrame([["e", 1]], orient="row"),
             (
-                "Design Matrices .* and .* contains non "
-                r"identical columns with the same name: \{'a'\}!"
+                "Design Matrices .* and .* contains "
+                r"columns with the same name: \{'a'\}!"
             ),
             id="not_unique_keys",
         ),


### PR DESCRIPTION
**Issue**
We want to have no overlaps of parameter names in different design matrix instances.


**Approach**
<img width="1241" height="471" alt="image" src="https://github.com/user-attachments/assets/71ec2c5d-be77-4f0a-9d4d-4883a0cfaea6" />


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
