### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,9 @@ on:
       python-version:
         type: string
 
+permissions:
+   contents: read
+
 jobs:
   build-wheels:
     timeout-minutes: 10

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,6 +8,9 @@ on:
    tags: "*"
  pull_request:
 
+permissions:
+   contents: read
+
 env:
   ERT_SHOW_BACKTRACE: 1   # resdata print on failure https://github.com/equinor/resdata/blob/5fdf0280726a2670161ed536705dc9156aea39be/lib/util/util_abort.cpp#L96
   UV_FROZEN: true         # https://docs.astral.sh/uv/configuration/environment/#uv_frozen

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
   OMP_NUM_THREADS: 1

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -7,6 +7,9 @@ on:
      - 'version-**'
  pull_request:
 
+permissions:
+   contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,6 +7,9 @@ on:
      - 'version-**'
  pull_request:
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
 

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -7,6 +7,10 @@ on:
         type: string
       test-type:
         type: string
+
+permissions:
+   contents: read
+
 env:
   ERT_SHOW_BACKTRACE: 1
   ERT_PYTEST_ARGS: '--cov=ert --cov=everest --cov=_ert --cov-report=xml:cov_main.xml --junit-xml=junit.xml -o junit_family=legacy -v --durations=25 --benchmark-disable'

--- a/.github/workflows/test_ert_with_flow.yml
+++ b/.github/workflows/test_ert_with_flow.yml
@@ -6,6 +6,9 @@ on:
       python-version:
         type: string
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
 

--- a/.github/workflows/test_ert_with_slurm.yml
+++ b/.github/workflows/test_ert_with_slurm.yml
@@ -6,6 +6,9 @@ on:
       python-version:
         type: string
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
 

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -10,6 +10,9 @@ on:
       test-type:
         type: string
 
+permissions:
+   contents: read
+
 env:
   NO_PROJECT_RES: 1
   UV_FROZEN: true

--- a/.github/workflows/test_everest_models.yml
+++ b/.github/workflows/test_everest_models.yml
@@ -6,6 +6,9 @@ name: Test Everest Models
 
 on: [pull_request]
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
   OMP_NUM_THREADS: 1

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -7,6 +7,9 @@ name: Test Semeio
 
 on: [pull_request]
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
   OMP_NUM_THREADS: 1

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -7,6 +7,9 @@ on:
      - 'version-**'
  pull_request:
 
+permissions:
+   contents: read
+
 env:
   UV_FROZEN: true
 

--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 8 * * 1"
 
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Checked that update_lockfile worked here: https://github.com/equinor/ert/actions/runs/19468564215


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
