### PR TITLE
Update ruff, ignore new rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,14 @@ repos:
         exclude: test-data/ert/eclipse/parse/ERROR.PRT # exact format is needed for testing
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.14.5
     hooks:
     - id: ruff-check
       args: [ --fix ]
     - id: ruff-format
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.8.14
+    rev: 0.9.10
     hooks:
       - id: uv-lock
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ ignore = [
     "PLW1641", # eq-without-hash
     "PLR0904", # too-many-public-methods
     "PLR1702", # too-many-nested-blocks
+    "ASYNC240", # blocking-path-method-in-async-function
 ]
 
 # Allow EN DASH (U+2013)

--- a/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 
 import pytest

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -17,7 +17,6 @@ from PyQt6.QtWidgets import (
 )
 from pytestqt.qtbot import QtBot
 
-import ert
 import ert.run_models
 from ert.config import ErtConfig
 from ert.ensemble_evaluator import state


### PR DESCRIPTION
Fixing the new rule ASYNC240 belongs in its own issue

**Issue**
Resolves usage of old ruff.

**Approach**
`pre-commit autoupdate`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
