### PR TITLE
Enforce style, typing/rapid-tests first to save CI minutes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,8 +20,18 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  run-pre-commit:
+    uses: ./.github/workflows/run_pre_commit.yml
+
+  check-typing:
+    uses: ./.github/workflows/typing.yml
+
+  run-codspeed:
+    needs: [run-pre-commit, check-typing]
+    uses: ./.github/workflows/codspeed.yml
 
   build-wheels:
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +42,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   test-linux-ert:
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +57,7 @@ jobs:
     secrets: inherit
 
   test-linux-everest:
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +79,7 @@ jobs:
     secrets: inherit
 
   test-slurm:
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +92,7 @@ jobs:
     secrets: inherit
 
   test-ert-with-flow:
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +106,7 @@ jobs:
 
   test-mac-main-everest:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') # only perform mac tests on main branch and tags
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -108,6 +123,7 @@ jobs:
 
   test-mac-main-ert:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') # only perform mac tests on main branch and tags
+    needs: [run-pre-commit, check-typing]
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +139,7 @@ jobs:
     secrets: inherit
 
   docs-ert:
+    needs: [run-pre-commit, check-typing]
     name: Test ert docs
     strategy:
       fail-fast: false

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
    contents: read
@@ -13,9 +13,6 @@ permissions:
 env:
   UV_FROZEN: true
   OMP_NUM_THREADS: 1
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   benchmarks:

--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -1,21 +1,17 @@
-name: Style
+name: Run pre-commit
 
 on:
  push:
    branches:
      - main
      - 'version-**'
- pull_request:
+ workflow_call:
 
 permissions:
    contents: read
 
 env:
   UV_FROZEN: true
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   check-style:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -5,17 +5,13 @@ on:
    branches:
      - main
      - 'version-**'
- pull_request:
+ workflow_call:
 
 permissions:
    contents: read
 
 env:
   UV_FROZEN: true
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   type-checking:


### PR DESCRIPTION
Restructure workflows such that:
- Typing and `pre-commit` style/testing are run first (in build_test.yml)
- Codecov and `build_test` workflow jobs depend on the two jobs

This could mitigate a lot of wasted CI minutes catching Style, Typing and lack of initial testing.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
