### PR TITLE
Fix ert templates when creating restart experiment

### DIFF
--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -92,7 +92,7 @@ class MultipleDataAssimilation(UpdateRunModel, InitialEnsembleRunModel):
                     observations=prior.experiment.observations,
                     simulation_arguments=prior.experiment.metadata,
                     name=f"Restart from {prior.name}",
-                    templates=prior.experiment.templates_configuration,
+                    templates=self.ert_templates,
                 )
             except (KeyError, ValueError) as err:
                 raise ErtRunError(

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -134,10 +134,18 @@ def _esmda_run(run_experiment, source_root, tmp_path_factory):
 
 
 def _ensemble_experiment_run(
-    run_experiment, source_root, tmp_path_factory, failing_reals
+    run_experiment,
+    source_root,
+    tmp_path_factory,
+    failing_reals: bool,
+    with_templates: bool,
 ):
     path = tmp_path_factory.mktemp("test-data")
     _new_poly_example(source_root, path)
+    if with_templates:
+        (path / "foo.tmpl").write_text("template contents", encoding="utf-8")
+        with (path / "poly.ert").open("a", encoding="utf-8") as f:
+            f.write("RUN_TEMPLATE foo.tmpl foo.txt")
     with (
         pytest.MonkeyPatch.context() as mp,
         _open_main_window(path / "poly.ert") as (
@@ -206,7 +214,13 @@ def ensemble_experiment_has_run(
     tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory
 ):
     yield from _ensemble_experiment_has_run(
-        tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, True
+        tmp_path,
+        monkeypatch,
+        run_experiment,
+        source_root,
+        tmp_path_factory,
+        failing_reals=True,
+        with_templates=False,
     )
 
 
@@ -215,16 +229,28 @@ def ensemble_experiment_has_run_no_failure(
     tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory
 ):
     yield from _ensemble_experiment_has_run(
-        tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, False
+        tmp_path,
+        monkeypatch,
+        run_experiment,
+        source_root,
+        tmp_path_factory,
+        failing_reals=False,
+        with_templates=True,
     )
 
 
 def _ensemble_experiment_has_run(
-    tmp_path, monkeypatch, run_experiment, source_root, tmp_path_factory, failing
+    tmp_path,
+    monkeypatch,
+    run_experiment,
+    source_root,
+    tmp_path_factory,
+    failing_reals,
+    with_templates,
 ):
     monkeypatch.chdir(tmp_path)
     test_files = _ensemble_experiment_run(
-        run_experiment, source_root, tmp_path_factory, failing
+        run_experiment, source_root, tmp_path_factory, failing_reals, with_templates
     )
     shutil.copytree(test_files, tmp_path, dirs_exist_ok=True)
     yield from open_gui_with_config(tmp_path / "poly.ert")


### PR DESCRIPTION
This fixes a regression from 7f2114f1 where the template contents were put into the new experiment instead of the template specification.

An existing test was modified to catch the regression, verified to expose the problem and to solve it.

**Issue**
Resolves #12330 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
