### PR TITLE
Fix _generate_run_path exporting gen kw parameters one by one

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -217,17 +217,12 @@ class GenKwConfig(ParameterConfig):
         real_nr: int,
         ensemble: Ensemble,
     ) -> dict[str, dict[str, float | str]]:
-        df = ensemble.load_parameters(self.name, real_nr, transformed=True).drop(
+        df = ensemble.load_parameters(self.group_name, real_nr, transformed=True).drop(
             "realization"
         )
 
         assert isinstance(df, pl.DataFrame)
-        if not df.width == 1:
-            raise ValueError(
-                f"GEN_KW {self.group_name}:{self.name} should be a single parameter!"
-            )
-
-        data = df.to_dicts()[0]
+        data = {k: v for i in df.to_dicts() for k, v in i.items()}
         return {self.group_name: data}
 
     def load_parameters(

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -117,12 +117,19 @@ def _generate_parameter_files(
     """
     exports: dict[str, dict[str, float | str]] = {}
 
+    exported_gen_kw_groups = set()
     for param in parameter_configs:
         # For the first iteration we do not write the parameter
         # to run path, as we expect to read if after the forward
         # model has completed.
         if param.forward_init and iteration == 0:
             continue
+        if isinstance(param, GenKwConfig):
+            if param.group_name in exported_gen_kw_groups:
+                continue
+            else:
+                exported_gen_kw_groups.add(param.group_name)
+
         export_values = param.write_to_runpath(Path(run_path), iens, fs)
         if export_values:
             for group, vals in export_values.items():


### PR DESCRIPTION
**Issue**
Resolves #12271


**Approach**
This commit fixes the issue where if you have a lot of parameters, creating the runpath will take a very long while. This is due to us reading the parquet file for every parameter for every realization. Batching all gen kw parameters by using group_name instead of name speeds this up greatly.


(Screenshot of new behavior in GUI if applicable)

| Parameter Count | Main | PR   |
| -------------- | ---- | ---- |
| 100            | 12s  | N/A  |
| 200            | 29s  | N/A  |
| 300            | 48s  | 5.6s |
| 400            | 76s  | 7.4s |
| 1000           | 303s  | 17s  |


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
