### PR TITLE
Remove get_runtime from RunModel API

### DIFF
--- a/src/ert/ensemble_evaluator/__init__.py
+++ b/src/ert/ensemble_evaluator/__init__.py
@@ -2,7 +2,13 @@ from ._ensemble import LegacyEnsemble as Ensemble
 from ._ensemble import Realization
 from .config import EvaluatorServerConfig
 from .evaluator import EnsembleEvaluator
-from .event import EndEvent, FullSnapshotEvent, SnapshotUpdateEvent, WarningEvent
+from .event import (
+    EndEvent,
+    FullSnapshotEvent,
+    SnapshotUpdateEvent,
+    StartEvent,
+    WarningEvent,
+)
 from .snapshot import EnsembleSnapshot, FMStepSnapshot, RealizationSnapshot
 
 __all__ = [
@@ -16,5 +22,6 @@ __all__ = [
     "Realization",
     "RealizationSnapshot",
     "SnapshotUpdateEvent",
+    "StartEvent",
     "WarningEvent",
 ]

--- a/src/ert/ensemble_evaluator/event.py
+++ b/src/ert/ensemble_evaluator/event.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
@@ -40,6 +41,11 @@ class FullSnapshotEvent(_UpdateEvent):
 
 class SnapshotUpdateEvent(_UpdateEvent):
     event_type: Literal["SnapshotUpdateEvent"] = "SnapshotUpdateEvent"
+
+
+class StartEvent(BaseModel):
+    event_type: Literal["StartEvent"] = "StartEvent"
+    timestamp: datetime
 
 
 class EndEvent(BaseModel):

--- a/src/ert/gui/simulation/run_dialog.py
+++ b/src/ert/gui/simulation/run_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from queue import SimpleQueue
 from typing import assert_never, cast
@@ -35,6 +36,7 @@ from ert.ensemble_evaluator import (
     EndEvent,
     FullSnapshotEvent,
     SnapshotUpdateEvent,
+    StartEvent,
     WarningEvent,
 )
 from ert.ensemble_evaluator import identifiers as ids
@@ -258,6 +260,7 @@ class RunDialog(QFrame):
         self._fm_step_label.setObjectName("fm_step_label")
         self._fm_step_overview = FMStepOverview(self._snapshot_model, self)
 
+        self._start_time: datetime | None = None
         self.running_time = QLabel("Running time:\n -")
         self.running_time.setMinimumWidth(150)
         self.queue_system = QLabel("")
@@ -524,9 +527,11 @@ class RunDialog(QFrame):
 
     @Slot()
     def _on_ticker(self) -> None:
-        runtime = self._run_model_api.get_runtime()
-        running_time = f"Running time: {humanize.precisedelta(runtime)}"
-        self.running_time.setText(running_time[0:14] + "\n" + running_time[14:])
+        if self._start_time:
+            humanized_runtime = humanize.precisedelta(
+                datetime.now() - self._start_time, minimum_unit="seconds", format="%d"
+            )
+            self.running_time.setText(f"Running time:\n{humanized_runtime}")
 
         maximum_memory_usage = self._snapshot_model.root.max_memory_usage
 
@@ -543,6 +548,8 @@ class RunDialog(QFrame):
     def _on_event(self, event: object) -> None:
         model = self._snapshot_model
         match event:
+            case StartEvent():
+                self._start_time = event.timestamp
             case EndEvent(failed=failed, msg=msg):
                 self.simulation_done.emit(failed, msg)
                 self._ticker.stop()

--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -15,6 +15,7 @@ from ert.ensemble_evaluator.event import (
     EndEvent,
     FullSnapshotEvent,
     SnapshotUpdateEvent,
+    StartEvent,
     WarningEvent,
 )
 
@@ -90,16 +91,17 @@ StatusEvents = (
     AnalysisStatusEvent
     | AnalysisTimeEvent
     | EndEvent
-    | EverestStatusEvent
     | EverestBatchResultEvent
+    | EverestStatusEvent
     | FullSnapshotEvent
-    | SnapshotUpdateEvent
+    | RunModelDataEvent
     | RunModelErrorEvent
     | RunModelStatusEvent
     | RunModelTimeEvent
     | RunModelUpdateBeginEvent
-    | RunModelDataEvent
     | RunModelUpdateEndEvent
+    | SnapshotUpdateEvent
+    | StartEvent
     | WarningEvent
 )
 

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -10,13 +10,13 @@ import os
 import queue
 import shutil
 import threading
-import time
 import traceback
 import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, MutableSequence
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
@@ -69,7 +69,13 @@ from ert.workflow_runner import WorkflowRunner
 from ..base_model_context import BaseModelWithContextSupport
 from ..run_arg import RunArg
 from ._create_run_path import create_run_path
-from .event import EndEvent, FullSnapshotEvent, SnapshotUpdateEvent, StatusEvents
+from .event import (
+    EndEvent,
+    FullSnapshotEvent,
+    SnapshotUpdateEvent,
+    StartEvent,
+    StatusEvents,
+)
 
 if TYPE_CHECKING:
     from ert.plugins import ErtRuntimePlugins
@@ -143,7 +149,6 @@ class RunModelAPI:
     supports_rerunning_failed_realizations: bool
     start_simulations_thread: StartSimulationsThreadFn
     cancel: Callable[[], None]
-    get_runtime: Callable[[], int]
     has_failed_realizations: Callable[[], bool]
 
 
@@ -168,8 +173,6 @@ class RunModelConfig(BaseModelWithContextSupport):
 
 class RunModel(RunModelConfig, ABC):
     # Private attributes initialized in model_post_init
-    _start_time: int | None = PrivateAttr(None)
-    _stop_time: int | None = PrivateAttr(None)
     _initial_realizations_mask: list[bool] = PrivateAttr()
     _completed_realizations_mask: list[bool] = PrivateAttr(default_factory=list)
     _storage: Storage = PrivateAttr()
@@ -215,7 +218,6 @@ class RunModel(RunModelConfig, ABC):
     def api(self) -> RunModelAPI:
         return RunModelAPI(
             experiment_name=self.name(),
-            get_runtime=self.get_runtime,
             start_simulations_thread=self.start_simulations_thread,
             has_failed_realizations=self.has_failed_realizations,
             supports_rerunning_failed_realizations=self.supports_rerunning_failed_realizations,
@@ -399,9 +401,9 @@ class RunModel(RunModelConfig, ABC):
         def handle_captured_event(message: Warning | str) -> None:
             self.send_event(WarningEvent(msg=str(message)))
 
+        start_timestamp = datetime.now()
         try:
-            self._start_time = int(time.time())
-            self._stop_time = None
+            self.send_event(StartEvent(timestamp=start_timestamp))
             with (
                 capture_specific_warning(PostSimulationWarning, handle_captured_event),
                 captured_logs(error_messages),
@@ -456,7 +458,6 @@ class RunModel(RunModelConfig, ABC):
         finally:
             self._storage.close()
             self._clean_env_context()
-            self._stop_time = int(time.time())
             self.send_event(
                 EndEvent(
                     failed=failed,
@@ -470,6 +471,10 @@ class RunModel(RunModelConfig, ABC):
                         else "Experiment completed."
                     ),
                 )
+            )
+            logger.info(
+                "Experiment run finished in: "
+                f"{(datetime.now() - start_timestamp).total_seconds():g}s"
             )
 
     @abstractmethod
@@ -491,13 +496,6 @@ class RunModel(RunModelConfig, ABC):
         if traceback is None:
             return f"{exception}\n{msg}"
         return f"{exception}\n{traceback}\n{msg}"
-
-    def get_runtime(self) -> int:
-        if self._start_time is None:
-            return 0
-        elif self._stop_time is None:
-            return round(time.time() - self._start_time)
-        return self._stop_time - self._start_time
 
     def get_current_status(self) -> dict[str, int]:
         status: dict[str, int] = defaultdict(int)
@@ -822,7 +820,6 @@ class RunModel(RunModelConfig, ABC):
             f"Experiment run ended with number of realizations failing: "
             f"{len(starting_realizations) - num_successful_realizations}"
         )
-        logger.info(f"Experiment run finished in: {self.get_runtime()}s")
         self.run_workflows(
             fixtures=PostSimulationFixtures(
                 storage=self._storage,

--- a/src/everest/gui/everest_client.py
+++ b/src/everest/gui/everest_client.py
@@ -128,7 +128,6 @@ class EverestClient:
             supports_rerunning_failed_realizations=False,
             start_simulations_thread=start_fn,
             cancel=self.stop,
-            get_runtime=self.get_runtime,
             has_failed_realizations=lambda: False,
         )
 

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
@@ -112,14 +112,6 @@ def mock_set_is_simulation_running():
 
 
 @pytest.fixture
-def mock_get_runtime():
-    mock = MagicMock()
-    with patch("ert.run_models.run_model.RunModel.get_runtime", mock) as _mock:
-        _mock.return_value = 10
-        yield _mock
-
-
-@pytest.fixture
 def mock_set_env_key():
     mock = MagicMock()
     with patch("ert.run_models.run_model.RunModel.set_env_key", mock) as _mock:
@@ -184,15 +176,6 @@ def test_that_terminating_experiment_shows_a_confirmation_dialog(
         .findChild(QLabel)
         .text()
     )
-
-
-@pytest.mark.integration_test
-def test_run_dialog_polls_run_model_for_runtime(
-    qtbot, mock_set_is_simulation_running, mock_get_runtime, run_dialog: RunDialog
-):
-    qtbot.waitUntil(lambda: run_dialog.is_simulation_done() is True, timeout=10000)
-    mock_get_runtime.assert_any_call()
-    mock_set_is_simulation_running.assert_has_calls([call(True), call(False)])
 
 
 @pytest.mark.integration_test

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -14,7 +14,7 @@ from pydantic import ConfigDict
 
 from ert.config import ErtConfig, GenKwConfig, ModelConfig, QueueConfig, QueueSystem
 from ert.config.queue_config import LsfQueueOptions
-from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig
+from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig, StartEvent
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
 from ert.plugins import ErtRuntimePlugins
 from ert.run_models.run_model import RunModel, UserCancelled
@@ -71,6 +71,7 @@ def test_status_when_rerunning_on_non_rerunnable_model(use_tmpdir):
     brm.start_simulations_thread(
         EvaluatorServerConfig(use_token=False), rerun_failed_realizations=True
     )
+    assert isinstance(brm._status_queue.get(), StartEvent)
     assert brm._status_queue.get() == EndEvent(
         event_type="EndEvent",
         failed=True,


### PR DESCRIPTION
This allows removal of the start_time property of a RunModel, which defies serialization of the object, as it is a runtime property.

Instead of storing the starttime as a property, we send it as a StartEvent message, letting event clients be able to calculate the runtime themselves.

Logging of experiment runtime is kept, but with a bonus bugfix in that a message for every ensemble stating that the experiment is fixed, has been removed. Now we emit this log message only at the end, instead of 4 times in the case of the standard es_mda for example.

**Issue**
Resolves #10974 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
