### PR TITLE
Optimize write_to_runpath for scalar parameters

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -217,18 +217,7 @@ class GenKwConfig(ParameterConfig):
         real_nr: int,
         ensemble: Ensemble,
     ) -> dict[str, dict[str, float | str]]:
-        df = ensemble.load_parameters(self.name, real_nr, transformed=True).drop(
-            "realization"
-        )
-
-        assert isinstance(df, pl.DataFrame)
-        if not df.width == 1:
-            raise ValueError(
-                f"GEN_KW {self.group_name}:{self.name} should be a single parameter!"
-            )
-
-        data = df.to_dicts()[0]
-        return {self.group_name: data}
+        raise NotImplementedError
 
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -16,6 +16,7 @@ from ert.config import (
     Field,
     ForwardModelStep,
     GenKwConfig,
+    ParameterCardinality,
     ParameterConfig,
     SurfaceConfig,
 )
@@ -115,16 +116,28 @@ def _generate_parameter_files(
         Returns the union of parameters returned by write_to_runpath for each
         parameter_config.
     """
+    # preload scalar parameters for this realization
+    keys = [
+        p.name
+        for p in parameter_configs
+        if p.cardinality == ParameterCardinality.multiple_configs_per_ensemble_dataset
+    ]
+    scalar_data: dict[str, float | str] = {}
+    if keys:
+        df = fs._load_scalar_keys(keys=keys, realizations=iens, transformed=True)
+        scalar_data = df.to_dicts()[0]
     exports: dict[str, dict[str, float | str]] = {}
-
     for param in parameter_configs:
         # For the first iteration we do not write the parameter
         # to run path, as we expect to read if after the forward
         # model has completed.
         if param.forward_init and iteration == 0:
             continue
-
-        export_values = param.write_to_runpath(Path(run_path), iens, fs)
+        export_values: dict[str, dict[str, float | str]] | None = None
+        if param.name in scalar_data:
+            export_values = {param.group_name: {param.name: scalar_data[param.name]}}
+        else:
+            export_values = param.write_to_runpath(Path(run_path), iens, fs)
         if export_values:
             for group, vals in export_values.items():
                 exports.setdefault(group, {}).update(vals)


### PR DESCRIPTION
**Approach**

We do pre-load pd.Dataframe now avoid loading the file #parameters times for each realization.
There is still place to improve this though, mainly since we can pre-load all the realizations.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
