### PR TITLE
Remove integration_test from some tests

### DIFF
--- a/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
+++ b/tests/ert/unit_tests/analysis/test_misfit_preprocessor.py
@@ -68,7 +68,6 @@ def test_that_get_nr_primary_components_is_according_to_theory(p, rho, seed):
 
 
 @pytest.mark.parametrize("nr_observations", [4, 7, 12])
-@pytest.mark.integration_test
 def test_that_correlated_and_independent_observations_are_grouped_separately(
     nr_observations,
 ):
@@ -183,7 +182,6 @@ def test_edge_cases_with_few_observations_return_default_values(nr_observations)
         (4, 6),
     ],
 )
-@pytest.mark.integration_test
 def test_main_correctly_separates_distinct_correlation_groups(
     nr_obs_group_a, nr_obs_group_b
 ):

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -668,7 +668,6 @@ cases_to_test = [
 # readable/accessible wrt single test case failures
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_manual_update_matches_snapshot(
     case, copy_case, snapshot, change_to_tmpdir
 ):
@@ -704,7 +703,6 @@ def test_that_dumped_manual_update_matches_snapshot(
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_evaluate_ensemble_matches_snapshot(
     case, copy_case, snapshot, change_to_tmpdir
 ):
@@ -739,7 +737,6 @@ def test_that_dumped_evaluate_ensemble_matches_snapshot(
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_ensemble_experiment_matches_snapshot(
     case, copy_case, snapshot, change_to_tmpdir
 ):
@@ -764,7 +761,6 @@ def test_that_dumped_ensemble_experiment_matches_snapshot(
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_ensemble_smoother_matches_snapshot(
     case, copy_case, snapshot, change_to_tmpdir
 ):
@@ -789,7 +785,6 @@ def test_that_dumped_ensemble_smoother_matches_snapshot(
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_enif_matches_snapshot(case, copy_case, snapshot, change_to_tmpdir):
     config_dir, config_file = case.split("/")
     copy_case(config_dir)
@@ -812,7 +807,6 @@ def test_that_dumped_enif_matches_snapshot(case, copy_case, snapshot, change_to_
 
 @pytest.mark.filterwarnings("ignore::ert.config.ConfigWarning")
 @pytest.mark.parametrize("case", cases_to_test)
-@pytest.mark.integration_test
 def test_that_dumped_esmda_matches_snapshot(
     case, copy_case, snapshot, change_to_tmpdir
 ):

--- a/tests/ert/unit_tests/scheduler/test_generic_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_generic_driver.py
@@ -155,7 +155,6 @@ async def test_repeated_submit_same_iens(driver: Driver, tmp_path, monkeypatch):
     assert Path("submissionrace").read_text(encoding="utf-8") == "submit2\n"
 
 
-@pytest.mark.integration_test
 @pytest.mark.flaky(reruns=5)
 async def test_kill_actually_kills(driver: Driver, tmp_path, pytestconfig, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -91,7 +91,6 @@ def capturing_bsub(monkeypatch, tmp_path):
     )
 
 
-@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "bjobs_script, bhist_script, exit_code",
     [
@@ -254,7 +253,6 @@ async def test_that_realization_memory_parameter_sets_bsub_rusage_option():
     assert "-R rusage[mem=1]" in Path("captured_bsub_args").read_text(encoding="utf-8")
 
 
-@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "bsub_script, expectation",
     [
@@ -325,7 +323,6 @@ async def test_that_when_bsub_has_exit_code_1_its_output_is_in_the_error_message
     )
 
 
-@pytest.mark.integration_test
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "mocked_iens2jobid, realizations_to_kill, "
@@ -851,7 +848,6 @@ async def test_parse_bhist(bhist_output, expected):
 empty_states = _parse_jobs_dict({})
 
 
-@pytest.mark.integration_test
 @pytest.mark.parametrize(
     "previous_bhist, bhist_output, expected_states",
     [

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -368,7 +368,6 @@ async def test_that_qsub_will_retry_and_succeed(
     await driver.submit(0, "sleep 10")
 
 
-@pytest.mark.integration_test
 @pytest.mark.parametrize(
     ("exit_code, error_msg"),
     [

--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -39,7 +39,6 @@ def capturing_sbatch(monkeypatch, tmp_path):
     sbatch_path.chmod(sbatch_path.stat().st_mode | stat.S_IEXEC)
 
 
-@pytest.mark.integration_test
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     "sbatch_script, scontrol_script, sacct_script, exit_code",


### PR DESCRIPTION
Some tests seem to now run quickly and does not have any failures logged.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
