### PR TITLE
Disregard unupdated parameters with EnIF

### DIFF
--- a/src/ert/analysis/_enif_update.py
+++ b/src/ert/analysis/_enif_update.py
@@ -160,10 +160,14 @@ def analysis_EnIF(
         Y=S.T,
         verbose_level=5,
     )
-
+    updated_parameters = [
+        p
+        for p, config in source_ensemble.experiment.parameter_configuration.items()
+        if config.update
+    ]
     # Learn the precision matrix block-sparse over parameter groups
     Prec_u = sp.sparse.csc_matrix((0, 0), dtype=float)
-    for param_group in parameters:
+    for param_group in updated_parameters:
         config_node = source_ensemble.experiment.parameter_configuration[param_group]
         X_local = source_ensemble.load_parameters_numpy(param_group, iens_active_index)
         X_local_scaler = StandardScaler()
@@ -215,7 +219,7 @@ def analysis_EnIF(
 
     # Iterate over parameters to store the updated ensemble
     parameters_updated = 0
-    for param_group in parameters:
+    for param_group in updated_parameters:
         log_msg = f"Storing data for {param_group}.."
         logger.info(log_msg)
         progress_callback(AnalysisStatusEvent(msg=log_msg))
@@ -241,7 +245,7 @@ def analysis_EnIF(
         )
     _copy_unupdated_parameters(
         list(source_ensemble.experiment.parameter_configuration.keys()),
-        parameters,
+        updated_parameters,
         iens_active_index,
         source_ensemble,
         target_ensemble,

--- a/src/ert/analysis/_update_commons.py
+++ b/src/ert/analysis/_update_commons.py
@@ -340,11 +340,12 @@ def _all_parameters(
 ) -> npt.NDArray[np.float64]:
     """Return all parameters in assimilation problem"""
 
-    param_groups = list(ensemble.experiment.parameter_configuration.keys())
-
+    groups_to_update = [
+        k for k, v in ensemble.experiment.parameter_configuration.items() if v.update
+    ]
     param_arrays = [
         ensemble.load_parameters_numpy(param_group, iens_active_index)
-        for param_group in param_groups
+        for param_group in groups_to_update
     ]
 
     return np.vstack(param_arrays)

--- a/tests/ert/unit_tests/run_models/test_enif.py
+++ b/tests/ert/unit_tests/run_models/test_enif.py
@@ -1,0 +1,70 @@
+import queue
+from argparse import Namespace
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from ert.config import ErtConfig
+from ert.ensemble_evaluator import EvaluatorServerConfig
+from ert.mode_definitions import (
+    ENIF_MODE,
+)
+from ert.run_models import create_model
+from ert.storage import open_storage
+from tests.ert.conftest import _create_design_matrix
+
+
+@pytest.mark.integration_test
+def test_that_enif_update_does_not_update_design_matrix_parameters(
+    copy_case,
+):
+    """
+    Runs EnIF on poly.ert with hardcoded parameter "a" values in design matrix,
+    then expect parameter "a" values to remain unchanged after second run
+    """
+    num_realizations = 10
+
+    copy_case("poly_example")
+    config_file = Path("poly.ert")
+
+    _create_design_matrix(
+        "poly_design.xlsx",
+        pl.DataFrame(
+            {
+                "REAL": list(range(num_realizations)),
+                "a": [1] * num_realizations,  # ["a"].to_list(),
+            }
+        ),
+    )
+
+    with open(config_file, "a", encoding="utf-8") as fh:
+        fh.write(f"NUM_REALIZATIONS {num_realizations}\n")
+        fh.write("RANDOM_SEED 123456789\n")
+        fh.write("DESIGN_MATRIX poly_design.xlsx\n")
+
+    evaluator_server_config = EvaluatorServerConfig()
+    ert_config_with_dm = ErtConfig.from_file("poly.ert")
+
+    enif_with_dm = create_model(
+        ert_config_with_dm,
+        args=Namespace(
+            mode=ENIF_MODE,
+            experiment_name="enif_with_dm",
+            target_ensemble="ens_with_dm_%d",
+        ),
+        status_queue=queue.SimpleQueue(),
+    )
+
+    enif_with_dm.start_simulations_thread(evaluator_server_config)
+
+    with open_storage(enif_with_dm.storage_path, mode="r") as storage:
+        experiment_with_dm = storage.get_experiment_by_name("enif_with_dm")
+
+        prior_with_dm = experiment_with_dm.get_ensemble_by_name("ens_with_dm_0")
+        posterior_with_dm = experiment_with_dm.get_ensemble_by_name("ens_with_dm_1")
+
+        prior_with_dm_a = prior_with_dm.load_parameters("a")["a"]
+        posterior_with_dm_a = posterior_with_dm.load_parameters("a")["a"]
+
+        assert posterior_with_dm_a.equals(prior_with_dm_a)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/11511

Approach: After some discussions, it has been decided that we will first omit all `update==False` parameters from EnIF update. This implies that EnIF will completely disregard any effect unupdated parameters (including those from design matrix) have on responses, and update accordingly. 

Theoretical feasibility of [skipping only categoricals + having EnIF consider but not update design parameters](https://github.com/equinor/ert/compare/main...yngve-sk:ert:25.11.try-fixup-enif-drogonahm-skip-only-categoricals) should be investigated more closely.