### PR TITLE
Do not install qt on test-data setups

### DIFF
--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -33,10 +33,6 @@ jobs:
         fetch-depth: 0
         filter: tree:0
 
-    - uses: ./.github/actions/install_dependencies_qt
-      with:
-        os: ${{ matrix.os }}
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
It should be possible to run ert from the commandline without install qt.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
