### PR TITLE
Remove span for scheduler.run

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -32,7 +32,7 @@ from ert.storage import (
     RealizationStorageState,
     load_realization_parameters_and_responses,
 )
-from ert.trace import trace, tracer
+from ert.trace import trace
 from ert.warnings import PostSimulationWarning
 
 from .driver import Driver, FailedSubmit
@@ -239,7 +239,6 @@ class Job:
                 f"{method_name} spent {elapsed_time} seconds waiting for files"
             )
 
-    @tracer.start_as_current_span(f"{__name__}.run")
     async def run(
         self,
         sem: asyncio.BoundedSemaphore,


### PR DESCRIPTION
Removes subspan for scheduler.run.
Logs will be propagated to parent span.

This will drastically reduce the span count. Especially for Everest.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
