### PR TITLE
Restructure parameters.json output

### DIFF
--- a/docs/ert/getting_started/configuration/poly_new/guide.rst
+++ b/docs/ert/getting_started/configuration/poly_new/guide.rst
@@ -378,11 +378,9 @@ This should return something similar to:
 .. code-block:: json
 
     {
-        "COEFFS" : {
-        "a" : 0.7974556153339885,
-        "b" : 1.400852435132108,
-        "c" : 1.9495650072493478
-        }
+        "a" : {"value" : 0.7974556153339885},
+        "b" : {"value" : 1.400852435132108},
+        "c" : {"value" : 1.9495650072493478}
     }
 
 2. **Inspecting the results**: Each simulation generated a unique file named ``poly.out`` reflecting the varying outcomes.

--- a/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
@@ -3,11 +3,11 @@ import json
 from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
-    coeffs = json.load(f)["COEFFS"]
+    coeffs = json.load(f)
 
 
 def evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+    return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
 
 output = [evaluate(coeffs, x) for x in range(50)]

--- a/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
@@ -3,11 +3,11 @@ import json
 from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
-    coeffs = json.load(f)["COEFFS"]
+    coeffs = json.load(f)
 
 
 def evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+    return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
 
 output = [evaluate(coeffs, x) for x in range(10)]

--- a/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
@@ -3,11 +3,11 @@ import json
 from pathlib import Path
 
 with open("parameters.json", encoding="utf-8") as f:
-    coeffs = json.load(f)["COEFFS"]
+    coeffs = json.load(f)
 
 
 def evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+    return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
 
 output = [evaluate(coeffs, x) for x in range(10)]

--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -1296,9 +1296,7 @@ runpath called: ``parameters.json``.
 
 
         {
-        "ID" : {
-        "A" : 0.88,
-        },
+        "A" : {"value" : 0.88},
         }
 
 
@@ -1312,7 +1310,7 @@ This can then be used in a forward model, an example from python below:
     if __name__ == "__main__":
         with open("parameters.json", encoding="utf-8") as f:
             parameters = json.load(f)
-        # parameters is a dict with {"ID": {"A": <value>}}
+        # parameters is a dict with {"A": {"value": <value>}}
 
 
 

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -79,18 +79,18 @@ def _value_export_json(
     if len(values) == 0:
         return
 
-    # Hierarchical
-    json_out: dict[str, float | dict[str, float | str]] = {
-        key: dict(param_map.items()) for key, param_map in values.items()
-    }
+    # parameter file is {param: {"value": value}}
+    json_out: dict[str, dict[str, float | str]] = {}
+    for param_map in values.values():
+        for param, value in param_map.items():
+            json_out[param] = {"value": value}
 
     # Disallow NaN from being written: ERT produces the parameters and the only
     # way for the output to be NaN is if the input is invalid or if the sampling
     # function is buggy. Either way, that would be a bug and we can report it by
     # having json throw an error.
-    json.dump(
-        json_out, path.open("w"), allow_nan=False, indent=0, separators=(", ", " : ")
-    )
+    with path.open("w") as f:
+        json.dump(json_out, f, allow_nan=False, indent=0, separators=(", ", " : "))
 
 
 def _generate_parameter_files(

--- a/test-data/ert/flow_example/resources/SPE1.DATA.jinja2
+++ b/test-data/ert/flow_example/resources/SPE1.DATA.jinja2
@@ -88,11 +88,11 @@ TOPS
 
 PORO
 -- Constant porosity of 0.3 throughout all 300 grid cells
-    300*{{parameters.FIELD_PROPERTIES.POROSITY}} /
+    300*{{parameters.POROSITY.value}} /
 
 PERMX
 -- The layers have perm. 500mD, 50mD and 200mD, respectively.
-	100*500 100*{{100 * parameters.FIELD_PROPERTIES.X_MID_PERMEABILITY}} 100*200 /
+	100*500 100*{{100 * parameters.X_MID_PERMEABILITY.value}} 100*200 /
 
 PERMY
 -- Equal to PERMX

--- a/test-data/ert/heat_equation/heat_equation.py
+++ b/test-data/ert/heat_equation/heat_equation.py
@@ -73,12 +73,10 @@ if __name__ == "__main__":
     rng = np.random.default_rng(iens)
 
     parameters = load_parameters("parameters.json")
-    init_temp_scale = parameters["INIT_TEMP_SCALE"]
-    corr_length = parameters["CORR_LENGTH"]
 
     if iteration == 0:
         cond = sample_prior_conductivity(
-            ensemble_size=1, nx=nx, rng=rng, corr_length=float(corr_length["x"])
+            ensemble_size=1, nx=nx, rng=rng, corr_length=float(parameters["x"]["value"])
         ).reshape(nx, nx)
 
         resfo.write(
@@ -97,7 +95,7 @@ if __name__ == "__main__":
     # Note that this could be avoided if we used an implicit solver.
     dt = dx**2 / (4 * np.max(cond))
 
-    scaled_u_init = u_init * float(init_temp_scale["t"])
+    scaled_u_init = u_init * float(parameters["t"]["value"])
 
     response = heat_equation(scaled_u_init, cond, dx, dt, k_start, k_end, rng)
 

--- a/test-data/ert/poly_example/poly_eval.py
+++ b/test-data/ert/poly_example/poly_eval.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 def _load_coeffs(filename):
     with open(filename, encoding="utf-8") as f:
-        return json.load(f)["COEFFS"]
+        return json.load(f)
 
 
 def _evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+    return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
 
 if __name__ == "__main__":

--- a/test-data/ert/rft_example/resources/SPE1.DATA.jinja2
+++ b/test-data/ert/rft_example/resources/SPE1.DATA.jinja2
@@ -96,17 +96,17 @@ TOPS
 	100*8325 /
 
 PORO
-    300*{{parameters.FIELD_PROPERTIES.POROSITY}} /
+    300*{{parameters.POROSITY.value}} /
 
 PERMX
-	100*500 100*{{100 * parameters.FIELD_PROPERTIES.X_MID_PERMEABILITY}} 100*200 /
+	100*500 100*{{100 * parameters.X_MID_PERMEABILITY.value}} 100*200 /
 
 PERMY
 -- Equal to PERMX
 	100*500 100*50 100*200 /
 
 PERMZ
-	100*500 100*{{100 * parameters.FIELD_PROPERTIES.Z_MID_PERMEABILITY}} 100*200 /
+	100*500 100*{{100 * parameters.Z_MID_PERMEABILITY.value}} 100*200 /
 ECHO
 
 PROPS
@@ -273,7 +273,7 @@ EQUIL
 -- Item 9: Set to 0 as this is the only value supported by OPM
 
 -- Item #: 1 2    3    4 5    6 7 8 9
-	8400 {{parameters.FIELD_PROPERTIES.EQL_PRESSURE}} 8450 0 8300 0 1 0 0 /
+	8400 {{parameters.EQL_PRESSURE.value}} 8450 0 8300 0 1 0 0 /
 
 RSVD
 -- Dissolved GOR is initially constant with depth through the reservoir.

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -236,10 +236,11 @@ def copy_poly_case_with_design_matrix(copy_case):
 
                     def _load_coeffs(filename):
                         with open(filename, encoding="utf-8") as f:
-                            return json.load(f)["DESIGN_MATRIX"]
+                            return json.load(f)
 
                     def _evaluate(coeffs, x):
-                        return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                        return (coeffs["a"]["value"] * x**2 +
+                                coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                     if __name__ == "__main__":
                         coeffs = _load_coeffs("parameters.json")

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -128,7 +128,8 @@ import json
 
 def _load_coeffs(filename):
     with open(filename, encoding="utf-8") as f:
-        return json.load(f)["COEFFS"]
+        raw_json = json.load(f)
+        return {k: v["value"] for k, v in raw_json.items()}
 
 
 def _evaluate(coeffs, x):

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -68,13 +68,11 @@ def test_run_poly_example_with_design_matrix(copy_poly_case_with_design_matrix, 
     with open(real_0_iter_0_parameters_json_path, mode="r+", encoding="utf-8") as fs:
         parameters_contents = json.load(fs)
     assert isinstance(parameters_contents, dict)
-    design_matrix_content = parameters_contents.get("DESIGN_MATRIX")
-    assert isinstance(design_matrix_content, dict)
-    for k, v in design_matrix_content.items():
+    for k, v in parameters_contents.items():
         if k == "category":
-            assert isinstance(v, str)
+            assert isinstance(v["value"], str)
         else:
-            assert isinstance(v, float | int)
+            assert isinstance(v["value"], float | int)
 
 
 @pytest.mark.usefixtures(
@@ -132,10 +130,11 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
 
                 def _load_coeffs(filename):
                     with open(filename, encoding="utf-8") as f:
-                        return json.load(f)["DESIGN_MATRIX"]
+                        return json.load(f)
 
                 def _evaluate(coeffs, x):
-                    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                    return (coeffs["a"]["value"] * x**2 +
+                            coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                 if __name__ == "__main__":
                     coeffs = _load_coeffs("parameters.json")
@@ -254,10 +253,11 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
 
                 def _load_coeffs(filename):
                     with open(filename, encoding="utf-8") as f:
-                        return json.load(f)["DESIGN_MATRIX"]
+                        return json.load(f)
 
                 def _evaluate(coeffs, x):
-                    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                    return (coeffs["a"]["value"] * x**2 +
+                            coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                 if __name__ == "__main__":
                     coeffs = _load_coeffs("parameters.json")
@@ -346,8 +346,7 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
                 def _load_coeffs(filename):
                     with open(filename, encoding="utf-8") as f:
                         params = json.load(f)
-                        params = params["COEFFS_A"] | params["DESIGN_MATRIX"] | params["COEFFS_C"]
-                        return params
+                        return {k: v["value"] for k, v in params.items()}
 
                 def _evaluate(coeffs, x):
                     return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
@@ -357,7 +356,7 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
                     output = [_evaluate(coeffs, x) for x in range(10)]
                     with open("poly.out", "w", encoding="utf-8") as f:
                         f.write("\\n".join(map(str, output)))
-                """  # noqa: E501
+                """
         ),
         encoding="utf-8",
     )

--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -184,10 +184,11 @@ def test_that_reals_with_load_failure_in_prior_become_parent_failure_in_posterio
 
                 def _load_coeffs(filename):
                     with open(filename, encoding="utf-8") as f:
-                        return json.load(f)["COEFFS"]
+                        return json.load(f)
 
                 def _evaluate(coeffs, x):
-                    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                    return (coeffs["a"]["value"] * x**2 +
+                            coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                 if __name__ == "__main__":
                     # Kill one realization per iteration

--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -110,7 +110,8 @@ poly_eval = """\
 #!/usr/bin/env python3
 import json
 import numpy as np
-coeffs = json.load(open("parameters.json"))["COEFFS"]
+json_raw = json.load(open("parameters.json"))
+coeffs = {{k: v["value"] for k, v in json_raw.items()}}
 c = [np.array(coeffs[f"coeff_" + str(i)]) for i in range(len(coeffs))]
 with open("poly.out", "w", encoding="utf-8") as f:
     f.write("\\n".join(map(str, [np.polyval(c, x) for x in range({num_points})])))

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -171,10 +171,11 @@ def _ensemble_experiment_run(
 
                         def _load_coeffs(filename):
                             with open(filename, encoding="utf-8") as f:
-                                return json.load(f)["COEFFS"]
+                                return json.load(f)
 
                         def _evaluate(coeffs, x):
-                            return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                            return (coeffs["a"]["value"] * x**2 +
+                                    coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                         if __name__ == "__main__":
                             if int(os.getenv("_ERT_REALIZATION_NUMBER")) % 2 == 0:

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -331,11 +331,11 @@ import json
 
 def _load_coeffs(filename):
     with open(filename, encoding="utf-8") as f:
-        return json.load(f)["COEFFS"]
+        return json.load(f)
 
 
 def _evaluate(coeffs, x):
-    return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+    return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
 
 if __name__ == "__main__":

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -34,10 +34,11 @@ def test_rerun_failed_all_realizations(opened_main_window_poly, qtbot):
 
                     def _load_coeffs(filename):
                         with open(filename, encoding="utf-8") as f:
-                            return json.load(f)["COEFFS"]
+                            return json.load(f)
 
                     def _evaluate(coeffs, x):
-                        return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                        return (coeffs["a"]["value"] * x**2 +
+                                coeffs["b"]["value"] * x + coeffs["c"]["value"])
 
                     if __name__ == "__main__":
                         if {failing_reals}:
@@ -118,10 +119,10 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
 
                     def _load_coeffs(filename):
                         with open(filename, encoding="utf-8") as f:
-                            return json.load(f)["COEFFS"]
+                            return json.load(f)
 
                     def _evaluate(coeffs, x):
-                        return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                        return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
                     if __name__ == "__main__":
                         if int(os.getenv("_ERT_REALIZATION_NUMBER")) in {failing_reals!s}:
@@ -286,10 +287,10 @@ def test_rerun_failed_realizations_evaluate_ensemble(
 
                     def _load_coeffs(filename):
                         with open(filename, encoding="utf-8") as f:
-                            return json.load(f)["COEFFS"]
+                            return json.load(f)
 
                     def _evaluate(coeffs, x):
-                        return coeffs["a"] * x**2 + coeffs["b"] * x + coeffs["c"]
+                        return coeffs["a"]["value"] * x**2 + coeffs["b"]["value"] * x + coeffs["c"]["value"]
 
                     if __name__ == "__main__":
                         if int(os.getenv("_ERT_REALIZATION_NUMBER")) in {failing_reals!s}:


### PR DESCRIPTION
**Issue**
This makes the parameters.json file "flat". The groups has been removed and thus going 

**from:**
```json
{
"CEOFFS ": {"a": 1.3, "b":1.5 } 
}
```
**to:**

```json
{ "a": { "value":1.3 }, "b": { "value":1.5 } }
```

This also updates poly_eval.py in poly_example.

Note: Once this commit hits stable, it will require to update: https://ert.readthedocs.io/en/latest/about/release_notes.html

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
