### PR TITLE
Deprecate GEO_ID

### DIFF
--- a/docs/everest/configuration/index.rst
+++ b/docs/everest/configuration/index.rst
@@ -42,8 +42,7 @@ The value of a variable can be set in three different ways:
 2. Everest pre-defines the following variables:
 
    ``realization``
-       Evaluates to the string "<GEO_ID>", which is replaced by the realization
-       number during execution of the forward model.
+       Evaluates to the realization ID during execution of the forward model.
 
    ``configpath``
        The fully qualified path to the directory that contains the configuration

--- a/docs/everest/development.rst
+++ b/docs/everest/development.rst
@@ -86,7 +86,7 @@ Each `model_realization` can contain several `simulations` (i.e., forward model
 runs). This is the key difference between the hierarchical data model of EVEREST
 and ERT (Fig 3).
 
-NOTE: `<MODEL_ID>` (or `<GEO_ID>` due to legacy reasons) is
+NOTE: `<MODEL_ID>` (or `<REALIZATION_ID>` due to legacy reasons) is
 inserted (and substituted) in the `run_path` for each `model_realization`.
 
 .. figure:: images/Everest_vs_Ert_01.png

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -329,7 +329,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
             runpath_format_string=str(
                 Path(everest_config.simulation_dir)
                 / "batch_<ITER>"
-                / "realization_<GEO_ID>"
+                / "realization_<REALIZATION_ID>"
                 / "<SIM_DIR>"
             ),
             eclbase_format_string=eclbase
@@ -1076,7 +1076,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
         for sim_id, (model_realization, perturbation) in enumerate(
             zip(sim_to_model_realization, sim_to_perturbation, strict=True)
         ):
-            substitutions[f"<GEO_ID_{sim_id}_{ensemble.iteration}>"] = str(
+            substitutions[f"<REALIZATION_ID_{sim_id}_{ensemble.iteration}>"] = str(
                 int(model_realization)
             )
             if perturbation >= 0:

--- a/src/ert/substitutions.py
+++ b/src/ert/substitutions.py
@@ -32,9 +32,9 @@ class Substitutions(UserDict[str, str]):
             "<ITER>": str(iteration),
         }
 
-        model_id_key = f"<GEO_ID_{realization}_{iteration}>"
+        model_id_key = f"<REALIZATION_ID_{realization}_{iteration}>"
         if model_id_key in self:
-            extra_data["<GEO_ID>"] = self[model_id_key]
+            extra_data["<REALIZATION_ID>"] = self[model_id_key]
         sim_id_key = f"<SIM_DIR_{realization}_{iteration}>"
         if sim_id_key in self:
             extra_data["<SIM_DIR>"] = self[sim_id_key]

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -15,7 +15,7 @@ from ert.config.forward_model_step import (
 
 
 def _is_dir_all_model(source: str, model_realizations: list[int]) -> bool:
-    """Expands <GEO_ID> for all realizations and if:
+    """Expands <REALIZATION_ID> for all realizations and if:
     - all are directories, returns True,
     - all are files, returns False,
     - some are non-existing, raises an AssertionError
@@ -23,7 +23,7 @@ def _is_dir_all_model(source: str, model_realizations: list[int]) -> bool:
 
     is_dir = []
     for model_realization in model_realizations:
-        model_source = source.replace("<GEO_ID>", str(model_realization))
+        model_source = source.replace("<REALIZATION_ID>", str(model_realization))
         if not os.path.exists(model_source):
             msg = (
                 "Expected source to exist for data installation, "

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -72,15 +72,15 @@ class InstallDataContext:
                 source = item.source
                 target = item.target
 
-            if "<GEO_ID>" not in source:
+            if "<REALIZATION_ID>" not in source:
                 self._set_symlink(source, target, None)
 
         return self
 
     def _set_symlink(self, source: str, target: str, realization: int | None) -> None:
         if realization is not None:
-            source = source.replace("<GEO_ID>", str(realization))
-            target = target.replace("<GEO_ID>", str(realization))
+            source = source.replace("<REALIZATION_ID>", str(realization))
+            target = target.replace("<REALIZATION_ID>", str(realization))
 
         tmp_target = Path(self._temp_dir.name) / Path(target)
         if tmp_target.exists():
@@ -101,7 +101,7 @@ class InstallDataContext:
 
     def add_links_for_realization(self, realization: int) -> None:
         for data in self._install_data:
-            if data.source is not None and "<GEO_ID>" in data.source:
+            if data.source is not None and "<REALIZATION_ID>" in data.source:
                 self._set_symlink(data.source, data.target, realization)
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
@@ -242,8 +242,8 @@ def as_abs_path(path: str, config_dir: str) -> str:
 
 
 def expand_model_id_paths(path_source: str, realizations: list[int]) -> list[str]:
-    if "<GEO_ID>" in path_source:
-        return [path_source.replace("<GEO_ID>", str(r)) for r in realizations]
+    if "<REALIZATION_ID>" in path_source:
+        return [path_source.replace("<REALIZATION_ID>", str(r)) for r in realizations]
     return [path_source]
 
 
@@ -251,7 +251,8 @@ def check_path_exists(
     path_source: str, config_path: Path | None, realizations: list[int]
 ) -> None:
     """Check if the given path exists. If the given path contains <CONFIG_PATH>
-    or GEO_ID they will be expanded and all instances of expanded paths need to exist.
+    or REALIZATION_ID they will be expanded and all instances of expanded paths
+    need to exist.
     """
     if not isinstance(path_source, str):
         raise ValueError(

--- a/src/everest/config_file_loader.py
+++ b/src/everest/config_file_loader.py
@@ -26,7 +26,7 @@ SUBSTITUTION_PATTERN = r"(r\{\{.*?\}\})"
 
 # Jinja vars which should NOT be included in definitions portion of config.
 ERT_CONFIG_TEMPLATES = {
-    "realization": "GEO_ID",
+    "realization": "REALIZATION_ID",
     "runpath_file": "RUNPATH_FILE",
 }
 
@@ -67,7 +67,7 @@ def _get_definitions(
                     f"Internal key {key} specified by user as {defs[key]}. "
                     f"Overriding as {val}"
                 )
-            defs[key] = f"<{val}>"  # ert uses <GEO_ID> as format
+            defs[key] = f"<{val}>"  # ert uses <REALIZATION_ID> as format
     else:
         logging.getLogger(EVEREST).warning("Empty configuration file provided!")
 
@@ -159,6 +159,17 @@ def yaml_file_to_substituted_config_dict(config_path: str) -> dict[str, Any]:
 
     # Replace in definitions
     config = jenv.from_string(txt).render(**definitions)
+
+    # Handle deprecated use of <GEO_ID>:
+    config, count = re.subn(
+        rf"<\s*{re.escape('GEO_ID')}\s*>", "<REALIZATION_ID>", config
+    )
+    if count > 0:
+        message = r"<GEO_ID> is deprecated, please replace with 'r{{realization}}'."
+        print(message)
+        logging.getLogger(EVEREST).warning(
+            "Deprecated key <GEO_ID> replaced by <REALIZATION_ID>."
+        )
 
     # Load the config with definitions again as yaml
     yaml = YAML(typ="safe", pure=True).load(config)

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -562,7 +562,7 @@ def test_that_deprecated_runpath_substitution_remain_valid(make_run_path):
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize("itr", [0, 1, 2, 17])
 def test_write_runpath_file(storage, itr):
-    runpath_fmt = "simulations/<GEO_ID>/realization-<IENS>/iter-<ITER>"
+    runpath_fmt = "simulations/<REALIZATION_ID>/realization-<IENS>/iter-<ITER>"
     runpath_list_path = "a_file_name"
     ert_config = ErtConfig.from_file_contents(
         dedent(
@@ -585,7 +585,7 @@ def test_write_runpath_file(storage, itr):
     mask[13] = False
     global_substitutions = ert_config.substitutions
     for i in range(num_realizations):
-        global_substitutions[f"<GEO_ID_{i}_{itr}>"] = str(10 * i)
+        global_substitutions[f"<REALIZATION_ID_{i}_{itr}>"] = str(10 * i)
     run_path = Runpaths.from_config(ert_config)
     sample_prior(prior_ensemble, [i for i, active in enumerate(mask) if active], 123)
     run_args = create_run_arguments(
@@ -615,7 +615,7 @@ def test_write_runpath_file(storage, itr):
     exp_runpaths = [
         runpath_fmt.replace("<ITER>", str(itr))
         .replace("<IENS>", str(run_arg.iens))
-        .replace("<GEO_ID>", str(10 * run_arg.iens))
+        .replace("<REALIZATION_ID>", str(10 * run_arg.iens))
         for run_arg in run_args
         if run_arg.active
     ]

--- a/tests/everest/test_config_file_loader.py
+++ b/tests/everest/test_config_file_loader.py
@@ -67,7 +67,7 @@ def test_get_definitions(tmp_path):
         "eclbase": "eclipse/ECL",
         "numeric_key": 1,
         "bool_key": True,
-        "realization": "<GEO_ID>",
+        "realization": "<REALIZATION_ID>",
     }
 
     assert definitions == expected_definitions

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -482,7 +482,7 @@ def test_that_min_realizations_success_is_nonnegative():
 def test_that_install_data_allows_runpath_root_as_target(
     target, link, change_to_tmpdir
 ):
-    data = {"source": "relative/path_<GEO_ID>", "target": target, "link": link}
+    data = {"source": "relative/path_<REALIZATION_ID>", "target": target, "link": link}
     Path("config_dir/relative/path_0").mkdir(parents=True)
     Path("config_dir/test.yml").write_text(" ", encoding="utf-8")
     config = everest_config_with_defaults(

--- a/tests/everest/test_cvar.py
+++ b/tests/everest/test_cvar.py
@@ -22,7 +22,7 @@ def test_mathfunc_cvar(copy_math_func_test_data_to_tmp):
         "model": {"realizations": [0, 1]},
         "forward_model": [
             (
-                "distance3 --point-file point.json --realization <GEO_ID> "
+                "distance3 --point-file point.json --realization <REALIZATION_ID> "
                 "--target 0.5 0.5 0.5 --out distance"
             )
         ],

--- a/tests/everest/test_everest_run_model.py
+++ b/tests/everest/test_everest_run_model.py
@@ -173,7 +173,7 @@ def test_substitutions_from_everest_config(
             f"{config_dir}"
             "/custom_output_folder"
             "/the_simulations_dir/"
-            "batch_<ITER>/realization_<GEO_ID>/<SIM_DIR>"
+            "batch_<ITER>/realization_<REALIZATION_ID>/<SIM_DIR>"
         ),
         "<ECL_BASE>": "ECLBASE<IENS>",
         "<ECLBASE>": "ECLBASE<IENS>",

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -414,3 +414,20 @@ to read summary data from forward model, do:
         keys: ['FOPR', 'WOPR']
 """.strip()
     )
+
+
+def test_that_geo_id_is_deprecated(min_config, change_to_tmpdir, caplog, capsys):
+    config = min_config
+    config["forward_model"] = ["step1 <GEO_ID>"]
+
+    with open("config.yml", mode="w", encoding="utf-8") as f:
+        yaml.dump(config, f)
+
+    config_dict = yaml_file_to_substituted_config_dict("config.yml")
+
+    assert config_dict["forward_model"][0] == "step1 <REALIZATION_ID>"
+    assert "Deprecated key <GEO_ID> replaced by <REALIZATION_ID>." in caplog.text
+    assert (
+        r"<GEO_ID> is deprecated, please replace with 'r{{realization}}'."
+        in capsys.readouterr().out
+    )

--- a/tests/everest/test_objective_type.py
+++ b/tests/everest/test_objective_type.py
@@ -22,11 +22,11 @@ def test_objective_type(copy_math_func_test_data_to_tmp):
         "model": {"realizations": [0, 1]},
         "forward_model": [
             (
-                "distance3 --point-file point.json --realization <GEO_ID> "
+                "distance3 --point-file point.json --realization <REALIZATION_ID> "
                 "--target 0.5 0.5 0.5 --out distance"
             ),
             (
-                "distance3 --point-file point.json --realization <GEO_ID> "
+                "distance3 --point-file point.json --realization <REALIZATION_ID> "
                 "--target 0.5 0.5 0.5 --out stddev"
             ),
         ],

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -340,12 +340,12 @@ def test_that_install_data_raises_error_on_missing_copy_file(tmp_path):
 
 def test_that_install_data_raises_error_on_missing_copy_directory(tmp_path):
     config_directory = tmp_path / "config_dir"
-    source_directory = config_directory / "<GEO_ID>"
+    source_directory = config_directory / "<REALIZATION_ID>"
     realizations = [0, 1, 2]
 
     for realization in realizations:
         realization_dir = source_directory.with_name(
-            source_directory.name.replace("<GEO_ID>", str(realization))
+            source_directory.name.replace("<REALIZATION_ID>", str(realization))
         )
         realization_dir.mkdir(parents=True)
 


### PR DESCRIPTION
**Issue**
Resolves #11619


**Approach**
This replaces every instance of `GEO_ID `with `REALIZATION_ID`. A warning is added if `<GEO_ID>` is used in the everest configuration file, and it is replaced with `<REALIZATION_ID>`.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
