### PR TITLE
Remove the detached_node_output directory

### DIFF
--- a/src/everest/config/server_config.py
+++ b/src/everest/config/server_config.py
@@ -14,12 +14,7 @@ from ert.config.queue_config import (
 )
 from ert.dark_storage.client import ErtClientConnectionInfo
 
-from ..strings import (
-    CERTIFICATE_DIR,
-    DETACHED_NODE_DIR,
-    HOSTFILE_NAME,
-    SESSION_DIR,
-)
+from ..strings import CERTIFICATE_DIR, HOSTFILE_NAME, SESSION_DIR
 from .simulator_config import check_removed_config
 
 
@@ -116,10 +111,6 @@ class ServerConfig(BaseModel):
         return data
 
     @staticmethod
-    def get_detached_node_dir(output_dir: str) -> str:
-        return os.path.join(os.path.abspath(output_dir), DETACHED_NODE_DIR)
-
-    @staticmethod
     def get_hostfile_path(output_dir: str) -> str:
         return os.path.join(ServerConfig.get_session_dir(output_dir), HOSTFILE_NAME)
 
@@ -127,7 +118,7 @@ class ServerConfig(BaseModel):
     def get_session_dir(output_dir: str) -> str:
         """Return path to the session directory containing information about the
         certificates and host information"""
-        return os.path.join(ServerConfig.get_detached_node_dir(output_dir), SESSION_DIR)
+        return os.path.join(os.path.abspath(output_dir), SESSION_DIR)
 
     @staticmethod
     def get_certificate_dir(output_dir: str) -> str:

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 def _configure_loggers(
-    detached_dir: Path, log_dir: Path, logging_level: int, output_file: str | None
+    log_dir: Path, logging_level: int, output_file: str | None
 ) -> None:
     def make_handler_config(path: Path, log_level: int) -> dict[str, Any]:
         makedirs_if_needed(str(path.parent))
@@ -46,7 +46,7 @@ def _configure_loggers(
         "version": 1,
         "handlers": {
             "endpoint_log": make_handler_config(
-                detached_dir / "endpoint.log", logging_level
+                log_dir / "everserver.log", logging_level
             ),
             "everest_log": make_handler_config(log_dir / "everest.log", logging_level),
             "forward_models_log": make_handler_config(
@@ -151,7 +151,6 @@ def main() -> None:
     ):
         try:
             _configure_loggers(
-                detached_dir=Path(ServerConfig.get_detached_node_dir(output_dir)),
                 log_dir=Path(output_dir) / OPTIMIZATION_LOG_DIR,
                 logging_level=options.logging_level,
                 output_file=log_file.name,

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -2,7 +2,6 @@ from enum import StrEnum
 
 CERTIFICATE_DIR = "cert"
 
-DETACHED_NODE_DIR = "detached_node_output"
 DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -6,10 +6,7 @@ import yaml
 
 from everest.bin.main import start_everest
 from everest.bin.utils import cleanup_logging
-from everest.config import (
-    EverestConfig,
-    ServerConfig,
-)
+from everest.config import EverestConfig
 from everest.config.forward_model_config import ForwardModelStepConfig
 from everest.config.install_job_config import InstallForwardModelStepConfig
 
@@ -50,8 +47,7 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
 
     everest_output_path = os.path.join(os.getcwd(), "everest_output")
     everest_logs_dir_path = everest_config.log_dir
-    detached_node_dir = ServerConfig.get_detached_node_dir(everest_config.output_dir)
-    endpoint_log_path = os.path.join(detached_node_dir, "endpoint.log")
+    everserver_log_path = os.path.join(everest_logs_dir_path, "everserver.log")
     everest_log_path = os.path.join(everest_logs_dir_path, "everest.log")
     forward_model_log_path = os.path.join(everest_logs_dir_path, "forward_models.log")
 
@@ -59,7 +55,7 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     assert os.path.exists(everest_logs_dir_path)
     assert os.path.exists(forward_model_log_path)
     assert os.path.exists(everest_log_path)
-    assert os.path.exists(endpoint_log_path)
+    assert os.path.exists(everserver_log_path)
 
     assert "everest.detached.everserver INFO: Output directory:" in Path(
         everest_log_path
@@ -68,7 +64,7 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
         forward_model_log_path
     ).read_text(encoding="utf-8")
 
-    endpoint_logs = Path(endpoint_log_path).read_text(encoding="utf-8")
+    endpoint_logs = Path(everserver_log_path).read_text(encoding="utf-8")
     # Avoid cases where optimization finished before we get a chance to check that
     # the everest server has started
     if endpoint_logs:


### PR DESCRIPTION
**Issue**
Resolves #12328


**Approach**
- Move the .session directory to the everest output directory.
- Move the log to the everest logs directory.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
