### PR TITLE
Fix test_update to account for CONST distribution disabling update

### DIFF
--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -219,11 +219,13 @@ def test_update_lowers_generalized_variance_or_deactivates_observations(
                 # other errors are discussed here:
                 # https://github.com/equinor/ert/issues/9581
                 # https://github.com/equinor/ert/issues/9585
+                # in case of CONST distribution update is set to FALSE
                 assert (
                     "No active observations" in se
                     or "Matrix is singular" in se
                     or "math domain error" in se
                     or "math range error" in se
+                    or "All parameters are set to UPDATE:FALSE" in se
                 )
 
         if any("Ill-conditioned matrix" not in str(w.message) for w in all_warnings):


### PR DESCRIPTION
This adds a fallback when we draw CONST distributions only, which set gen_kw update flag to False.


**Approach**
Add an error message into assert.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
