### PR TITLE
Have EnsembleEvaluator.listen_for_messages return early on socket issues

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -369,6 +369,7 @@ class EnsembleEvaluator:
                     logger.warning(
                         "Evaluator receiver closed, no new messages are received"
                     )
+                    return  # The socket is closed, and we won't re-establish it.
                 else:
                     logger.error(f"Unexpected error when listening to messages: {e}")
             except asyncio.CancelledError:


### PR DESCRIPTION
**Issue**
Resolves #12433


**Approach**
This commit makes the method return early on zmq.ENOTSOCK exception as it in one case logged
400_000 times after an experiment was cancelled. This might have
been due to a race condition of shutting down while some realizations
were starting, and the socket was being closed while jobs were
connecting. This is the easiest fix, as we do not attempt to
re-establish the socket later anyways.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
