### PR TITLE
Remove pydantic setting use_enum_values=True

### DIFF
--- a/src/ert/config/queue_config.py
+++ b/src/ert/config/queue_config.py
@@ -51,7 +51,6 @@ class QueueOptions(
     BaseModelWithContextSupport,
     validate_assignment=True,
     extra="forbid",
-    use_enum_values=True,
     validate_default=True,
 ):
     name: QueueSystem

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -2,6 +2,7 @@ import logging
 import os
 from argparse import ArgumentParser
 from copy import copy
+from enum import StrEnum
 from itertools import chain
 from pathlib import Path
 from sys import float_info
@@ -28,6 +29,8 @@ from pydantic.json_schema import SkipJsonSchema
 from pydantic_core import ErrorDetails
 from pydantic_core.core_schema import ValidationInfo
 from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml.nodes import ScalarNode
+from ruamel.yaml.representer import Representer
 
 from ert.base_model_context import BaseModelWithContextSupport, use_runtime_plugins
 from ert.config import (
@@ -1098,6 +1101,12 @@ to read summary data from forward model, do:
         yaml = YAML(typ="safe", pure=True) if safe_and_pure else YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)
         yaml.preserve_quotes = True
+
+        def strenum_representer(dumper: Representer, data: StrEnum) -> ScalarNode:
+            return dumper.represent_str(data.value)
+
+        yaml.representer.add_multi_representer(StrEnum, strenum_representer)
+
         yaml.default_flow_style = False
         yaml.dump(config, output_file)
 


### PR DESCRIPTION
Reverting back to pydantic default behaviour. This implies at least that the queue_system member of QueueConfig is always of type QueueSystem, and never just a `str`, which breaks what the type hints say.

**Issue**
Related to https://github.com/equinor/ert/issues/12462

**Approach**
Modify ruamel instead.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
