### PR TITLE
Fix timeout handling in test

### DIFF
--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -608,7 +608,7 @@ def test_that_exception_in_run_model_is_displayed_in_a_suggestor_window_after_si
 
         def assert_failure_in_error_dialog(run_dialog):
             nonlocal handler_done
-            wait_until(lambda: run_dialog.fail_msg_box is not None, timeout=5000)
+            wait_until(lambda: run_dialog.fail_msg_box is not None, timeout=10000)
             suggestor_termination_window = run_dialog.fail_msg_box
             assert suggestor_termination_window
             text = (


### PR DESCRIPTION
This avoids waiting 360s if there is an assertion error inside the handler. Related to #12470. The real issue in the flaky-test is the timeout which is probably unrelated. Should not take 5 seconds for the error message to appear.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
