### PR TITLE
Reapply "Add positional data to SummaryObservations"

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -30,7 +30,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 17
+_LOCAL_STORAGE_VERSION = 18
 
 
 class _Migrations(BaseModel):
@@ -499,6 +499,7 @@ class LocalStorage(BaseMode):
             to15,
             to16,
             to17,
+            to18,
         )
 
         try:
@@ -545,6 +546,7 @@ class LocalStorage(BaseMode):
                     14: to15,
                     15: to16,
                     16: to17,
+                    17: to18,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to18.py
+++ b/src/ert/storage/migration/to18.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+info = (
+    "Added localization attributes to summary observations."
+    "Added RFT observations."
+    "No change to current storage, only additions. "
+    "Bumping to 17 to indicate appended schema in storage."
+)
+
+
+def migrate(path: Path) -> None:
+    pass

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -91,6 +91,9 @@ def test_make_observations():
             key="WOPR:OP1",
             value=0.1,
             date="2010-03-31",
+            location_x=None,
+            location_y=None,
+            location_range=None,
         ),
         GeneralObservation(
             name="WPR_DIFF_1",

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -1,6 +1,8 @@
 import os
+import re
 from contextlib import suppress
 from pathlib import Path
+from textwrap import dedent
 
 import hypothesis.strategies as st
 import pytest
@@ -8,9 +10,12 @@ from hypothesis import given, settings
 from resfo_utilities.testing import summaries
 
 from ert.config import (
+    ConfigValidationError,
+    ErtConfig,
     InvalidResponseFile,
     SummaryConfig,
 )
+from ert.config._create_observation_dataframes import DEFAULT_LOCATION_RANGE_M
 
 
 @settings(max_examples=10)
@@ -64,3 +69,96 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
         SummaryConfig(
             name="summary", input_files=["CASE"], keys=["FOPR"]
         ).read_from_file(str(tmp_path / "DOES_NOT_EXIST"), 1, 0)
+
+
+def create_summary_observation(loc_config_lines):
+    config = dedent(
+        """
+    NUM_REALIZATIONS 3
+    ECLBASE ECLIPSE_CASE_%d
+    OBS_CONFIG observations
+    GEN_KW KW_NAME template.txt kw.txt prior.txt
+    RANDOM_SEED 1234
+    """
+    )
+    obs_config = dedent(
+        """
+        SUMMARY_OBSERVATION FOPR_1
+        {
+        VALUE      = 0.9;
+        ERROR      = 0.05;
+        DATE       = 2014-09-10;
+        KEY        = FOPR;
+        """
+        + loc_config_lines
+        + """
+        };
+        """
+    )
+    Path("config.ert").write_text(config, encoding="utf-8")
+    Path("observations").write_text(obs_config, encoding="utf-8")
+    Path("template.txt").write_text("MY_KEYWORD <MY_KEYWORD>", encoding="utf-8")
+    Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
+
+    ert_config = ErtConfig.from_file("config.ert")
+    return ert_config.observations["summary"]
+
+
+def test_that_summary_observations_can_be_instantiated_with_localization(
+    tmpdir,
+):
+    with tmpdir.as_cwd():
+        summary_observations = create_summary_observation(
+            """
+            LOCATION_X=10;
+            LOCATION_Y=10;
+            LOCATION_RANGE=10;
+            """
+        )
+        assert all(
+            loc_key in summary_observations.columns
+            and summary_observations[loc_key][0] == 10
+            for loc_key in ["location_x", "location_y", "location_range"]
+        )
+        assert len(summary_observations.columns) == 8
+
+
+def test_that_summary_observations_without_location_range_gets_defaulted(
+    tmpdir,
+):
+    with tmpdir.as_cwd():
+        summary_observations = create_summary_observation(
+            """
+            LOCATION_X=10;
+            LOCATION_Y=10;
+            """
+        )
+        assert "location_range" in summary_observations.columns
+        assert summary_observations["location_range"][0] == DEFAULT_LOCATION_RANGE_M
+
+
+@pytest.mark.parametrize(
+    "loc_config_lines",
+    [
+        "LOCATION_X=10;\n",
+        "LOCATION_Y=10;\n",
+        "LOCATION_RANGE=10;\n",
+        "LOCATION_Y=10;\nLOCATION_RANGE=10;\n",
+        "LOCATION_X=10;\nLOCATION_RANGE=10;\n",
+    ],
+)
+def test_that_summary_observations_raises_config_validation_error_when_loc_x_or_loc_y_are_undefined_given_any_loc_key(  # noqa: E501
+    tmpdir,
+    loc_config_lines,
+):
+    location_pattern = r"LOCATION_[a-zA-Z]*"
+    matches = re.findall(location_pattern, loc_config_lines)
+    expected_err_msgs = [
+        "Localization for observation FOPR_1 is misconfigured.",
+        f"Only {', '.join(matches)} were provided.",
+        "ensure that both LOCATION_X and LOCATION_Y are defined",
+    ]
+    with pytest.raises(ConfigValidationError) as e, tmpdir.as_cwd():
+        create_summary_observation(loc_config_lines)
+    for msg in expected_err_msgs:
+        assert msg in str(e.value)


### PR DESCRIPTION
This reverts commit 17b11b30c7adaaf2a3fdc73d80ddaa1a1b1cf115 which reverted 5c058ffc89882b04232e5465bb6a9f11714be02d. 
This was necessary to insert a different to17 storage migration to fix a critical bug with the 16 storage version.
That is why this will now become 18 instead of 17.
This is the first time I make a storage migration, please double check that everything seems right.