### PR TITLE
Update release highlights on parameters.json format

### DIFF
--- a/docs/ert/about/release_notes.rst
+++ b/docs/ert/about/release_notes.rst
@@ -27,6 +27,33 @@
 Highlighted changes
 ===================
 
+Version 18.0
+------------
+
+Format change of parameters.json
+################################
+
+We’ve changed the format of the parameters.json file located in the runpath of each
+realization. The groups have been dropped, so that all parameters are now at the
+top level. For example, the old format:
+
+.. code-block:: text
+
+  {"COEFFS" : {"a":  0.88}}
+
+
+is now:
+
+.. code-block:: text
+
+  {"a" : {"value" : 0.88}}
+
+
+.. note::
+    This has impact on TEMPLATE_RENDER forward model, which when used with
+    parameters.json needs to be adjusted:
+    from `{{my_input.COEFFS.a}}` to `{{my_input.a.value}}`.
+
 Version 16.0
 ------------
 


### PR DESCRIPTION
**Issue**
Resolves #12453 


**Approach**
Update release highlights

(Screenshot of new behavior in GUI if applicable)
<img width="720" height="486" alt="image" src="https://github.com/user-attachments/assets/2b06e5c0-3f89-47cb-8f85-d2b5a442bf50" />



- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
