### PR TITLE
Enforce all ruff rules already passing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,27 +196,36 @@ line-length = 88
 [tool.ruff.lint]
 select = [
     "A",     # flake8-builtins
+    "AIR",
     "ANN204", # return type special methods
     "ASYNC", # flake8-async
     "B",     # flake-8-bugbear
     "C4",    # flake8-comprehensions
+    "DJ",
     "E",     # pycodestyle
     "F",     # pyflakes
+    "FA",
     "FURB",  # refurb
     "G",     # logging-format
     "I",     # isort
     "ICN",   # flake8-import-conventions
+    "INT",
     "LOG",   # logging
     "NPY",   # numpy specific rules
     "PIE",   # flake8-pie
     "PL",    # pylint
+    "PLE",
+    "Q",
+    "RSE",
     "RSE",   # flake8-raise
     "RUF",   # ruff specific rules
     "SIM",   # flake-8-simplify
+    "SLOT",
     "TRY203",
     "TRY300",
     "UP",    # pyupgrade
     "W",     # pycodestyle
+    "YTT"
 ]
 preview = true
 ignore = [


### PR DESCRIPTION
**Issue**
Resolves the possibility of a lot of ruff issues sneaking un-noticed into the codebase

**Approach**
* Ask an AI to create a script to find all ruff rulesets that we currently pass but not enforce. 
* Fix the script. 
* Run the script.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
