### PR TITLE
Remove redundant .name attr from response configs

### DIFF
--- a/src/ert/config/ensemble_config.py
+++ b/src/ert/config/ensemble_config.py
@@ -132,7 +132,7 @@ class EnsembleConfig(BaseModel):
                 response_configs.append(instance)
 
         return cls(
-            response_configs={response.name: response for response in response_configs},
+            response_configs={response.type: response for response in response_configs},
             parameter_configs={
                 parameter.name: parameter for parameter in parameter_configs
             },

--- a/src/ert/config/everest_response.py
+++ b/src/ert/config/everest_response.py
@@ -25,7 +25,7 @@ class EverestResponse(ResponseConfig):
     def metadata(self) -> list[ResponseMetadata]:
         return [
             ResponseMetadata(
-                response_type=self.name,
+                response_type=self.type,
                 response_key=response_key,
                 finalized=self.has_finalized_keys,
                 filter_on=None,
@@ -76,12 +76,12 @@ class EverestResponse(ResponseConfig):
             if all(isinstance(err, FileNotFoundError) for err in errors):
                 raise FileNotFoundError(
                     "Could not find one or more files/directories while reading "
-                    f"{self.name}: {','.join([str(err) for err in errors])}"
+                    f"{self.type}: {','.join([str(err) for err in errors])}"
                 )
             else:
                 raise InvalidResponseFile(
                     "Error reading "
-                    f"{self.name}, errors: {','.join([str(err) for err in errors])}"
+                    f"{self.type}, errors: {','.join([str(err) for err in errors])}"
                 )
 
         combined = pl.concat(datasets_per_name)
@@ -90,7 +90,6 @@ class EverestResponse(ResponseConfig):
 
 class EverestConstraintsConfig(EverestResponse):
     type: Literal["everest_constraints"] = "everest_constraints"
-    name: str = "everest_constraints"
     targets: list[float | None]
     upper_bounds: list[float]
     lower_bounds: list[float]
@@ -101,7 +100,6 @@ responses_index.add_response_type(EverestConstraintsConfig)
 
 class EverestObjectivesConfig(EverestResponse):
     type: Literal["everest_objectives"] = "everest_objectives"
-    name: str = "everest_objectives"
     weights: list[float | None]
     objective_types: list[Literal["mean", "stddev"]]
 

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -21,7 +21,6 @@ from .responses_index import responses_index
 
 class GenDataConfig(ResponseConfig):
     type: Literal["gen_data"] = "gen_data"
-    name: str = "gen_data"
     report_steps_list: list[list[int] | None] = Field(default_factory=list)
     has_finalized_keys: bool = True
 
@@ -29,7 +28,7 @@ class GenDataConfig(ResponseConfig):
     def metadata(self) -> list[ResponseMetadata]:
         return [
             ResponseMetadata(
-                response_type=self.name,
+                response_type=self.type,
                 response_key=response_key,
                 finalized=self.has_finalized_keys,
                 filter_on={"report_step": report_steps}
@@ -198,12 +197,12 @@ class GenDataConfig(ResponseConfig):
             if all(isinstance(err, FileNotFoundError) for err in errors):
                 raise FileNotFoundError(
                     "Could not find one or more files/directories while reading "
-                    f"GEN_DATA {self.name}: {','.join([str(err) for err in errors])}"
+                    f"GEN_DATA {self.type}: {','.join([str(err) for err in errors])}"
                 )
             else:
                 raise InvalidResponseFile(
                     "Error reading GEN_DATA "
-                    f"{self.name}, errors: {','.join([str(err) for err in errors])}"
+                    f"{self.type}, errors: {','.join([str(err) for err in errors])}"
                 )
 
         combined = pl.concat(datasets_per_name)

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -31,7 +31,6 @@ class ResponseMetadata(BaseModel):
 
 class ResponseConfig(BaseModel):
     type: str
-    name: str
     input_files: list[str] = Field(default_factory=list)
     keys: list[str] = Field(default_factory=list)
     has_finalized_keys: bool = False

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -19,14 +19,13 @@ logger = logging.getLogger(__name__)
 
 class SummaryConfig(ResponseConfig):
     type: Literal["summary"] = "summary"
-    name: str = "summary"
     has_finalized_keys: bool = False
 
     @property
     def metadata(self) -> list[ResponseMetadata]:
         return [
             ResponseMetadata(
-                response_type=self.name,
+                response_type=self.type,
                 response_key=response_key,
                 filter_on=None,
                 finalized=self.has_finalized_keys,

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -30,7 +30,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 18
+_LOCAL_STORAGE_VERSION = 20
 
 
 class _Migrations(BaseModel):
@@ -505,6 +505,7 @@ class LocalStorage(BaseMode):
             to17,
             to18,
             to19,
+            to20,
         )
 
         try:
@@ -553,6 +554,7 @@ class LocalStorage(BaseMode):
                     16: to17,
                     17: to18,
                     18: to19,
+                    19: to20,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to20.py
+++ b/src/ert/storage/migration/to20.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+from typing import Any
+
+info = "Remove redundant .name attribute from responses."
+
+
+def config_without_name_attr(config: dict[str, Any]) -> dict[str, Any]:
+    new_json = {**config}
+    new_json.pop("name", None)
+
+    return new_json
+
+
+def migrate(path: Path) -> None:
+    for response_json_path in path.glob("experiments/*/responses.json"):
+        old_json = json.loads((response_json_path).read_text(encoding="utf-8"))
+        new_json = {
+            response_type: config_without_name_attr(config)
+            for response_type, config in old_json.items()
+        }
+
+        response_json_path.write_text(json.dumps(new_json, indent=2), encoding="utf-8")

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
@@ -258,7 +258,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "gen_data_%d.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -233,7 +233,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "poly.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -303,7 +303,6 @@
   "response_configuration": [
     {
       "type": "summary",
-      "name": "summary",
       "input_files": [
         "SNAKE_OIL_FIELD"
       ],
@@ -316,7 +315,6 @@
     },
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "snake_oil_opr_diff_%d.txt",
         "snake_oil_wpr_diff_%d.txt",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
@@ -244,7 +244,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "gen_data_%d.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -219,7 +219,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "poly.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -289,7 +289,6 @@
   "response_configuration": [
     {
       "type": "summary",
-      "name": "summary",
       "input_files": [
         "SNAKE_OIL_FIELD"
       ],
@@ -302,7 +301,6 @@
     },
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "snake_oil_opr_diff_%d.txt",
         "snake_oil_wpr_diff_%d.txt",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
@@ -258,7 +258,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "gen_data_%d.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -233,7 +233,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "poly.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -303,7 +303,6 @@
   "response_configuration": [
     {
       "type": "summary",
-      "name": "summary",
       "input_files": [
         "SNAKE_OIL_FIELD"
       ],
@@ -316,7 +315,6 @@
     },
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "snake_oil_opr_diff_%d.txt",
         "snake_oil_wpr_diff_%d.txt",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
@@ -258,7 +258,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "gen_data_%d.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -233,7 +233,6 @@
   "response_configuration": [
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "poly.out"
       ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -303,7 +303,6 @@
   "response_configuration": [
     {
       "type": "summary",
-      "name": "summary",
       "input_files": [
         "SNAKE_OIL_FIELD"
       ],
@@ -316,7 +315,6 @@
     },
     {
       "type": "gen_data",
-      "name": "gen_data",
       "input_files": [
         "snake_oil_opr_diff_%d.txt",
         "snake_oil_wpr_diff_%d.txt",

--- a/tests/ert/unit_tests/storage/migration/test_to20.py
+++ b/tests/ert/unit_tests/storage/migration/test_to20.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+from ert.storage.migration.to20 import config_without_name_attr, migrate
+
+
+def test_that_name_is_removed_from_responses_json_for_single_object():
+    summary_config = {
+        "name": "summary",
+        "input_files": ["CASE"],
+        "keys": ["FOPR"],
+        "has_finalized_keys": True,
+        "refcase": ["1996-01-03 00:00:00", "1996-01-02 00:00:00"],
+        "type": "summary",
+    }
+
+    result = config_without_name_attr(summary_config)
+
+    assert "name" not in result
+    summary_config.pop("name")
+    assert summary_config == result
+    assert result == config_without_name_attr(result)
+
+
+def test_that_name_is_removed_from_responses_json_file_for_all_experiments(use_tmpdir):
+    gendata_with_name = {
+        "name": "gen_data",
+        "input_files": ["gen%d.txt"],
+        "keys": ["GEN"],
+        "has_finalized_keys": True,
+        "report_steps_list": [[1]],
+        "type": "gen_data",
+    }
+
+    summary_with_name = {
+        "name": "summary",
+        "input_files": ["CASE"],
+        "keys": ["FOPR"],
+        "has_finalized_keys": True,
+        "refcase": ["1996-01-03 00:00:00", "1996-01-02 00:00:00"],
+        "type": "summary",
+    }
+
+    gendata_without_name = {**gendata_with_name}
+    gendata_without_name.pop("name")
+    summary_without_name = {**summary_with_name}
+    summary_without_name.pop("name")
+
+    experiment_paths = []
+    for i in range(5):
+        experiment_path = Path("experiments") / f"exp_{i}"
+        experiment_path.mkdir(parents=True, exist_ok=True)
+        experiment_paths.append(experiment_path)
+
+        # Add responses.json to each experiment
+        with open(experiment_path / "responses.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {"gen_data": gendata_with_name, "summary": summary_with_name},
+                f,
+                indent=2,
+            )
+
+    migrate(Path("."))
+
+    # Validate responses.json files no longer contain 'name' field
+    for experiment_path in experiment_paths:
+        with open(experiment_path / "responses.json", encoding="utf-8") as f:
+            migrated_responses = json.load(f)
+
+        assert migrated_responses == {
+            "gen_data": gendata_without_name,
+            "summary": summary_without_name,
+        }

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -159,30 +159,6 @@ def test_that_storage_matches(
         assert isinstance(df, pl.DataFrame)
         assert dict(df.schema) == {"BPR": pl.Float64, "realization": pl.Int64}
         assert df["realization"].to_list() == list(range(ensemble.ensemble_size))
-        snapshot.assert_match(
-            json.dumps(
-                {
-                    k: v.model_dump(mode="json")
-                    for k, v in sorted(experiment.parameter_configuration.items())
-                },
-                default=str,
-                indent=2,
-            )
-            + "\n",
-            "parameters",
-        )
-        snapshot.assert_match(
-            json.dumps(
-                {
-                    k: v.model_dump(mode="json")
-                    for k, v in sorted(experiment.response_configuration.items())
-                },
-                default=str,
-                indent=2,
-            )
-            + "\n",
-            "responses",
-        )
 
         summary_data = ensemble.load_responses(
             "summary",
@@ -203,7 +179,6 @@ def test_that_storage_matches(
             },
             "observations",
         )
-
         gen_data = ensemble.load_responses(
             "gen_data", tuple(range(ensemble.ensemble_size))
         )
@@ -220,6 +195,10 @@ def test_that_storage_matches(
         ensemble.save_response("summary", ensemble.load_responses("summary", (0,)), 0)
         assert ensemble.experiment._has_finalized_response_keys("summary")
         assert ensemble.experiment.response_type_to_response_keys["summary"] == ["FOPR"]
+
+        assert all(
+            "name" not in response for response in experiment.response_info.values()
+        )
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
Prerequisite for https://github.com/equinor/ert/pull/11513, faulty migration in `to7` before did not remove name from JSON dump of gendata, thus it has to be removed for all migrated storages.