### PR TITLE
Use implicit string concatenation. Enforce with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ select = [
     "I",     # isort
     "ICN",   # flake8-import-conventions
     "INT",
+    "ISC",
     "LOG",   # logging
     "NPY",   # numpy specific rules
     "PIE",   # flake8-pie

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -567,15 +567,15 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
             "--color-always",
             action="store_true",
             help="Force coloring of monitor output, which is automatically"
-            + " disabled if the output stream is not a terminal.",
+            " disabled if the output stream is not a terminal.",
             default=False,
         )
         cli_parser.add_argument(
             "--disable-monitoring",
             action="store_true",
             help="Monitoring will continuously print the status of the realisations"
-            + " classified into Waiting, Pending, Running, Failed, Finished"
-            + " and Unknown.",
+            " classified into Waiting, Pending, Running, Failed, Finished"
+            " and Unknown.",
             default=False,
         )
         cli_parser.add_argument(

--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -39,9 +39,9 @@ deprecated_keywords_list = [
             keyword=kw,
             message=partial(
                 lambda line, kw: f"Using {kw} with substitution strings "
-                + "that are not of the form '<KEY>' is deprecated. "
-                + f"Please change {line[0]} to "
-                + f"<{line[0].replace('<', '').replace('>', '')}>",
+                "that are not of the form '<KEY>' is deprecated. "
+                f"Please change {line[0]} to "
+                f"<{line[0].replace('<', '').replace('>', '')}>",
                 kw=kw,
             ),
             check=lambda line: not DeprecationInfo.is_angle_bracketed(str(line[0])),

--- a/tests/ert/unit_tests/config/test_parser_error_collection.py
+++ b/tests/ert/unit_tests/config/test_parser_error_collection.py
@@ -726,7 +726,7 @@ def test_that_unicode_decode_error_is_localized_random_line_single_insert():
 
         with pytest.raises(
             ConfigValidationError,
-            match=r"Unsupported non UTF-8 character " "'ÿ' found in file: .*test.ert",
+            match=r"Unsupported non UTF-8 character 'ÿ' found in file: .*test.ert",
         ) as caught_error:
             ErtConfig.from_file("test.ert")
 

--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -78,8 +78,8 @@ def test_that_reading_summaries_returns_the_contents_of_the_file(
         (b"1", b"1", "Failed to read summary file"),
         (
             b"\x00\x00\x00\x10FOOOOOOO\x00\x00\x00\x01"
-            + b"INTE"
-            + b"\x00\x00\x00\x10"
+            b"INTE"
+            b"\x00\x00\x00\x10"
             + (4).to_bytes(4, signed=True, byteorder="big")
             + b"\x00" * 4,
             b"",
@@ -87,8 +87,8 @@ def test_that_reading_summaries_returns_the_contents_of_the_file(
         ),
         (
             b"\x00\x00\x00\x10STARTDAT\x00\x00\x00\x01"
-            + b"INTE"
-            + b"\x00\x00\x00\x10"
+            b"INTE"
+            b"\x00\x00\x00\x10"
             + (4).to_bytes(4, signed=True, byteorder="big")
             + b"\x00" * 4
             + (4).to_bytes(4, signed=True, byteorder="big"),

--- a/tests/ert/unit_tests/resources/test_templating.py
+++ b/tests/ert/unit_tests/resources/test_templating.py
@@ -49,16 +49,16 @@ dual_input = "{{ well_drill_north.PROD1 }} vs {{ well_drill_south.PROD1 }}"
 
 multiple_input_template = (
     "FILENAME\n"
-    + "F1 {{parameters.key1.subkey1}}\n"
-    + "OTH {{second.key1.subkey2}}\n"
-    + "OTH_TEST {{third.key1.subkey1}}"
+    "F1 {{parameters.key1.subkey1}}\n"
+    "OTH {{second.key1.subkey2}}\n"
+    "OTH_TEST {{third.key1.subkey1}}"
 )
 
 multiple_input_template_no_param = (
     "FILENAME\n"
-    + "F1 {{not_the_standard_parameters.key1.subkey1}}\n"
-    + "OTH {{second.key1.subkey2}}\n"
-    + "OTH_TEST {{third.key1.subkey1}}"
+    "F1 {{not_the_standard_parameters.key1.subkey1}}\n"
+    "OTH {{second.key1.subkey2}}\n"
+    "OTH_TEST {{third.key1.subkey1}}"
 )
 
 default_parameters = {


### PR DESCRIPTION
Ruff rule ISC003

Checks for string literals that are explicitly concatenated (using the`+` operator).

For string literals that wrap across multiple lines, implicit string concatenation within parentheses is preferred over explicit concatenation using the + operator, as the former is more readable.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
