### PR TITLE
Add QUEUE_SYSTEM LOCAL to minimal tests

### DIFF
--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -647,9 +647,9 @@ def test_that_a_failing_job_shows_error_message_with_context(
 def test_that_gui_plotter_works_when_no_data(qtbot, monkeypatch, use_tmpdir):
     monkeypatch.setattr(PlotApi, "get_all_ensembles", lambda _: [])
     config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1\n")
-        f.write("ENSPATH storage")
+    Path(config_file).write_text(
+        "NUM_REALIZATIONS 1\nENSPATH storage\nQUEUE_SYSTEM LOCAL", encoding="utf-8"
+    )
 
     args_mock = Mock()
     args_mock.config = config_file
@@ -682,9 +682,9 @@ def test_that_gui_plotter_works_when_no_data(qtbot, monkeypatch, use_tmpdir):
 def test_right_click_plot_button_opens_external_plotter(qtbot, use_tmpdir, monkeypatch):
     monkeypatch.setattr(PlotApi, "get_all_ensembles", lambda _: [])
     config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1\n")
-        f.write("ENSPATH storage")
+    Path(config_file).write_text(
+        "NUM_REALIZATIONS 1\nENSPATH storage\nQUEUE_SYSTEM LOCAL", encoding="utf-8"
+    )
 
     # Open up storage to create it, so that dark storage can be mounted onto it
     # Not creating will result in dark storage hanging/lagging

--- a/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/simulation/test_run_dialog.py
@@ -126,7 +126,9 @@ def run_dialog(qtbot: QtBot, use_tmpdir, mock_set_env_key, monkeypatch):
     monkeypatch.setattr(
         "ert.ensemble_evaluator.EnsembleEvaluator.BATCHING_INTERVAL", 0.01
     )
-    Path(config_file).write_text("NUM_REALIZATIONS 1", encoding="utf-8")
+    Path(config_file).write_text(
+        "NUM_REALIZATIONS 1\nQUEUE_SYSTEM LOCAL", encoding="utf-8"
+    )
     args_mock = Mock()
     args_mock.config = config_file
     ert_config = ErtConfig.from_file(config_file)
@@ -593,7 +595,9 @@ def test_that_exception_in_run_model_is_displayed_in_a_suggestor_window_after_si
     qtbot: QtBot, use_tmpdir
 ):
     config_file = "minimal_config.ert"
-    Path(config_file).write_text("NUM_REALIZATIONS 1", encoding="utf-8")
+    Path(config_file).write_text(
+        "NUM_REALIZATIONS 1\nQUEUE_SYSTEM LOCAL", encoding="utf-8"
+    )
     args_mock = Mock()
     args_mock.config = config_file
 
@@ -735,10 +739,13 @@ def test_that_design_matrix_show_parameters_button_is_visible(
         design_matrix_df.to_excel(xl_write, index=False, sheet_name="DesignSheet")
 
     config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write("NUM_REALIZATIONS 1")
-        if design_matrix_entry:
-            f.write(f"\nDESIGN_MATRIX {xls_filename}")
+    design_matrix_config = (
+        f"\nDESIGN_MATRIX {xls_filename}" if design_matrix_entry else ""
+    )
+    Path(config_file).write_text(
+        "NUM_REALIZATIONS 1\nQUEUE_SYSTEM LOCAL" + design_matrix_config,
+        encoding="utf-8",
+    )
 
     args_mock = Mock()
     args_mock.config = config_file
@@ -917,9 +924,14 @@ def test_that_ert_chooses_minimum_realization_with_design_matrix(
     config_num_realizations = 10
     expected_num_realizations = min(dm_realizations, config_num_realizations)
     config_file = "minimal_config.ert"
-    with open(config_file, "w", encoding="utf-8") as f:
-        f.write(f"NUM_REALIZATIONS {config_num_realizations}")
-        f.write(f"\nDESIGN_MATRIX {xls_filename}")
+    Path(config_file).write_text(
+        (
+            f"NUM_REALIZATIONS {config_num_realizations}\n"
+            f"DESIGN_MATRIX {xls_filename}\n"
+            "QUEUE_SYSTEM LOCAL"
+        ),
+        encoding="utf-8",
+    )
 
     args_mock = Mock()
     args_mock.config = config_file


### PR DESCRIPTION
This is to avoid the possibility for any site-configuration to interfere with where minimal Ert configurations actually run

**Issue**
Resolves maybe hanging on-premise integration tests

**Approach**
Be explicit about queues.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
