### PR TITLE
Fix raw formatting for big numbers in parameter export and templating

### DIFF
--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -60,15 +60,17 @@ def _value_export_txt(
     with path.open("w") as f:
         for key, param_map in values.items():
             for param, value in param_map.items():
-                if isinstance(value, (int | float)):
-                    if key == DESIGN_MATRIX_GROUP:
-                        print(f"{param} {value:g}", file=f)
-                    else:
-                        print(f"{key}:{param} {value:g}", file=f)
-                elif key == DESIGN_MATRIX_GROUP:
-                    print(f"{param} {value}", file=f)
+                if isinstance(value, int):
+                    value_str = str(value)
+                elif isinstance(value, float):
+                    value_str = f"{value:g}"
                 else:
-                    print(f"{key}:{param} {value}", file=f)
+                    value_str = str(value)
+
+                if key == DESIGN_MATRIX_GROUP:
+                    print(f"{param} {value_str}", file=f)
+                else:
+                    print(f"{key}:{param} {value_str}", file=f)
 
 
 def _value_export_json(
@@ -214,11 +216,15 @@ def _make_param_substituter(
     param_substituter = deepcopy(substituter)
     for values in param_data.values():
         for param_name, value in values.items():
-            if isinstance(value, (int, float)):
-                formatted_value = f"{value:.6g}"
+            if isinstance(value, int):
+                formatted_value = str(value)
+            elif isinstance(value, float):
+                formatted_value = f"{value:g}"
             else:
                 formatted_value = str(value)
+
             param_substituter[f"<{param_name}>"] = formatted_value
+
     return param_substituter
 
 

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -94,6 +94,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
                 "REAL": list(range(num_realizations)),
                 "a": a_values,
                 "category": 5 * ["cat1"] + 5 * ["cat2"],
+                "big_integer": [1e10 + i for i in range(num_realizations)],
             }
         ),
         pl.DataFrame(default_values, orient="row"),
@@ -117,10 +118,11 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         encoding="utf-8",
     )
 
-    # This adds a dummy category parameter to COEFFS GENKW
-    # which will be overridden by the design matrix catagorical entries
+    # This adds a dummy category and big_numbers parameter to COEFFS GENKW
+    # which will be overridden by the design matrix entries
     with open("coeff_priors", "a", encoding="utf-8") as f:
-        f.write("category UNIFORM 0 1")
+        f.write("category UNIFORM 0 1\n")
+        f.write("big_numbers UNIFORM 0 1\n")
 
     Path("poly_eval.py").write_text(
         dedent(
@@ -153,6 +155,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
                 b: <b>
                 c: <c>
                 category: <category>
+                big_integer: <big_integer>
                 """
         ),
         encoding="utf-8",
@@ -185,6 +188,9 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         np.testing.assert_array_equal(
             params["category"].to_list(), 5 * ["cat1"] + 5 * ["cat2"]
         )
+        np.testing.assert_array_equal(
+            params["big_integer"].to_list(), [1e10 + i for i in range(10)]
+        )
         np.testing.assert_array_equal(params["b"].to_list(), 10 * [1])
         np.testing.assert_array_equal(params["c"].to_list(), 10 * [2])
     with open("poly_out/realization-0/iter-0/my_output", encoding="utf-8") as f:
@@ -193,12 +199,14 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         assert output[1] == "b: 1"
         assert output[2] == "c: 2"
         assert output[3] == "category: cat1"
+        assert output[4] == "big_integer: 10000000000"
     with open("poly_out/realization-5/iter-0/my_output", encoding="utf-8") as f:
         output = [line.strip() for line in f]
         assert output[0] == "a: 5"
         assert output[1] == "b: 1"
         assert output[2] == "c: 2"
         assert output[3] == "category: cat2"
+        assert output[4] == "big_integer: 10000000005"
 
 
 @pytest.mark.usefixtures(

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -177,6 +177,7 @@ number_regex = r"[-+]?(?:\d*\.\d+|\d+)"
             + r"LOG10_KW_NAME:MY_KEYWORD "
             + number_regex,
         ),
+        ("CONST 1.54", False, "KW_NAME:MY_KEYWORD 1.54\n"),
         ("CONST 1.0", False, "KW_NAME:MY_KEYWORD 1\n"),
         ("DUNIF 5 1 5", False, r"KW_NAME:MY_KEYWORD " + number_regex),
         ("ERRF 1 2 0.1 0.1", False, r"KW_NAME:MY_KEYWORD " + number_regex),


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/12427


**Approach**
Make sure that the formatting stays raw for integers.
Floats will use notation with `:g`  to keep the current state.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
