### PR TITLE
Fix openpbs integration test timing out

### DIFF
--- a/tests/ert/unit_tests/scheduler/bin/qdel
+++ b/tests/ert/unit_tests/scheduler/bin/qdel
@@ -27,7 +27,9 @@ for jobid in "$@"; do
         continue
     fi
     pid=$(cat "${jobdir}/${jobid}.pid")
-    kill $pid
+    if kill -0 $pid 2>/dev/null; then
+        kill $pid
+    fi
     done
 if [ "$found_error" = true ]; then
     exit 1

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -14,6 +14,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from ert.cli.main import ErtCliError
+from ert.ensemble_evaluator.evaluator import EnsembleEvaluator
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE
 from ert.scheduler.openpbs_driver import (
     JOB_STATES,
@@ -31,6 +32,7 @@ from ert.scheduler.openpbs_driver import (
     _create_job_class,
     _parse_jobs_dict,
 )
+from ert.scheduler.scheduler import Scheduler
 from tests.ert.ui_tests.cli.run_cli import run_cli
 from tests.ert.utils import poll
 
@@ -600,6 +602,8 @@ def test_openpbs_driver_with_poly_example_failing_submit_fails_ert_and_propagate
 def test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_exception_to_user(  # noqa: E501
     monkeypatch, caplog, queue_name_config
 ):
+    monkeypatch.setattr(EnsembleEvaluator, "BATCHING_INTERVAL", 0.05)
+    monkeypatch.setattr(Scheduler, "BATCH_KILLING_INTERVAL", 0.01)
     monkeypatch.setattr(
         OpenPBSDriver, "poll", partial(mock_failure, "Status polling failed")
     )


### PR DESCRIPTION
This commit fixes the issue where our mocked qdel bineries fails if the job has already finished (i.e - it was already killed by the TERMINATE_MSG over zmq), and would retry for 30 seconds. This was  visible in "test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_exception_to_user"

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
