### PR TITLE
Remove redundant usage of .name from gen_data

### DIFF
--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -198,7 +198,7 @@ class GenDataConfig(ResponseConfig):
             if all(isinstance(err, FileNotFoundError) for err in errors):
                 raise FileNotFoundError(
                     "Could not find one or more files/directories while reading "
-                    f"GEN_DATA {self.name}: {','.join([str(err) for err in errors])}"
+                    f"GEN_DATA: {','.join([str(err) for err in errors])}"
                 )
             else:
                 raise InvalidResponseFile(


### PR DESCRIPTION
The error now only lists the files and directories that were not found. The `name` is anyway always `gen_data`