### PR TITLE
Detect missing arguments to DESIGN_MATRIX

### DIFF
--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -315,6 +315,8 @@ class SchemaItem:
         self, line: Sequence[FileContextToken]
     ) -> Sequence[FileContextToken | dict[FileContextToken, FileContextToken]]:
         n = self.options_after
+        if not line:
+            return []
         if isinstance(n, Varies):
             args, kwargs = parse_variable_options(list(line), n.max_positionals)
             return [*args, kwargs]  # type: ignore

--- a/tests/ert/unit_tests/config/parsing/test_schema_items.py
+++ b/tests/ert/unit_tests/config/parsing/test_schema_items.py
@@ -11,6 +11,14 @@ def test_that_schema_argc_min_one_raises_on_zero_arguments():
         parse_contents("OPTIONS", schema, "dummy_filename")
 
 
+def test_that_schema_argc_min_one_with_options_after_raises_on_zero_arguments():
+    schema = ConfigSchemaDict(
+        OPTIONS=SchemaItem(kw="OPTIONS", argc_min=1, options_after=1)
+    )
+    with pytest.raises(ConfigValidationError, match="must have at least 1 argument"):
+        parse_contents("OPTIONS", schema, "dummy_filename")
+
+
 def test_that_a_schema_item_can_contain_only_options():
     all_options_item = SchemaItem(
         kw="OPTIONS",

--- a/tests/ert/unit_tests/config/test_analysis_config.py
+++ b/tests/ert/unit_tests/config/test_analysis_config.py
@@ -62,6 +62,18 @@ def test_analysis_config_from_file_is_same_as_from_dict(monkeypatch, tmp_path):
     )
 
 
+def test_design_matrix_keyword_with_no_args_gives_validation_error():
+    with pytest.raises(ConfigValidationError, match="DESIGN_MATRIX must have at least"):
+        ErtConfig.from_file_contents(
+            dedent(
+                """
+                NUM_REALIZATIONS 1
+                DESIGN_MATRIX
+                """
+            )
+        )
+
+
 def test_merging_ignores_identical_design_matrices(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     with pd.ExcelWriter(tmp_path / "my_design_matrix.xlsx") as xl_write:


### PR DESCRIPTION
If no arguments are given in the config file to DESIGN_MATRIX, a TypeError would be displayed:

`   TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'dict'
`
This commit adds detection and a test for this case.

**Issue**
Resolves #12570 

**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
