### PR TITLE
Revert "Deprecate DESIGN_KW"

### DIFF
--- a/src/ert/config/parsing/config_schema_deprecations.py
+++ b/src/ert/config/parsing/config_schema_deprecations.py
@@ -217,15 +217,4 @@ deprecated_keywords_list = [
         ),
         check=lambda line: line[0] == "DESIGN2PARAMS",
     ),
-    DeprecationInfo(
-        keyword="FORWARD_MODEL",
-        message=(
-            "FORWARD_MODEL DESIGN_KW will be replaced with RUN_TEMPLATE. "
-            "DESIGN2PARAMS has been replaced by DESIGN_MATRIX, so the "
-            "parameters are already available for magic string replacement "
-            "with the RUN_TEMPLATE keyword. Please use this format: "
-            "'RUN_TEMPLATE my_text_file_template.txt my_text_output_file.txt'"
-        ),
-        check=lambda line: line[0] == "DESIGN_KW",
-    ),
 ]

--- a/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
+++ b/tests/ert/unit_tests/config/parsing/test_config_schema_deprecations.py
@@ -230,27 +230,3 @@ def test_that_forward_model_design2params_is_deprecated():
             "<designsheet>=TheDesignSheet, <defaultssheet>=TheDefaultsSheet)"
         )
         ErtConfig.from_file_contents(f"NUM_REALIZATIONS 1\n{config}")
-
-
-def test_that_forward_model_design_kw_is_deprecated():
-    # Create a mock DESIGN_KW forward model step, since it is not installed
-    mock_design_kw_step = UserInstalledForwardModelStep(
-        name="DESIGN_KW",
-        executable="design_kw",
-    )
-
-    with (
-        patch(
-            "ert.config.ert_config.installed_forward_model_steps_from_dict",
-            return_value={"DESIGN_KW": mock_design_kw_step},
-        ),
-        pytest.warns(
-            ConfigWarning,
-            match="FORWARD_MODEL DESIGN_KW will be replaced with RUN_TEMPLATE.",
-        ),
-    ):
-        config = (
-            "FORWARD_MODEL DESIGN_KW(<template_file>=template.tmpl, "
-            "<result_file>=output.txt)"
-        )
-        ErtConfig.from_file_contents(f"NUM_REALIZATIONS 1\n{config}")


### PR DESCRIPTION
This reverts commit f67ebd5a4c70b960524a82c4368627f4dce4db7f.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
