### PR TITLE
Provide deprecation message for webviz-ert

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -105,6 +105,7 @@ def run_webviz_ert(args: Namespace, _: ErtRuntimePlugins | None = None) -> None:
     ---------------------------------------------------------------
     """
             )
+            logger.info("Show Webviz-ert deprecation warning")
             webviz_kwargs = {
                 "experimental_mode": args.experimental_mode,
                 "verbose": args.verbose,


### PR DESCRIPTION
**Issue**
Resolves #12582 

**Approach**
Added colourful message
Added logging statement to measure usage of webviz-ert and/or the message being shown

<img width="959" height="405" alt="Screenshot 2026-01-06 at 15 25 01" src="https://github.com/user-attachments/assets/d0316ffe-c214-41a5-839e-a3a07444d75f" />

Verified using `bash` and `csh`, and locally on TGX.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
