### PR TITLE
Improve error message on invalid key:value format

### DIFF
--- a/src/ert/config/parsing/_option_dict.py
+++ b/src/ert/config/parsing/_option_dict.py
@@ -51,10 +51,14 @@ def option_dict(option_list: Sequence[str], offset: int) -> dict[str, str]:
                 result[key] = val
             else:
                 raise ConfigValidationError.with_context(
-                    f"Invalid argument {option_pair!r}", option_pair
+                    "Option argument should be of the form 'key':'value', "
+                    f"got {option_pair!r}",
+                    option_pair,
                 )
         else:
             raise ConfigValidationError.with_context(
-                f"Invalid argument {option_pair!r}", option_pair
+                "Option argument should be of the form 'key':'value', "
+                f"got {option_pair!r}",
+                option_pair,
             )
     return result

--- a/tests/ert/unit_tests/config/parsing/test_variable_options.py
+++ b/tests/ert/unit_tests/config/parsing/test_variable_options.py
@@ -29,7 +29,10 @@ def test_parse_config(input_config, expected):
 
 
 def test_that_positional_arguments_must_come_before_named_arguments():
-    with pytest.raises(ValueError, match="Invalid argument 'positional'"):
+    with pytest.raises(
+        ValueError,
+        match="Option argument should be of the form 'key':'value', got 'positional'",
+    ):
         parse_variable_options(
             [
                 "NAME",

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -269,12 +269,12 @@ def test_the_user_gets_a_warning_about_input_transform_usage(parse_field_line):
 @pytest.mark.parametrize(
     "invalid_argument", ["doesnthavecolon", "colonafter:", ":colonbefore"]
 )
-def test_invalid_argument_gives_a_user_error_message(
+def test_invalid_keyvalue_gives_a_user_error_message(
     parse_field_line, invalid_argument
 ):
     with pytest.raises(
         ConfigValidationError,
-        match=f"Line 3.*Invalid argument '{invalid_argument}'",
+        match=f"Line 3.*Option argument should be .* '{invalid_argument}'",
     ):
         _ = parse_field_line(
             f"FIELD f parameter out.roff INIT_FILES:file.init {invalid_argument}"


### PR DESCRIPTION
**Issue**
Resolves #12585 


**Approach**
Rewrite text and adapt tests.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
