### PR TITLE
Fix test that was made flaky

### DIFF
--- a/tests/ert/unit_tests/shared/test_threading.py
+++ b/tests/ert/unit_tests/shared/test_threading.py
@@ -19,8 +19,9 @@ def test_exception_can_be_caught():
     # Using ErtThread throws an exception on the main thread so that pytest can
     # catch it.
     thread = ErtThread(target=watch_out_im_gonna_throw)
-    thread.start()
-    with pytest.raises(ErtThreadError, match="I threw") as e:
+    with pytest.raises(ErtThreadError, match="I threw") as e:  # noqa: PT012
+        # Whichever of these that raises varies:
+        thread.start()
         thread.join()
 
     assert "Traceback (most recent call last):" in str(e)
@@ -36,8 +37,9 @@ def test_exception_are_logged_with_traceback(caplog):
     # Using ErtThread throws an exception on the main thread so that pytest can
     # catch it.
     thread = ErtThread(target=watch_out_im_gonna_throw)
-    thread.start()
-    with pytest.raises(ErtThreadError):
+    with pytest.raises(ErtThreadError):  # noqa: PT012
+        # Whichever of these that raises varies:
+        thread.start()
         thread.join()
     assert "Traceback (most recent call last):" in caplog.messages[0]
     assert " line 9, in watch_out_im_gonna_throw" in caplog.messages[0]


### PR DESCRIPTION
Both thread.start() and thread.join() can raise, whichever depends on concurrency. Add a noqa statement to skip the ruff rule PT012 which wants to have only one statement for a pytest.raises construct.

**Issue**
Resolves https://github.com/equinor/komodo-releases/actions/runs/20768637739/job/59640953277

**Approach**
`noqa: PT012`

Reproduced with `pytest-repeat`. Not reproducible after the fix.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
