### PR TITLE
Create copy all messages button in Suggestor

### DIFF
--- a/tests/ert/unit_tests/gui/test_suggestor.py
+++ b/tests/ert/unit_tests/gui/test_suggestor.py
@@ -1,8 +1,11 @@
-import pytest
-from PyQt6.QtWidgets import QWidget
+import re
 
-from ert.config import ErrorInfo
+import pytest
+from PyQt6.QtWidgets import QApplication, QPushButton, QWidget
+
+from ert.config import ErrorInfo, WarningInfo
 from ert.gui.ertwidgets import Suggestor
+from ert.gui.ertwidgets.suggestor.suggestor import _CopyAllButton
 
 
 @pytest.mark.parametrize(
@@ -21,3 +24,34 @@ def test_suggestor_combines_errors_with_the_same_message(qtbot, errors, expected
     msg_layout = msgs.layout()
     assert msg_layout is not None
     assert msg_layout.count() == expected_num
+
+
+def test_that_copy_all_button_concatenates_errors_warnings_and_deprecations(qtbot):
+    errors = [ErrorInfo("error", filename="script.py", line="5")]
+    warnings = [WarningInfo("warning", filename="script.py", line="6")]
+    deprecations = [
+        WarningInfo("deprecation", filename="script.py", line="7", is_deprecation=True)
+    ]
+    suggestor = Suggestor(errors, warnings, deprecations, lambda: None)
+
+    all_buttons = suggestor.findChildren(QPushButton)
+    copy_all_button = next(
+        button for button in all_buttons if isinstance(button, _CopyAllButton)
+    )
+    copy_all_button.click()
+
+    expected_clipboard = """error
+    script.py: Line 5
+
+    warning
+    script.py: Line 6
+
+    deprecation
+    script.py: Line 7"""
+
+    def remove_whitespaces(s: str) -> str:
+        return re.sub(r"\s+", "", s)
+
+    assert remove_whitespaces(QApplication.clipboard().text()) == remove_whitespaces(
+        expected_clipboard
+    )


### PR DESCRIPTION
Resolves specific request from user on slack.

My first iterations consisted of a class method which I wanted to insert among the other buttons, hence the refactoring of the other buttons. That refactoring was strictly not necessary for the final code, but I still believe it is an improvement, so I decided to keep it.

https://github.com/user-attachments/assets/7de90984-97ad-498b-9ab9-132a2531140c



This pull request implements a "Copy all messages" button in the Suggestor widget, allowing users to copy all error, warning, and deprecation messages to the clipboard with a single click.

Key Changes:

Added a new _CopyAllButton class that extends CopyButton to copy all messages at once
Refactored the action buttons layout to accommodate the new copy all button alongside existing close/continue buttons
Added comprehensive tests to verify the copy all functionality works correctly across different message types

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
