### PR TITLE
Solve and enforce ruff FLY rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ select = [
     "FA",
     "FAST",
     "FIX",
+    "FLY",
     "FURB",  # refurb
     "G",     # logging-format
     "I",     # isort

--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -545,8 +545,10 @@ def _handle_rft_observation(
 
     return pl.DataFrame(
         {
-            "response_key": ":".join(
-                [rft_observation.well, rft_observation.date, rft_observation.property]
+            "response_key": (
+                f"{rft_observation.well}:"
+                f"{rft_observation.date}:"
+                f"{rft_observation.property}"
             ),
             "observation_key": rft_observation.name,
             "east": pl.Series([location[0]], dtype=pl.Float32),

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -81,7 +81,7 @@ def stop_server(
     for retry in range(retries):
         try:
             url, cert, auth = server_context
-            stop_endpoint = "/".join([url, EverEndpoints.stop])
+            stop_endpoint = f"{url}/{EverEndpoints.stop}"
             response = requests.post(
                 stop_endpoint,
                 verify=cert,
@@ -105,7 +105,7 @@ def start_experiment(
     for retry in range(retries):
         try:
             url, cert, auth = server_context
-            start_endpoint = "/".join([url, EverEndpoints.start_experiment])
+            start_endpoint = f"{url}/{EverEndpoints.start_experiment}"
             response = requests.post(
                 start_endpoint,
                 verify=cert,

--- a/src/everest/gui/everest_client.py
+++ b/src/everest/gui/everest_client.py
@@ -44,7 +44,7 @@ class EverestClient:
 
     def _http_get(self, endpoint: EverEndpoints) -> requests.Response:
         return requests.get(
-            "/".join([self._url, endpoint]),
+            f"{self._url}/{endpoint}",
             verify=self._cert,
             auth=(self._username, self._password),
             proxies={"http": None, "https": None},  # type: ignore
@@ -52,7 +52,7 @@ class EverestClient:
 
     def _http_post(self, endpoint: EverEndpoints) -> requests.Response:
         return requests.post(
-            "/".join([self._url, endpoint]),
+            f"{self._url}/{endpoint}",
             verify=self._cert,
             auth=(self._username, self._password),
             proxies={"http": None, "https": None},  # type: ignore

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 
@@ -96,16 +97,13 @@ def test_that_multiple_workflow_jobs_are_ordered_correctly(order):
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
     Path("workflow").write_text(
-        "\n".join(
-            [
-                "DEFINE <A> 1",
-                "foo <A>",
-                "bar <A>",
-                "DEFINE <A> 3",
-                "foo <A>",
-                "baz <A>",
-            ]
-        ),
+        textwrap.dedent("""
+            DEFINE <A> 1
+            foo <A>
+            bar <A>
+            DEFINE <A> 3
+            foo <A>
+            baz <A>"""),
         encoding="utf-8",
     )
 
@@ -131,12 +129,7 @@ def test_that_redefine_in_workflow_overwrites_in_subsequent_lines():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_unknown_jobs_gives_error():
     Path("workflow").write_text(
-        "\n".join(
-            [
-                "boo <A>",
-                "kingboo <A>",
-            ]
-        ),
+        "boo <A>\nkingboo <A>",
         encoding="utf-8",
     )
 

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -166,15 +166,9 @@ def test_load_forward_model_gen_data(setup_case):
         """
     )
     run_path = Path("simulations/realization-0/iter-0/")
-    (run_path / "response_0.out").write_text(
-        "\n".join(["1", "2", "3"]), encoding="utf-8"
-    )
-    (run_path / "response_1.out").write_text(
-        "\n".join(["4", "5", "5"]), encoding="utf-8"
-    )
-    (run_path / "response_0.out_active").write_text(
-        "\n".join(["1", "0", "1"]), encoding="utf-8"
-    )
+    (run_path / "response_0.out").write_text("1\n2\n3", encoding="utf-8")
+    (run_path / "response_1.out").write_text("4\n5\n5", encoding="utf-8")
+    (run_path / "response_0.out_active").write_text("1\n0\n1", encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("gen_data", (0,))
@@ -191,8 +185,8 @@ def test_single_valued_gen_data_with_active_info_is_loaded(setup_case):
     )
 
     run_path = Path("simulations/realization-0/iter-0/")
-    (run_path / "response_0.out").write_text("\n".join(["1"]), encoding="utf-8")
-    (run_path / "response_0.out_active").write_text("\n".join(["1"]), encoding="utf-8")
+    (run_path / "response_0.out").write_text("1", encoding="utf-8")
+    (run_path / "response_0.out_active").write_text("1", encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -208,8 +202,8 @@ def test_that_all_deactivated_values_are_loaded(setup_case):
     )
 
     run_path = Path("simulations/realization-0/iter-0/")
-    (run_path / "response_0.out").write_text("\n".join(["-1"]), encoding="utf-8")
-    (run_path / "response_0.out_active").write_text("\n".join(["0"]), encoding="utf-8")
+    (run_path / "response_0.out").write_text("-1", encoding="utf-8")
+    (run_path / "response_0.out_active").write_text("0", encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     response = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -245,10 +239,8 @@ def test_loading_gen_data_without_restart(storage, run_args):
         runpaths=Runpaths.from_config(ert_config),
     )
     run_path = Path("simulations/realization-0/iter-0/")
-    (run_path / "response.out").write_text("\n".join(["1", "2", "3"]), encoding="utf-8")
-    (run_path / "response.out_active").write_text(
-        "\n".join(["1", "0", "1"]), encoding="utf-8"
-    )
+    (run_path / "response.out").write_text("1\n2\n3", encoding="utf-8")
+    (run_path / "response.out_active").write_text("1\n0\n1", encoding="utf-8")
 
     load_parameters_and_responses_from_runpath(str(run_path), prior_ensemble, [0])
     df = prior_ensemble.load_responses("RESPONSE", (0,))
@@ -317,10 +309,8 @@ def test_loading_from_any_available_iter(storage, run_args, itr):
         runpaths=Runpaths.from_config(ert_config),
     )
     run_path = Path(f"simulations/realization-0/iter-{itr if itr is not None else 0}/")
-    (run_path / "response.out").write_text("\n".join(["1", "2", "3"]), encoding="utf-8")
-    (run_path / "response.out_active").write_text(
-        "\n".join(["1", "0", "1"]), encoding="utf-8"
-    )
+    (run_path / "response.out").write_text("1\n2\n3", encoding="utf-8")
+    (run_path / "response.out_active").write_text("1\n0\n1", encoding="utf-8")
 
     run_path_format = str(
         Path(


### PR DESCRIPTION
**Issue**
Resolves str.join calls that can be replaced by f-strings

**Approach**
ruff auto-fix (plus some manual fix)

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
