### PR TITLE
Allow perturbation_magnitude to be set in globally or in all variables

### DIFF
--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -292,6 +292,84 @@ def test_that_invalid_control_unique_entry(variables, unique_key):
         )
 
 
+def test_that_perturbation_magnitude_is_required_when_one_variables_does_not_set_it():
+    with pytest.raises(
+        ValueError,
+        match=r"A default perturbation_magnitude for all variables must be set",
+    ):
+        everest_config_with_defaults(
+            controls=[
+                {
+                    "name": "group_0",
+                    "type": "well_control",
+                    "min": 0,
+                    "max": 1,
+                    "initial_guess": 0,
+                    "variables": [
+                        {"name": "w00"},
+                        {"name": "w01", "perturbation_magnitude": 0.01},
+                    ],
+                }
+            ]
+        )
+
+
+def test_that_perturbation_magnitude_is_required():
+    with pytest.raises(
+        ValueError,
+        match=r"A default perturbation_magnitude for all variables must be set",
+    ):
+        everest_config_with_defaults(
+            controls=[
+                {
+                    "name": "group_0",
+                    "type": "well_control",
+                    "min": 0,
+                    "max": 1,
+                    "initial_guess": 0,
+                    "variables": [
+                        {"name": "w00"},
+                    ],
+                }
+            ]
+        )
+
+
+def test_that_perturbation_magnitude_can_be_set_per_variable():
+    everest_config_with_defaults(
+        controls=[
+            {
+                "name": "group_0",
+                "type": "well_control",
+                "min": 0,
+                "max": 1,
+                "initial_guess": 0,
+                "variables": [
+                    {"name": "w00", "perturbation_magnitude": 0.01},
+                ],
+            }
+        ]
+    )
+
+
+def test_that_perturbation_magnitude_can_be_set_for_all_variables():
+    everest_config_with_defaults(
+        controls=[
+            {
+                "name": "group_0",
+                "type": "well_control",
+                "min": 0,
+                "max": 1,
+                "initial_guess": 0,
+                "perturbation_magnitude": 0.01,
+                "variables": [
+                    {"name": "w00"},
+                ],
+            }
+        ]
+    )
+
+
 def test_that_invalid_control_undefined_fields():
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Previously it was always required at the controls level, even if all variables specified an override, yielding the global perturbation_magnitude a dummy.

**Issue**
Resolves #12591 


**Approach**
Allow None valued for perturbation_magnitude at the upper level in the Pydantic schema and add a custom validator to check that it is defined either at the upper level, or for all control variables.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
