### PR TITLE
Move makedirs_if_needed from everest to ert

### DIFF
--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -34,7 +34,7 @@ from ert.shared import __file__ as ert_shared_path
 from ert.shared import find_available_socket, get_machine_name
 from ert.shared.storage.command import add_parser_options
 from ert.trace import tracer
-from everest.util import makedirs_if_needed
+from ert.utils import makedirs_if_needed
 
 DARK_STORAGE_APP = "ert.dark_storage.app:app"
 

--- a/src/ert/utils/__init__.py
+++ b/src/ert/utils/__init__.py
@@ -1,8 +1,12 @@
 import logging
+import os
 import time
 from collections.abc import Callable
+from datetime import UTC, datetime
 from functools import wraps
 from typing import ParamSpec, TypeVar
+
+from _ert.utils import file_safe_timestamp
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -30,3 +34,19 @@ def log_duration(
         return wrapper
 
     return decorator
+
+
+def makedirs_if_needed(path: str, roll_if_exists: bool = False) -> None:
+    if os.path.isdir(path):
+        if not roll_if_exists:
+            return
+        _roll_dir(path)  # exists and should be rolled
+    os.makedirs(path)
+
+
+def _roll_dir(old_name: str) -> None:
+    old_name = os.path.realpath(old_name)
+    timestamp = file_safe_timestamp(datetime.now(UTC).isoformat())
+    new_name = f"{old_name}__{timestamp}"
+    os.rename(old_name, new_name)
+    logging.getLogger().info(f"renamed {old_name} to {new_name}")

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -16,6 +16,7 @@ from _ert.threading import ErtThread
 from ert.config import QueueSystem
 from ert.services import ErtServer
 from ert.storage.local_experiment import ExperimentState
+from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
     start_experiment,
@@ -24,7 +25,6 @@ from everest.detached import (
 )
 from everest.everest_storage import EverestStorage
 from everest.util import (
-    makedirs_if_needed,
     version_info,
     warn_user_that_runpath_is_nonempty,
 )

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -31,6 +31,7 @@ from ert.storage import (
     ExperimentStatus,
     open_storage,
 )
+from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig
 from everest.config.server_config import ServerConfig
 from everest.detached import (
@@ -40,7 +41,6 @@ from everest.detached import (
     wait_for_server_to_stop,
 )
 from everest.strings import EVEREST, OPT_PROGRESS_ID, SIM_PROGRESS_ID
-from everest.util import makedirs_if_needed
 
 JOB_SUCCESS = "Finished"
 JOB_RUNNING = "Running"

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -17,6 +17,7 @@ from ert.services._base_service import BaseServiceExit
 from ert.storage import ExperimentStatus
 from ert.storage.local_experiment import ExperimentState
 from ert.trace import tracer
+from ert.utils import makedirs_if_needed
 from everest.config import ServerConfig
 from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
@@ -25,7 +26,7 @@ from everest.strings import (
     EXPERIMENT_SERVER,
     OPTIMIZATION_LOG_DIR,
 )
-from everest.util import makedirs_if_needed, version_info
+from everest.util import version_info
 
 logger = logging.getLogger(__name__)
 

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from datetime import UTC, datetime
 
 from ropt.version import version as ropt_version
 
@@ -8,20 +6,12 @@ try:
     from ert.shared.version import version as ert_version
 except ImportError:
     ert_version = "0.0.0"
-from _ert.utils import file_safe_timestamp
+
 from everest.strings import EVEREST
 
 
 def version_info() -> str:
     return f"everest:{ert_version}, ropt:{ropt_version}, ert:{ert_version}"
-
-
-def makedirs_if_needed(path: str, roll_if_exists: bool = False) -> None:
-    if os.path.isdir(path):
-        if not roll_if_exists:
-            return
-        _roll_dir(path)  # exists and should be rolled
-    os.makedirs(path)
 
 
 def warn_user_that_runpath_is_nonempty() -> None:
@@ -34,11 +24,3 @@ def warn_user_that_runpath_is_nonempty() -> None:
         "be used if not configured correctly.\n"
     )
     logging.getLogger(EVEREST).warning("Everest is running in an existing runpath")
-
-
-def _roll_dir(old_name: str) -> None:
-    old_name = os.path.realpath(old_name)
-    timestamp = file_safe_timestamp(datetime.now(UTC).isoformat())
-    new_name = f"{old_name}__{timestamp}"
-    os.rename(old_name, new_name)
-    logging.getLogger(EVEREST).info(f"renamed {old_name} to {new_name}")

--- a/tests/ert/unit_tests/test_utils.py
+++ b/tests/ert/unit_tests/test_utils.py
@@ -1,0 +1,54 @@
+import os.path
+
+from ert.utils import makedirs_if_needed
+
+
+def test_makedirs(change_to_tmpdir):
+    output_dir = os.path.join("unittest_everest_output")
+    cwd = os.getcwd()
+
+    # assert output dir (/tmp/tmpXXXX) is empty
+    assert not os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 0
+
+    # create output folder
+    makedirs_if_needed(output_dir)
+
+    # assert output folder created
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 1
+
+
+def test_makedirs_already_exists(change_to_tmpdir):
+    output_dir = os.path.join("unittest_everest_output")
+    cwd = os.getcwd()
+
+    # create outputfolder and verify it's existing
+    makedirs_if_needed(output_dir)
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 1
+
+    # run makedirs_if_needed again, verify nothing happened
+    makedirs_if_needed(output_dir)
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 1
+
+
+def test_makedirs_roll_existing(change_to_tmpdir):
+    output_dir = os.path.join("unittest_everest_output")
+    cwd = os.getcwd()
+
+    # create outputfolder and verify it's existing
+    makedirs_if_needed(output_dir)
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 1
+
+    # run makedirs_if_needed again, verify old dir rolled
+    makedirs_if_needed(output_dir, True)
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 2
+
+    # run makedirs_if_needed again, verify old dir rolled
+    makedirs_if_needed(output_dir, True)
+    assert os.path.isdir(output_dir)
+    assert len(os.listdir(cwd)) == 3

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -24,6 +24,7 @@ from ert.dark_storage.client import ErtClientConnectionInfo
 from ert.plugins import ErtRuntimePlugins
 from ert.scheduler.event import FinishedEvent
 from ert.services import ErtServer
+from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig
 from everest.config.forward_model_config import ForwardModelStepConfig
 from everest.config.install_job_config import InstallForwardModelStepConfig
@@ -37,7 +38,6 @@ from everest.detached import (
     wait_for_server,
     wait_for_server_to_stop,
 )
-from everest.util import makedirs_if_needed
 from tests.everest.utils import everest_config_with_defaults
 
 

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -9,8 +9,8 @@ from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
 from ert.storage import open_storage
+from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig
-from everest.util import makedirs_if_needed
 from tests.everest.utils import get_optimal_result
 
 CONFIG_FILE_MULTIOBJ = "config_multiobj.yml"

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -6,7 +6,6 @@ import pytest
 
 from ert.storage import open_storage
 from ert.storage.local_experiment import ExperimentState, ExperimentStatus
-from everest import util
 from everest.bin.utils import get_experiment_status, show_scaled_controls_warning
 from everest.strings import EVEREST
 from tests.everest.utils import (
@@ -37,57 +36,6 @@ def test_get_values(change_to_tmpdir):
     )
 
     config.environment.output_folder = rel_out_dir
-
-
-def test_makedirs(change_to_tmpdir):
-    output_dir = os.path.join("unittest_everest_output")
-    cwd = os.getcwd()
-
-    # assert output dir (/tmp/tmpXXXX) is empty
-    assert not os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 0
-
-    # create output folder
-    util.makedirs_if_needed(output_dir)
-
-    # assert output folder created
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 1
-
-
-def test_makedirs_already_exists(change_to_tmpdir):
-    output_dir = os.path.join("unittest_everest_output")
-    cwd = os.getcwd()
-
-    # create outputfolder and verify it's existing
-    util.makedirs_if_needed(output_dir)
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 1
-
-    # run makedirs_if_needed again, verify nothing happened
-    util.makedirs_if_needed(output_dir)
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 1
-
-
-def test_makedirs_roll_existing(change_to_tmpdir):
-    output_dir = os.path.join("unittest_everest_output")
-    cwd = os.getcwd()
-
-    # create outputfolder and verify it's existing
-    util.makedirs_if_needed(output_dir)
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 1
-
-    # run makedirs_if_needed again, verify old dir rolled
-    util.makedirs_if_needed(output_dir, True)
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 2
-
-    # run makedirs_if_needed again, verify old dir rolled
-    util.makedirs_if_needed(output_dir, True)
-    assert os.path.isdir(output_dir)
-    assert len(os.listdir(cwd)) == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This function is not used exclusively by Everest, so it should be moved to a location where it is natural to be shared between Ert and Everest.

Its logging was everest specific - which was a bug when called from the Ert side, now we do not try to state in the logging from which side we were called from

**Issue**
Resolves ert code depending on everest code.


**Approach**
🚛 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
