### PR TITLE
Reduce useless logging in ES update

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -322,10 +322,6 @@ def analysis_ES(
         logger.info(log_msg)
         progress_callback(AnalysisStatusEvent(msg=log_msg))
 
-        log_msg = f"There are {num_obs} responses and {ensemble_size} realizations."
-        logger.info(log_msg)
-        progress_callback(AnalysisStatusEvent(msg=log_msg))
-
         if (param_count := (~non_zero_variance_mask).sum()) > 0:
             log_msg = (
                 f"There are {param_count} parameters with 0 variance "
@@ -382,6 +378,10 @@ def analysis_ES(
             )
 
         else:
+            log_msg = f"There are {num_obs} responses and {ensemble_size} realizations."
+            logger.info(log_msg)
+            progress_callback(AnalysisStatusEvent(msg=log_msg))
+
             # In-place multiplication is not yet supported, therefore avoiding @=
             param_ensemble_array[non_zero_variance_mask] = param_ensemble_array[  # noqa: PLR6104
                 non_zero_variance_mask


### PR DESCRIPTION
**Issue**
Resolves #12393 

This will reduce the logging every month by:

Avoid 0 updates to params with 0 variance
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz2NMQrDMBAE%252B7zicGU3wZA%252BkCpVOn3gIi%252BWwDqJ0ymGkMdHTpFim2GYvZXilD3q6UN7gIJcTLhDoGxY6Eq85vEyL9NfeKBWXkE%252Bi3GUSoP7ce6bqbBygkEr7dFCJy%252FWyOJBFtg63DaSbPQEtbIcJ%252Beht2tLqYvvo9vExukLB1tOuZoAAAA%253D/limit/1000)
62505

Remove ‘start’ statement when storing parameters
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz3KMQ6DMAwF0J1TWJlgQ2KvxNSJCS5gJb8hQxxkG1Wqenjo0je%252F%252BTg25QjrvvTeoaCtVDwhUHYkehDn1k9jGv5hgRlnUGziXMQorN60SKbEzvRqGu5rZ62s5fN7p3g%252FXHXDX4RqAAAA/limit/1000)
~75000

Avoid duplicates log statements for localization
[Go to Log Analytics and run query](https://portal.azure.com/#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fe823d00d-e01a-4af3-b71b-61df62a8e3ea%2Fresourcegroups%2Ffmu-logging%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Ffmu-logs/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAz3LMQrCQBAF0N5TDKmSTrAXrKxsJBcYNp91IPsn7OwiBA8fbezfu23bXDUhTh95v1AhsxXcQVRtWOQqmn28nJfpDx6I0AxJzqbGkOHZSWOW1ZOutmszpziHb4leilbbf7yzjdMBWFw%252BgHEAAAA%253D/limit/1000)
6000


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
