### PR TITLE
Avoid flooding warnings of type LinAlg ill-conditioned matrix

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import re
 import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
@@ -441,6 +442,9 @@ def smoother_update(
         with warnings.catch_warnings():
             original_showwarning = warnings.showwarning
 
+            ILL_CONDITIONED_RE = re.compile(
+                r"^LinAlgWarning:.*ill[- ]?conditioned\s+matrix", re.IGNORECASE
+            )
             LIMIT_ILL_CONDITIONED_WARNING = 1000
             illconditioned_warn_counter = 0
 
@@ -454,7 +458,7 @@ def smoother_update(
             ) -> None:
                 nonlocal illconditioned_warn_counter
 
-                if str(message).startswith("LinAlgWarning: Ill-conditioned matrix"):
+                if ILL_CONDITIONED_RE.search(str(message)):
                     illconditioned_warn_counter += 1
 
                 if illconditioned_warn_counter < LIMIT_ILL_CONDITIONED_WARNING:


### PR DESCRIPTION
We just received yet another wave of `LinAlgWarning: Ill-conditioned matrix ` warnings.
This time "only" 170513 occurrences from one simulation.

Last wave was in excess of 1.5 million.
https://equinor.slack.com/archives/C019REYBD54/p1755591287919859

Related to https://github.com/equinor/ert/pull/10930/changes#diff-636527661d6dcb9dc9554d4db4bd8d303771b625e35a6a66b849e1eaf068a862R416-R426

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
