### PR TITLE
Remove noisy warning for empty keys in summaries

### DIFF
--- a/src/ert/config/_read_summary.py
+++ b/src/ert/config/_read_summary.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import fnmatch
 import re
-import warnings
 from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 from enum import Enum, auto
@@ -158,10 +157,10 @@ def _read_spec(
             if kw.summary_variable == "TIME":
                 date_index = i
                 date_unit_str = kw.unit
-        except InvalidSummaryKeyError as err:
-            warnings.warn(
-                f"Found {err} in summary specification, key not loaded", stacklevel=2
-            )
+        except InvalidSummaryKeyError:
+            # InvalidSummaryKeyError will happen under normal conditions when
+            # the the number of wells set for WELLDIMS in the .DATA file is
+            # larger than the number of declared wells/groups/etc. These are skipped.
             continue
 
         if should_load_key(key):


### PR DESCRIPTION
This warning was shown to ocurr too often.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
