### PR TITLE
Make Ertserver.session() a module level function

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -19,7 +19,7 @@ from pandas.errors import ParserError
 from resfo_utilities import history_key
 
 from ert.config import ParameterConfig, ResponseMetadata
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.storage.local_experiment import _parameters_adapter as parameter_config_adapter
 from ert.storage.realization_storage_state import RealizationStorageState
 
@@ -51,13 +51,13 @@ class PlotApiKeyDefinition(NamedTuple):
 
 class PlotApi:
     def __init__(self, ens_path: Path) -> None:
-        self.ens_path = ens_path
+        self.ens_path: Path = ens_path
         self._all_ensembles: list[EnsembleObject] | None = None
         self._timeout = 120
 
     @property
     def api_version(self) -> str:
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             try:
                 response = client.get("/version", timeout=self._timeout)
                 self._check_response(response)
@@ -83,7 +83,7 @@ class PlotApi:
             return self._all_ensembles
 
         self._all_ensembles = []
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             try:
                 response = client.get("/experiments", timeout=self._timeout)
                 self._check_response(response)
@@ -139,7 +139,7 @@ class PlotApi:
         all_keys: dict[str, PlotApiKeyDefinition] = {}
         all_params = {}
 
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             response = client.get("/experiments", timeout=self._timeout)
             self._check_response(response)
 
@@ -166,7 +166,7 @@ class PlotApi:
     def responses_api_key_defs(self) -> list[PlotApiKeyDefinition]:
         key_defs: dict[str, PlotApiKeyDefinition] = {}
 
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             response = client.get("/experiments", timeout=self._timeout)
             self._check_response(response)
 
@@ -228,7 +228,7 @@ class PlotApi:
         response_key: str,
         filter_on: dict[str, Any] | None = None,
     ) -> pd.DataFrame:
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             response = client.get(
                 f"/ensembles/{ensemble_id}/responses/{PlotApi.escape(response_key)}",
                 headers={"accept": "application/x-parquet"},
@@ -256,7 +256,7 @@ class PlotApi:
                 return df
 
     def data_for_parameter(self, ensemble_id: str, parameter_key: str) -> pd.DataFrame:
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             parameter = client.get(
                 f"/ensembles/{ensemble_id}/parameters/{PlotApi.escape(parameter_key)}",
                 headers={"accept": "application/x-parquet"},
@@ -298,7 +298,7 @@ class PlotApi:
             assert key_def.response_metadata is not None
             actual_response_key = key_def.response_metadata.response_key
             filter_on = key_def.filter_on
-            with ErtServer.session(project=self.ens_path) as client:
+            with create_ertserver_client(self.ens_path) as client:
                 response = client.get(
                     f"/ensembles/{ensemble.id}/responses/{PlotApi.escape(actual_response_key)}/observations",
                     timeout=self._timeout,
@@ -386,7 +386,7 @@ class PlotApi:
         if not ensemble:
             return np.array([])
 
-        with ErtServer.session(project=self.ens_path) as client:
+        with create_ertserver_client(self.ens_path) as client:
             response = client.get(
                 f"/ensembles/{ensemble.id}/parameters/{PlotApi.escape(key)}/std_dev",
                 params={"z": z},

--- a/src/ert/services/__init__.py
+++ b/src/ert/services/__init__.py
@@ -1,3 +1,8 @@
-from .ert_server import ErtServer, ErtServerExit, ServerBootFail
+from .ert_server import (
+    ErtServer,
+    ErtServerExit,
+    ServerBootFail,
+    create_ertserver_client,
+)
 
-__all__ = ["ErtServer", "ErtServerExit", "ServerBootFail"]
+__all__ = ["ErtServer", "ErtServerExit", "ServerBootFail", "create_ertserver_client"]

--- a/src/ert/services/ert_server.py
+++ b/src/ert/services/ert_server.py
@@ -331,21 +331,6 @@ class ErtServer:
             "None of the URLs provided for the ert storage server worked."
         )
 
-    @classmethod
-    def session(cls, project: os.PathLike[str], timeout: int | None = None) -> Client:
-        """
-        Start a HTTP transaction with the server
-        """
-        inst = cls.connect(timeout=timeout, project=project)
-        info = inst.fetch_connection_info()
-        return Client(
-            conn_info=ErtClientConnectionInfo(
-                base_url=inst.fetch_url(),
-                auth_token=inst.fetch_auth()[1],
-                cert=info["cert"],
-            )
-        )
-
     @property
     def logger(self) -> logging.Logger:
         return logging.getLogger("ert.shared.storage")
@@ -479,3 +464,16 @@ class ErtServer:
     def wait(self) -> None:
         if self._thread_that_starts_server_process is not None:
             self._thread_that_starts_server_process.join()
+
+
+def create_ertserver_client(project: Path, timeout: int | None = None) -> Client:
+    """Read connection info from file in path and create HTTP client."""
+    connection = ErtServer.connect(timeout=timeout, project=project)
+    info = connection.fetch_connection_info()
+    return Client(
+        conn_info=ErtClientConnectionInfo(
+            base_url=connection.fetch_url(),
+            auth_token=connection.fetch_auth()[1],
+            cert=info["cert"],
+        )
+    )

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -14,7 +14,7 @@ import anyio
 
 from _ert.threading import ErtThread
 from ert.config import QueueSystem
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.storage.local_experiment import ExperimentState
 from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig, ServerConfig
@@ -169,7 +169,7 @@ async def run_everest(options: argparse.Namespace) -> None:
     )
 
     try:
-        ErtServer.session(
+        create_ertserver_client(
             Path(ServerConfig.get_session_dir(options.config.output_dir)), timeout=1
         )
         server_running = True
@@ -233,7 +233,7 @@ async def run_everest(options: argparse.Namespace) -> None:
 
     print("Waiting for server ...")
     logger.debug("Waiting for response from everserver")
-    client = ErtServer.session(
+    client = create_ertserver_client(
         Path(ServerConfig.get_session_dir(options.config.output_dir))
     )
     wait_for_server(client, timeout=600)

--- a/src/everest/bin/kill_script.py
+++ b/src/everest/bin/kill_script.py
@@ -12,7 +12,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from everest.bin.utils import setup_logging
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import stop_server, wait_for_server_to_stop
@@ -74,7 +74,7 @@ def _handle_keyboard_interrupt(signal: int, _: Any, after: bool = False) -> None
 
 def kill_everest(options: argparse.Namespace) -> None:
     try:
-        client = ErtServer.session(
+        client = create_ertserver_client(
             Path(ServerConfig.get_session_dir(options.config.output_dir)), timeout=1
         )
         server_context = ServerConfig.get_server_context_from_conn_info(

--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -7,7 +7,7 @@ from functools import partial
 from pathlib import Path
 from textwrap import dedent
 
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.storage import ErtStorageException, ExperimentState
 from everest.config import EverestConfig, ServerConfig
 from everest.everest_storage import EverestStorage
@@ -82,7 +82,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
 def monitor_everest(options: argparse.Namespace) -> None:
     config: EverestConfig = options.config
     try:
-        with ErtServer.session(
+        with create_ertserver_client(
             Path(ServerConfig.get_session_dir(config.output_dir)), timeout=1
         ) as client:
             server_context = ServerConfig.get_server_context_from_conn_info(

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -26,7 +26,7 @@ from ert.ensemble_evaluator import (
 from ert.ensemble_evaluator.event import EndEvent
 from ert.logging import LOGGING_CONFIG
 from ert.plugins.plugin_manager import ErtPluginManager
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.storage import (
     ExperimentStatus,
     open_storage,
@@ -106,7 +106,7 @@ def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) 
             "The optimization will be stopped and the program will exit..."
         )
         try:
-            client = ErtServer.session(
+            client = create_ertserver_client(
                 Path(ServerConfig.get_session_dir(options.config.output_dir))
             )
             server_context = ServerConfig.get_server_context_from_conn_info(

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -12,8 +12,7 @@ import yaml
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from ert.plugins.plugin_manager import ErtPluginManager
-from ert.services import ErtServer
-from ert.services.ert_server import ErtServerExit
+from ert.services import ErtServer, ErtServerExit, create_ertserver_client
 from ert.storage import ExperimentStatus
 from ert.storage.local_experiment import ExperimentState
 from ert.trace import tracer
@@ -167,7 +166,7 @@ def main() -> None:
                 timeout=240, project=Path(server_path), logging_config=log_file.name
             ) as server:
                 server.fetch_connection_info()
-                with ErtServer.session(project=Path(server_path)) as client:
+                with create_ertserver_client(Path(server_path)) as client:
                     done = False
                     while not done:
                         response = client.get(

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -13,7 +13,7 @@ from PyQt6.QtWidgets import (
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.simulation.run_dialog import RunDialog
 from ert.plugins import ErtPluginManager
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from everest.config import ServerConfig
 from everest.detached import wait_for_server
 from everest.gui.everest_client import EverestClient
@@ -43,7 +43,7 @@ class EverestMainWindow(QMainWindow):
         self.setCentralWidget(self.central_widget)
 
     def run(self) -> None:
-        storage_client = ErtServer.session(
+        storage_client = create_ertserver_client(
             Path(ServerConfig.get_session_dir(self.output_dir))
         )
         wait_for_server(storage_client, 60)

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -24,8 +24,8 @@ from ert.dark_storage.app import app
 from ert.dark_storage.endpoints import ensembles, experiments
 from ert.dark_storage.endpoints.observations import get_observations_for_response
 from ert.dark_storage.endpoints.responses import get_response
+from ert.gui.tools.plot import plot_api
 from ert.gui.tools.plot.plot_api import PlotApi
-from ert.services import ErtServer
 from ert.storage import Storage, open_storage
 
 T = TypeVar("T")
@@ -56,7 +56,7 @@ def get_response_autofilter(
 @pytest.fixture(autouse=True)
 def use_testclient(monkeypatch):
     client = TestClient(app)
-    monkeypatch.setattr(ErtServer, "session", lambda project: client)
+    monkeypatch.setattr(plot_api, "create_ertserver_client", lambda project: client)
 
     def test_escape(s: str) -> str:
         """

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
+from ert.gui.tools.plot import plot_api
 from ert.gui.tools.plot.plot_api import PlotApi
-from ert.services import ErtServer
 
 
 class MockResponse:
@@ -35,7 +35,7 @@ def api(tmpdir, source_root, monkeypatch):
     def session(project: str):
         yield MagicMock(get=mocked_requests_get)
 
-    monkeypatch.setattr(ErtServer, "session", session)
+    monkeypatch.setattr(plot_api, "create_ertserver_client", session)
 
     with tmpdir.as_cwd():
         test_data_root = source_root / "test-data" / "ert"

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -17,8 +17,8 @@ from ert.config import GenKwConfig, SummaryConfig
 from ert.config.response_config import ResponseMetadata
 from ert.dark_storage import common
 from ert.dark_storage.app import app
+from ert.gui.tools.plot import plot_api
 from ert.gui.tools.plot.plot_api import PlotApi, PlotApiKeyDefinition
-from ert.services import ErtServer
 from ert.storage import open_storage
 from tests.ert.unit_tests.gui.tools.plot.conftest import MockResponse
 
@@ -26,7 +26,7 @@ from tests.ert.unit_tests.gui.tools.plot.conftest import MockResponse
 @pytest.fixture(autouse=True)
 def use_testclient(monkeypatch):
     client = TestClient(app)
-    monkeypatch.setattr(ErtServer, "session", lambda project: client)
+    monkeypatch.setattr(plot_api, "create_ertserver_client", lambda project: client)
 
     def test_escape(s: str) -> str:
         """
@@ -46,7 +46,7 @@ def use_testclient(monkeypatch):
     client.get = get_without_timeout
 
 
-def test_key_def_structure(api):
+def test_key_def_structure(api: PlotApi):
     key_defs = api.parameters_api_key_defs + api.responses_api_key_defs
     fopr = next(x for x in key_defs if x.key == "FOPR")
     fopr_expected = {

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -23,7 +23,7 @@ from ert.config.queue_config import (
 from ert.dark_storage.client import ErtClientConnectionInfo
 from ert.plugins import ErtRuntimePlugins
 from ert.scheduler.event import FinishedEvent
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig
 from everest.config.forward_model_config import ForwardModelStepConfig
@@ -59,7 +59,7 @@ async def test_https_requests(change_to_tmpdir):
     makedirs_if_needed(Path(everest_config.output_dir), roll_if_exists=True)
     await start_server(everest_config, logging_level=logging.INFO)
 
-    session = ErtServer.session(
+    session = create_ertserver_client(
         Path(ServerConfig.get_session_dir(everest_config.output_dir)), 240
     )
     wait_for_server(session, 240)

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -12,7 +12,7 @@ import yaml
 from fastapi import FastAPI
 from starlette.responses import Response
 
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.shared import find_available_socket
 from everest.bin.everest_script import everest_entry
 from everest.config import EverestConfig, ServerConfig
@@ -189,7 +189,7 @@ def test_that_multiple_everest_clients_can_connect_to_server(
     )
 
     everest_main_thread.start()
-    client = ErtServer.session(
+    client = create_ertserver_client(
         Path(ServerConfig.get_session_dir(ever_config.output_dir))
     )
 

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -26,7 +26,10 @@ def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
         assert ensemble_names == set(batches)
 
 
-@patch("ert.services.ErtServer.session", side_effect=[TimeoutError(), MagicMock()])
+@patch(
+    "everest.bin.everest_script.create_ertserver_client",
+    side_effect=[TimeoutError(), MagicMock()],
+)
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch("everest.bin.everest_script.run_detached_monitor")
 @patch("everest.bin.everest_script.wait_for_server")

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -15,7 +15,7 @@ import ert
 from ert.dark_storage.app import app
 from ert.ensemble_evaluator import EndEvent
 from ert.scheduler.event import FinishedEvent
-from ert.services import ErtServer
+from ert.services import create_ertserver_client
 from ert.storage import ExperimentState
 from everest.bin.utils import get_experiment_status
 from everest.config import EverestConfig, ServerConfig
@@ -64,7 +64,9 @@ async def wait_for_server_to_complete(config):
                 return
 
     driver = await start_server(config, logging.DEBUG)
-    client = ErtServer.session(Path(ServerConfig.get_session_dir(config.output_dir)))
+    client = create_ertserver_client(
+        Path(ServerConfig.get_session_dir(config.output_dir))
+    )
     wait_for_server(client, 120)
     start_experiment(
         server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),


### PR DESCRIPTION
The session() function is merely a convencience function that connects and creates a httpx client from the connection. By moving it out the class, it becomes easier to set a descriptive name on the ErtServer class.

**Issue**
Resolves #12632 


**Approach**
🚛 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
