### PR TITLE
Fix test failing for environments where floating point numbers are localized

### DIFF
--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -86,13 +86,6 @@ def test_surface_param(
 ):
     values = [[0.0, 1.0], [2.0, 3.0]]
     with tmpdir.as_cwd():
-        config = dedent(
-            """
-        JOBNAME my_name%d
-        NUM_REALIZATIONS 1
-        """
-        )
-        config += config_str
         expect_surface = RegularSurface(
             ncol=2,
             nrow=2,
@@ -107,7 +100,7 @@ def test_surface_param(
         expect_surface.to_file("surf0.irap", fformat="irap_ascii")
 
         with open("config.ert", mode="w", encoding="utf-8") as fh:
-            fh.writelines(config)
+            fh.writelines(f"NUM_REALIZATIONS 1\n{config_str}\n")
         ensemble_config, fs = create_runpath(storage, "config.ert")
         assert ensemble_config["MY_PARAM"].forward_init is expect_forward_init
         # We try to load the parameters from the forward model, this would fail if


### PR DESCRIPTION
This avoids an issue with resdata.geometry.Surface where floating point formatting
is erronously localized in irap files. This only applies to one test in ert so it is enough
to work around it by using xtgeo instead.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
