### PR TITLE
Fix wrong source package in forward models doc

### DIFF
--- a/src/ert/config/forward_model_step.py
+++ b/src/ert/config/forward_model_step.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -95,9 +96,24 @@ class ForwardModelStepOptions(TypedDict, total=False):
     required_keywords: NotRequired[list[str]]
 
 
+def _get_source_package() -> str:
+    """Return the top-level package name of the calling forward model step.
+
+    Finds the documentation() call (stack[2]) under the forward model step class
+    and return its parent module
+    """
+    stack = inspect.stack()
+    if len(stack) > 2:
+        caller_frame = stack[2]
+        caller_module = inspect.getmodule(caller_frame.frame)
+        if caller_module:
+            return caller_module.__name__.split(".")[0]
+    return "not found"
+
+
 class ForwardModelStepDocumentation(BaseModel):
     config_file: str | None = Field(default=None)
-    source_package: str = Field(default="ert")
+    source_package: str = Field(default_factory=_get_source_package)
     source_function_name: str = Field(default="ert")
     description: str = Field(default="No description")
     examples: str = Field(default="No examples")

--- a/tests/ert/unit_tests/docs/test_ert_documentation.py
+++ b/tests/ert/unit_tests/docs/test_ert_documentation.py
@@ -1,5 +1,8 @@
+import re
+
 import pytest
 
+from ert.plugins.plugin_manager import ErtPluginManager
 from ert.shared._doc_utils.ert_jobs import _ErtDocumentation
 
 
@@ -115,3 +118,23 @@ def test_divide_into_categories_job_source(test_input, expected_source_package):
     categories = _ErtDocumentation._divide_into_categories(test_input)
     result = [docs.job_source for docs in categories["other"]["other"]]
     assert expected_source_package == result
+
+
+@pytest.mark.parametrize("fm_step", ErtPluginManager().forward_model_steps)
+def test_that_forward_model_step_documentation_defaults_to_plugins_source_package(
+    fm_step,
+):
+    # The test assumes that repr(fm_step) returns a string on format:
+    # "<class 'fully.qualified.class.name'>"
+    match_qualified_class_name = re.match(r"\<class '(.*?)'>", repr(fm_step))
+    assert match_qualified_class_name, "Could not get qualified class name from fm_step"
+    qualified_class_name = match_qualified_class_name[1]
+
+    source_package = qualified_class_name.split(".")[0]
+    documentation = fm_step.documentation()
+
+    if documentation:
+        assert documentation.source_package == source_package, (
+            f"{qualified_class_name} documentation reports source_package="
+            f"{documentation.source_package}, expected {source_package}"
+        )


### PR DESCRIPTION
Some forward models wrongly stated ert as the source package due to ert being the default source_package value in the
ForwardModelStepDocumentation class.
With this commit the source package of the ForwardModelStepPlugin will be used as default value if it is not set explicitly.

**Issue**
Resolves #12402 

**Approach**
- Added test to check if the source package returned by forward_model_steps matches their actual source package
- Installed some packages containing installable_forward_model_steps and verified that the test failed 
- Introduced a get_source_package function that will make the forward module documentation use the correct package by default
- Verified that the test passed

**Checklist**
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
