### PR TITLE
Hide log_scale button in GUI if negative values in data

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -164,6 +164,7 @@ class PlotWidget(QWidget):
         vbox.addSpacing(8)
         self.setLayout(vbox)
 
+        self._negative_values_in_data = False
         self._dirty = True
         self._active = False
         self.resetPlot()
@@ -176,11 +177,15 @@ class PlotWidget(QWidget):
         self._figure.clear()
 
     def _sync_log_checkbox(self) -> None:
-        if type(self._plotter).__name__ in {
-            "HistogramPlot",
-            "DistributionPlot",
-            "GaussianKDEPlot",
-        }:
+        if (
+            type(self._plotter).__name__
+            in {
+                "HistogramPlot",
+                "DistributionPlot",
+                "GaussianKDEPlot",
+            }
+            and self._negative_values_in_data is False
+        ):
             self._log_checkbox.setVisible(True)
         else:
             self._log_checkbox.setVisible(False)
@@ -203,8 +208,11 @@ class PlotWidget(QWidget):
     ) -> None:
         self.resetPlot()
         try:
+            self._sync_log_checkbox()
             plot_context.log_scale = (
-                self._log_checkbox.isVisible() and self._log_checkbox.isChecked()
+                self._log_checkbox.isVisible()
+                and self._log_checkbox.isChecked()
+                and self._negative_values_in_data is False
             )
             self._plotter.plot(
                 self._figure,
@@ -215,7 +223,6 @@ class PlotWidget(QWidget):
                 key_def,
             )
             self._canvas.draw()
-            self._sync_log_checkbox()
         except Exception as e:
             exc_type, _, exc_tb = sys.exc_info()
             sys.stderr.write("-" * 80 + "\n")

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -284,6 +284,15 @@ class PlotWindow(QMainWindow):
                 except BaseException as e:
                     handle_exception(e)
 
+            negative_values_in_data = False
+            if key_def.parameter is not None and key_def.parameter.type == "gen_kw":
+                for data in ensemble_to_data_map.values():
+                    data = data.T
+                    if data.le(0).any().any():
+                        negative_values_in_data = True
+                        break
+
+            plot_widget._negative_values_in_data = negative_values_in_data
             observations = None
             if key_def.observations and selected_ensembles:
                 try:

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -1,10 +1,15 @@
+from typing import cast
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QLabel, QPushButton
+from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
 
+from ert.config.gen_kw_config import GenKwConfig
+from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
+from ert.gui.tools.plot.plot_widget import PlotWidget
 from ert.gui.tools.plot.plot_window import PlotWindow, create_error_dialog
 from ert.services import ErtServer
 
@@ -38,3 +43,109 @@ def test_warning_is_visible_on_incompatible_plot_api_version(
         assert label
         assert label.isVisible()
         assert label.text().startswith("<b>Plot API version mismatch detected")
+
+
+@pytest.mark.integration_test
+def test_that_plotting_gen_kw_parameter_with_negative_values_hides_log_scale_checkbox(
+    qtbot: QtBot, monkeypatch
+):
+    """This test verifies that the log scale checkbox is hidden when plotting a gen_kw
+    with negative values. It also makes sure that the plotter remembers if log scale
+    was used, and re-applies it when switching back."""
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    monkeypatch.setattr(
+        "ert.gui.tools.plot.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.tools.plot.plot_window.PlotApi", mock_plot_api_cls)
+
+    plot_api_key_def_positive = PlotApiKeyDefinition(
+        "gen_kw_a",
+        index_type=None,
+        metadata={"data_origin": "GEN_KW"},
+        observations=False,
+        dimensionality=1,
+        parameter=GenKwConfig(
+            name="gen_kw_a", distribution={"name": "uniform", "min": 0, "max": 1}
+        ),
+    )
+    plot_api_key_def_negative = PlotApiKeyDefinition(
+        "gen_kw_b",
+        index_type=None,
+        metadata={"data_origin": "GEN_KW"},
+        observations=False,
+        dimensionality=1,
+        parameter=GenKwConfig(
+            name="gen_kw_b", distribution={"name": "uniform", "min": -1, "max": 0}
+        ),
+    )
+
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = [
+        plot_api_key_def_positive,
+        plot_api_key_def_negative,
+    ]
+
+    def mock_data_for_parameter(ensemble_id: str, parameter_key: str) -> pd.DataFrame:
+        if parameter_key == "gen_kw_a":
+            return pd.DataFrame({0: [0.1, 0.5, 0.9]})
+        return pd.DataFrame({0: [-0.1, -0.5, -0.9]})
+
+    mock_plot_api.data_for_parameter.side_effect = mock_data_for_parameter
+    mock_plot_api.has_history_data.return_value = False
+
+    mock_plot_api.get_all_ensembles.return_value = [
+        EnsembleObject(
+            "ensemble",
+            "ensemble",
+            False,
+            "experiment",
+            "2026-01-01T00:00:00",
+        )
+    ]
+
+    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    qtbot.addWidget(plot_window)
+    plot_window.show()
+
+    plot_widget = plot_window._central_tab.currentWidget()
+    assert plot_widget is not None
+
+    log_checkbox = plot_widget.findChild(QCheckBox, name="log_scale_checkbox")
+    assert log_checkbox.isVisible()
+    assert not log_checkbox.isChecked()
+
+    def get_x_axis_scale() -> str:
+        return (
+            cast(PlotWidget, plot_window._central_tab.currentWidget())
+            ._figure.axes[0]
+            .xaxis.get_scale()
+        )
+
+    assert get_x_axis_scale() == "linear"
+
+    qtbot.mouseClick(log_checkbox, Qt.MouseButton.LeftButton)
+    # Default selection is the first key (gen_kw_a), which has only positive values.
+    qtbot.waitUntil(lambda: get_x_axis_scale() == "log", timeout=5000)
+    assert log_checkbox.isChecked()
+
+    # Select the second key (gen_kw_b), which has negative values.
+    data_type_keys_widget = plot_window._data_type_keys_widget.data_type_keys_widget
+    data_type_keys_widget.setCurrentIndex(
+        plot_window._data_type_keys_widget.filter_model.index(1, 0)
+    )
+    qtbot.waitUntil(lambda: not log_checkbox.isVisible(), timeout=5000)
+    assert get_x_axis_scale() == "linear"
+
+    # Switch back to the first key (gen_kw_a) with positive values.
+    data_type_keys_widget.setCurrentIndex(
+        plot_window._data_type_keys_widget.filter_model.index(0, 0)
+    )
+    qtbot.waitUntil(log_checkbox.isVisible, timeout=5000)
+    assert log_checkbox.isChecked(), "Log scale checkbox should still be checked"
+    assert get_x_axis_scale() == "log", "Plot scale should still be log"


### PR DESCRIPTION
**Issue**
Resolves #12527 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
