### PR TITLE
Raise error if rft observations csv contains observations with value -1 and error 0

### DIFF
--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -11,8 +11,6 @@ import numpy as np
 import pandas as pd
 from pydantic import BaseModel, Field
 
-from ert.config.parsing.config_errors import ConfigWarning
-
 from .parsing import (
     ConfigWarning,
     ErrorInfo,
@@ -301,37 +299,44 @@ class RFTObservation(BaseModel):
             )
 
         rft_observations = []
+        invalid_observations = []
         for row in csv_file.itertuples(index=True):
-            value = validate_float(
-                str(getattr(row, observed_property)), observed_property
+            rft_observation = cls(
+                name=f"{observation_dict['name']}[{row.Index}]",
+                well=str(row.WELL_NAME),
+                date=str(row.DATE),
+                property=observed_property,
+                value=validate_float(
+                    str(getattr(row, observed_property)), observed_property
+                ),
+                error=validate_float(str(row.ERROR), "ERROR"),
+                north=validate_float(str(row.NORTH), "NORTH"),
+                east=validate_float(str(row.EAST), "EAST"),
+                tvd=validate_float(str(row.TVD), "TVD"),
             )
-            error = validate_float(str(row.ERROR), "ERROR")
             # A value of -1 and error of 0 is used by fmu.tools.rms create_rft_ertobs to
             # indicate missing data. If encountered in an rft observations csv file
-            # it should be skipped.
-            if value == -1 and error == 0:
-                ConfigWarning.warn(
-                    (
-                        "Invalid value=-1 and error=0 detected for well "
-                        f"{row.WELL_NAME} at date {row.DATE} in {filename}. "
-                        "The observation at that date will be ignored."
-                    ),
-                    filename,
-                )
+            # it should raise an error and ask the user to remove invalid observations.
+            if rft_observation.value == -1 and rft_observation.error == 0:
+                invalid_observations.append(rft_observation)
             else:
-                rft_observations.append(
-                    cls(
-                        name=f"{observation_dict['name']}[{row.Index}]",
-                        well=str(row.WELL_NAME),
-                        date=str(row.DATE),
-                        property=observed_property,
-                        value=value,
-                        error=error,
-                        north=validate_float(str(row.NORTH), "NORTH"),
-                        east=validate_float(str(row.EAST), "EAST"),
-                        tvd=validate_float(str(row.TVD), "TVD"),
-                    )
-                )
+                rft_observations.append(rft_observation)
+
+        if invalid_observations:
+            well_list = "\n - ".join(
+                [
+                    f"{observation.well} at date {observation.date}"
+                    for observation in invalid_observations
+                ]
+            )
+            raise ObservationConfigError.with_context(
+                (
+                    f"Invalid value=-1 and error=0 detected in {filename} for "
+                    f"well(s):\n - {well_list}\n"
+                    "The invalid observation(s) must be removed from the file."
+                ),
+                filename,
+            )
         return rft_observations
 
     @classmethod


### PR DESCRIPTION
A value of -1 and error of 0 is used by fmu.tools.rms create_rft_ertobs to indicate missing data. If encountered in an rft observations csv file, an error should be raised asking the user to remove such invalid observations from the file. 

**Issue**
Resolves #12448


**Approach**
Added test to ensure rows with value -1 and error 0 raises an appropriate error
and added required functionality.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
