### PR TITLE
Make the parameters table in "Manage Experiments" read-only

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -11,6 +11,7 @@ from polars import DataFrame
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import (
+    QAbstractItemView,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -165,6 +166,9 @@ class _EnsembleWidget(QWidget):
         observations_frame.setLayout(observations_layout)
 
         self._parameters_table = QTableWidget()
+        self._parameters_table.setEditTriggers(
+            QAbstractItemView.EditTrigger.NoEditTriggers
+        )
         self._export_params_button = QPushButton("Export...")
         self._export_params_button.clicked.connect(self.onClickExportParameters)
 

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -6,7 +6,14 @@ import numpy as np
 import polars as pl
 import pytest
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QFrame, QPushButton, QTableWidget, QTextEdit
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QFrame,
+    QPushButton,
+    QTableWidget,
+    QTextEdit,
+)
 
 from ert.config import ErtConfig, SummaryConfig
 from ert.gui.ertnotifier import ErtNotifier
@@ -587,6 +594,9 @@ def test_that_parameters_pane_is_populated_correctly(
     assert model.columnCount() == 11, (
         "The Snake oil test case should have 11 parameters"
     )
+
+    triggers = parameters_frame.findChild(QTableWidget).editTriggers()
+    assert triggers == QAbstractItemView.EditTrigger.NoEditTriggers
 
 
 def test_that_export_parameters_button_opens_the_export_dialog(


### PR DESCRIPTION
This ensures that the data presented to the user is identical with the data exported. It follows the same approach how other tables in ERT are made non-editable.


I was considering to add a test for this in different ways. It seems that there are no such tests for the other tables with the same "read-only" property. I also found some pitfalls w.r.t. tests:
* Testing for the `NoEditTriggers` property in the test does not actually reproduce the behavior of user when interacting with the GUI, but is reliable. **Therefore, I chose this approach for the test**.
* Other non-editable tables don't seem to have tests about for whether they are editable or not.
* We could implement non-editable tables by (additionally?) removing the `ItemIsEditable` flag from each model describing a table cell instead of removing edit triggers. In this case the test would need updates.
* I did not find a way to programmatically edit the table cells using the test framework that reliably reproduce the user behavior without using methods that rely on the event loop, e.g., imitating mouse clicks and button presses.
  * Imitating mouse clicks and button presses etc. depends on the event loop which can lead to flaky tests. The `pytest-qt` package advises to [avoid actions depending on the event loop](https://pytest-qt.readthedocs.io/en/latest/tutorial.html).
  * Using the programmatic approach, e.g., using `setText` is not covered by the event triggers which means that `setText` succeeds even if the cell itself is non-editable.
   
**Issue**
Resolves https://github.com/equinor/ert/issues/12574


**Approach**
The triggers to edit the `QTableWidget` are removed. It follows the same approach how other tables in ERT are made non-editable.

This video should show that the clicking/double clicking on the grid cell does not enter the "Edit" mode of the cell. I don't know if there is a better way to show that the cell is not editable.

https://github.com/user-attachments/assets/d179fb3b-12c0-438c-9101-880df83b519e


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
