### PR TITLE
Improve performance of grdecl writing

### DIFF
--- a/src/ert/field_utils/grdecl_io.py
+++ b/src/ert/field_utils/grdecl_io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import operator
 import os
 from collections.abc import Iterator
@@ -257,6 +258,9 @@ def import_bgrdecl(
     raise ValueError(f"Did not find field parameter {field_name} in {file_path}")
 
 
+_BUFFER_SIZE = 2**20  # 1.04 megabytes
+
+
 def export_grdecl(
     values: np.ma.MaskedArray[Any, np.dtype[np.float32]] | npt.NDArray[np.float32],
     file_path: str | os.PathLike[str],
@@ -271,12 +275,25 @@ def export_grdecl(
     if binary:
         resfo.write(file_path, [(param_name.ljust(8), values.astype(np.float32))])
     else:
-        with open(file_path, "w", encoding="utf-8") as fh:
-            fh.write(param_name + "\n")
-            for i, v in enumerate(values):
-                fh.write(" ")
-                fh.write(f"{v:3e}")
-                if i % 6 == 5:
-                    fh.write("\n")
+        length = values.shape[0]
+        per_line = 6
+        iters = 5
+        per_iter = per_line * iters
+        fmt = " ".join(["%3e"] * per_line)
+        fmt = "\n".join([fmt] * iters) + "\n"
+        with (
+            open(file_path, "wb+", 0) as fh,
+            io.BufferedWriter(fh, _BUFFER_SIZE) as bw,
+            io.TextIOWrapper(bw, write_through=True, encoding="utf-8") as tw,
+        ):
+            tw.write(param_name + "\n")
+            i = 0
+            while i + per_iter <= length:
+                tw.write(fmt % tuple(values[i : i + per_iter]))
+                i += per_iter
 
-            fh.write(" /\n")
+            for j, v in enumerate(values[length - (length % per_iter) :]):
+                tw.write(f" {v:3e}")
+                if j % 6 == 5:
+                    tw.write("\n")
+            tw.write(" /\n")

--- a/tests/ert/performance_tests/test_grdecl_performance.py
+++ b/tests/ert/performance_tests/test_grdecl_performance.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from ert.field_utils import save_field
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_save_grdecl(benchmark):
+    rng = np.random.default_rng(42)
+    values = rng.standard_normal(
+        dtype=np.float32,
+        size=(100, 100, 100),
+    )
+    field = np.ma.masked_array(values)
+
+    def run():
+        save_field(field, "FOPR", "test.grdecl", "grdecl")
+
+    benchmark(run)


### PR DESCRIPTION
Seemingly takes about half the time to do on my machine by writing one line at the time.
There is a way to do slightly faster by using np.savetxt, but that means copying the
values which would increase memory usage.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
