### PR TITLE
Add seperate error color for darkmode

### DIFF
--- a/src/ert/gui/ertwidgets/listeditbox.py
+++ b/src/ert/gui/ertwidgets/listeditbox.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
 )
 from typing_extensions import override
 
+from .. import is_dark_mode
 from .validationsupport import ValidationSupport
 
 
@@ -164,7 +165,14 @@ class ListEditBox(QWidget):
                     break
 
         validity_type = ValidationSupport.WARNING
-        color = ValidationSupport.ERROR_COLOR if not valid else self._valid_color
+        if is_dark_mode():
+            color = (
+                ValidationSupport.DARKMODE_ERROR_COLOR
+                if not valid
+                else self._valid_color
+            )
+        else:
+            color = ValidationSupport.ERROR_COLOR if not valid else self._valid_color
         self._validation_support.setValidationMessage(message, validity_type)
         self._list_edit_line.setToolTip(message)
         palette.setColor(self._list_edit_line.backgroundRole(), color)

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -8,6 +8,7 @@ from PyQt6.QtCore import QSize
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QFileDialog, QHBoxLayout, QLineEdit, QToolButton, QWidget
 
+from .. import is_dark_mode
 from .validationsupport import ValidationSupport
 
 if TYPE_CHECKING:
@@ -107,7 +108,14 @@ class PathChooser(QWidget):
 
         validity_type = ValidationSupport.WARNING
 
-        color = ValidationSupport.ERROR_COLOR if not valid else self.valid_color
+        if is_dark_mode():
+            color = (
+                ValidationSupport.DARKMODE_ERROR_COLOR
+                if not valid
+                else self.valid_color
+            )
+        else:
+            color = ValidationSupport.ERROR_COLOR if not valid else self.valid_color
 
         self._validation_support.setValidationMessage(message, validity_type)
         self._path_line.setToolTip(message)

--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -6,6 +6,7 @@ from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QLineEdit
 from typing_extensions import override
 
+from .. import is_dark_mode
 from .validationsupport import ValidationSupport
 
 if TYPE_CHECKING:
@@ -65,9 +66,16 @@ class StringBox(QLineEdit):
 
                 palette = QPalette()
                 if not status:
-                    palette.setColor(
-                        self.backgroundRole(), ValidationSupport.ERROR_COLOR
-                    )
+                    if is_dark_mode():
+                        palette.setColor(
+                            self.backgroundRole(),
+                            ValidationSupport.DARKMODE_ERROR_COLOR,
+                        )
+                    else:
+                        palette.setColor(
+                            self.backgroundRole(),
+                            ValidationSupport.ERROR_COLOR,
+                        )
                     self.setPalette(palette)
                     self._validation.setValidationMessage(
                         str(status), ValidationSupport.EXCLAMATION

--- a/src/ert/gui/ertwidgets/textbox.py
+++ b/src/ert/gui/ertwidgets/textbox.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QTextEdit
 
+from .. import is_dark_mode
 from .validationsupport import ValidationSupport
 
 if TYPE_CHECKING:
@@ -51,9 +52,15 @@ class TextBox(QTextEdit):
 
                 palette = QPalette()
                 if not status:
-                    palette.setColor(
-                        self.backgroundRole(), ValidationSupport.ERROR_COLOR
-                    )
+                    if is_dark_mode():
+                        palette.setColor(
+                            self.backgroundRole(),
+                            ValidationSupport.DARKMODE_ERROR_COLOR,
+                        )
+                    else:
+                        palette.setColor(
+                            self.backgroundRole(), ValidationSupport.ERROR_COLOR
+                        )
                     self.setPalette(palette)
                     self._validation.setValidationMessage(
                         str(status), ValidationSupport.EXCLAMATION

--- a/src/ert/gui/ertwidgets/validationsupport.py
+++ b/src/ert/gui/ertwidgets/validationsupport.py
@@ -8,6 +8,8 @@ from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtGui import QColor, QEnterEvent
 from PyQt6.QtWidgets import QFrame, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
+from ert.gui import is_dark_mode
+
 if TYPE_CHECKING:
     from PyQt6.QtCore import QEvent
     from PyQt6.QtGui import QHideEvent
@@ -18,6 +20,15 @@ class ErrorPopup(QWidget):
         "<html>"
         "<table style='background-color: #ffdfdf;'width='100%%'>"
         "<tr><td style='font-weight: bold; padding-left: 5px;'>Warning:</td></tr>"
+        "%s"
+        "</table>"
+        "</html>"
+    )
+
+    darkmode_error_template = (
+        "<html>"
+        "<table style='background-color: #b03941;'width='100%%'>"
+        "<tr><td style='font-weight: bold; padding-left: 0px;'>Warning:</td></tr>"
         "%s"
         "</table>"
         "</html>"
@@ -46,7 +57,13 @@ class ErrorPopup(QWidget):
     def presentError(self, widget: QWidget, error: str) -> None:
         assert isinstance(widget, QWidget)
 
-        self._error_widget.setText(ErrorPopup.error_template % html.escape(error))
+        if is_dark_mode():
+            self._error_widget.setText(
+                self.darkmode_error_template % html.escape(error)
+            )
+        else:
+            self._error_widget.setText(self.error_template % html.escape(error))
+
         self.show()
 
         size_hint = self.sizeHint()
@@ -63,6 +80,7 @@ class ErrorPopup(QWidget):
 class ValidationSupport(QObject):
     STRONG_ERROR_COLOR = QColor(255, 215, 215)
     ERROR_COLOR = QColor(255, 235, 235)
+    DARKMODE_ERROR_COLOR = QColor(176, 57, 64)
     INVALID_COLOR = QColor(235, 235, 255)
 
     WARNING = "warning"


### PR DESCRIPTION
**Issue**
Resolves #12659 

**Approach**
Introduce new error and background color for warnings when in darkmode

(Screenshot of new behavior in GUI if applicable)
New: 
<img width="1076" height="465" alt="bilde" src="https://github.com/user-attachments/assets/0a304308-bcb5-4a40-9b1e-17fb9ed74f38" />

Old: 
<img width="958" height="277" alt="bilde" src="https://github.com/user-attachments/assets/bb29065a-9226-4426-8aee-df93a8fe8eb6" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
