### PR TITLE
Relax forward_model_step source_package  test

### DIFF
--- a/tests/ert/unit_tests/docs/test_ert_documentation.py
+++ b/tests/ert/unit_tests/docs/test_ert_documentation.py
@@ -121,20 +121,20 @@ def test_divide_into_categories_job_source(test_input, expected_source_package):
 
 
 @pytest.mark.parametrize("fm_step", ErtPluginManager().forward_model_steps)
-def test_that_forward_model_step_documentation_defaults_to_plugins_source_package(
+def test_that_forward_model_step_documentation_source_package_matches_the_actual_source_package(  # noqa: E501
     fm_step,
 ):
     # The test assumes that repr(fm_step) returns a string on format:
     # "<class 'fully.qualified.class.name'>"
     match_qualified_class_name = re.match(r"\<class '(.*?)'>", repr(fm_step))
     assert match_qualified_class_name, "Could not get qualified class name from fm_step"
-    qualified_class_name = match_qualified_class_name[1]
+    qualified_class_name: str = match_qualified_class_name[1]
 
-    source_package = qualified_class_name.split(".")[0]
     documentation = fm_step.documentation()
 
     if documentation:
-        assert documentation.source_package == source_package, (
-            f"{qualified_class_name} documentation reports source_package="
-            f"{documentation.source_package}, expected {source_package}"
+        assert qualified_class_name.startswith(documentation.source_package), (
+            f"Documentation mismatch in {fm_step!r} "
+            f"source_package ('{documentation.source_package}') does not match "
+            f"the start of the full qualified path ('{qualified_class_name}')."
         )


### PR DESCRIPTION
**Issue**
Resolves #12729 

**Approach**
Allow documentation source_package to point to
any subpackage matching the start of the fully qualified class name

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
