### PR TITLE
Speed up load scalar keys drastically

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Self, cast, overload
@@ -248,8 +248,8 @@ class GenKwConfig(ParameterConfig):
             }
         ]
 
-    def transform_data(self) -> Callable[[float], float]:
-        return self.distribution.transform
+    def transform_numpy(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return self.distribution.transform_numpy(x)
 
     @classmethod
     def _parse_distribution(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -614,9 +614,7 @@ class LocalEnsemble(BaseMode):
             df = df.with_columns(
                 [
                     pl.col(col)
-                    .map_elements(
-                        tmp_configuration[col].transform_data(),
-                    )
+                    .map_batches(tmp_configuration[col].transform_series)
                     .cast(df[col].dtype)
                     .alias(col)
                     for col in df.columns

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import networkx as nx
+import numpy as np
 import pytest
 from lark import Token
 
@@ -457,7 +458,10 @@ def test_gen_kw_trans_func(tmpdir, params, xinput, expected):
             update=False,
             distribution=GenKwConfig._parse_distribution(name, dist_name, values),
         )
-        assert abs(cfg.distribution.transform(xinput) - expected) < 10**-15
+        out = float(
+            cfg.distribution.transform_numpy(np.asarray([xinput], dtype=np.float64))[0]
+        )
+        assert abs(out - expected) < 10**-15
 
 
 def test_gen_kw_objects_equal(tmpdir):

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -706,6 +706,6 @@ def test_run_model_warns_about_cpu_over_spending_as_post_simulation_warning(
     )
 
     with warnings.catch_warnings(record=True) as W:
-        brm._evaluate_and_postprocess(AsyncMock(), AsyncMock(), AsyncMock())
+        brm._evaluate_and_postprocess(MagicMock(), MagicMock(), MagicMock())
         assert any(isinstance(w.message, PostSimulationWarning) for w in W)
         assert any(expected_msg in str(w.message) for w in W)


### PR DESCRIPTION
Resolves #12766 
**Issue**
Load scalar keys is very slow with transformed=True.


**Approach**
Result (before is 001, this pr is 002):
```
(py312-arm-venv) arm64 ➜  ert git:(speedup_load_scalars) ✗ pytest-benchmark compare 0001 0002 --sort=fullname   

---------------------------------------------------------------------------------------------------------------- benchmark: 22 tests ----------------------------------------------------------------------------------------------------------------
Name (time in s)                                                                           Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_create_run_path_load_scalar_keys_performance[const] (0001_34af627)                 2.2278 (13.30)     2.3724 (13.51)     2.2972 (13.21)    0.0669 (39.95)     2.2809 (13.15)    0.1258 (54.07)         2;0  0.4353 (0.08)          5           1
test_create_run_path_load_scalar_keys_performance[const] (0002_e8f3763)                 0.1675 (1.0)       0.1875 (1.07)      0.1764 (1.01)     0.0082 (4.89)      0.1734 (1.0)      0.0146 (6.30)          3;0  5.6676 (0.99)          6           1
test_create_run_path_load_scalar_keys_performance[derrf] (0001_34af627)                17.6676 (105.46)   18.9590 (107.94)   18.3160 (105.35)   0.4702 (280.56)   18.3861 (106.03)   0.5435 (233.69)        2;0  0.0546 (0.01)          5           1
test_create_run_path_load_scalar_keys_performance[derrf] (0002_e8f3763)                 0.1825 (1.09)      0.2024 (1.15)      0.1931 (1.11)     0.0078 (4.67)      0.1938 (1.12)     0.0134 (5.75)          2;0  5.1779 (0.90)          6           1
test_create_run_path_load_scalar_keys_performance[dunif] (0001_34af627)                 3.7821 (22.57)     3.8395 (21.86)     3.8105 (21.92)    0.0257 (15.37)     3.8084 (21.96)    0.0478 (20.56)         2;0  0.2624 (0.05)          5           1
test_create_run_path_load_scalar_keys_performance[dunif] (0002_e8f3763)                 0.1712 (1.02)      0.1833 (1.04)      0.1785 (1.03)     0.0049 (2.90)      0.1779 (1.03)     0.0066 (2.83)          1;0  5.6010 (0.97)          5           1
test_create_run_path_load_scalar_keys_performance[errf] (0001_34af627)                 11.7525 (70.15)    11.9251 (67.89)    11.8713 (68.28)    0.0695 (41.49)    11.8811 (68.52)    0.0712 (30.60)         1;0  0.0842 (0.01)          5           1
test_create_run_path_load_scalar_keys_performance[errf] (0002_e8f3763)                  0.1784 (1.06)      0.1875 (1.07)      0.1818 (1.05)     0.0033 (1.95)      0.1806 (1.04)     0.0036 (1.54)          2;0  5.5012 (0.96)          6           1
test_create_run_path_load_scalar_keys_performance[lognormal] (0001_34af627)             5.8158 (34.71)     5.8935 (33.55)     5.8469 (33.63)    0.0365 (21.79)     5.8287 (33.61)    0.0652 (28.02)         1;0  0.1710 (0.03)          5           1
test_create_run_path_load_scalar_keys_performance[lognormal] (0002_e8f3763)             0.1847 (1.10)      0.2058 (1.17)      0.1916 (1.10)     0.0076 (4.53)      0.1890 (1.09)     0.0067 (2.87)          1;1  5.2194 (0.91)          6           1
test_create_run_path_load_scalar_keys_performance[logunif] (0001_34af627)               3.9081 (23.33)     3.9833 (22.68)     3.9343 (22.63)    0.0306 (18.24)     3.9211 (22.61)    0.0408 (17.55)         1;0  0.2542 (0.04)          5           1
test_create_run_path_load_scalar_keys_performance[logunif] (0002_e8f3763)               0.1788 (1.07)      0.1857 (1.06)      0.1839 (1.06)     0.0029 (1.71)      0.1851 (1.07)     0.0023 (1.0)           1;1  5.4374 (0.95)          5           1
test_create_run_path_load_scalar_keys_performance[normal] (0001_34af627)                4.2287 (25.24)     4.2719 (24.32)     4.2476 (24.43)    0.0224 (13.34)     4.2366 (24.43)    0.0428 (18.42)         2;0  0.2354 (0.04)          5           1
test_create_run_path_load_scalar_keys_performance[normal] (0002_e8f3763)                0.1720 (1.03)      0.1928 (1.10)      0.1803 (1.04)     0.0074 (4.42)      0.1802 (1.04)     0.0090 (3.89)          2;0  5.5451 (0.96)          6           1
test_create_run_path_load_scalar_keys_performance[raw] (0001_34af627)                   1.6128 (9.63)      1.7100 (9.74)      1.6611 (9.55)     0.0459 (27.40)     1.6696 (9.63)     0.0879 (37.81)         3;0  0.6020 (0.10)          5           1
test_create_run_path_load_scalar_keys_performance[raw] (0002_e8f3763)                   0.1752 (1.05)      0.1947 (1.11)      0.1806 (1.04)     0.0072 (4.28)      0.1784 (1.03)     0.0039 (1.68)          1;1  5.5369 (0.96)          6           1
test_create_run_path_load_scalar_keys_performance[triangular] (0001_34af627)            6.5534 (39.12)     6.7421 (38.38)     6.6758 (38.40)    0.0817 (48.73)     6.7184 (38.74)    0.1250 (53.75)         1;0  0.1498 (0.03)          5           1
test_create_run_path_load_scalar_keys_performance[triangular] (0002_e8f3763)            0.1789 (1.07)      0.2019 (1.15)      0.1857 (1.07)     0.0085 (5.07)      0.1844 (1.06)     0.0069 (2.95)          1;1  5.3843 (0.94)          6           1
test_create_run_path_load_scalar_keys_performance[truncated_normal] (0001_34af627)      2.3197 (13.85)     2.5468 (14.50)     2.4092 (13.86)    0.0881 (52.56)     2.4029 (13.86)    0.1165 (50.07)         2;0  0.4151 (0.07)          5           1
test_create_run_path_load_scalar_keys_performance[truncated_normal] (0002_e8f3763)      0.1812 (1.08)      0.1986 (1.13)      0.1860 (1.07)     0.0069 (4.09)      0.1825 (1.05)     0.0075 (3.24)          1;0  5.3774 (0.93)          6           1
test_create_run_path_load_scalar_keys_performance[uniform] (0001_34af627)               3.2219 (19.23)     3.4753 (19.79)     3.3529 (19.29)    0.1057 (63.08)     3.3108 (19.09)    0.1666 (71.64)         2;0  0.2982 (0.05)          5           1
test_create_run_path_load_scalar_keys_performance[uniform] (0002_e8f3763)               0.1722 (1.03)      0.1756 (1.0)       0.1739 (1.0)      0.0017 (1.0)       0.1739 (1.00)     0.0033 (1.41)          3;0  5.7518 (1.0)           5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
