### PR TITLE
Mark tests using TCP ports as flaky

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ def pytest_collection_modifyitems(config, items):
         fixtures = getattr(item, "fixturenames", ())
         if "qtbot" in fixtures or "qapp" in fixtures or "qtmodeltester" in fixtures:
             item.add_marker("requires_window_manager")
+        if "unused_tcp_port" in fixtures:
+            item.add_marker(pytest.mark.flaky(rerun=3))
         if any(
             f in fixtures
             for f in [


### PR DESCRIPTION
The unused_tcp_port fixture from pytest-asyncio has a race condition where the socket might get bound by a different process between the time it was found and the test has a chance to bind it.

**Issue**
Resolves https://github.com/equinor/ert/issues/12651


**Approach**
Marking the tests as flaky was suggested in https://github.com/equinor/ert/issues/12651.

The marker `pytest.mark.rerun(3)` is added to all tests requesting a TCP port via the `unused_tcp_port` fixture by configuring the marker in `conftest.py`. This way, we do not need to manually mark the tests as flaky.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
