### PR TITLE
Fix codspeed workflow deprecation warning

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,7 +38,7 @@ jobs:
           uv pip install pytest-codspeed
       - uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: simulation
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             uv run pytest tests/ert/performance_tests --codspeed --timeout=1200 -m "not memory_test"


### PR DESCRIPTION

**Issue**
Deprecation Warning (https://github.com/equinor/ert/actions/runs/21480945564/job/61878686720?pr=12743)


**Approach**
_Short This commit fixes the warning `The 'instrumentation' runner mode is deprecated and will be removed in a future version. Please use 'simulation' instead.`
 of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
