### PR TITLE
Refactor observation tests to stop using ErtConfig.observations

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -59,7 +59,7 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
             f"Config contains forward model step {fm_step_name} {count} time(s)",
         )
 
-    if not ert_config.observations and args.mode not in {
+    if not ert_config.observation_declarations and args.mode not in {
         ENSEMBLE_EXPERIMENT_MODE,
         TEST_RUN_MODE,
         WORKFLOW_MODE,

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -15,6 +15,7 @@ import xtgeo
 
 from ert.analysis import smoother_update
 from ert.config import ErtConfig, ESSettings, ObservationSettings
+from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
 
@@ -435,7 +436,9 @@ def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc
         new_experiment = storage.create_experiment(
             parameters=config.ensemble_config.parameter_configuration,
             responses=config.ensemble_config.response_configuration,
-            observations=config.observations,
+            observations=create_observation_dataframes(
+                config.observation_declarations, None
+            ),
             name="exp-zero-var",
         )
         new_prior = storage.create_ensemble(

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
 )
 
 from ert.config import ErtConfig, SummaryConfig
+from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_info_widget import (
@@ -162,7 +163,9 @@ def test_that_init_updates_the_info_tab(qtbot):
         ensemble = storage.create_experiment(
             parameters=config.ensemble_config.parameter_configuration,
             responses=config.ensemble_config.response_configuration,
-            observations=config.observations,
+            observations=create_observation_dataframes(
+                config.observation_declarations, None
+            ),
             name="my-experiment",
         ).create_ensemble(
             ensemble_size=config.runpath_config.num_realizations, name="default"

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -25,6 +25,7 @@ from ert.config import (
     QueueSystem,
     RFTConfig,
 )
+from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config.ert_config import _split_string_into_sections, create_forward_model_json
 from ert.config.forward_model_step import (
     ForwardModelStepPlugin,
@@ -2733,7 +2734,9 @@ def test_that_breakthrough_observations_can_be_internalized_in_ert_config():
         """,
     )
 
-    breakthrough_observations = config.observations["breakthrough"]
+    breakthrough_observations = create_observation_dataframes(
+        config.observation_declarations, None
+    )["breakthrough"]
     assert breakthrough_observations["observation_key"].to_list() == ["BRT_OBS"]
     assert breakthrough_observations["response_key"].to_list() == [
         "BREAKTHROUGH:WWCT:OP_1:0.1"

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -16,7 +16,10 @@ from ert.config import (
     InvalidResponseFile,
     SummaryConfig,
 )
-from ert.config._create_observation_dataframes import DEFAULT_LOCALIZATION_RADIUS
+from ert.config._create_observation_dataframes import (
+    DEFAULT_LOCALIZATION_RADIUS,
+    create_observation_dataframes,
+)
 
 
 @settings(max_examples=10)
@@ -102,7 +105,9 @@ def create_summary_observation(loc_config_lines):
     Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
 
     ert_config = ErtConfig.from_file("config.ert")
-    return ert_config.observations["summary"]
+    return create_observation_dataframes(ert_config.observation_declarations, None)[
+        "summary"
+    ]
 
 
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
@@ -198,7 +203,9 @@ def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internal
         obs_lines.insert(observation_index + 2 + i, line)
     new_obs_content = "\n".join(obs_lines)
     Path("observations/observations.txt").write_text(new_obs_content, encoding="utf-8")
-    summary = ErtConfig.from_file("snake_oil.ert").observations["summary"]
+    summary = create_observation_dataframes(
+        ErtConfig.from_file("snake_oil.ert").observation_declarations, None
+    )["summary"]
     assert summary["east"].dtype == pl.Float32
     assert summary["north"].dtype == pl.Float32
     assert summary["radius"].dtype == pl.Float32

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -11,6 +11,7 @@ from resdata.summary import Summary
 
 from ert.analysis import ErtAnalysisError, smoother_update
 from ert.config import ErtConfig, ESSettings, ObservationSettings
+from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.data import MeasuredData
 from ert.sample_prior import sample_prior
 from ert.storage.local_ensemble import load_parameters_and_responses_from_runpath
@@ -21,7 +22,9 @@ def prior_ensemble(storage, ert_config):
     return storage.create_experiment(
         parameters=ert_config.ensemble_config.parameter_configuration,
         responses=ert_config.ensemble_config.response_configuration,
-        observations=ert_config.observations,
+        observations=create_observation_dataframes(
+            ert_config.observation_declarations, None
+        ),
     ).create_ensemble(ensemble_size=3, name="prior")
 
 


### PR DESCRIPTION
**Issue**
Resolves #12751 

**Approach**
Refactored a couple of tests to utilize `make_observation` and `create_observation_dataframe` instead of the `ErtConfig.observations` property. The helper function `make_observation` inside `test_observations.py` has been renamed to `ert_config_from_parser` and changed to now only parse obs config via `parse_observations`.

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
