### PR TITLE
Add hook for plugins to provide `get_ip_address()`

### DIFF
--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -254,3 +254,20 @@ Minimal example to log to a new file:
         formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
         fh.setFormatter(formatter)
         return fh
+
+
+IP address configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+The way Ert chooses IP addresses for communicating with cluster jobs can be configured by plugins.
+
+.. autofunction:: ert.plugins.hook_specifications.net_utils.get_ip_address
+
+Minimal example to override how Ert chooses the IP address:
+
+.. code-block:: python
+
+   import ert
+
+    @ert.plugin(name="my_plugin")
+    def get_ip_address():
+        return "127.0.0.1"

--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -4,7 +4,7 @@ import warnings
 
 import zmq
 
-from ert.shared import get_ip_address
+from ert.plugins.plugin_manager import get_ip_address
 from ert.shared import get_machine_name as ert_shared_get_machine_name
 from ert.shared.constants import PORT_RANGE
 

--- a/src/ert/plugins/hook_specifications/__init__.py
+++ b/src/ert/plugins/hook_specifications/__init__.py
@@ -10,6 +10,7 @@ from .jobs import (
     legacy_ertscript_workflow,
 )
 from .logging import add_log_handle_to_root, add_span_processor
+from .net_utils import get_ip_address
 from .site_config import site_configurations
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "add_span_processor",
     "ertscript_workflow",
     "forward_model_configuration",
+    "get_ip_address",
     "help_links",
     "installable_forward_model_steps",
     "installable_workflow_jobs",

--- a/src/ert/plugins/hook_specifications/net_utils.py
+++ b/src/ert/plugins/hook_specifications/net_utils.py
@@ -1,0 +1,13 @@
+from ert.plugins.plugin_manager import hook_specification
+
+
+@hook_specification
+def get_ip_address() -> str:  # type: ignore
+    """Ert uses network communication over TCP/IP and needs to provide potential
+    network clients with which IP address is to be used to contact the main Ert
+    process. By default, Ert will check the operating system routing table to
+    get the IP address in use for non-localhost connections.
+
+    On machines exposing several IP addresses, the correct IP is non-trivial
+    to pick, and by specifying this hook in an installed plugin, any custom
+    code can be injected in order to pick the correct IP."""

--- a/tests/ert/unit_tests/plugins/dummy_plugins.py
+++ b/tests/ert/unit_tests/plugins/dummy_plugins.py
@@ -93,3 +93,11 @@ class DummyFMStep(ForwardModelStepPlugin):
 @plugin(name="dummy")
 def installable_forward_model_steps():
     return [DummyFMStep]
+
+
+PLUGIN_IP_ADDRESS = "1.0.0.127"
+
+
+@plugin(name="dummy")
+def get_ip_address():
+    return PLUGIN_IP_ADDRESS

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -8,7 +8,7 @@ import ert.plugins.hook_implementations
 from ert.plugins import ErtPluginManager, ErtRuntimePlugins, plugin
 from ert.trace import trace, tracer
 from tests.ert.unit_tests.plugins import dummy_plugins
-from tests.ert.unit_tests.plugins.dummy_plugins import DummyFMStep
+from tests.ert.unit_tests.plugins.dummy_plugins import PLUGIN_IP_ADDRESS, DummyFMStep
 
 
 def test_no_plugins():
@@ -265,3 +265,16 @@ def test_that_plugin_manager_with_two_site_configurations_raises_error():
 
     with pytest.raises(ValueError, match="Only one site configuration is allowed"):
         ErtPluginManager(plugins=[SiteOne, SiteTwo]).get_site_configurations()
+
+
+def test_get_ip_address(monkeypatch, tmpdir):
+    default_ip_address = "10.10.10.10"
+    monkeypatch.setattr(
+        "ert.shared.net_utils.get_ip_address", lambda: default_ip_address
+    )
+    with tmpdir.as_cwd():
+        pm = ErtPluginManager(plugins=[dummy_plugins])
+        default_plugin = ErtPluginManager(plugins=[])
+        assert default_plugin.get_ip_address() != pm.get_ip_address()
+        assert default_plugin.get_ip_address() == default_ip_address
+        assert pm.get_ip_address() == PLUGIN_IP_ADDRESS


### PR DESCRIPTION
This commit fixes the PRIORITIZE_PRIVATE_IP_ADDRESS site config setting by using the old implementation when it is False, and the one introduced in 0e1fa0523069f37f3289a8dcfec7736b5de3c434 if it is set to True.

**Issue**
Resolves #12782 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
