### PR TITLE
Limit capturing of warnings from forward model steps

### DIFF
--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -581,4 +581,8 @@ async def log_warnings_from_forward_model(
                     )
             if timeout_seconds <= 0:
                 break
+    if log_count >= max_logged_warnings:
+        logger.warning(
+            "Reached maximum number of forward model step warnings to extract"
+        )
     return timeout_seconds

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -483,6 +483,7 @@ async def test_log_warnings_from_forward_model(
             warnings.simplefilter("error")
             await log_warnings_from_forward_model(realization, start_time - 1)
         assert emitted_warning_str not in caplog.text
+    assert "Reached maximum number" not in caplog.text
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -505,6 +506,7 @@ async def test_old_warnings_are_not_logged(realization, caplog, mocker):
     job_start_time = time.time() + 1  # Pretend that the job started in the future
     await log_warnings_from_forward_model(realization, job_start_time)
     assert "FutureWarning: Feature XYZ" not in caplog.text
+    assert "Reached maximum number" not in caplog.text
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -535,6 +537,7 @@ async def test_long_warning_from_forward_model_is_truncated(
     for line in caplog.text.splitlines():
         if "Realization 0 step foo.0 warned" in line:
             assert len(line) <= 2048 + 91
+    assert "Reached maximum number" not in caplog.text
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -564,6 +567,7 @@ async def test_deduplication_of_repeated_warnings_from_forward_model(
         in caplog.text
     )
     assert caplog.text.count(emitted_warning_str) == 1
+    assert "Reached maximum number" not in caplog.text
 
 
 @pytest.mark.filterwarnings("ignore:FutureWarning")
@@ -591,6 +595,7 @@ async def test_excessive_warnings_from_fm_step_can_be_capped(
         realization, start_time - 1, max_logged_warnings=log_count_cap
     )
     assert caplog.text.count("FutureWarning") == max(0, log_count_cap)
+    assert "Reached maximum number" in caplog.text
 
 
 async def test_log_warnings_from_forward_model_can_detect_files_being_created_after_delay(  # noqa: E501


### PR DESCRIPTION
Leaving this uncapped can give an arbitrary amount of log messages, which will be useless the user seeing this in the GUI, and will also clog the logging system.

**Issue**
Resolves #12781 


**Approach**
⛔ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
