### PR TITLE
Fix inconsistent adaptive localization correlation threshold

### DIFF
--- a/src/ert/config/analysis_module.py
+++ b/src/ert/config/analysis_module.py
@@ -30,6 +30,18 @@ es_description = """
         U, w, V.T = svd(D_delta) then we assume that U @ U.T = I.
     """
 
+loc_description = """
+    The default adaptive localization correlation threshold
+    is computed as 3/sqrt(ensemble_size), where ensemble_size
+    is the number of active realizations in the ensemble.
+
+    You can override this value by setting a custom threshold here or in the config.
+    """
+
+cust_loc_thresh_description = """
+    Adaptive localization correlation threshold:
+    """
+
 
 class ESSettings(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
@@ -40,13 +52,16 @@ class ESSettings(BaseModel):
     inversion: Annotated[
         InversionTypeES, Field(title="Inversion algorithm", description=es_description)
     ] = "EXACT"
-    localization: Annotated[bool, Field(title="Adaptive localization")] = False
+    localization: Annotated[
+        bool, Field(title="Enable adaptive localization", description=loc_description)
+    ] = False
     localization_correlation_threshold: Annotated[
         float | None,
         Field(
             ge=0.0,
             le=1.0,
-            title="Adaptive localization correlation threshold",
+            title="Custom adaptive localization correlation threshold",
+            description=cust_loc_thresh_description,
         ),
     ] = None
     distance_localization: Annotated[

--- a/src/ert/gui/ertwidgets/analysismoduleedit.py
+++ b/src/ert/gui/ertwidgets/analysismoduleedit.py
@@ -26,6 +26,7 @@ class AnalysisModuleEdit(QWidget):
         layout = QHBoxLayout()
 
         variables_popup_button = QToolButton()
+        variables_popup_button.setObjectName("analysis_variables_popup_button")
         variables_popup_button.setIcon(QIcon("img:edit.svg"))
         variables_popup_button.clicked.connect(self.showVariablesPopup)
         variables_popup_button.setMaximumSize(20, 20)

--- a/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
+++ b/src/ert/gui/ertwidgets/analysismodulevariablespanel.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLayout,
+    QVBoxLayout,
     QWidget,
 )
 
@@ -61,25 +62,45 @@ class AnalysisModuleVariablesPanel(QWidget):
         layout.addRow("Singular value truncation", self.truncation_spinner)
 
         layout.addRow(self.create_horizontal_line())
-        layout.addRow(QLabel("[EXPERIMENTAL]"))
+        layout.addRow(QLabel("Localization"))
+
+        loc_options = AnalysisModule.model_fields["localization"]
+        layout.addRow(QLabel(loc_options.description))
 
         localization_frame = QFrame()
-        localization_frame.setLayout(QHBoxLayout())
-        lf_layout = cast(QLayout, localization_frame.layout())
-        lf_layout.setContentsMargins(0, 0, 0, 0)
+        localization_frame.setLayout(QVBoxLayout())
+        main_loc_layout = cast(QLayout, localization_frame.layout())
+        main_loc_layout.setContentsMargins(0, 0, 0, 0)
 
-        metadata = AnalysisModule.model_fields["localization_correlation_threshold"]
-        local_checkbox = QCheckBox(metadata.title)
-        local_checkbox.setObjectName("localization")
-        local_checkbox.clicked.connect(
+        checkbox_frame = QFrame()
+        checkbox_layout = QHBoxLayout()
+        checkbox_frame.setLayout(checkbox_layout)
+        checkbox_layout.setContentsMargins(0, 0, 0, 0)
+
+        localization_metadata = AnalysisModule.model_fields["localization"]
+        localization_checkbox = QCheckBox(localization_metadata.title)
+        localization_checkbox.setObjectName("localization")
+        localization_checkbox.clicked.connect(
             partial(
                 self.valueChangedCheckBox,
                 "localization",
-                local_checkbox,
+                localization_checkbox,
             )
         )
+        localization_checkbox.setChecked(analysis_module.localization)
+
+        checkbox_layout.addWidget(localization_checkbox)
+        checkbox_layout.addStretch(1)
+        main_loc_layout.addWidget(checkbox_frame)
+
+        spinner_frame = QFrame()
+        spinner_layout = QHBoxLayout()
+        spinner_frame.setLayout(spinner_layout)
+        spinner_layout.setContentsMargins(0, 0, 0, 0)
+
         var_name = "localization_correlation_threshold"
         metadata = AnalysisModule.model_fields[var_name]
+
         self.local_spinner = self.createDoubleSpinBox(
             var_name,
             analysis_module.correlation_threshold(ensemble_size),
@@ -88,14 +109,20 @@ class AnalysisModuleVariablesPanel(QWidget):
             0.1,
         )
         self.local_spinner.setObjectName("localization_threshold")
-        self.local_spinner.setEnabled(local_checkbox.isChecked())
+        self.local_spinner.setEnabled(localization_checkbox.isChecked())
 
-        lf_layout.addWidget(local_checkbox)
-        lf_layout.addWidget(self.local_spinner)
+        loc_corr_thresh_options = AnalysisModule.model_fields[
+            "localization_correlation_threshold"
+        ]
+        spinner_layout.addWidget(QLabel(loc_corr_thresh_options.description))
+
+        spinner_layout.addWidget(self.local_spinner)
+        spinner_layout.addStretch(1)
+        main_loc_layout.addWidget(spinner_frame)
+
+        localization_checkbox.stateChanged.connect(self.local_spinner.setEnabled)
+
         layout.addRow(localization_frame)
-
-        local_checkbox.stateChanged.connect(self.local_spinner.setEnabled)
-        local_checkbox.setChecked(analysis_module.localization)
 
         self.setLayout(layout)
         self.blockSignals(False)

--- a/src/ert/gui/experiments/ensemble_smoother_panel.py
+++ b/src/ert/gui/experiments/ensemble_smoother_panel.py
@@ -98,7 +98,10 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         layout.addRow("Ensemble format:", self._ensemble_format_field)
 
         self._analysis_module_edit = AnalysisModuleEdit(
-            analysis_config.es_settings, len(active_realizations)
+            analysis_config.es_settings,
+            sum(
+                active_realizations
+            ),  # only use active realizations for setting threshold
         )
         self._analysis_module_edit.setObjectName("ensemble_smoother_edit")
         layout.addRow("Analysis module:", self._analysis_module_edit)

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -162,8 +162,12 @@ class ManualUpdatePanel(ExperimentConfigPanel):
                 self._number_of_realizations_label.setText(
                     f"<b>{ensemble.ensemble_size}</b>"
                 )
-                self._analysis_module_edit.ensemble_size = ensemble.ensemble_size
-                self._analysis_module_edit.setEnabled(bool(ensemble.ensemble_size))
+                # only use active realizations for setting threshold
+                active_realizations_size = sum(
+                    self._active_realizations_model.getActiveRealizationsMask()
+                )
+                self._analysis_module_edit.ensemble_size = active_realizations_size
+                self._analysis_module_edit.setEnabled(bool(active_realizations_size))
         except OSError as err:
             logger.error(str(err))
             Suggestor(

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -119,7 +119,10 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._createInputForWeights(layout)
 
         self._analysis_module_edit = AnalysisModuleEdit(
-            analysis_config.es_settings, len(active_realizations)
+            analysis_config.es_settings,
+            sum(
+                active_realizations
+            ),  # only use active realizations for setting threshold
         )
         layout.addRow("Analysis module:", self._analysis_module_edit)
         self._active_realizations_field = StringBox(


### PR DESCRIPTION
**Issue**
Resolves #12155 


**Approach**
Change input of threshold calculation to only consider active realizations

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
