### PR TITLE
Use unique dates for lookup in refcase test

### DIFF
--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import ExitStack as does_not_raise
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
 from typing import cast
@@ -473,14 +473,29 @@ def test_that_the_date_keyword_sets_the_general_index_by_looking_up_time_map():
     assert observations["gen_data"].to_dicts()[0]["report_step"] == restart
 
 
-@given(summary=summaries(), data=st.data())
+@given(data=st.data())
 @pytest.mark.integration_test
 def test_that_the_date_keyword_sets_the_report_step_by_looking_up_refcase(
-    tmp_path_factory: pytest.TempPathFactory, summary, data
+    tmp_path_factory: pytest.TempPathFactory, data
 ):
+    start_date, *times = sorted(
+        data.draw(
+            st.lists(
+                st.dates(min_value=date(1969, 1, 1), max_value=date(2100, 1, 1)),
+                min_size=2,
+                unique=True,
+            )
+        )
+    )
+    times = [(t - start_date).total_seconds() / 3600 for t in times]
+    smspec, unsmry = data.draw(
+        summaries(
+            start_date=st.just(datetime.combine(start_date, datetime.min.time())),
+            time_deltas=st.just(times),
+        )
+    )
     with pytest.MonkeyPatch.context() as patch:
         patch.chdir(tmp_path_factory.mktemp("history_observation_values_are_fetched"))
-        smspec, unsmry = summary
         smspec.to_file("ECLIPSE_CASE.SMSPEC")
         unsmry.to_file("ECLIPSE_CASE.UNSMRY")
         start_date = smspec.start_date.to_datetime()


### PR DESCRIPTION
After changing to migrating observation configs for users a corner case was introduced where it may be ambiguous which report step was ment as we round to seconds.

This changes the test to only apply to refcases with unique dates. There is still the question of whether it is good enough for the migration to work when the refcase has sufficiently distinct report step times.

Resolves #12721


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
