### PR TITLE
Fix slow adaptive localization benchmark

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -41,4 +41,4 @@ jobs:
           mode: simulation
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
-            uv run pytest tests/ert/performance_tests --codspeed --timeout=3000 -m "not memory_test"
+            uv run pytest tests/ert/performance_tests --codspeed --timeout=1200 -m "not memory_test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ log_cli = "false"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 360
-session_timeout = 3000
+session_timeout = 1800
 timeout_func_only = true # Do not apply timeout to fixtures which can be slow but cached
 
 [tool.setuptools_scm]

--- a/tests/ert/performance_tests/test_analysis.py
+++ b/tests/ert/performance_tests/test_analysis.py
@@ -19,10 +19,10 @@ def test_and_benchmark_adaptive_localization_with_fields(
 
     rng = np.random.default_rng(42)
 
-    num_grid_cells = 500
+    num_grid_cells = 250
     num_parameters = num_grid_cells * num_grid_cells
-    num_observations = 50
-    num_ensemble = 25
+    num_observations = 10
+    num_ensemble = 20
 
     # Create a tridiagonal matrix that maps responses to parameters.
     # Being tridiagonal, it ensures that each response is influenced
@@ -83,7 +83,7 @@ def test_and_benchmark_adaptive_localization_with_fields(
             "restart": 0,
             "index": i,
             "value": float(observations[i]),
-            "error": 1.0,
+            "error": abs(observation_noise[i]),
         }
         for i in range(len(observations))
     ]


### PR DESCRIPTION
In 4156859a8f4dfea862bb1ecf41ff551511a527be the timeout of tests was increased due to the benchmarks slowing down.

This slowdown was due to the slowest test
`test_and_benchmark_adaptive_localization_with_fields` having its inputs changed to error always being equal to 1. This was done because error now being validated to strictly greater than zero.

This commit changes the errors back to being set by observation_noise, just taking the absolute value. Also, the number of observations is scaled down to reduce time taken as the input will change regardless.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
