### PR TITLE
Avoid race condition for multiple everest monitors

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -338,7 +338,7 @@ class ExperimentRunner:
 
                 if isinstance(item, EndEvent):
                     # Wait for subscribers to receive final events
-                    for sub in shared_data.subscribers.values():
+                    for sub in list(shared_data.subscribers.values()):
                         await sub.is_done()
                     break
             await simulation_future


### PR DESCRIPTION
If several monitors (each is a subscriber) are attached to an everest server, the server could crash with a RuntimeError when tearing down;

```
Traceback (most recent call last):
  File "/data/projects/ert/src/ert/dark_storage/endpoints/experiment_server.py", line 341, in run
    for sub in shared_data.subscribers.values():
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: dictionary changed size during iteration
```

This is because there is an await in the loop execution body, which allows the async loop to add a new subscriber while we are iterating.

By expanding the values() iterator to a fixed list before looping, we avoid the possibility of a race condition (but we are leaving behind the possible late added subscriber)

Repeated testing with multiple monitors with this patch has not revealed any further issues.

**Issue**
Resolves #12806


**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
