### PR TITLE
Fix ignoring of expected warnings while testing

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -570,7 +570,7 @@ async def test_deduplication_of_repeated_warnings_from_forward_model(
     assert "Reached maximum number" not in caplog.text
 
 
-@pytest.mark.filterwarnings("ignore:FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*FutureWarning.*")
 @pytest.mark.parametrize("log_count_cap", [-10, -1, 0, 1, 3])
 @pytest.mark.usefixtures("use_tmpdir")
 async def test_excessive_warnings_from_fm_step_can_be_capped(


### PR DESCRIPTION
**Issue**
Resolves noise in pytest output

**Approach**
Ignore

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
