### PR TITLE
Have drivers use max_runtime when submitting jobs

### DIFF
--- a/src/ert/scheduler/__init__.py
+++ b/src/ert/scheduler/__init__.py
@@ -19,17 +19,25 @@ if TYPE_CHECKING:
 
 
 def create_driver(
-    queue_options: QueueOptions, poll_period: float = _POLL_PERIOD
+    queue_options: QueueOptions,
+    poll_period: float = _POLL_PERIOD,
+    max_runtime: int | None = None,
 ) -> Driver:
     match queue_options.name:
         case QueueSystem.LOCAL:
             return LocalDriver()
         case QueueSystem.TORQUE:
             return OpenPBSDriver(
-                **queue_options.driver_options, poll_period=poll_period
+                **queue_options.driver_options,
+                poll_period=poll_period,
+                max_runtime=max_runtime,
             )
         case QueueSystem.LSF:
-            return LsfDriver(**queue_options.driver_options, poll_period=poll_period)
+            return LsfDriver(
+                **queue_options.driver_options,
+                poll_period=poll_period,
+                max_runtime=max_runtime,
+            )
         case QueueSystem.SLURM:
             return SlurmDriver(
                 **dict(

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -38,6 +38,7 @@ class Driver(ABC):
     """Adapter for the HPC cluster."""
 
     POLLING_TIMEOUT_PERIOD = 600
+    _MAX_RUNTIME_QUEUE_SYSTEM_PADDING_SECONDS = 600
 
     def __init__(self, activate_script: str = "") -> None:
         self._event_queue: asyncio.Queue[DriverEvent] | None = None

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -148,9 +148,12 @@ class SlurmDriver(Driver):
             sbatch_with_args.append(f"--nodelist={self._include_hosts}")
         if self._exclude_hosts:
             sbatch_with_args.append(f"--exclude={self._exclude_hosts}")
-        if self._max_runtime and int(self._max_runtime):
+        if self._max_runtime and int(self._max_runtime) > 0:
+            total_max_runtime = (
+                self._max_runtime + Driver._MAX_RUNTIME_QUEUE_SYSTEM_PADDING_SECONDS
+            )
             sbatch_with_args.append(
-                f"--time={_seconds_to_slurm_time_format(self._max_runtime)}"
+                f"--time={_seconds_to_slurm_time_format(total_max_runtime)}"
             )
         if self._queue_name:
             sbatch_with_args.append(f"--partition={self._queue_name}")


### PR DESCRIPTION
**Issue**
Resolves #11730


**Approach**
This commit makes it so that all drivers will submit jobs to the cluster with a max runtime specifier equal to max_runtime set in config plus a padding of ten minutes, to let the queue system itself handle rogue jobs. This is to prevent hanging jobs being stuck on the cluster if Ert goes down unexpectedly, and won't be able to handle max_runtime expiring.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
