### PR TITLE
Convert infinite objectives and constraints to NaN

### DIFF
--- a/src/everest/optimizer/opt_model_transforms.py
+++ b/src/everest/optimizer/opt_model_transforms.py
@@ -262,13 +262,16 @@ class ObjectiveScaler(ObjectiveTransform):
     def to_optimizer(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
         """Transform objectives to optimizer space.
 
+        Infinite values are converted  to Nan, which causes the corresponding
+        realization to be treated as failed.
+
         Args:
             objectives: The objectives to transform.
 
         Returns:
             The negative of the scaled objectives.
         """
-        return -objectives / self._scales
+        return np.where(np.isfinite(objectives), -objectives / self._scales, np.nan)
 
     def from_optimizer(self, objectives: NDArray[np.float64]) -> NDArray[np.float64]:
         """Transform objectives to user space.
@@ -357,13 +360,16 @@ class ConstraintScaler(NonLinearConstraintTransform):
     def to_optimizer(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
         """Transform constraints to optimizer space.
 
+        Infinite values are converted  to Nan, which causes the corresponding
+        realization to be treated as failed.
+
         Args:
             constraints: The constraints to transform.
 
         Returns:
             The scaled constraints.
         """
-        return constraints / self._scales
+        return np.where(np.isfinite(constraints), constraints / self._scales, np.nan)
 
     def from_optimizer(self, constraints: NDArray[np.float64]) -> NDArray[np.float64]:
         """Transform constraints to user space.

--- a/tests/everest/test_domain_transforms.py
+++ b/tests/everest/test_domain_transforms.py
@@ -251,6 +251,23 @@ def test_that_objective_auto_scaling_with_zero_objectives_fails(ever_config):
         transforms["objective_scaler"].calculate_auto_scales(np.zeros((2, 2)), [0, 1])
 
 
+def test_that_infinite_objectives_are_converted_to_nan(ever_config):
+    transforms = get_optimization_domain_transforms(
+        [c.to_ert_parameter_config() for c in ever_config.controls],
+        ever_config.create_ert_objectives_config(),
+        ever_config.input_constraints,
+        ever_config.create_ert_output_constraints_config(),
+        ever_config.model,
+        False,
+    )
+    transforms["objective_scaler"].calculate_auto_scales([4.0, 1.0], [0, 1])
+    assert np.all(
+        np.isnan(
+            transforms["objective_scaler"].to_optimizer(np.asarray([-np.inf, np.inf]))
+        )
+    )
+
+
 def test_output_constraint_no_scaling(ever_config):
     transforms = get_optimization_domain_transforms(
         [c.to_ert_parameter_config() for c in ever_config.controls],
@@ -339,3 +356,20 @@ def test_that_output_constraint_auto_scaling_with_zero_constraints_fails(ever_co
         match="Auto-scaling of the constraints failed to estimate a positive scale",
     ):
         transforms["constraint_scaler"].calculate_auto_scales(np.zeros((2, 2)), [0, 1])
+
+
+def test_that_infinite_output_constraints_are_converted_to_nan(ever_config):
+    transforms = get_optimization_domain_transforms(
+        [c.to_ert_parameter_config() for c in ever_config.controls],
+        ever_config.create_ert_objectives_config(),
+        ever_config.input_constraints,
+        ever_config.create_ert_output_constraints_config(),
+        ever_config.model,
+        False,
+    )
+    transforms["constraint_scaler"].calculate_auto_scales([2.0, 1.0], [0, 1])
+    assert np.all(
+        np.isnan(
+            transforms["constraint_scaler"].to_optimizer(np.asarray([-np.inf, np.inf]))
+        )
+    )


### PR DESCRIPTION
**Issue**
Resolves #12747


**Approach**
This fixes a bug where infinite objective or output constraint values will cause the mean objective or gradient to be infinite. Infinite values are converted to Nan, which will cause the offending realization to be excluded from the objective or gradient calculation.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
