### PR TITLE
Remove erroneous comment

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -547,13 +547,9 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
 
     @property
     def _everest_control_configs(self) -> list[EverestControl]:
-        controls = [
+        return [
             c for c in self.parameter_configuration if c.type == "everest_parameters"
         ]
-
-        # There will and must always be one EverestControl config for an
-        # Everest optimization.
-        return controls
 
     @cached_property
     def _transforms(self) -> EverestOptModelTransforms:

--- a/test-data/everest/eightcells/everest/model/config.yml
+++ b/test-data/everest/eightcells/everest/model/config.yml
@@ -19,6 +19,23 @@ controls:
         initial_guess: 250
         min: 10
         max: 500
+  -
+    name: group_rate
+    type: generic_control
+    perturbation_magnitude: 50
+    variables:
+      -
+        name: OP1
+        index: 1
+        initial_guess: 50
+        min: 10
+        max: 500
+      -
+        name: WI1
+        index: 1
+        initial_guess: 250
+        min: 10
+        max: 500
 
 objective_functions:
   - name: rf


### PR DESCRIPTION
If there are two top level entries in the controls section in the Everest configuration file, this list will have length 2, not 1 as the comment implies.

**Issue**
Resolves itch

**Approach**
✂️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
