### PR TITLE
Add missing dimensionality to EverestControl

### DIFF
--- a/src/ert/config/everest_control.py
+++ b/src/ert/config/everest_control.py
@@ -152,6 +152,7 @@ class EverestControl(ParameterConfig):
     """
 
     type: Literal["everest_parameters"] = "everest_parameters"
+    dimensionality: Literal[1] = 1
     input_keys: list[str] = field(default_factory=list)
     forward_init: bool = False
     output_file: str = ""


### PR DESCRIPTION
Resolves ERT plotter not opening on everest experiment