### PR TITLE
Make migration deterministic over filesystem

### DIFF
--- a/src/ert/storage/migration/to25.py
+++ b/src/ert/storage/migration/to25.py
@@ -49,7 +49,7 @@ def _observation_row_to_declaration(
 def migrate_parameters_responses_and_observations_into_experiment_index(
     path: Path,
 ) -> None:
-    for exp_path in path.glob("experiments/*"):
+    for exp_path in sorted(path.glob("experiments/*")):
         if not exp_path.is_dir():
             continue
 
@@ -67,7 +67,7 @@ def migrate_parameters_responses_and_observations_into_experiment_index(
 
         obs_dir = exp_path / "observations"
         if obs_dir.exists():
-            for obs_file in obs_dir.glob("*"):
+            for obs_file in sorted(obs_dir.glob("*")):
                 df = pl.read_parquet(obs_file)
                 experiment_json["observations"].extend(
                     [


### PR DESCRIPTION
The test of this function has exposed flakyness, which can be reproduced by tweaking the order of files returned by glob().

pathlib.Path.glob() returns filenames in arbitrary order.

**Issue**
Resolves #12863 


**Approach**
🧠 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
