### PR TITLE
Add everest objectives/constraints over iteration plot

### DIFF
--- a/src/ert/dark_storage/endpoints/parameters.py
+++ b/src/ert/dark_storage/endpoints/parameters.py
@@ -114,6 +114,22 @@ def get_parameter_std_dev(
 
 
 def data_for_parameter(ensemble: Ensemble, key: str) -> pd.DataFrame:
+    param_info = ensemble.experiment.parameter_info.get(key)
+
+    if (
+        param_info
+        and param_info.get("type") == "everest_parameters"
+        and (everest_controls := ensemble.realization_controls) is not None
+        and key in everest_controls.columns
+    ):
+        columns_to_select = [
+            col
+            for col in ["batch_id", "realization", key]
+            if col in everest_controls.columns
+        ]
+
+        return everest_controls.select(columns_to_select).to_pandas()
+
     try:
         df = ensemble.load_scalar_keys([key], transformed=True)
         if df.is_empty():

--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -187,4 +187,17 @@ def data_for_response(
 
         except (ValueError, KeyError, ColumnNotFoundError):
             return pd.DataFrame()
+
+    if response_type in {"everest_objectives", "everest_constraints"}:
+        df = (
+            ensemble.realization_objectives
+            if response_type == "everest_objectives"
+            else ensemble.realization_constraints
+        )
+        if df is None or response_key not in df.columns:
+            return pd.DataFrame()
+
+        columns = ["batch_id", "realization", response_key]
+        return df.select(columns).to_pandas()
+
     return pd.DataFrame()

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from .plottery.plots.misfits import MisfitsPlot
     from .plottery.plots.statistics import StatisticsPlot
     from .plottery.plots.std_dev import StdDevPlot
+    from .plottery.plots.values_over_iteration_plot import (
+        ValuesOverIterationsPlot,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +126,7 @@ class PlotWidget(QWidget):
             "DistributionPlot",
             "CrossEnsembleStatisticsPlot",
             "StdDevPlot",
+            "ValuesOverIterationsPlot",
             "MisfitsPlot",
         ],
         parent: QWidget | None = None,

--- a/src/ert/gui/tools/plot/plottery/plots/__init__.py
+++ b/src/ert/gui/tools/plot/plottery/plots/__init__.py
@@ -6,6 +6,7 @@ from .histogram import HistogramPlot
 from .misfits import MisfitsPlot
 from .statistics import StatisticsPlot
 from .std_dev import StdDevPlot
+from .values_over_iteration_plot import ValuesOverIterationsPlot
 
 __all__ = [
     "CrossEnsembleStatisticsPlot",
@@ -16,4 +17,5 @@ __all__ = [
     "MisfitsPlot",
     "StatisticsPlot",
     "StdDevPlot",
+    "ValuesOverIterationsPlot",
 ]

--- a/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from matplotlib.ticker import MaxNLocator
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    from matplotlib.figure import Figure
+
+    from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.tools.plot.plottery import PlotContext
+
+
+class ValuesOverIterationsPlot:
+    """Plot of a value for each realization over iterations.
+
+    Layout:
+        X-axis: iteration
+        Y-axis: value
+        Glyphs: One line chart per realization, with a dot at each iteration.
+
+    Input data: assumed to be a dictionary of DataFrames, where
+    each DataFrame contains columns for 'batch_id', 'realization', and
+    exactly one other column (named according to its source data,
+    i.e., objective or control name) which is treated as the value to plot.
+    """
+
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = False
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+        config = plot_context.plotConfig()
+        axes = figure.add_subplot(111)
+
+        plot_context.y_axis = plot_context.VALUE_AXIS
+        plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.deactivateDateSupport()
+
+        all_dfs = []
+        for _ensemble, df in ensemble_to_data_map.items():
+            if not df.empty:
+                all_dfs.append(df)
+
+        combined = pd.concat(all_dfs, ignore_index=True)
+
+        # Assume only one value is in the input data to make it same across
+        # controls, constraints, and objectives
+        value_col = next(
+            c for c in combined.columns if c not in {"batch_id", "realization"}
+        )
+
+        realizations = sorted(combined["realization"].unique())
+
+        for realization in realizations:
+            data = combined[combined["realization"] == realization].sort_values(
+                "batch_id"
+            )
+            if data.empty:
+                continue
+
+            color = config.nextColor()
+            axes.plot(
+                data["batch_id"],
+                data[value_col],
+                "-o",
+                label=f"Realization {int(realization)}",
+                color=color,
+                markersize=4,
+            )
+
+        axes.set_xlabel("Iteration")
+        axes.set_ylabel(value_col)
+        axes.legend(title="Realization")
+        axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        axes.grid(True)
+        figure.tight_layout()


### PR DESCRIPTION
Tentative PR with Everest plots (naming etc is subject to improvement)

How to test manually:
```
everest run test-data/everest/math_func/config_advanced.yml 
```

Add absolute enspath to `poly.ert`: add the absolute path to `test-data/everest/math_func/everest_output/simulation_results`, by running for example `realpath test-data/everest/math_func/everest_output/simulation_results ` in the terminal.
Then open poly with `ert gui` and open the plotter.

Example poly.ert config:
```
...
ENSPATH /Users/someone/Project/Repositories/ert/test-data/everest/math_func/everest_output/simulation_results
... 
```

<img width="1378" height="708" alt="Screenshot 2026-02-13 at 14 18 13" src="https://github.com/user-attachments/assets/67a3fcc1-50ae-4d0b-8c30-58138b936081" />


controls:
<img width="1369" height="735" alt="Screenshot 2026-02-13 at 15 08 42" src="https://github.com/user-attachments/assets/ac32220a-8153-4694-b5a3-c462b5d98f15" />
