### PR TITLE
Solve Futurewarning on functools.partials

### DIFF
--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import logging
 import uuid
-from functools import partial
 from threading import Event
 from unittest.mock import MagicMock
 
@@ -83,10 +82,13 @@ async def test_when_task_fails_evaluator_raises_exception(
         end_event=Event(),
     )
 
+    async def task_that_fails(*args, **kwargs):
+        return await mock_failure(error_msg, *args, **kwargs)
+
     monkeypatch.setattr(
         EnsembleEvaluator,
         task,
-        partial(mock_failure, error_msg),
+        task_that_fails,
     )
     with pytest.raises(RuntimeError, match=error_msg):
         await evaluator.run_and_get_successful_realizations()

--- a/tests/ert/unit_tests/scheduler/test_job.py
+++ b/tests/ert/unit_tests/scheduler/test_job.py
@@ -143,7 +143,12 @@ async def test_job_run_sends_expected_events(
     scheduler.driver._job_error_message_by_iens = {}
 
     job = Job(scheduler, realization)
-    job._verify_checksum = partial(job._verify_checksum, timeout=0)
+    original_verify_checksum = job._verify_checksum
+
+    async def verify_checksum_with_timeout(lock, _timeout=0):
+        return await original_verify_checksum(lock, timeout=_timeout)
+
+    job._verify_checksum = verify_checksum_with_timeout
     job.started.set()
 
     job_run_task = asyncio.create_task(


### PR DESCRIPTION
In Python 3.13, this
functools.partial will emit a FutureWarning when used as a method.

In this commit, an explicit function is used instead of functools.partial.

**Issue**
Resolves #12869 

**Approach**
Copilot

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
