### PR TITLE
Mute test warning on config with a SUMMARY key

### DIFF
--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2704,6 +2704,7 @@ def test_that_zone_map_can_be_set_per_realization():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_breakthrough_observations_can_be_internalized_in_ert_config():
     obs_path = Path("observations")
 

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -188,6 +188,7 @@ def test_that_summary_observations_raises_error_given_unknown_localization_key(
 
 
 @pytest.mark.usefixtures("copy_snake_oil_case")
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internalized():
     obs_content = Path("observations/observations.txt").read_text(encoding="utf-8")
     obs_lines = obs_content.split("\n")
@@ -218,6 +219,7 @@ def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internal
     assert localized_entry["radius"].to_list() == [3]
 
 
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_defaulted_summary_obs_values_have_type_float32(tmpdir):
     with tmpdir.as_cwd():
         summary_observations = create_summary_observation(loc_config_lines="")

--- a/tests/ert/unit_tests/dark_storage/test_parameters.py
+++ b/tests/ert/unit_tests/dark_storage/test_parameters.py
@@ -6,6 +6,7 @@ from ert.storage import open_storage
 
 
 @pytest.mark.integration_test
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_asking_for_non_existent_key_doesnt_raise(
     symlinked_heat_equation_storage_es,
 ):
@@ -18,6 +19,7 @@ def test_that_asking_for_non_existent_key_doesnt_raise(
 
 
 @pytest.mark.integration_test
+@pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_asking_for_existing_key_with_group_returns_data(
     symlinked_heat_equation_storage_es,
 ):


### PR DESCRIPTION
This is because we mock the summary data

**Issue**
Resolves visual noise in test output

**Approach**
Mute.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
