### PR TITLE
Increase timeout and reduce reruns

### DIFF
--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -141,8 +141,8 @@ line: 2, column: 18. controls -> 0 -> initial_guess
 
 
 @pytest.mark.skip_mac_ci
-@pytest.mark.flaky(reruns=5)
-@pytest.mark.timeout(60)
+@pytest.mark.flaky(reruns=3)
+@pytest.mark.timeout(120)
 @pytest.mark.integration_test
 @pytest.mark.xdist_group(name="starts_everest")
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")


### PR DESCRIPTION
Maybe it will make this test less flaky

**Issue**
Maybe aids flakyness.

**Approach**
Partial revert of https://github.com/equinor/ert/pull/12842

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
