### PR TITLE
Fix plotting categorical data crashes ert

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -287,8 +287,8 @@ class PlotWindow(QMainWindow):
             negative_values_in_data = False
             if key_def.parameter is not None and key_def.parameter.type == "gen_kw":
                 for data in ensemble_to_data_map.values():
-                    data = data.T
-                    if data.le(0).any().any():
+                    numeric = data.select_dtypes(include=["number"])
+                    if not numeric.empty and numeric.le(0).any().any():
                         negative_values_in_data = True
                         break
 


### PR DESCRIPTION

**Issue**
Resolves #12886


**Approach**
This commit fixes the issue where the non-negative-data check in PlotWindow raises a TypeError for categorical data from design_matrix. The new behavior is to ignore non-numerical columns when looking for negative values to disable the log_scale button.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
