### PR TITLE
Add observation location to storage API

### DIFF
--- a/src/ert/dark_storage/endpoints/observations.py
+++ b/src/ert/dark_storage/endpoints/observations.py
@@ -9,9 +9,7 @@ import polars as pl
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 
 from ert.dark_storage import json_schema as js
-from ert.dark_storage.common import (
-    get_storage,
-)
+from ert.dark_storage.common import get_storage
 from ert.dark_storage.endpoints.responses import response_to_pandas_x_axis_fns
 from ert.storage import Experiment, Storage
 
@@ -45,6 +43,9 @@ def get_observations(
             errors=observation["errors"],
             values=observation["values"],
             x_axis=observation["x_axis"],
+            east=observation["east"],
+            north=observation["north"],
+            radius=observation["radius"],
             name=observation["name"],
         )
         for observation in _get_observations(experiment)
@@ -98,6 +99,9 @@ async def get_observations_for_response(
             errors=obs["errors"],
             values=obs["values"],
             x_axis=obs["x_axis"],
+            east=obs["east"],
+            north=obs["north"],
+            radius=obs["radius"],
             name=obs["name"],
         )
         for obs in obss
@@ -153,6 +157,9 @@ def _get_observations(
                     "values": obs_df["values"].to_list(),
                     "errors": obs_df["errors"].to_list(),
                     "x_axis": obs_df["x_axis"].to_list(),
+                    "east": obs_df["east"].to_list(),
+                    "north": obs_df["north"].to_list(),
+                    "radius": obs_df["radius"].to_list(),
                 }
             )
 

--- a/src/ert/dark_storage/json_schema/observation.py
+++ b/src/ert/dark_storage/json_schema/observation.py
@@ -30,6 +30,9 @@ class _Observation:
     errors: list[float]
     values: list[float]
     x_axis: list[Any]
+    east: list[float | None] | None = None
+    north: list[float | None] | None = None
+    radius: list[float | None] | None = None
     records: list[UUID] | None = None
 
 

--- a/tests/ert/unit_tests/dark_storage/conftest.py
+++ b/tests/ert/unit_tests/dark_storage/conftest.py
@@ -65,6 +65,12 @@ def dark_storage_client_snake_oil(monkeypatch):
 
 
 @pytest.fixture
+def dark_storage_client_heat_equation(monkeypatch):
+    with dark_storage_app_(monkeypatch) as dark_app, TestClient(dark_app) as client:
+        yield client
+
+
+@pytest.fixture
 def env(monkeypatch):
     monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
 

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -257,6 +257,36 @@ def test_get_experiment_observations(poly_example_tmp_dir, dark_storage_client):
     assert len(response_json[0]["errors"]) == 5
     assert len(response_json[0]["values"]) == 5
     assert len(response_json[0]["x_axis"]) == 5
+    assert response_json[0]["east"] == 5 * [None]
+    assert response_json[0]["north"] == 5 * [None]
+    assert response_json[0]["radius"] == 5 * [None]
+
+
+@pytest.mark.integration_test
+def test_that_heat_equation_get_observations_with_locations(
+    symlink_heat_equation_storage_es, dark_storage_client_heat_equation
+):
+    resp: Response = dark_storage_client_heat_equation.get("/experiments")
+    experiment_json = resp.json()
+    experiment_id = experiment_json[0]["id"]
+
+    resp: Response = dark_storage_client_heat_equation.get(
+        f"/experiments/{experiment_id}/observations"
+    )
+    response_json = resp.json()
+    assert len(response_json) == 48
+
+    obs_by_name = {obs["name"]: obs for obs in response_json}
+
+    obs = obs_by_name["HEAT_5_7_132"]
+    assert obs["east"] == [4.5]
+    assert obs["north"] == [16.5]
+    assert obs["radius"] == [3]
+
+    obs = obs_by_name["HEAT_5_3_10"]
+    assert obs["east"] == [4.5]
+    assert obs["north"] == [12.5]
+    assert obs["radius"] == [3]
 
 
 @pytest.mark.integration_test
@@ -275,6 +305,8 @@ def test_get_record_observations(poly_example_tmp_dir, dark_storage_client):
     assert len(response_json[0]["errors"]) == 5
     assert len(response_json[0]["values"]) == 5
     assert len(response_json[0]["x_axis"]) == 5
+    assert response_json[0]["east"] == 5 * [None]
+    assert response_json[0]["north"] == 5 * [None]
 
 
 @pytest.mark.integration_test

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -681,6 +681,8 @@ general_observations = st.builds(
     index=st.integers(min_value=1, max_value=10000),
     value=st.floats(allow_nan=False, allow_infinity=False),
     error=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
+    east=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
+    north=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
 )
 
 observations = st.lists(


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/12902

**Approach**
Propagate locations of observation to the API.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
