### PR TITLE
Make restart on ES_MDA work with changed ensamble size

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -45,6 +45,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _create_combined_ensemble_mask(
+    ens_mask: npt.NDArray[np.bool_], active_realizations: list[bool] | None
+) -> npt.NDArray[np.bool_]:
+    if active_realizations is None:
+        return ens_mask
+
+    ens_mask_indices = set(np.flatnonzero(ens_mask))
+    active_realizations_indices = set(np.flatnonzero(active_realizations))
+
+    if len(ens_mask) >= len(active_realizations):
+        ens_mask_indices &= active_realizations_indices
+
+        new_mask = np.zeros_like(ens_mask, dtype=bool)
+        if ens_mask_indices:
+            new_mask[list(ens_mask_indices)] = True
+    else:
+        active_realizations_indices &= ens_mask_indices
+
+        new_mask = np.zeros_like(active_realizations, dtype=bool)
+        if active_realizations_indices:
+            new_mask[list(active_realizations_indices)] = True
+
+    return new_mask
+
+
 def perform_ensemble_update(
     parameters: Iterable[str],
     observations: Iterable[str],
@@ -238,8 +263,7 @@ def smoother_update(
         rng = np.random.default_rng()
 
     ens_mask = prior_storage.get_realization_mask_with_responses()
-    if active_realizations:
-        ens_mask &= active_realizations
+    ens_mask = _create_combined_ensemble_mask(ens_mask, active_realizations)
 
     smoother_snapshot = SmootherSnapshot(
         source_ensemble_name=prior_storage.name,

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -8,6 +8,7 @@ import pytest
 from tabulate import tabulate
 
 from ert.analysis import ErtAnalysisError, ObservationStatus, smoother_update
+from ert.analysis._es_update import _create_combined_ensemble_mask
 from ert.analysis._update_commons import (
     _compute_observation_statuses,
     _OutlierColumns,
@@ -1141,3 +1142,47 @@ def test_update_subset_parameters(storage, uniform_parameter, obs):
     assert len(
         posterior_ens.load_parameters("PARAMETER")["realization"]
     ) == active_realizations.count(True)
+
+
+@pytest.mark.parametrize(
+    ("ens_mask", "active_realizations", "expected"),
+    [
+        pytest.param(
+            np.array([True, False, True, True]),
+            None,
+            np.array([True, False, True, True]),
+            id="no_active_realizations",
+        ),
+        pytest.param(
+            np.array([True, False, True, True]),
+            [True, True, False, True],
+            np.array([True, False, False, True]),
+            id="intersecting_masks_same_length",
+        ),
+        pytest.param(
+            np.array([True, False, False, True]),
+            [True, True],
+            np.array([True, False, False, False]),
+            id="intersecting_masks_different_length_ens_mask_longer",
+        ),
+        pytest.param(
+            np.array([True, False, False, True]),
+            [True, True, False, True, True, False, True],
+            np.array([True, False, False, True, False, False, False]),
+            id="intersecting_masks_different_length_active_realizations_longer",
+        ),
+        pytest.param(
+            np.array([True, False, True, False]),
+            [False, True, False, True],
+            np.array([False, False, False, False]),
+            id="no_intersection",
+        ),
+    ],
+)
+def test_that_create_combined_ensemble_mask_handles_different_length_masks(
+    ens_mask: np.ndarray,
+    active_realizations: list[bool] | None,
+    expected: np.ndarray,
+) -> None:
+    result = _create_combined_ensemble_mask(ens_mask, active_realizations)
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
**Issue**
Resolves #12180


**Approach**
Created a function for re-mapping lists into sets, finding common indices and converting back to list for further processing. Comparing sets eliminates the problem of different length lists.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
