### PR TITLE
Fix polars exception on RFT size mismatch

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -261,6 +261,18 @@ class RFTConfig(ResponseConfig):
                                 for c in entry.connections
                             ]
                             if np.isdtype(values.dtype, np.float32):
+                                num_values = len(values)
+                                num_conns = len(entry.connections)
+                                if num_values != num_conns:
+                                    raise InvalidResponseFile(
+                                        "Could not read RFT from "
+                                        f"{run_path}/{filename}: "
+                                        f"RFT property {rft_property} for well {well} "
+                                        f"at {date.isoformat()} has {num_values} "
+                                        f"value{'s' if num_values != 1 else ''} "
+                                        f"but {num_conns} well "
+                                        f"connection{'s' if num_conns != 1 else ''}"
+                                    )
                                 fetched[well, date][rft_property] = values
         except (FileNotFoundError, InvalidRFTError) as err:
             raise InvalidResponseFile(

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -254,6 +254,28 @@ def test_that_missing_depth_raises_invalid_response_file(mock_resfo_file):
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
 
+def test_that_too_few_property_values_raises_invalid_response_file(mock_resfo_file):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name="WELL1",
+                ijks=((1, 1, 1), (2, 2, 2)),  # two connections
+            ),
+            ("PRESSURE", float_arr([100.0])),  # only one pressure value
+            ("DEPTH   ", float_arr([20.0])),
+        ],
+    )
+
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={"*": {"2000-01-01": ["PRESSURE"]}},
+    )
+    with pytest.raises(InvalidResponseFile, match="has 1 value but 2 well connections"):
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+
 def test_that_number_of_connections_can_be_different_per_well(mock_resfo_file):
     mock_resfo_file(
         "/tmp/does_not_exist/BASE.RFT",


### PR DESCRIPTION
**Issue**
Resolves #12836


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
