### PR TITLE
Include time-series plot in Everest mode

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -210,6 +210,7 @@ class PlotWindow(QMainWindow):
                 )
                 self.addPlotWidget(STD_DEV, StdDevPlot())
             else:
+                self.addPlotWidget(ENSEMBLE, EnsemblePlot())
                 self.addPlotWidget(EVEREST_CONTROLS_PLOT, ValuesOverIterationsPlot())
                 self.addPlotWidget(EVEREST_RESPONSES_PLOT, ValuesOverIterationsPlot())
 


### PR DESCRIPTION
This makes summary plotting possible, and also avoids a crash when selecting a summar variable with the other plot modes active

**Issue**
Resolves crash:
```
An error occurred during plotting. This stack trace is helpful for diagnosing the problem.--------------------------------------------------------------------------------
  File "/data/projects/ert/src/ert/gui/tools/plot/plot_widget.py", line 221, in updatePlot
    self._plotter.plot(
  File "/data/projects/ert/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py", line 64, in plot
    realizations = sorted(combined["realization"].unique())
                          ~~~~~~~~^^^^^^^^^^^^^^^
  File "/data/venv/lib64/python3.12/site-packages/pandas/core/frame.py", line 4378, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/venv/lib64/python3.12/site-packages/pandas/core/indexes/datetimes.py", line 971, in get_loc
    raise KeyError(key) from err
Exception type: KeyError
'realization'
```



**Approach**
<img width="943" height="681" alt="image" src="https://github.com/user-attachments/assets/31be07d1-4532-491c-ac22-98301578d9ff" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
