### PR TITLE
Extract create_flattened_cube_graph to graph_utils

### DIFF
--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import logging
 import os
 from collections.abc import Callable, Iterator
@@ -26,6 +25,7 @@ from ert.substitutions import substitute_runpath_name
 from ert.utils import log_duration
 
 from ._str_to_bool import str_to_bool
+from .graph_utils import create_flattened_cube_graph
 from .parameter_config import ParameterConfig
 from .parsing import ConfigValidationError, ConfigWarning
 
@@ -35,34 +35,6 @@ if TYPE_CHECKING:
     from ert.storage import Ensemble
 
 _logger = logging.getLogger(__name__)
-
-
-def create_flattened_cube_graph(px: int, py: int, pz: int) -> nx.Graph[int]:
-    """graph created with nodes numbered from 0 to px*py*pz
-    corresponds to the "vectorization" or flattening of
-    a 3D cube with shape (px,py,pz) in the same way as
-    reshaping such a cube into a one-dimensional array.
-    The indexing scheme used to create the graph reflects
-    this flattening process"""
-
-    G: nx.Graph[int] = nx.Graph()
-    for x, y, z in itertools.product(range(px), range(py), range(pz)):
-        # Flatten the 3D index to a single index
-        index = x * py * pz + y * pz + z
-
-        # Connect to the right neighbor (y-direction)
-        if y < py - 1:
-            G.add_edge(index, index + pz)
-
-        # Connect to the bottom neighbor (x-direction)
-        if x < px - 1:
-            G.add_edge(index, index + py * pz)
-
-        # Connect to the neighbor in front (z-direction)
-        if z < pz - 1:
-            G.add_edge(index, index + 1)
-
-    return G
 
 
 class Field(ParameterConfig):

--- a/src/ert/config/graph_utils.py
+++ b/src/ert/config/graph_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import itertools
+
+import networkx as nx
+
+
+def create_flattened_cube_graph(px: int, py: int, pz: int) -> nx.Graph[int]:
+    """Graph created with nodes numbered from 0 to px*py*pz
+    corresponds to the "vectorization" or flattening of
+    a 3D cube with shape (px,py,pz) in the same way as
+    reshaping such a cube into a one-dimensional array.
+    The indexing scheme used to create the graph reflects
+    this flattening process"""
+
+    graph: nx.Graph[int] = nx.Graph()
+    for x, y, z in itertools.product(range(px), range(py), range(pz)):
+        index = x * py * pz + y * pz + z
+
+        if y < py - 1:
+            graph.add_edge(index, index + pz)
+
+        if x < px - 1:
+            graph.add_edge(index, index + py * pz)
+
+        if z < pz - 1:
+            graph.add_edge(index, index + 1)
+
+    return graph

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -13,7 +13,7 @@ from surfio import IrapHeader, IrapSurface
 from ert.substitutions import substitute_runpath_name
 
 from ._str_to_bool import str_to_bool
-from .field import create_flattened_cube_graph
+from .graph_utils import create_flattened_cube_graph
 from .parameter_config import InvalidParameterFile, ParameterConfig
 from .parsing import ConfigValidationError, ErrorInfo
 

--- a/tests/ert/unit_tests/config/test_graph_utils.py
+++ b/tests/ert/unit_tests/config/test_graph_utils.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from ert.config.graph_utils import create_flattened_cube_graph
+
+
+@pytest.mark.parametrize(
+    ("px", "py", "pz"),
+    [
+        (1, 1, 1),
+        (1, 1, 8),
+        (1, 8, 1),
+        (8, 1, 1),
+        (2, 2, 2),
+        (2, 3, 4),
+        (3, 5, 7),
+        (8, 8, 8),
+    ],
+)
+def test_that_flattened_graph_edges_connect_neighboring_grid_cells(px, py, pz):
+    flattened_graph = create_flattened_cube_graph(px, py, pz)
+    grid_shape = (px, py, pz)
+
+    for flat_node_a, flat_node_b in flattened_graph.edges():
+        cell_coord_a = np.unravel_index(flat_node_a, grid_shape)
+        cell_coord_b = np.unravel_index(flat_node_b, grid_shape)
+
+        manhattan_distance = sum(
+            abs(coord_a - coord_b)
+            for coord_a, coord_b in zip(cell_coord_a, cell_coord_b, strict=True)
+        )
+
+        assert manhattan_distance == 1, (
+            f"Nodes {flat_node_a} and {flat_node_b} are connected, but "
+            f"their coordinates {cell_coord_a} and {cell_coord_b} are not neighbors."
+        )


### PR DESCRIPTION
I initially thought that I could do this using networkx built-int methods like so:

```python
    grid_graph = nx.grid_graph((range(px), range(py), range(pz)))
    return nx.convert_node_labels_to_integers(grid_graph, ordering="sorted")
```

This changed behaviour in ways I did not expect though and a shapshot test failed.
So, I've added a property test that will fail if someone tries to do the same.

---

Moves the function from field.py to a dedicated module so both Field and SurfaceConfig can import it without a cross-dependency.

Adds a unit test verifying that every edge connects face-adjacent cells in the flattened index space.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
