### PR TITLE
Increase bsub and bjobs timeouts preparing for LSF patch weekend

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -37,7 +37,7 @@ class FailedSubmit(RuntimeError):
 class Driver(ABC):
     """Adapter for the HPC cluster."""
 
-    POLLING_TIMEOUT_PERIOD = 600
+    POLLING_TIMEOUT_PERIOD = 60 * 30
 
     def __init__(self, activate_script: str = "") -> None:
         self._event_queue: asyncio.Queue[DriverEvent] | None = None

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -280,8 +280,8 @@ class LsfDriver(Driver):
         self._iens2jobid: MutableMapping[int, str] = {}
         self._max_attempt: int = 100
         self._sleep_time_between_bkills = 30
-        self._sleep_time_between_cmd_retries = 3
-        self._max_bsub_attempts = 10
+        self._sleep_time_between_cmd_retries = 30
+        self._max_bsub_attempts = 60
 
         self._poll_period = poll_period
 


### PR DESCRIPTION
Increasing this timeout should allow for a 15 minute maintenance window for the LSF server where it is allowed to be irresponsive.

