### PR TITLE
Remove high contrast warning

### DIFF
--- a/src/ert/gui/detect_mode.py
+++ b/src/ert/gui/detect_mode.py
@@ -1,15 +1,6 @@
 from typing import cast
 
-from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QApplication, QWidget
-
-
-def is_high_contrast_mode() -> bool:
-    app = cast(QWidget, QApplication.instance())
-    return (
-        app is not None
-        and app.palette().color(QPalette.ColorRole.Window).lightness() > 245
-    )
 
 
 def is_dark_mode() -> bool:

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QMainWindow,
     QMenu,
-    QMessageBox,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -35,7 +34,7 @@ from ert.gui.tools.workflows import WorkflowsTool
 from ert.plugins import ErtRuntimePlugins
 from ert.trace import get_trace_id
 
-from .detect_mode import is_dark_mode, is_high_contrast_mode
+from .detect_mode import is_dark_mode
 from .experiments import ExperimentPanel, RunDialog
 
 logger = logging.getLogger(__name__)
@@ -119,20 +118,6 @@ class ErtMainWindow(QMainWindow):
         else:
             self.side_frame.setStyleSheet("background-color: lightgray;")
             logger.info("Running Ert with light mode")
-
-        if is_high_contrast_mode():
-            msg_box = QMessageBox()
-            msg_box.setText(
-                "High contrast mode detected. This is not supported by Ert "
-                "and some features may not work as expected."
-            )
-            msg_box.setWindowTitle("Warning")
-            msg_box.setStyleSheet(
-                "QMessageBox {color: black; background-color: white;} "
-                "QLabel {color: black;} QPushButton {color: black;}"
-            )
-            msg_box.update()
-            msg_box.exec()
 
         self.vbox_layout = QVBoxLayout(self.side_frame)
         self.side_frame.setLayout(self.vbox_layout)


### PR DESCRIPTION
**Issue**
Resolves #12687 


**Approach**
Remove high contrast detectin and warning, due to many false positives disrupting developers, and the very limited usefullnes of this feature. Its only a warning and thus has low value. 

We can add full High Contrast support if we upgrade PyQt to >=6.10, but that requires RHEL9...
https://www.qt.io/blog/high-contrast-mode-in-qt-6.10

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
