### PR TITLE
Avoid site-config in cli tests

### DIFF
--- a/tests/ert/ui_tests/cli/test_setting_random_seeds.py
+++ b/tests/ert/ui_tests/cli/test_setting_random_seeds.py
@@ -12,6 +12,7 @@ from ert.mode_definitions import (
 from .run_cli import run_cli
 
 
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 @pytest.mark.parametrize("experiment_type", [TEST_RUN_MODE, ENSEMBLE_EXPERIMENT_MODE])
 def test_that_cli_uses_config_random_seed_when_specified(
     caplog, use_tmpdir, experiment_type
@@ -36,6 +37,7 @@ def test_that_cli_uses_config_random_seed_when_specified(
     assert "'random_seed': 12345" in seed_logs[0]
 
 
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 @pytest.mark.parametrize("experiment_type", [TEST_RUN_MODE, ENSEMBLE_EXPERIMENT_MODE])
 def test_that_cli_generates_different_seeds_for_consecutive_runs(
     caplog, use_tmpdir, experiment_type


### PR DESCRIPTION
No reason to run this on anything else than the default local driver

**Issue**
Resolves https://github.com/equinor/komodo-releases/actions/runs/22425458610/job/64933959440


**Approach**
Use fixture for avoiding site-config. An alternative would be to just add `QUEUE_SYSTEM LOCAL` in the config, but maybe we can cover more using the fixture.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
