### PR TITLE
Have scheduler kill hanging cluster jobs

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -62,6 +62,9 @@ class SubmitSleeper:
 class Scheduler:
     BATCH_KILLING_INTERVAL = 1.5
 
+    # Seconds for driver to report job as finished after checksum arrival
+    ORPHAN_KILL_DELAY = 60
+
     def __init__(
         self,
         driver: Driver,
@@ -110,6 +113,7 @@ class Scheduler:
         self._realization_ids_to_kill: list[int] = []
         self._kill_task: asyncio.Task[None] | None = None
         self._stop_kill_task = asyncio.Event()
+        self._watchdog_tasks: list[asyncio.Task[None]] = []
 
     async def kill_all_jobs(self) -> None:
         await self.cancel_all_jobs()
@@ -197,7 +201,30 @@ class Scheduler:
             event = await self._manifest_queue.get()
             if type(event) is ForwardModelStepChecksum:
                 self.checksum.update(event.checksums)
+                iens = int(event.real)
+                task = asyncio.create_task(
+                    self._kill_if_driver_lags(iens),
+                    name=f"orphan-watchdog-{iens}",
+                )
+                self._watchdog_tasks.append(task)
             self._manifest_queue.task_done()
+
+    async def _kill_if_driver_lags(self, iens: int) -> None:
+        """Kill realization *iens* if the driver hasn't reported it
+        finished within the grace period after checksum arrival."""
+        job = self._jobs[iens]
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(job.returncode), timeout=self.ORPHAN_KILL_DELAY
+            )
+        except TimeoutError:
+            logger.warning(
+                f"Realization {iens}: checksum received but driver has not "
+                f"reported the job as finished after {self.ORPHAN_KILL_DELAY}s. "
+                "Assuming orphaned child processes are keeping the cluster job "
+                "alive. Sending a signal to the queue system to kill the job now"
+            )
+            await self.schedule_kill(iens)
 
     async def _publisher(self) -> None:
         if self._ensemble_evaluator_queue is None:
@@ -335,6 +362,9 @@ class Scheduler:
             )
             if self._kill_task:
                 await self._kill_task
+            for watchdog_task in self._watchdog_tasks:
+                watchdog_task.cancel()
+            await asyncio.gather(*self._watchdog_tasks, return_exceptions=True)
         if self._cancelled:
             logger.debug("Scheduler has been cancelled, jobs are stopped.")
             return False

--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from _ert.events import (
+    ForwardModelStepChecksum,
     RealizationFailed,
     RealizationStoppedLongRunning,
     RealizationTimeout,
@@ -895,3 +896,44 @@ async def test_batch_killing_runs_batches_in_parallell(
     next_batch_ready_event.set()
     assert sch._kill_task is not None
     await sch._kill_task
+
+
+@pytest.mark.timeout(10)
+async def test_that_scheduler_kills_jobs_when_driver_lags_after_checksum(
+    realization, mock_driver, caplog
+):
+    """When all FM steps are done (checksum received) but the driver has not
+    reported the job as finished, the scheduler should kill the job after
+    ORPHAN_KILL_DELAY seconds.  This handles the case where orphaned child
+    processes (spawned outside the cluster job's process group) keep the
+    cluster job alive indefinitely."""
+    wait_started = asyncio.Event()
+    kill_called = asyncio.Event()
+
+    async def wait():
+        wait_started.set()
+        await asyncio.sleep(10)  # Simulate a job that never exits on its own
+
+    async def kill():
+        kill_called.set()
+
+    manifest_queue: asyncio.Queue[ForwardModelStepChecksum] = asyncio.Queue()
+    driver = mock_driver(wait=wait, kill=kill)
+    sch = scheduler.Scheduler(driver, [realization], manifest_queue=manifest_queue)
+    sch.ORPHAN_KILL_DELAY = 0  # Fire immediately after the next event-loop tick
+    sch.BATCH_KILLING_INTERVAL = 0.1
+
+    scheduler_task = asyncio.create_task(sch.execute())
+
+    await asyncio.wait_for(wait_started.wait(), timeout=5)
+
+    await manifest_queue.put(
+        ForwardModelStepChecksum(
+            real=str(realization.iens),
+            checksums={realization.run_arg.runpath: {}},
+        )
+    )
+    await asyncio.wait_for(scheduler_task, timeout=5)
+
+    assert kill_called.is_set(), "driver.kill was never called by the watchdog"
+    assert "orphaned child processes" in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #12965


**Approach**
This commit makes scheduler kill jobs running on the cluster if the evaluator has received a message that the job is finished, but the driver disagrees. This can be due to one of the forward model steps spawning new processes that Ert does not see. This fixes the issue where the orphan processes caused the drivers to report jobs as still running, and hanging the run.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
