### PR TITLE
Remove logging of successful realizations in _evaluate_and_postprocess

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -814,19 +814,6 @@ class RunModel(RunModelConfig, ABC):
 
         num_successful_realizations = len(successful_realizations)
         self.validate_successful_realizations_count()
-        logger.info(f"Experiment ran on QUEUESYSTEM: {self.queue_config.queue_system}")
-        logger.info(
-            f"Experiment ran with number of realizations: {len(starting_realizations)} "
-            f"out of a total {self.ensemble_size}"
-        )
-        logger.info(
-            f"Experiment run ended with number of realizations succeeding: "
-            f"{num_successful_realizations}"
-        )
-        logger.info(
-            f"Experiment run ended with number of realizations failing: "
-            f"{len(starting_realizations) - num_successful_realizations}"
-        )
 
         # 0 means no violation
         if self._max_parallelism_violation.amount > 0 and isinstance(

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -164,13 +164,6 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
-    def verify_logged_realization_status(realization_count: int, failed_count: int):
-        expected_success = realization_count - failed_count
-        assert f"number of realizations succeeding: {expected_success}" in caplog.text
-        assert f"number of realizations failing: {failed_count}" in caplog.text
-
-    verify_logged_realization_status(num_reals, len(failing_reals_first_try))
-
     # Assert that the number of boxes in the detailed view is
     # equal to the number of realizations
     realization_widget = run_dialog._tab_widget.currentWidget()
@@ -204,10 +197,6 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
 
-    verify_logged_realization_status(
-        len(failing_reals_first_try), len(failing_reals_second_try)
-    )
-
     # We expect to have the same amount of realizations in list_model
     # since we reuse the snapshot_model
     realization_widget = run_dialog._tab_widget.currentWidget()
@@ -236,10 +225,6 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
 
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-
-    verify_logged_realization_status(
-        len(failing_reals_second_try), len(failing_reals_third_try)
-    )
 
     # We expect to have the same amount of realizations in list_model
     # since we reuse the snapshot_model


### PR DESCRIPTION
Remove logging that only affected some of the simulation modes.
Have grepped json-output from grafana to see if this affects queries found in widgets.

**Approach**
✂️ 

(Screenshot of new behavior in GUI if applicable)

These messages produces these statistics that are not representative of how the state actually is.
<img width="951" height="273" alt="Screenshot 2026-02-26 at 11 59 56" src="https://github.com/user-attachments/assets/bcffc18e-30da-41ac-9ba1-4c6ca17b51de" />

Rewritten query using other statements paint a very different picture.
<img width="951" height="273" alt="Screenshot 2026-02-26 at 12 00 03" src="https://github.com/user-attachments/assets/18029ba3-c65d-4f4e-9519-b21ffef85ecd" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
