### PR TITLE
Have AnalysisModuleEdit be styling consistent

### DIFF
--- a/src/ert/gui/ertwidgets/analysismoduleedit.py
+++ b/src/ert/gui/ertwidgets/analysismoduleedit.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QMargins, Qt
 from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QHBoxLayout, QToolButton, QWidget
+from PyQt6.QtWidgets import QHBoxLayout, QPushButton, QWidget
 
 from .analysismodulevariablespanel import AnalysisModuleVariablesPanel
 from .closabledialog import ClosableDialog
@@ -25,11 +25,10 @@ class AnalysisModuleEdit(QWidget):
 
         layout = QHBoxLayout()
 
-        variables_popup_button = QToolButton()
+        variables_popup_button = QPushButton("Edit")
         variables_popup_button.setObjectName("analysis_variables_popup_button")
         variables_popup_button.setIcon(QIcon("img:edit.svg"))
         variables_popup_button.clicked.connect(self.showVariablesPopup)
-        variables_popup_button.setMaximumSize(20, 20)
 
         layout.addWidget(variables_popup_button, 0, Qt.AlignmentFlag.AlignLeft)
         layout.setContentsMargins(QMargins(0, 0, 0, 0))

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -518,7 +518,7 @@ def test_that_inversion_type_can_be_set_from_gui(qtbot, opened_main_window_poly)
 
     QTimer.singleShot(500, handle_analysis_module_panel)
     qtbot.mouseClick(
-        get_child(es_edit, QToolButton), Qt.MouseButton.LeftButton, delay=1
+        get_child(es_edit, QPushButton), Qt.MouseButton.LeftButton, delay=1
     )
 
 

--- a/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
+++ b/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QDialog,
     QDoubleSpinBox,
-    QToolButton,
+    QPushButton,
 )
 from pytestqt.qtbot import QtBot
 
@@ -157,7 +157,7 @@ def _open_and_capture_threshold(panel, qtbot):
 
     QTimer.singleShot(500, inspect_and_close_dialog)
 
-    button = panel.findChild(QToolButton, "analysis_variables_popup_button")
+    button = panel.findChild(QPushButton, "analysis_variables_popup_button")
     qtbot.mouseClick(button, Qt.MouseButton.LeftButton)
 
     assert captured_value is not None


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/12834


**Approach**
This commit changes the edit button with a pencil from a QToolButton to QPushButton, so it will look more consistent with the Show Parameters button.

(Screenshot of new behavior in GUI if applicable)
Before:
<img width="1505" height="832" alt="image" src="https://github.com/user-attachments/assets/0f360f9c-6e1b-483a-acf9-fc3713189e67" />

After:
<img width="1504" height="839" alt="image" src="https://github.com/user-attachments/assets/0be89fa8-79e1-4f80-8453-b9865ad226d7" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
