### PR TITLE
Have DESIGN_MATRIX validate xlsx file for corruption

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import polars as pl
+from fastexcel import CalamineError
 from polars.exceptions import InvalidOperationError
 
 from .distribution import RawSettings
@@ -223,6 +224,10 @@ class DesignMatrix:
             )
         except pl.exceptions.NoDataError as err:
             raise ValueError("Design sheet headers are empty.") from err
+        except CalamineError as err:
+            raise ValueError(
+                "File could not be loaded. It seems to be either invalid or corrupted."
+            ) from err
         design_matrix_df = (
             pl.read_excel(
                 self.xls_filename,

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2783,3 +2783,31 @@ def test_that_random_seed_is_logged_with_reproduction_instructions(caplog):
     latest_seed_message = seed_logs[-1]
     expected_seed_message = f"RANDOM_SEED {seed}"
     assert latest_seed_message == expected_seed_message
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_corrupt_xlsx_design_matrix_raises_config_validation_error():
+    dm_file = "corrupt_design_matrix.xlsx"
+    Path("config.ert").write_text(
+        dedent(f"""
+            NUM_REALIZATIONS 1
+            DESIGN_MATRIX {dm_file}
+            """),
+        encoding="utf-8",
+    )
+    Path(dm_file).write_text(
+        dedent(
+            """
+            THIS IS NOT A VALID DESIGN MATRIX FILE
+            """
+        ),
+        encoding="utf-8",
+    )
+    with (
+        pytest.raises(
+            ConfigValidationError,
+            match=r"File could not be loaded. "
+            "It seems to be either invalid or corrupted",
+        ),
+    ):
+        ErtConfig.from_file("config.ert")


### PR DESCRIPTION
**Issue**
Resolves #13002 


**Approach**
This commit fixes the issue where passing a corrupt xlsx file to DESIGN_MATRIX caused it to crash Ert. This commit handles it by raising a ConfigValidatitonError instead.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
