### PR TITLE
Fix GEN_KW update flag matching parameter name

### DIFF
--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -194,6 +194,7 @@ class GenKwConfig(ParameterConfig):
                 "to exclude this from updates, set UPDATE:FALSE.\n",
                 gen_kw_key,
             )
+        # "CONST" not in params and parsed.option.update
         try:
             return [
                 cls(
@@ -203,7 +204,7 @@ class GenKwConfig(ParameterConfig):
                         params[0], params[1], params[2:]
                     ),
                     forward_init=False,
-                    update="CONST" not in params and parsed.options.update,
+                    update=params[1] != "CONST" and parsed.options.update,
                 )
                 for params in distributions_spec
             ]

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -861,6 +861,25 @@ def test_that_const_keyword_sets_update_to_false(tmpdir):
         assert gen_kw_config.update is False
 
 
+def test_that_parameter_named_const_with_non_const_distribution_is_updatable(tmp_path):
+    """Regression: update flag should only check the distribution type,
+    not match "CONST" anywhere in the parameter definition.
+    """
+    parameter_file = tmp_path / "parameter.txt"
+    parameter_file.write_text("CONST NORMAL 0 1", encoding="utf-8")
+
+    configs = GenKwConfig.from_config_list(
+        [
+            "MY_KW",
+            (str(parameter_file), parameter_file.read_text(encoding="utf-8")),
+            {},
+        ]
+    )
+    assert len(configs) == 1
+    assert configs[0].name == "CONST"
+    assert configs[0].update is True
+
+
 def test_that_unexpected_positional_arg_count_raises_validation_error(tmp_path):
     parameter_file = tmp_path / "parameter.txt"
     parameter_file.write_text("KEY NORMAL 0 1", encoding="utf-8")


### PR DESCRIPTION
The update flag was set using `"CONST" not in params`, which searches the entire list including the parameter name. A parameter named "CONST" with a non-CONST
distribution would incorrectly get update=False.

Narrow the check to only inspect the distribution type at params[1].

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
