### PR TITLE
Fix `test_event_reporter.py` setting incorrect variable

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -172,7 +172,7 @@ def test_report_with_failed_reporter_but_finished_jobs():
 
         # prevent router to receive messages
         mock_server.store_messages = False
-        mock_server.dont_ack_messages = True
+        mock_server.ack_messages = False
 
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
         reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=100, rss=10)))
@@ -197,7 +197,7 @@ def test_report_with_reconnected_reporter_but_finished_jobs():
         )
 
         # prevent router from receiving messages
-        mock_server.dont_ack_messages = True
+        mock_server.ack_messages = False
         mock_server.store_messages = False
 
         reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
@@ -206,7 +206,7 @@ def test_report_with_reconnected_reporter_but_finished_jobs():
         reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=1100, rss=10)))
 
         # enable router receiving messages
-        mock_server.dont_ack_messages = False
+        mock_server.ack_messages = True
         mock_server.store_messages = True
 
         reporter.report(Finish())


### PR DESCRIPTION
**Approach**
Commit b119765cbffa4f10f9699cde9663ecf34d844ad1 set the incorrect flag, dont_ack_messages instead of ack_messages. 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
