### PR TITLE
Skip plotting when no parameters are supplied

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/std_dev.py
+++ b/src/ert/gui/tools/plot/plottery/plots/std_dev.py
@@ -28,7 +28,9 @@ class StdDevPlot:
         std_dev_data: dict[str, npt.NDArray[np.float32]],
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
-        ensemble_count = len(plot_context.ensembles())
+        ensembles = plot_context.ensembles()
+        if (ensemble_count := len(ensembles)) == 0:
+            return
         layer = plot_context.layer
         if layer is not None:
             vmin: float = np.inf
@@ -40,7 +42,7 @@ class StdDevPlot:
             figure.set_layout_engine("constrained")
             gridspec = figure.add_gridspec(2, ensemble_count, hspace=0.2)
 
-            for i, ensemble in enumerate(reversed(plot_context.ensembles()), start=1):
+            for i, ensemble in enumerate(reversed(ensembles), start=1):
                 ax_heat = figure.add_subplot(gridspec[0, i - 1])
                 ax_box = figure.add_subplot(gridspec[1, i - 1])
                 data = std_dev_data[ensemble.name]

--- a/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
+++ b/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
@@ -49,3 +49,18 @@ def test_stddev_plot_shows_boxplot(plot_context: PlotContext):
         annotation[0].get_text()
         == f"Min: {min_value:.2f}\nMean: {mean_value:.2f}\nMax: {max_value:.2f}"
     )
+
+
+def test_that_stddev_plot_does_not_crash_and_returns_early_when_no_ensembles():
+    figure = Figure()
+    context = Mock(spec=PlotContext)
+    context.ensembles.return_value = []
+    context.layer = 0
+    StdDevPlot().plot(
+        figure,
+        context,
+        {},
+        {},
+        {},
+    )
+    assert len(figure.axes) == 0


### PR DESCRIPTION
**Issue**
Resolves #12981


**Approach**
Return early from `plot` function if no parameters are supplied. 
Include a small test to verify that no crash or plotting occurs when no parameters. 

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
