### PR TITLE
Narrow StandardESUpdate constructor parameters

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -285,7 +285,11 @@ def smoother_update(
             rng, SurfaceConfig, progress_callback
         )
         standard_strategy = StandardESUpdate(
-            smoother_snapshot, es_settings, rng, progress_callback
+            smoother_snapshot,
+            es_settings.inversion,
+            es_settings.enkf_truncation,
+            rng,
+            progress_callback,
         )
 
         for param_name in parameters:
@@ -308,7 +312,11 @@ def smoother_update(
     else:
         # Standard ES for all parameters
         standard_strategy = StandardESUpdate(
-            smoother_snapshot, es_settings, rng, progress_callback
+            smoother_snapshot,
+            es_settings.inversion,
+            es_settings.enkf_truncation,
+            rng,
+            progress_callback,
         )
         for param_name in parameters:
             strategy_map[param_name] = standard_strategy

--- a/src/ert/analysis/_update_strategies/__init__.py
+++ b/src/ert/analysis/_update_strategies/__init__.py
@@ -18,7 +18,8 @@ Example usage:
 
     # Create strategies with dependencies
     standard_strategy = StandardESUpdate(
-        smoother_snapshot, settings, rng, progress_callback
+        smoother_snapshot, settings.inversion, settings.enkf_truncation,
+        rng, progress_callback,
     )
     adaptive_strategy = AdaptiveLocalizationUpdate(
         settings.correlation_threshold, rng, progress_callback

--- a/src/ert/analysis/_update_strategies/_standard.py
+++ b/src/ert/analysis/_update_strategies/_standard.py
@@ -22,7 +22,7 @@ from ert.analysis.snapshots import SmootherSnapshot
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.config import ESSettings, ParameterConfig
+    from ert.config import ParameterConfig
 
     from ._protocol import ObservationContext
 
@@ -42,8 +42,10 @@ class StandardESUpdate:
     ----------
     smoother_snapshot : SmootherSnapshot
         Snapshot object for error reporting.
-    settings : ESSettings
-        ES analysis settings.
+    inversion : str
+        Inversion algorithm to use (e.g., "EXACT").
+    enkf_truncation : float
+        Singular value truncation threshold.
     rng : np.random.Generator
         Random number generator for reproducibility.
     progress_callback : Callable[[AnalysisEvent], None]
@@ -63,12 +65,14 @@ class StandardESUpdate:
     def __init__(
         self,
         smoother_snapshot: SmootherSnapshot,
-        settings: ESSettings,
+        inversion: str,
+        enkf_truncation: float,
         rng: np.random.Generator,
         progress_callback: Callable[[AnalysisEvent], None],
     ) -> None:
         self._smoother_snapshot = smoother_snapshot
-        self._settings = settings
+        self._inversion = inversion
+        self._enkf_truncation = enkf_truncation
         self._rng = rng
         self._progress_callback = progress_callback
         self._T: npt.NDArray[np.float64] | None = None
@@ -91,14 +95,14 @@ class StandardESUpdate:
             observations=obs_context.observation_values,
             alpha=1,
             seed=self._rng,
-            inversion=self._settings.inversion.lower(),
+            inversion=self._inversion.lower(),
         )
 
         try:
             self._T = smoother.compute_transition_matrix(
                 Y=obs_context.responses,
                 alpha=1.0,
-                truncation=self._settings.enkf_truncation,
+                truncation=self._enkf_truncation,
             )
         except scipy.linalg.LinAlgError as err:
             msg = (


### PR DESCRIPTION
Replace ESSettings dependency with the two fields actually used: inversion and enkf_truncation.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
