### PR TITLE
Set httpcore loglevel to WARNING for everserver

### DIFF
--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -58,6 +58,9 @@ def _configure_loggers(
             "uvicorn": {
                 "level": logging.WARNING,
             },
+            "httpcore": {
+                "level": logging.WARNING,
+            },
             EVERSERVER: {
                 "handlers": ["endpoint_log"],
                 "level": logging_level,


### PR DESCRIPTION
**Issue**
Resolves #13016


**Approach**
The everserver process builds its own logging configuration in `_configure_loggers()` (`src/everest/detached/everserver.py`) and does not load `logger.conf`. This means the `httpcore: WARNING` level already configured for Ert never applies to the everserver, causing `everest_output/everserver.log` to be flooded with DEBUG statements from httpcore.

This PR adds `httpcore` to the everserver's logging config dict with level `WARNING`, following the identical pattern already used for `uvicorn` in the same dict.

Note: `logger.conf` also suppresses `httpx_retries`. This PR keeps the change minimal to what the issue requests, but happy to add `httpx_retries` here too if desired.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')