### PR TITLE
Have _create_run_path progress show in GUI

### DIFF
--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -66,6 +66,7 @@ from ert.run_models.event import (
     EverestBatchResultEvent,
     RunModelDataEvent,
     RunModelErrorEvent,
+    RunPathCreationEvent,
 )
 from ert.shared.status.utils import (
     byte_with_unit,
@@ -74,7 +75,13 @@ from ert.shared.status.utils import (
 )
 
 from .queue_emitter import QueueEmitter
-from .view import DiskSpaceWidget, ProgressWidget, RealizationWidget, UpdateWidget
+from .view import (
+    DiskSpaceWidget,
+    ProgressWidget,
+    RealizationWidget,
+    RunpathCreationProgressWidget,
+    UpdateWidget,
+)
 from .view.disk_space_widget import MountType
 
 _TOTAL_PROGRESS_TEMPLATE = "Total progress {total_progress}% — {iteration_label}"
@@ -617,6 +624,28 @@ class RunDialog(QFrame):
                 self._tab_widget.setTabText(
                     event.batch, _batch_type_text(event.batch, batch_types)
                 )
+            case RunPathCreationEvent():
+                if event.sub_type == "StartingTotalRunPathCreation":
+                    runpath_creation_progress_widget = RunpathCreationProgressWidget(
+                        self
+                    )
+                    tab_index = self._tab_widget.addTab(
+                        runpath_creation_progress_widget, "Creating runpaths..."
+                    )
+                    self._tab_widget.setCurrentIndex(tab_index)
+                    runpath_creation_progress_widget.handle_event(event)
+                elif event.sub_type == "FinishedTotalRunPathCreation":
+                    last_index = self._tab_widget.count() - 1
+                    runpath_widget = self._tab_widget.widget(last_index)
+                    self._tab_widget.removeTab(last_index)
+                    if isinstance(runpath_widget, RunpathCreationProgressWidget):
+                        runpath_widget.deleteLater()
+                else:
+                    runpath_widget = self._tab_widget.widget(
+                        self._tab_widget.count() - 1
+                    )
+                    if isinstance(runpath_widget, RunpathCreationProgressWidget):
+                        runpath_widget.handle_event(event)
 
     def _get_update_widget(self, iteration: int) -> UpdateWidget:
         for i in range(self._tab_widget.count()):

--- a/src/ert/gui/experiments/view/__init__.py
+++ b/src/ert/gui/experiments/view/__init__.py
@@ -1,6 +1,13 @@
 from .disk_space_widget import DiskSpaceWidget
 from .progress_widget import ProgressWidget
 from .realization import RealizationWidget
+from .runpath_creation_widget import RunpathCreationProgressWidget
 from .update import UpdateWidget
 
-__all__ = ["DiskSpaceWidget", "ProgressWidget", "RealizationWidget", "UpdateWidget"]
+__all__ = [
+    "DiskSpaceWidget",
+    "ProgressWidget",
+    "RealizationWidget",
+    "RunpathCreationProgressWidget",
+    "UpdateWidget",
+]

--- a/src/ert/gui/experiments/view/runpath_creation_widget.py
+++ b/src/ert/gui/experiments/view/runpath_creation_widget.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from PyQt6.QtCore import QSize
+from PyQt6.QtGui import QMovie
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ert.run_models._create_run_path import RunPathCreationEvent
+
+
+class RunpathCreationProgressWidget(QWidget):
+    """Progress bar shown as a tab while runpaths are being created."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._total: int = 1
+
+        spin_movie = QMovie("img:loading.gif")
+        spin_movie.setSpeed(60)
+        spin_movie.setScaledSize(QSize(16, 16))
+        spin_movie.start()
+        self._spinner = QLabel()
+        self._spinner.setFixedSize(QSize(16, 16))
+        self._spinner.setMovie(spin_movie)
+
+        self._label = QLabel("Preparing runpaths...")
+
+        self._bar = QProgressBar()
+        self._bar.setRange(0, 1)
+        self._bar.setValue(0)
+        self._bar.setTextVisible(False)
+        self._bar.setFixedHeight(8)
+        self._bar.setStyleSheet("""
+            QProgressBar {
+                border: none;
+                border-radius: 4px;
+                background-color: rgba(128, 128, 128, 0.2);
+            }
+            QProgressBar::chunk {
+                border-radius: 4px;
+                background-color: #43A047;
+            }
+        """)
+
+        spinner_row = QHBoxLayout()
+        spinner_row.setSpacing(6)
+        spinner_row.addStretch()
+        spinner_row.addWidget(self._spinner)
+        spinner_row.addWidget(self._label)
+        spinner_row.addStretch()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+        layout.addWidget(self._bar)
+        layout.addLayout(spinner_row)
+        layout.addStretch()
+
+    def handle_event(self, event: RunPathCreationEvent) -> None:
+        if event.sub_type == "StartingTotalRunPathCreation":
+            self._total = (
+                1
+                if event.total_runpaths_to_create is None
+                else event.total_runpaths_to_create
+            )
+            self._bar.setRange(0, self._total)
+            self._bar.setValue(0)
+            self._label.setText(f"0 / {self._total} runpaths created")
+
+        elif event.sub_type == "TotalRunPathCreationUpdate":
+            if event.created_runpaths_count is not None:
+                self._bar.setValue(event.created_runpaths_count)
+                self._label.setText(
+                    f"{event.created_runpaths_count} / {self._total} runpaths created"
+                )

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -6,7 +6,7 @@ import math
 import os
 import time
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from copy import deepcopy
 from datetime import UTC, datetime
 from pathlib import Path
@@ -28,6 +28,7 @@ from ert.config import (
 from ert.config.design_matrix import DESIGN_MATRIX_GROUP
 from ert.config.distribution import LogNormalSettings, LogUnifSettings
 from ert.config.ert_config import create_forward_model_json
+from ert.run_models.event import RunPathCreationEvent
 from ert.substitutions import Substitutions, substitute_runpath_name
 from ert.utils import log_duration
 
@@ -274,6 +275,8 @@ def create_run_path(
     parameters_file: str,
     runpaths: Runpaths,
     context_env: dict[str, str] | None = None,
+    handle_run_path_creation_event: Callable[[RunPathCreationEvent], None]
+    | None = None,
 ) -> None:
     if context_env is None:
         context_env = {}
@@ -308,85 +311,110 @@ def create_run_path(
             for row in scalar_df.to_dicts()
         }
         timings["load_scalar_keys"] = time.perf_counter() - start_time
+    total_active_realizations = [run_arg.active for run_arg in run_args].count(True)
+    if handle_run_path_creation_event:
+        event = RunPathCreationEvent(
+            sub_type="StartingTotalRunPathCreation",
+            total_runpaths_to_create=total_active_realizations,
+        )
+        handle_run_path_creation_event(event)
 
-    for run_arg in run_args:
-        run_path = Path(run_arg.runpath)
-        if run_arg.active:
-            run_path.mkdir(parents=True, exist_ok=True)
-            start_time = time.perf_counter()
-            scalar_data = scalar_data_by_realization.get(run_arg.iens, {})
-
-            (param_data, detailed_parameter_timings) = _generate_parameter_files(
-                ensemble.experiment.parameter_configuration.values(),
-                parameters_file,
-                run_path,
-                run_arg.iens,
-                ensemble,
-                ensemble.iteration,
-                scalar_data=scalar_data,
-            )
-            for parameter_type, duration in detailed_parameter_timings.items():
-                if parameter_type not in timings:
-                    timings[parameter_type] = 0.0
-                timings[parameter_type] += duration
-
-            timings["generate_parameter_files"] += time.perf_counter() - start_time
-            real_iter_substituter = substituter.real_iter_substituter(
-                run_arg.iens, ensemble.iteration
-            )
-            param_substituter = _make_param_substituter(
-                real_iter_substituter, param_data
-            )
-            for (
-                source_file_content,
-                target_file,
-            ) in ensemble.experiment.templates_configuration:
+    try:
+        runpath_count = 0
+        for run_arg in run_args:
+            run_path = Path(run_arg.runpath)
+            if run_arg.active:
+                run_path.mkdir(parents=True, exist_ok=True)
                 start_time = time.perf_counter()
-                target_file = real_iter_substituter.substitute(target_file)
-                timings["substitute_real_iter"] += time.perf_counter() - start_time
-                start_time = time.perf_counter()
-                result = param_substituter.substitute(source_file_content)
-                timings["substitute_parameters"] += time.perf_counter() - start_time
-                start_time = time.perf_counter()
-                target = run_path / target_file
-                if not target.parent.exists():
-                    os.makedirs(
-                        target.parent,
-                        exist_ok=True,
-                    )
-                target.write_text(result)
-                timings["result_file_to_target"] += time.perf_counter() - start_time
+                scalar_data = scalar_data_by_realization.get(run_arg.iens, {})
 
-            path = run_path / "jobs.json"
-            start_time = time.perf_counter()
-            _backup_if_existing(path)
-            timings["backup_if_existing"] = time.perf_counter() - start_time
-            start_time = time.perf_counter()
-            forward_model_output = create_forward_model_json(
-                context=substitutions,
-                forward_model_steps=forward_model_steps,
-                user_config_file=user_config_file,
-                env_vars={**env_vars, **context_env},
-                env_pr_fm_step=env_pr_fm_step,
-                run_id=run_arg.run_id,
-                iens=run_arg.iens,
-                itr=ensemble.iteration,
-            )
-            Path(run_path / "jobs.json").write_bytes(
-                orjson.dumps(
-                    forward_model_output,
-                    option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
+                (param_data, detailed_parameter_timings) = _generate_parameter_files(
+                    ensemble.experiment.parameter_configuration.values(),
+                    parameters_file,
+                    run_path,
+                    run_arg.iens,
+                    ensemble,
+                    ensemble.iteration,
+                    scalar_data=scalar_data,
                 )
-            )
-            timings["jobs_to_json"] = time.perf_counter() - start_time
-            # Write MANIFEST file to runpath use to avoid NFS sync issues
-            start_time = time.perf_counter()
-            data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
-            Path(run_path / "manifest.json").write_bytes(
-                orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2)
-            )
-            timings["manifest_to_json"] = time.perf_counter() - start_time
-    logger.info(f"_create_run_path durations: {timings}")
-    runpaths.write_runpath_list(
-        [ensemble.iteration], [real.iens for real in run_args if real.active]
-    )
+                for parameter_type, duration in detailed_parameter_timings.items():
+                    if parameter_type not in timings:
+                        timings[parameter_type] = 0.0
+                    timings[parameter_type] += duration
+
+                timings["generate_parameter_files"] += time.perf_counter() - start_time
+                real_iter_substituter = substituter.real_iter_substituter(
+                    run_arg.iens, ensemble.iteration
+                )
+                param_substituter = _make_param_substituter(
+                    real_iter_substituter, param_data
+                )
+                for (
+                    source_file_content,
+                    target_file,
+                ) in ensemble.experiment.templates_configuration:
+                    start_time = time.perf_counter()
+                    target_file = real_iter_substituter.substitute(target_file)
+                    timings["substitute_real_iter"] += time.perf_counter() - start_time
+                    start_time = time.perf_counter()
+                    result = param_substituter.substitute(source_file_content)
+                    timings["substitute_parameters"] += time.perf_counter() - start_time
+                    start_time = time.perf_counter()
+                    target = run_path / target_file
+                    if not target.parent.exists():
+                        os.makedirs(
+                            target.parent,
+                            exist_ok=True,
+                        )
+                    target.write_text(result)
+                    timings["result_file_to_target"] += time.perf_counter() - start_time
+
+                path = run_path / "jobs.json"
+                start_time = time.perf_counter()
+                _backup_if_existing(path)
+                timings["backup_if_existing"] = time.perf_counter() - start_time
+                start_time = time.perf_counter()
+                forward_model_output = create_forward_model_json(
+                    context=substitutions,
+                    forward_model_steps=forward_model_steps,
+                    user_config_file=user_config_file,
+                    env_vars={**env_vars, **context_env},
+                    env_pr_fm_step=env_pr_fm_step,
+                    run_id=run_arg.run_id,
+                    iens=run_arg.iens,
+                    itr=ensemble.iteration,
+                )
+                Path(run_path / "jobs.json").write_bytes(
+                    orjson.dumps(
+                        forward_model_output,
+                        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
+                    )
+                )
+                timings["jobs_to_json"] = time.perf_counter() - start_time
+                # Write MANIFEST file to runpath use to avoid NFS sync issues
+                start_time = time.perf_counter()
+                data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
+                Path(run_path / "manifest.json").write_bytes(
+                    orjson.dumps(
+                        data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2
+                    )
+                )
+                timings["manifest_to_json"] = time.perf_counter() - start_time
+                runpath_count += 1
+                # Let upstream code know which runpath we just created
+                if handle_run_path_creation_event:
+                    event = RunPathCreationEvent(
+                        created_runpaths_count=runpath_count,
+                        total_runpaths_to_create=total_active_realizations,
+                        sub_type="TotalRunPathCreationUpdate",
+                    )
+                    handle_run_path_creation_event(event)
+
+        logger.info(f"_create_run_path durations: {timings}")
+        runpaths.write_runpath_list(
+            [ensemble.iteration], [real.iens for real in run_args if real.active]
+        )
+    finally:
+        if handle_run_path_creation_event:
+            event = RunPathCreationEvent(sub_type="FinishedTotalRunPathCreation")
+            handle_run_path_creation_event(event)

--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -88,6 +88,17 @@ class RunModelErrorEvent(RunModelEvent):
             self.data.to_csv("Report", output_path / str(self.run_id))
 
 
+class RunPathCreationEvent(BaseModel):
+    event_type: Literal["RunPathCreationEvent"] = "RunPathCreationEvent"
+    sub_type: Literal[
+        "StartingTotalRunPathCreation",
+        "FinishedTotalRunPathCreation",
+        "TotalRunPathCreationUpdate",
+    ]
+    created_runpaths_count: int | None = None
+    total_runpaths_to_create: int | None = None
+
+
 StatusEvents = (
     AnalysisStatusEvent
     | AnalysisTimeEvent
@@ -105,6 +116,7 @@ StatusEvents = (
     | StartEvent
     | WarningEvent
     | EnsembleEvaluationWarning
+    | RunPathCreationEvent
 )
 
 

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -784,6 +784,7 @@ class RunModel(RunModelConfig, ABC):
             parameters_file=self.runpath_config.gen_kw_export_name,
             runpaths=self._run_paths,
             context_env=self._context_env,
+            handle_run_path_creation_event=self.send_event,
         )
 
         self.run_workflows(

--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from queue import SimpleQueue
 from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
@@ -37,6 +38,9 @@ from ert.gui.experiments.multiple_data_assimilation_panel import (
     MultipleDataAssimilationPanel,
 )
 from ert.gui.experiments.view.realization import RealizationWidget
+from ert.gui.experiments.view.runpath_creation_widget import (
+    RunpathCreationProgressWidget,
+)
 from ert.gui.main import GUILogHandler, _setup_main_window
 from ert.gui.tools.file import FileDialog
 from ert.run_models import (
@@ -44,6 +48,7 @@ from ert.run_models import (
     EnsembleSmoother,
     MultipleDataAssimilation,
 )
+from ert.run_models._create_run_path import RunPathCreationEvent
 from ert.scheduler.job import Job
 from tests.ert import SnapshotBuilder
 from tests.ert.handle_run_path_dialog import handle_run_path_dialog
@@ -1070,3 +1075,84 @@ def test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog(
 
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=10000)
     assert run_dialog is not None
+
+
+def test_that_runpath_creation_events_add_update_and_remove_tab(qtbot: QtBot) -> None:
+    """After runpath creation is done the progress tab is removed and a subsequent
+    snapshot event must still produce a RealizationWidget tab as normal.
+    """
+    queue: SimpleQueue = SimpleQueue()
+    mock_api = MagicMock()
+    mock_api.experiment_name = "test"
+    notifier = MagicMock()
+
+    dialog = RunDialog("Test", mock_api, queue, notifier)
+    qtbot.addWidget(dialog)
+    dialog.setup_event_monitoring()
+
+    assert dialog._tab_widget.count() == 0
+
+    queue.put(
+        RunPathCreationEvent(
+            sub_type="StartingTotalRunPathCreation",
+            total_runpaths_to_create=3,
+        )
+    )
+    qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
+    assert "Creating runpaths" in dialog._tab_widget.tabText(0)
+    assert dialog._tab_widget.currentIndex() == 0
+    progress_widget = dialog._tab_widget.widget(0)
+    assert isinstance(progress_widget, RunpathCreationProgressWidget)
+    assert progress_widget._bar.maximum() == 3
+    assert progress_widget._bar.value() == 0
+
+    queue.put(
+        RunPathCreationEvent(
+            sub_type="TotalRunPathCreationUpdate",
+            created_runpaths_count=1,
+            total_runpaths_to_create=3,
+        )
+    )
+    qtbot.waitUntil(lambda: progress_widget._bar.value() == 1, timeout=2000)
+    assert "1 / 3" in progress_widget._label.text()
+
+    queue.put(
+        RunPathCreationEvent(
+            sub_type="TotalRunPathCreationUpdate",
+            created_runpaths_count=3,
+            total_runpaths_to_create=3,
+        )
+    )
+    qtbot.waitUntil(lambda: progress_widget._bar.value() == 3, timeout=2000)
+    assert "3 / 3" in progress_widget._label.text()
+
+    queue.put(RunPathCreationEvent(sub_type="FinishedTotalRunPathCreation"))
+    qtbot.waitUntil(lambda: dialog._tab_widget.count() == 0, timeout=2000)
+
+    # After the progress tab is removed the snapshot model must still add a
+    # RealizationWidget tab via rowsInserted and on_snapshot_new_iteration.
+    queue.put(
+        FullSnapshotEvent(
+            snapshot=(
+                SnapshotBuilder()
+                .add_fm_step(
+                    fm_step_id="0",
+                    index="0",
+                    name="fm_step_0",
+                    status=state.FORWARD_MODEL_STATE_START,
+                )
+                .build(["0", "1"], state.REALIZATION_STATE_UNKNOWN)
+            ),
+            iteration_label="Iter 0",
+            total_iterations=1,
+            progress=0.0,
+            realization_count=2,
+            status_count={"Unknown": 2},
+            iteration=0,
+        )
+    )
+    queue.put(EndEvent(failed=False, msg=""))
+
+    qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
+    assert isinstance(dialog._tab_widget.widget(0), RealizationWidget)
+    qtbot.waitUntil(dialog.is_experiment_done, timeout=2000)

--- a/tests/ert/unit_tests/gui/experiments/view/test_runpath_creation_widget.py
+++ b/tests/ert/unit_tests/gui/experiments/view/test_runpath_creation_widget.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pytestqt.qtbot import QtBot
+
+from ert.gui.experiments.view.runpath_creation_widget import (
+    RunpathCreationProgressWidget,
+)
+from ert.run_models.event import RunPathCreationEvent
+
+
+def _start(total: int = 5) -> RunPathCreationEvent:
+    return RunPathCreationEvent(
+        sub_type="StartingTotalRunPathCreation",
+        total_runpaths_to_create=total,
+    )
+
+
+def _update(n: int, total: int = 5) -> RunPathCreationEvent:
+    return RunPathCreationEvent(
+        sub_type="TotalRunPathCreationUpdate",
+        created_runpaths_count=n,
+        total_runpaths_to_create=total,
+    )
+
+
+def _finished() -> RunPathCreationEvent:
+    return RunPathCreationEvent(sub_type="FinishedTotalRunPathCreation")
+
+
+def test_that_widget_shows_correct_state_on_start(qtbot: QtBot) -> None:
+    widget = RunpathCreationProgressWidget()
+    qtbot.addWidget(widget)
+
+    widget.handle_event(_start(total=10))
+
+    assert widget._bar.maximum() == 10
+    assert widget._bar.value() == 0
+    assert "0" in widget._label.text()
+    assert "10" in widget._label.text()
+
+
+def test_that_widget_updates_label_and_bar_on_progress_events(qtbot: QtBot) -> None:
+    widget = RunpathCreationProgressWidget()
+    qtbot.addWidget(widget)
+    widget.handle_event(_start(total=4))
+
+    widget.handle_event(_update(1, total=4))
+    assert widget._bar.value() == 1
+    assert "1" in widget._label.text()
+
+    widget.handle_event(_update(3, total=4))
+    assert widget._bar.value() == 3
+    assert "3" in widget._label.text()
+
+
+def test_that_finish_event_is_ignored_by_widget(qtbot: QtBot) -> None:
+    widget = RunpathCreationProgressWidget()
+    qtbot.addWidget(widget)
+    widget.handle_event(_start())
+    widget.handle_event(_finished())

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -21,7 +21,11 @@ from ert.config import (
 from ert.config.parsing import lark_parser
 from ert.plugins import get_site_plugins
 from ert.run_arg import create_run_arguments
-from ert.run_models._create_run_path import _make_param_substituter, create_run_path
+from ert.run_models._create_run_path import (
+    _make_param_substituter,
+    create_run_path,
+)
+from ert.run_models.event import RunPathCreationEvent
 from ert.runpaths import Runpaths
 from ert.sample_prior import sample_prior
 from ert.storage import (
@@ -1116,3 +1120,48 @@ def test_that_parameters_as_magic_strings_are_substituted():
         ).substitute("<a> and <b>")
         == "1.01 and value"
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_create_run_path_emits_expected_events(prior_ensemble) -> None:
+    config = ErtConfig.from_dict({"NUM_REALIZATIONS": 5})
+    runpaths = Runpaths.from_config(config)
+    active_realizations = [False, True, False, False, True, True]
+    active_iens = [i for i, active in enumerate(active_realizations) if active]
+    assert active_iens == [1, 4, 5]
+
+    run_args = create_run_arguments(runpaths, active_realizations, prior_ensemble)
+
+    events: list[RunPathCreationEvent] = []
+    create_run_path(
+        run_args=run_args,
+        ensemble=prior_ensemble,
+        user_config_file=str(config.user_config_file),
+        forward_model_steps=config.forward_model_steps,
+        env_vars=config.env_vars,
+        env_pr_fm_step=config.env_pr_fm_step,
+        substitutions=config.substitutions,
+        parameters_file="parameters",
+        runpaths=runpaths,
+        handle_run_path_creation_event=events.append,
+    )
+
+    expected_count = len(active_iens)
+    assert len(events) == expected_count + 2
+
+    assert events[0].sub_type == "StartingTotalRunPathCreation"
+    assert events[0].total_runpaths_to_create == expected_count
+
+    update_events = events[1:-1]
+    # created_runpaths_count must be a sequential creation counter (1, 2, 3),
+    # not the iens of the realization (1, 4, 5).
+    expected_created_runpaths_counts = list(range(1, expected_count + 1))
+    assert expected_created_runpaths_counts != active_iens  # confirm the two differ
+    for event, expected_number in zip(
+        update_events, expected_created_runpaths_counts, strict=True
+    ):
+        assert event.sub_type == "TotalRunPathCreationUpdate"
+        assert event.created_runpaths_count == expected_number
+        assert event.total_runpaths_to_create == expected_count
+
+    assert events[-1].sub_type == "FinishedTotalRunPathCreation"


### PR DESCRIPTION
**Issue**
Resolves #9947


**Approach**
This commit makes _create_run_path emit RunPathCreationEvents
when starting to create runpaths, one event for every runpath created,
and another event when all runpaths are created. This is forwarded to
the run_model, and in the end shown in the RunDialog.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
