### PR TITLE
Avoid using pl.concat when loading scalars

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -652,7 +652,6 @@ class LocalEnsemble(BaseMode):
     def load_scalars(
         self, group: str | None = None, realizations: npt.NDArray[np.int_] | None = None
     ) -> pl.DataFrame:
-        dataframes = []
         gen_kws = [
             p
             for p in self.experiment.parameter_configuration.values()
@@ -661,22 +660,16 @@ class LocalEnsemble(BaseMode):
             and (group is None or p.group_name == group)
         ]
 
-        for config in gen_kws:
-            df = self.load_parameters(config.name, realizations, transformed=True)
-            assert isinstance(df, pl.DataFrame)
-            df = df.rename(
-                {
-                    col: f"{config.group_name}:{col}"
-                    for col in df.columns
-                    if col != "realization"
-                }
-            )
-            dataframes.append(df)
-
-        if not dataframes:
+        if not gen_kws:
             return pl.DataFrame()
 
-        return pl.concat(dataframes, how="align")
+        df = self.load_scalar_keys(
+            [config.name for config in gen_kws], realizations, transformed=True
+        )
+        df = df.rename(
+            {config.name: f"{config.group_name}:{config.name}" for config in gen_kws}
+        )
+        return df
 
     @require_write
     def save_observation_scaling_factors(self, dataset: pl.DataFrame) -> None:

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -18,7 +18,7 @@ import pytest
 from httpx import RequestError
 from starlette.testclient import TestClient
 
-from ert.config import SummaryConfig
+from ert.config import GenKwConfig, SummaryConfig
 from ert.dark_storage import common
 from ert.dark_storage.app import app
 from ert.dark_storage.endpoints import ensembles, experiments
@@ -323,6 +323,36 @@ def test_plot_api_big_summary_memory_usage(
     os.remove("memray.bin")
     total_memory_usage = stats.total_memory_allocated / (1024**2)
     assert total_memory_usage < max_memory_mb
+
+
+def test_that_load_scalars_handles_many_genkw_keys(benchmark, tmp_path):
+    storage_path = tmp_path / "storage"
+
+    reals = 100
+    num_keys = 10000
+    parameter_configs = [
+        GenKwConfig(
+            name=f"P{i}",
+            distribution={"name": "uniform", "min": 0.0, "max": 1.0},
+        )
+        for i in range(num_keys)
+    ]
+
+    with open_storage(storage_path, mode="w") as storage:
+        exp = storage.create_experiment(
+            experiment_config={"parameter_configs": parameter_configs},
+            name="perf-exp",
+        )
+        ensemble = exp.create_ensemble(ensemble_size=reals, name="default")
+        rng = np.random.default_rng(42)
+        values = rng.standard_normal(size=(reals, num_keys)).astype(np.float32)
+        df = pl.DataFrame(values, schema=[cfg.name for cfg in parameter_configs])
+        df = df.insert_column(
+            0, pl.Series("realization", np.arange(reals, dtype=np.int32))
+        )
+        df.write_parquet(ensemble.mount_point / "SCALAR.parquet")
+
+        benchmark(ensemble.load_scalars)
 
 
 def test_plotter_on_all_snake_oil_responses_time(api_and_snake_oil_storage, benchmark):


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/13033


**Approach**
Use directly load_scalar_keys.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
