### PR TITLE
Move popd so that CONFIG is a valid relative path

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -76,12 +76,11 @@ run_everest_eightcells_test() {
 
     everest run "$CONFIG" --skip-prompt --debug --disable-monitoring
     STATUS=$?
-    popd || exit 1
-
     if [ $STATUS -ne 0 ]; then
         echo "Everest eightcells test failed. Running everest kill"
         everest kill "$CONFIG"
     fi
+    popd || exit 1
 
     # Clean up the temp folder removing folders older than 7 days
     find "$RUNNER_ROOT" -maxdepth 1 -mtime +7 -user f_scout_ci -type d -exec rm -r {} \;


### PR DESCRIPTION
**Issue**
Resolves failure that can be observed when github actions is not run with `set -e`

**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
