### PR TITLE
Validate UserInstalledErtScriptWorkflow jobs on workflow load

### DIFF
--- a/src/ert/config/workflow.py
+++ b/src/ert/config/workflow.py
@@ -8,7 +8,7 @@ from ert.base_model_context import BaseModelWithContextSupport
 
 from .parsing import ConfigValidationError, ErrorInfo, init_workflow_schema, parse
 from .parsing.types import Defines
-from .workflow_job import ErtScriptWorkflow, WorkflowJob
+from .workflow_job import BaseErtScriptWorkflow, WorkflowJob
 
 
 class Workflow(BaseModelWithContextSupport):
@@ -66,7 +66,7 @@ class Workflow(BaseModelWithContextSupport):
                         ).set_context(job_name_with_context)
                     )
                     continue
-                if isinstance(job, ErtScriptWorkflow):
+                if isinstance(job, BaseErtScriptWorkflow):
                     try:
                         job.load_ert_script_class().validate(instructions)
                     except ConfigValidationError as err:

--- a/tests/ert/unit_tests/config/test_workflow.py
+++ b/tests/ert/unit_tests/config/test_workflow.py
@@ -6,7 +6,13 @@ from pathlib import Path
 import pytest
 from hypothesis import given, strategies
 
+from ert import ErtScript
 from ert.config import ConfigValidationError, ExecutableWorkflow, Workflow
+from ert.config.workflow_job import (
+    SiteInstalledErtScriptWorkflow,
+    UserInstalledErtScriptWorkflow,
+)
+from ert.storage import Storage
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -184,3 +190,52 @@ def test_args_validation(config, expectation, min_args, max_args):
                 ),
             },
         )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_validate_is_called_for_user_installed_ertscript_workflows():
+    """Regression test: validate() should run for UserInstalledErtScriptWorkflow,
+    not only for SiteInstalledErtScriptWorkflow (ErtScriptWorkflow) on workflow load.
+    """
+    Path("user_installed_ertscript.py").write_text(
+        textwrap.dedent("""
+            from ert import ErtScript
+            from ert.config import ConfigValidationError
+            from ert.storage import Storage
+
+            class SomeWorkflowJob(ErtScript):
+                @staticmethod
+                def validate(args):
+                    raise ConfigValidationError("user_installed validation ran")
+
+                def run(self, storage: Storage):
+                    pass
+        """),
+        encoding="utf-8",
+    )
+    Path("workflow").write_text("MY_JOB\n", encoding="utf-8")
+
+    job = UserInstalledErtScriptWorkflow(
+        name="MY_JOB", source="user_installed_ertscript.py"
+    )
+
+    with pytest.raises(ConfigValidationError, match="user_installed validation ran"):
+        Workflow.from_file("workflow", None, {"MY_JOB": job})
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_validate_is_called_for_site_installed_ertscript_workflows():
+    class SomeWorkflowJob(ErtScript):
+        @staticmethod
+        def validate(args):
+            raise ConfigValidationError("site_installed validation ran")
+
+        def run(self, storage: Storage):
+            pass
+
+    Path("workflow").write_text("MY_JOB\n", encoding="utf-8")
+
+    job = SiteInstalledErtScriptWorkflow(name="MY_JOB", ert_script=SomeWorkflowJob)
+
+    with pytest.raises(ConfigValidationError, match="site_installed validation ran"):
+        Workflow.from_file("workflow", None, {"MY_JOB": job})


### PR DESCRIPTION
The isinstance check in _parse_command_list used ErtScriptWorkflow
(an alias for SiteInstalledErtScriptWorkflow),
so UserInstalledErtScriptWorkflow was silently skipped.
This was introduced in c00176432ce74cba5ee9b58213dddc1d3a82f219 when the
two types were split but the validation code was not updated accordingly.

Use BaseErtScriptWorkflow to cover both variants.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
