### PR TITLE
Set update_lockfile job to only update to older than 7 days

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: |
           echo "\`\`\`" > uv_output.md
-          uv lock --upgrade 2>&1 | tee -a uv_output.md
+          uv lock --upgrade --exclude-newer=P7D 2>&1 | tee -a uv_output.md
           echo "\`\`\`" >> uv_output.md
 
       - name: Create pull request

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     rev: 0.10.7
     hooks:
       - id: uv-lock
+        args: ["--exclude-newer=P7D"]
 
 - repo: local
   hooks:


### PR DESCRIPTION
This is to allow package managers some time to respond to security incidents.
See https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html .

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
