### PR TITLE
Fix misplaced progress callbacks in ES/EnIF updates

### DIFF
--- a/src/ert/analysis/_enif_update.py
+++ b/src/ert/analysis/_enif_update.py
@@ -124,7 +124,6 @@ def analysis_EnIF(
     observation_values = filtered_data["observations"].to_numpy()
     observation_errors = filtered_data["std"].to_numpy()
 
-    progress_callback(AnalysisStatusEvent(msg="Loading observations and responses.."))
     num_obs = len(observation_values)
 
     smoother_snapshot.observations_and_responses = preprocessed_data.drop(

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -117,6 +117,8 @@ def perform_ensemble_update(
     parameters = list(strategy_map.keys())
     iens_active_index = np.flatnonzero(ens_mask)
 
+    progress_callback(AnalysisStatusEvent(msg="Loading observations and responses.."))
+
     # Preprocess observations and responses
     preprocessed_data = _preprocess_observations_and_responses(
         ensemble=source_ensemble,
@@ -136,7 +138,6 @@ def perform_ensemble_update(
     observation_values = filtered_data["observations"].to_numpy()
     observation_errors = filtered_data[_OutlierColumns.scaled_std].to_numpy()
 
-    progress_callback(AnalysisStatusEvent(msg="Loading observations and responses.."))
     num_obs = len(observation_values)
 
     smoother_snapshot = SmootherSnapshot(


### PR DESCRIPTION
Move "Loading observations and responses" status message before the actual preprocessing call in _es_update.py, and remove the duplicate message in _enif_update.py.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
