### PR TITLE
Reorder komodo sourcing in eightcells test

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -62,8 +62,6 @@ run_everest_eightcells_test() {
     echo "EIGHTCELLS_RUNPATH: $EIGHTCELLS_RUNPATH"
 
     disable_komodo
-    # shellcheck source=/dev/null
-    source "${_KOMODO_ROOT}/${_FULL_RELEASE_NAME}/enable"
 
     CONFIG="everest/model/config.yml"
     if [[ "$CI_RUNNER_LABEL" == "azure" ]]; then
@@ -73,6 +71,9 @@ run_everest_eightcells_test() {
         sed -i "s/name: local/name: lsf/g" "$CONFIG"
         export PATH=$PATH:/global/bin
     fi
+
+    # shellcheck source=/dev/null
+    source "${_KOMODO_ROOT}/${_FULL_RELEASE_NAME}/enable"
 
     everest run "$CONFIG" --skip-prompt --debug --disable-monitoring
     STATUS=$?


### PR DESCRIPTION
Reorder so that komodo is sourced after `/global/bin` is added to PATH. This ensures that `/global/bin` is included in `_PRE_KOMODO_PATH ` and so it perseveres on the everserver side. Could be that the forwarding of `_PRE_KOMODO_PATH ` is new behaviour in LSF.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
