### PR TITLE
Add logging of summed cputime and walltime over all realizations

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import threading
 import traceback
@@ -311,23 +312,40 @@ class EnsembleEvaluator:
     async def _stopped_handler(self, events: Sequence[EnsembleSucceeded]) -> None:
         if self.ensemble.status == ENSEMBLE_STATE_FAILED:
             return
+        await self.log_cpu_and_memory_consumption()
+        await self._append_message(self.ensemble.update_snapshot(events))
 
+    async def log_cpu_and_memory_consumption(self) -> None:
         max_memory_usage = -1
+        walltime_seconds: float = 0.0
+        cputime_seconds: float = 0.0
+        num_cpu = -1
+
+        # Max memory is the max over all realizations
+        # Seconds are summed over all realizations
         for (real_id, _), fm_step in self.ensemble.snapshot.get_all_fm_steps().items():
-            # Infer max memory usage
             memory_usage = fm_step.get(ids.MAX_MEMORY_USAGE) or "-1"
             max_memory_usage = max(int(memory_usage), max_memory_usage)
 
-            self.detect_overspent_cpu(
-                self.ensemble.reals[int(real_id)].num_cpu, real_id, fm_step
-            )
+            now = datetime.datetime.now()
+            walltime_seconds += (
+                (fm_step.get(ids.END_TIME) or now)
+                - (fm_step.get(ids.START_TIME) or now)
+            ).total_seconds()
+            cputime_seconds += fm_step.get(ids.CPU_SECONDS) or 0
+
+            num_cpu = self.ensemble.reals[int(real_id)].num_cpu
+            self.detect_overspent_cpu(num_cpu, real_id, fm_step)
+
+        logger.info(
+            f"Ensemble resource usage: {walltime_seconds=:g} {cputime_seconds=:g} "
+            f"{num_cpu=} {max_memory_usage=}"
+        )  # num_cpu is asserted constant over ensemble
 
         logger.info(
             "Ensemble ran with maximum memory usage for a "
             f"single realization job: {max_memory_usage}"
         )
-
-        await self._append_message(self.ensemble.update_snapshot(events))
 
     async def _cancelled_handler(self, events: Sequence[EnsembleCancelled]) -> None:
         if self.ensemble.status != ENSEMBLE_STATE_FAILED:


### PR DESCRIPTION
**Issue**
Adds logging that can aid in evaluating how the compute resources are utilized.

**Approach**
Log more.

The nearby log statement on max_memory_usage becomes superfluous by this change but
was kept for backwards compatibility - can remove this later.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
