### PR TITLE
Remove timestamp from experiment name

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -91,7 +91,12 @@ class EnsembleSelectListWidget(QListWidget):
         )
         cutoff = self.MAXIMUM_SELECTED if is_everest else self.MINIMUM_SELECTED
         for i, ensemble in enumerate(sorted_ensembles):
-            it = QListWidgetItem(f"{ensemble.experiment_name} : {ensemble.name}")
+            item_text = (
+                f"{ensemble.experiment_name} : {ensemble.name}"
+                if not is_everest
+                else ensemble.name
+            )
+            it = QListWidgetItem(item_text)
             it.setData(EnsembleSelectListWidgetItemDataRole.ENSEMBLE, ensemble)
             it.setData(
                 EnsembleSelectListWidgetItemDataRole.COLOR_INDEX,
@@ -101,7 +106,7 @@ class EnsembleSelectListWidget(QListWidget):
             self.addItem(it)
             self._ensemble_count += 1
             it.setToolTip(
-                f"{ensemble.experiment_name} : {ensemble.name}\n"
+                f"{item_text}\n"
                 f"Toggle up to {self.MAXIMUM_SELECTED} plots or reorder by"
                 "drag & drop\n"
                 f"Order determines draw order and color"


### PR DESCRIPTION
Removes the same timestamp from from the gui side if `is_everest` is true else it keeps the orginal format.

**Issue**
Resolves #12954

new proposed changes on the ui looks like this:
<img width="940" height="682" alt="Screenshot from 2026-03-11 08-08-38" src="https://github.com/user-attachments/assets/9d083977-bd62-43b9-9023-038bf3721584" />

