### PR TITLE
Increase codpseed tests timeout 1800 -> 2400

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ log_cli = "false"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 360
-session_timeout = 1800
+session_timeout = 2400
 timeout_func_only = true # Do not apply timeout to fixtures which can be slow but cached
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Commit e30e52f added a performance test that takes some time, so the codspeed tests have started timing out. This commit should be reverted once the slow surface exports have been fixed

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
