### PR TITLE
Correct docstring of test_update_raises_on_singular_matrix

### DIFF
--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -319,18 +319,17 @@ def test_update_handles_precision_loss_in_std_dev(tmp_path):
 
 def test_update_raises_on_singular_matrix(tmp_path):
     """
-    This is a regression test for precision loss in calculating
-    standard deviation.
+    Tests that smoother_update raises ErtAnalysisError with a
+    "singular matrix" message when the transition matrix cannot be computed.
     """
     gen_kw = GenKwConfig(
         name="coeff_0",
         group="COEFFS",
         distribution={"name": "const", "value": 0.1},
     )
-    # The values given here are chosen so that when computing
-    # `ens_std = S.std(ddof=0, axis=1)`, ens_std[0] is not zero even though
-    # all responses have the same value: 5.08078746e07.
-    # This is due to precision loss.
+    # Two realizations with a near-zero observation error (1e-32) produce a
+    # rank-deficient system, triggering the singular matrix error when
+    # computing the transition matrix.
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(
             name="ensemble_smoother",


### PR DESCRIPTION
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
