### PR TITLE
Display data when hovering observations

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -62,7 +62,7 @@ class EnsemblePlot:
                 )
                 zorder -= 1
 
-        plotObservations(observation_data, plot_context, axes)
+        observation_bars = plotObservations(observation_data, plot_context, axes)
         plotHistory(plot_context, axes)
 
         default_x_label = "Date" if plot_context.isDateSupportActive() else "Index"
@@ -73,6 +73,33 @@ class EnsemblePlot:
             default_x_label=default_x_label,
             default_y_label="Value",
         )
+
+        def hover(event):
+            if not observation_bars:
+                return
+
+            observation_lines = observation_bars.lines[2][0]
+            observation_dots = observation_bars.lines[0]
+            contains_cursor, index = observation_lines.contains(event)
+            if contains_cursor:
+                annotation.set_visible(True)
+                index = int(index["ind"][0])
+                x, y = observation_dots.properties()["xydata"][index]
+                annotation.xy = (x, y)
+            else:
+                annotation.set_visible(False)
+
+            figure.canvas.draw_idle()
+
+        annotation = axes.annotate(
+            "Test",
+            xy=(0, 0),
+            xytext=(20, 20),
+            textcoords="offset points",
+            bbox={"boxstyle": "round", "fc": "w"},
+        )
+        annotation.set_visible(False)
+        figure.canvas.mpl_connect("motion_notify_event", hover)
 
     @staticmethod
     def _plotLines(

--- a/src/ert/gui/tools/plot/plottery/plots/observations.py
+++ b/src/ert/gui/tools/plot/plottery/plots/observations.py
@@ -4,6 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import numpy as np
+from matplotlib.container import ErrorbarContainer
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 
 def plotObservations(
     observation_data: DataFrame, plot_context: PlotContext, axes: Axes
-) -> None:
+) -> ErrorbarContainer | None:
     key = plot_context.key()
     config = plot_context.plotConfig()
     ensemble_list = plot_context.ensembles()
@@ -25,7 +26,7 @@ def plotObservations(
         and observation_data is not None
         and not observation_data.empty
     ):
-        _plotObservations(axes, config, observation_data, value_column=key)
+        return _plotObservations(axes, config, observation_data, value_column=key)
 
 
 def _plotObservations(
@@ -33,7 +34,7 @@ def _plotObservations(
     plot_config: PlotConfig,
     data: DataFrame,
     value_column: str,
-) -> None:
+) -> ErrorbarContainer:
     """
     Observations are always plotted on top. z-order set to 1000
 
@@ -76,7 +77,7 @@ def _plotObservations(
             "yerr": data.loc["STD"].to_numpy(),
         }
 
-    axes.errorbar(
+    return axes.errorbar(
         **errorbar_data,
         fmt=style.line_style,
         ecolor=style.color,


### PR DESCRIPTION
Resolves #12966 (not really)
This is as far as I've gotten on this issue.

I managed to display some information on hovering observations, but I believe I will make a mess trying to connect the RFT observation to response data to the plotter.

I don't think it's worth the potential headache, and using the `motion_notify_event` might be too resource heavy.

Someone else feel free to take inspiration from this and continue the journey.