### PR TITLE
Use config es_settings instead of hardcoded ESSettings

### DIFF
--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -14,7 +14,7 @@ import resfo
 import xtgeo
 
 from ert.analysis import build_strategy_map, smoother_update
-from ert.config import ErtConfig, ESSettings, ObservationSettings
+from ert.config import ErtConfig, ObservationSettings
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
 
@@ -486,7 +486,7 @@ def test_field_param_update_using_heat_equation_zero_var_params_and_adaptive_loc
         with warnings.catch_warnings(record=True) as record:
             warnings.simplefilter("always")  # Ensure all warnings are always recorded
             with caplog.at_level(logging.INFO):
-                es_settings = ESSettings(localization=True)
+                es_settings = config.analysis_config.es_settings
                 strategy_map = build_strategy_map(
                     parameters=config.ensemble_config.parameters,
                     param_configs=new_prior.experiment.parameter_configuration,

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -86,7 +86,7 @@ def test_update_report(
     )
     events = []
 
-    es_settings = ESSettings(inversion="SUBSPACE")
+    es_settings = ert_config.analysis_config.es_settings
     strategy_map = build_strategy_map(
         parameters=ert_config.ensemble_config.parameters,
         param_configs=prior_ens.experiment.parameter_configuration,
@@ -162,7 +162,7 @@ def test_update_report_with_different_observation_status_from_smoother_update(
     )
     events = []
 
-    es_settings = ESSettings(inversion="SUBSPACE")
+    es_settings = ert_config.analysis_config.es_settings
     strategy_map = build_strategy_map(
         parameters=ert_config.ensemble_config.parameters,
         param_configs=prior_ens.experiment.parameter_configuration,
@@ -446,9 +446,6 @@ def test_update_snapshot(
     ]
     ert_config = snake_oil_case_storage
 
-    # Making sure that row scaling with a row scaling factor of 1.0
-    # results in the same update as with ES.
-    # Note: seed must be the same!
     experiment = snake_oil_storage.get_experiment_by_name("ensemble-experiment")
     prior_ens = experiment.get_ensemble_by_name("default_0")
     posterior_ens = snake_oil_storage.create_ensemble(
@@ -459,10 +456,9 @@ def test_update_snapshot(
         prior_ensemble=prior_ens,
     )
 
-    # Make sure we always have the same seed in updates
     rng = np.random.default_rng(42)
 
-    es_settings = ESSettings(inversion="SUBSPACE")
+    es_settings = ert_config.analysis_config.es_settings
     strategy_map = build_strategy_map(
         parameters=list(ert_config.ensemble_config.parameters),
         param_configs=prior_ens.experiment.parameter_configuration,


### PR DESCRIPTION
Replace hardcoded `ESSettings(inversion="SUBSPACE")` and `ESSettings(localization=True)` with `config.analysis_config.es_settings` in integration and UI tests. Also remove stale comments in `test_update_snapshot`.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
