### PR TITLE
Fix logging of wait-time for everserver startup

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -6,6 +6,7 @@ import logging
 import signal
 import socket
 import threading
+import time
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
@@ -233,12 +234,17 @@ async def run_everest(options: argparse.Namespace) -> None:
 
     print("Waiting for server ...")
     logger.debug("Waiting for response from everserver")
+    wait_start_time: float = time.monotonic()
     client = create_ertserver_client(
         Path(ServerConfig.get_session_dir(options.config.output_dir))
     )
     wait_for_server(client, timeout=600)
     print("Everest server found!")
-    logger.info("Got response from everserver. Starting experiment")
+    logger.info(
+        "Got response from everserver after "
+        f"waiting for {time.monotonic() - wait_start_time:g} seconds. "
+        "Starting experiment"
+    )
 
     start_experiment(
         server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -128,24 +128,27 @@ def extract_errors_from_file(path: str) -> list[str]:
 
 def wait_for_server(client: Client, timeout: float) -> None:
     """
-    Waits until the everest server has started. Polls every second
+    Waits until the everest server has started. Polls
     for server availability until timeout (measured in seconds).
 
-    Raise an exception if no response within the timeout.
+    Timeout is not strict as the server status is polled periodically and
+    each underlying HTTP request has its own timeout, the wall-clock
+    duration may exceed the requested timeout slightly.
+
+    Raises an exception if no response within the timeout.
     """
-    sleep_time: float = 1.0
-    slept_time: float = 0.0
-    while slept_time <= timeout:
+    wait_start_time: float = time.monotonic()
+    while time.monotonic() - wait_start_time <= timeout:
         if server_is_running(
             *ServerConfig.get_server_context_from_conn_info(client.conn_info)
         ):
-            logger.info(f"Waited {slept_time:g} seconds before everest server was up")
             return
-        if slept_time + sleep_time > timeout:
-            break
-        time.sleep(sleep_time)
-        slept_time += sleep_time
-    raise RuntimeError(f"Failed to get reply from server within {slept_time:g} seconds")
+        until_timeout = max(0, timeout - (time.monotonic() - wait_start_time))
+        time.sleep(min(1, until_timeout))
+    raise RuntimeError(
+        "Failed to get reply from server "
+        f"within {time.monotonic() - wait_start_time:g} seconds"
+    )
 
 
 def wait_for_server_to_stop(


### PR DESCRIPTION
**Issue**
Resolves #13009 

**Approach**
Rethink.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
