### PR TITLE
Deprecate the well section in Everest configs

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -313,6 +313,8 @@ class EverestConfig(BaseModelWithContextSupport):
         default=None,
         description=dedent(
             """
+            [Deprecated]
+
             An optional list of well configurations.
 
             Each well configuration consists of a `name` field, and an optional
@@ -874,6 +876,12 @@ to read summary data from forward model, do:
         return self
 
     @model_validator(mode="after")
+    def deprecate_wells(self) -> Self:
+        if "wells" in self.model_fields_set:
+            ConfigWarning.deprecation_warn(_WELLS_DEPRECATION)
+        return self
+
+    @model_validator(mode="after")
     def validate_that_environment_sim_folder_is_writeable(self) -> Self:
         environment = self.environment
         config_path = self.config_path
@@ -1149,3 +1157,44 @@ to read summary data from forward model, do:
             upper_bounds=[c.upper_bound for c in self.output_constraints],
             lower_bounds=[c.lower_bound for c in self.output_constraints],
         )
+
+
+_WELLS_DEPRECATION = """
+The `wells` section is deprecated and will be removed in a future version.
+
+The contents of the `wells` section is currently saved as a `wells.json` file in
+the working directory of each forward model run. It may be used as an input by
+the forward model. After removal of the `wells` section this file will not be
+generated anymore.
+
+Please remove the `wells` section and replace its functionality using one of the
+following options:
+
+1. No action is needed if none of your forward models require `wells.json`.
+
+2. If only the well names are needed, the forward model can read them from the
+   generated control files. For each entry in the `controls` section of the
+   configuration file, Everest generates a JSON file with the name of the
+   `control` group. These can be used instead of `wells.json`.
+
+3. Consult the documentation of the forward models. Some support entering the
+   required information from the `wells` section directly into the configuration
+   of the forward model itself.
+
+4. As a last resort: Create a YAML or a JSON file with the same content as the
+   `wells` section, and install it using an `install_data` entry in the Everest
+   configuration file:
+
+      install_data:
+        - source: <path_to_file>/wells.yaml
+            target: wells.yaml
+
+   Or: copy the content of the `wells` into an `install_data` entry to generate
+   a JSON file:
+
+      install_data:
+        - target: wells.json
+            data:
+            - name: INJ
+            - name: PROD
+"""

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -66,7 +66,7 @@ class InstallDataConfig(BaseModel):
             """
         ),
     )
-    data: dict[str, Any] | None = Field(
+    data: dict[str, Any] | list[Any] | None = Field(
         default=None,
         description=dedent(
             """

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -173,7 +173,6 @@ def test_that_control_variable_name_with_too_many_dots_is_invalid(min_config):
 def test_that_control_variable_without_too_many_dots_does_not_raise(min_config):
     weirdo_name = "something/with-symbols_=/()*&%$#!"
     min_config["controls"][0]["variables"][0]["name"] = weirdo_name
-    min_config["wells"] = [{"name": weirdo_name}]
     new_config = EverestConfig.model_validate(min_config)
     EverestConfig.model_validate(new_config.to_dict())
 

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -88,9 +88,6 @@ def test_that_optimization_config_is_initialized_with_cvar_config():
 
 def test_that_get_output_dir_returns_same_for_old_and_new():
     config_src = {
-        "wells": [
-            {"name": "w00"},
-        ],
         "controls": [
             {
                 "name": "group_0",
@@ -266,14 +263,6 @@ def test_that_log_level_property_is_consistent_with_environment_log_level():
     This test verifies that the computed setter/getter works as intended
     """
     config_src = {
-        "wells": [
-            {
-                "name": "dog",
-            },
-            {
-                "name": "w01",
-            },
-        ],
         "controls": [
             {
                 "name": "group_0",

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -47,9 +47,6 @@ def test_default_installed_jobs(tmp_path, monkeypatch):
     "config_yaml",
     [
         dedent("""
-    wells: [{ name: test}]
-    """),
-        dedent("""
     controls:
       - name: my_control
         type: well_control

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 
 import everest
 from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigWarning
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
@@ -162,7 +163,8 @@ def test_install_template(change_to_tmpdir):
     Path("the_optimal_template.tmpl").write_text(
         THE_OPTIMAL_TEMPLATE_TMPL, encoding="utf-8"
     )
-    config = EverestConfig.load_file("config.yml")
+    with pytest.warns(ConfigWarning, match="The `wells` section is deprecated"):
+        config = EverestConfig.load_file("config.yml")
     site_plugins = get_site_plugins()
     with use_runtime_plugins(get_site_plugins()):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)

--- a/tests/everest/test_wells.py
+++ b/tests/everest/test_wells.py
@@ -3,6 +3,7 @@ from contextlib import ExitStack as does_not_raise
 
 import pytest
 
+from ert.config import ConfigWarning
 from ert.run_models.everest_run_model import _get_internal_files
 from everest.config import EverestConfig, WellConfig
 
@@ -73,7 +74,8 @@ def test_that_well_names_must_be_unique(min_config):
 def test_well_config_to_wells_json(min_config, monkeypatch, tmp_path, config):
     monkeypatch.chdir(tmp_path)
     min_config["wells"] = config
-    ever_config = EverestConfig(**min_config)
+    with pytest.warns(ConfigWarning, match="The `wells` section is deprecated"):
+        ever_config = EverestConfig(**min_config)
     for datafile, data in _get_internal_files(ever_config).items():
         datafile.parent.mkdir(exist_ok=True, parents=True)
         datafile.write_text(data, encoding="utf-8")
@@ -105,3 +107,11 @@ def test_controls_config_to_wells_json(min_config, monkeypatch, tmp_path, variab
     with open("everest_output/.internal_data/wells.json", encoding="utf-8") as fin:
         wells_json = json.load(fin)
     assert wells_json == [{"name": "test"}]
+
+
+def test_that_wells_section_is_deprecated(min_config, monkeypatch, tmp_path):
+    min_config["controls"][0]["variables"] = [{"name": "test", "initial_guess": 0.1}]
+    monkeypatch.chdir(tmp_path)
+    min_config["wells"] = [{"name": "test"}]
+    with pytest.warns(ConfigWarning, match="The `wells` section is deprecated"):
+        EverestConfig(**min_config)


### PR DESCRIPTION
**Issue**
Resolves #13077


**Approach**
This PR adds a deprecation warning that prints instructions to replace the functionality of the `wells` section in the Everest configuration file.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
