### PR TITLE
Remove observations available everest

### DIFF
--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -106,9 +106,11 @@ class DataTypeKeysWidget(QWidget):
         layout.addWidget(self.data_type_keys_widget, 2)
         layout.addStretch()
 
-        if(not is_everest):
+        if not is_everest:
             layout.addWidget(
-                _Legend("Observations available", DataTypeKeysListModel.HAS_OBSERVATIONS)
+                _Legend(
+                    "Observations available", DataTypeKeysListModel.HAS_OBSERVATIONS
+                )
             )
 
         self.setLayout(layout)

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -251,7 +251,9 @@ class PlotWindow(QMainWindow):
 
             plot_case_objects = [obj for obj in ensembles if not obj.hidden]
 
-            self._data_type_keys_widget = DataTypeKeysWidget(self._key_definitions, is_everest)
+            self._data_type_keys_widget = DataTypeKeysWidget(
+                self._key_definitions, is_everest
+            )
             self._data_type_keys_widget.dataTypeKeySelected.connect(self.keySelected)
             self.addDock("Data types", self._data_type_keys_widget)
 


### PR DESCRIPTION
**Issue**
Resolves #12955


**Approach**
Used the `is_everest` boolean from `plot_window.py` as a flag for conditional inclusion of the legend. Added `is_everest` as param for `DataTypeKeysWidget`

<img width="2438" height="658" alt="image" src="https://github.com/user-attachments/assets/68a4929b-d665-455e-8e5e-c91f36024a7b" />

