### PR TITLE
Set seed in gui observation disabled test

### DIFF
--- a/tests/ert/ui_tests/gui/test_update_runs.py
+++ b/tests/ert/ui_tests/gui/test_update_runs.py
@@ -196,6 +196,9 @@ def poly_case_with_one_missing_response(source_root, tmp_path, run_experiment):
     """
     _new_poly_example(source_root, tmp_path, 2)
     config_path = tmp_path / "poly.ert"
+    # ensures observations are not disabled due to unlucky responses
+    with open(config_path, "a", encoding="utf-8") as f:
+        f.write("\nRANDOM_SEED 1234\n")
 
     with open_gui_with_config(config_path) as gui:
         run_experiment(EnsembleExperiment, gui)


### PR DESCRIPTION
Random seed caused some observations to become "Deactivated, outlier".
That in turn made the test flaky.