### PR TITLE
Remove deprecated USE_EE and USE_GE analysis config keys

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -1582,26 +1582,21 @@ ANALYSIS_SET_VAR keyword for the `STD_ENKF` module.
 INVERSION
 ^^^^^^^^^
 
-The analysis modules can specify inversion algorithm used.
-These can be manipulated from the config file using the
-ANALYSIS_SET_VAR keyword for the `STD_ENKF` module.
+Specifies the inversion algorithm used in the analysis step.
+Two options are available for the ``STD_ENKF`` module:
 
-**STD_ENKF**
+``EXACT`` — exact inversion using a Cholesky factorization (default)::
 
+    ANALYSIS_SET_VAR STD_ENKF INVERSION EXACT
 
-.. list-table:: Inversion Algorithms for Ensemble Smoother
-   :widths: 50 50 50
-   :header-rows: 1
+``SUBSPACE`` — approximate subspace inversion::
 
-   * - Description
-     - INVERSION
-     - Note
-   * - Exact inversion with diagonal R=I
-     - Deprecated: exact, 0
-     - Preferred name: EXACT
-   * - Subspace inversion with exact R
-     - Deprecated: SUBSPACE_EXACT_R, subspace, 1
-     - Preferred name: SUBSPACE
+    ANALYSIS_SET_VAR STD_ENKF INVERSION SUBSPACE
+
+When using ``SUBSPACE``, you may also want to tune the singular value
+truncation threshold (see :ref:`ENKF_TRUNCATION <enkf_truncation>`)::
+
+    ANALYSIS_SET_VAR STD_ENKF ENKF_TRUNCATION 0.95
 
 .. _localization:
 

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -104,7 +104,6 @@ class AnalysisConfig:
             }
         }
         deprecated_keys = ["ENKF_NCOMP", "ENKF_SUBSPACE_DIMENSION"]
-        deprecated_inversion_keys = ["USE_EE", "USE_GE"]
         errors = []
         all_errors = []
 
@@ -130,16 +129,6 @@ class AnalysisConfig:
                 errors.append(var_name)
                 continue
             if var_name == "ENKF_FORCE_NCOMP":
-                continue
-            if var_name in deprecated_inversion_keys:
-                all_errors.append(
-                    ConfigValidationError(
-                        f"Keyword {var_name} has been replaced by INVERSION and "
-                        "has no effect.\n\nPlease see "
-                        "https://ert.readthedocs.io/en/latest/reference/configuration/keywords.html#inversion-algorithm "  # noqa: E501
-                        "for documentation how to use this instead."
-                    )
-                )
                 continue
             if var_name == "INVERSION":
                 if value in inversion_str_map[module_name]:

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1523,8 +1523,6 @@ def test_validate_no_logs_when_overwriting_with_same_value(caplog):
 @pytest.mark.parametrize(
     ("obsolete_analysis_keyword", "error_msg"),
     [
-        ("USE_EE", "Keyword USE_EE has been replaced"),
-        ("USE_GE", "Keyword USE_GE has been replaced"),
         ("ENKF_NCOMP", r"ENKF_NCOMP keyword\(s\) has been removed"),
         (
             "ENKF_SUBSPACE_DIMENSION",


### PR DESCRIPTION
Given go-ahead here: https://equinor.slack.com/archives/C01MCMWD075/p1773232109000519

These keys were long-deprecated aliases for INVERSION and have been emitting config errors for some time. Remove the validation handling and associated tests.

Also rewrite the INVERSION docs section: replace the outdated table (which listed the removed aliases) with clear prose and usage examples for the two current options, EXACT and SUBSPACE.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
