### PR TITLE
Relax parameter array dtype from float64 to np.floating

### DIFF
--- a/src/ert/analysis/_update_strategies/_adaptive.py
+++ b/src/ert/analysis/_update_strategies/_adaptive.py
@@ -169,15 +169,15 @@ class AdaptiveLocalizationUpdate:
 
     def update(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         """Update parameters using adaptive localization with batching.
 
         Parameters
         ----------
-        param_ensemble : npt.NDArray[np.float64]
+        param_ensemble : npt.NDArray[np.floating]
             Parameter ensemble array.
         param_config : ParameterConfig
             Configuration for this parameter type.
@@ -186,7 +186,7 @@ class AdaptiveLocalizationUpdate:
 
         Returns
         -------
-        npt.NDArray[np.float64]
+        npt.NDArray[np.floating]
             Updated parameter ensemble array.
 
         Raises

--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -62,10 +62,10 @@ class DistanceLocalizationUpdate:
 
     def update(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         if self._obs_loc is None or self._smoother is None:
             raise RuntimeError("prepare() must be called before update()")
 
@@ -95,9 +95,9 @@ class DistanceLocalizationUpdate:
 
     def _update_field(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: Field,
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         assert self._obs_loc is not None
         assert self._smoother is not None
 
@@ -120,7 +120,7 @@ class DistanceLocalizationUpdate:
 
         ellipse_rotation = transform_local_ellipse_angle_to_local_coords(
             ertbox.rotation_angle,
-            np.zeros_like(self._obs_loc.main_range, dtype=np.float64),
+            np.zeros_like(self._obs_loc.main_range),
         )
 
         rho_matrix = calc_rho_for_2d_grid_layer(
@@ -145,9 +145,9 @@ class DistanceLocalizationUpdate:
 
     def _update_surface(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: SurfaceConfig,
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         assert self._obs_loc is not None
         assert self._smoother is not None
 
@@ -160,7 +160,7 @@ class DistanceLocalizationUpdate:
 
         rotation_angle = transform_local_ellipse_angle_to_local_coords(
             param_config.rotation,
-            np.zeros_like(self._obs_loc.main_range, dtype=np.float64),
+            np.zeros_like(self._obs_loc.main_range, dtype=np.floating),
         )
 
         if param_config.yflip != 1:

--- a/src/ert/analysis/_update_strategies/_protocol.py
+++ b/src/ert/analysis/_update_strategies/_protocol.py
@@ -173,15 +173,15 @@ class UpdateStrategy(Protocol):
 
     def update(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         """Update parameters using this strategy's algorithm.
 
         Parameters
         ----------
-        param_ensemble : npt.NDArray[np.float64]
+        param_ensemble : npt.NDArray[np.floating]
             Parameter ensemble array (num_params x ensemble_size).
         param_config : ParameterConfig
             Configuration for this parameter type.
@@ -190,7 +190,7 @@ class UpdateStrategy(Protocol):
 
         Returns
         -------
-        npt.NDArray[np.float64]
+        npt.NDArray[np.floating]
             Updated parameter ensemble array.
         """
         ...

--- a/src/ert/analysis/_update_strategies/_standard.py
+++ b/src/ert/analysis/_update_strategies/_standard.py
@@ -109,17 +109,17 @@ class StandardESUpdate:
 
     def update(
         self,
-        param_ensemble: npt.NDArray[np.float64],
+        param_ensemble: npt.NDArray[np.floating],
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         """Apply the transition matrix to update parameters.
 
         Only parameters with non-zero variance are updated.
 
         Parameters
         ----------
-        param_ensemble : npt.NDArray[np.float64]
+        param_ensemble : npt.NDArray[np.floating]
             Parameter ensemble array.
         param_config : ParameterConfig
             Configuration for this parameter type.
@@ -128,7 +128,7 @@ class StandardESUpdate:
 
         Returns
         -------
-        npt.NDArray[np.float64]
+        npt.NDArray[np.floating]
             Updated parameter ensemble array.
 
         Raises

--- a/src/ert/config/everest_control.py
+++ b/src/ert/config/everest_control.py
@@ -200,7 +200,7 @@ class EverestControl(ParameterConfig):
 
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
+        from_data: npt.NDArray[np.floating],
         iens_active_index: npt.NDArray[np.int_],
     ) -> Iterator[tuple[None, pl.DataFrame]]:
         df = pl.DataFrame(

--- a/src/ert/config/field.py
+++ b/src/ert/config/field.py
@@ -217,7 +217,7 @@ class Field(ParameterConfig):
 
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
+        from_data: npt.NDArray[np.floating],
         iens_active_index: npt.NDArray[np.int_],
     ) -> Iterator[tuple[int, xr.Dataset]]:
         dim_nx, dim_ny, dim_nz = (
@@ -233,7 +233,7 @@ class Field(ParameterConfig):
 
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         ds = ensemble.load_parameters(self.name, realizations)
         assert isinstance(ds, xr.Dataset)
         ensemble_size = len(ds.realizations)
@@ -252,7 +252,7 @@ class Field(ParameterConfig):
 
     def _transform_data(
         self, data_array: xr.DataArray
-    ) -> np.ma.MaskedArray[Any, np.dtype[np.float32]]:
+    ) -> np.ma.MaskedArray[Any, np.dtype[np.floating]]:
         return np.ma.MaskedArray(
             _field_truncate(
                 field_transform(

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -318,7 +318,7 @@ class GenKwConfig(ParameterConfig):
 
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         return (
             ensemble.load_parameters(self.name, realizations)
             .drop("realization")
@@ -328,7 +328,7 @@ class GenKwConfig(ParameterConfig):
 
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
+        from_data: npt.NDArray[np.floating],
         iens_active_index: npt.NDArray[np.int_],
     ) -> Iterator[tuple[int | None, pl.DataFrame]]:
         yield (
@@ -351,7 +351,7 @@ class GenKwConfig(ParameterConfig):
             }
         ]
 
-    def transform_numpy(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    def transform_numpy(self, x: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
         return self.distribution.transform_numpy(x)
 
     @classmethod

--- a/src/ert/config/parameter_config.py
+++ b/src/ert/config/parameter_config.py
@@ -85,7 +85,7 @@ class ParameterConfig(BaseModel):
     @abstractmethod
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
+        from_data: npt.NDArray[np.floating],
         iens_active_index: npt.NDArray[np.int_],
     ) -> Iterator[tuple[int | None, pl.DataFrame | xr.Dataset]]:
         """
@@ -96,7 +96,7 @@ class ParameterConfig(BaseModel):
     @abstractmethod
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         """
         Load the parameter from internal storage for the given ensemble.
         Must return array of shape (number of parameters, number of realizations).
@@ -123,7 +123,7 @@ class ParameterConfig(BaseModel):
     def group_name(self) -> str | None:
         return self.name
 
-    def transform_numpy(self, x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    def transform_numpy(self, x: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
         return x
 
     def transform_series(self, series: pl.Series) -> pl.Series:
@@ -137,7 +137,7 @@ class ParameterConfig(BaseModel):
 
     def sample_values(
         self, global_seed: str, active_realizations: list[int], num_realizations: int
-    ) -> npt.NDArray[np.double]:
+    ) -> npt.NDArray[np.floating]:
         """
         Generate reproducible standard-normal samples for active realizations.
 
@@ -155,7 +155,7 @@ class ParameterConfig(BaseModel):
         for a given global_seed regardless of currently active realizations.
 
         Returns:
-        - npt.NDArray[np.double]: Array of shape (len(active_realizations),
+        - npt.NDArray[np.floating]: Array of shape (len(active_realizations),
         containing sample values, one for each `active_realization`.
         """
         key_hash = sha256(

--- a/src/ert/config/surface_config.py
+++ b/src/ert/config/surface_config.py
@@ -189,7 +189,7 @@ class SurfaceConfig(ParameterConfig):
 
     def create_storage_datasets(
         self,
-        from_data: npt.NDArray[np.float64],
+        from_data: npt.NDArray[np.floating],
         iens_active_index: npt.NDArray[np.int_],
     ) -> Iterator[tuple[int, xr.Dataset]]:
         for i, realization in enumerate(iens_active_index):
@@ -219,7 +219,7 @@ class SurfaceConfig(ParameterConfig):
 
     def load_parameters(
         self, ensemble: Ensemble, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         ds = ensemble.load_parameters(self.name, realizations)
         assert isinstance(ds, xr.Dataset)
         ensemble_size = len(ds.realizations)

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -595,7 +595,7 @@ class LocalEnsemble(BaseMode):
 
     def load_parameters_numpy(
         self, group: str, realizations: npt.NDArray[np.int_]
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         if group in self.experiment.parameter_configuration:
             config = self.experiment.parameter_configuration[group]
             return config.load_parameters(self, realizations)
@@ -617,7 +617,7 @@ class LocalEnsemble(BaseMode):
 
     def save_parameters_numpy(
         self,
-        parameters: npt.NDArray[np.float64],
+        parameters: npt.NDArray[np.floating],
         param_group: str,
         iens_active_index: npt.NDArray[np.int_],
     ) -> None:
@@ -881,7 +881,7 @@ class LocalEnsemble(BaseMode):
 
     def calculate_std_dev_for_parameter_group(
         self, parameter_group: str
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.floating]:
         data = self.load_parameters(parameter_group)
         if isinstance(data, pl.DataFrame):
             return data.drop("realization").std().to_numpy().reshape(-1)


### PR DESCRIPTION
Fields and surfaces are typically stored as float32 to save memory, while scalars tend to use float64. There is no strong reason to enforce a specific width, so broaden the type annotations.

One of the tests failed on the first run of this PR which uncovered what looks like a flaky test. Fix here:
https://github.com/equinor/ert/pull/13105

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
