### PR TITLE
Deprecate control type

### DIFF
--- a/docs/everest/example.rst
+++ b/docs/everest/example.rst
@@ -34,7 +34,6 @@ everest_config.yml::
     controls:
       -
         name: point
-        type: generic_control
         min: -1.0
         max: 1.0
         initial_guess: 0
@@ -59,7 +58,6 @@ everest_config.yml::
     controls:
       -
         name: point
-        type: generic_control
         initial_guess: 0
         perturbation_magnitude : 0.001
         variables:
@@ -223,7 +221,6 @@ everest_config.yml::
     controls:
       -
         name: point
-        type: generic_control
         min: -1.0
         max: 1.0
         initial_guess: 0

--- a/src/everest/config/control_config.py
+++ b/src/everest/config/control_config.py
@@ -12,7 +12,7 @@ from typing import (
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, model_validator
 from ropt.enums import PerturbationType, VariableType
 
-from ert.config import EverestControl, SamplerConfig
+from ert.config import ConfigWarning, EverestControl, SamplerConfig
 
 from .control_variable_config import (
     ControlVariableConfig,
@@ -59,18 +59,26 @@ class ControlConfig(BaseModel):
         )
     )
     type: Literal["well_control", "generic_control"] = Field(
+        default="generic_control",
         description=dedent(
             r"""
+            [Deprecated]
+
             Control group type.
 
-            Only two allowed control types are accepted:
+            Two control types are accepted:
 
-            * `"well_control"`: Standard built-in Everest control type designed
-              for field optimization
-            * `"generic_control"`: Enables the user to define controls types to
-              be employed for customized optimization jobs.
+            * `"well_control"`: Indicates that the variable names in the group
+              are used to denote wells.
+            * `"generic_control"`: Indicates a generic group of variables.
+
+            The `type` field is currently only used in combination with the
+            `wells` section to validate well names. The `wells` section will be
+            removed in a future version, and `type` is deprecated and slated for
+            removal at the same time. The `type` field is now optional and may
+            be removed from your configuration if no `wells` section is defined.
             """
-        )
+        ),
     )
     variables: Annotated[
         ControlVariable,
@@ -286,6 +294,12 @@ class ControlConfig(BaseModel):
             raise ValueError(error)
         return self
 
+    @model_validator(mode="after")
+    def deprecate_wells(self) -> Self:
+        if "type" in self.model_fields_set:
+            ConfigWarning.deprecation_warn(_CONTROL_TYPE_DEPRECATION)
+        return self
+
     def __hash__(self) -> int:
         return hash(self.name)
 
@@ -388,3 +402,13 @@ class ControlConfig(BaseModel):
                 idx += 1
 
         return controls
+
+
+_CONTROL_TYPE_DEPRECATION = """
+The `controls.type` field is deprecated and will be removed in a future version.
+
+The `type` field in the `controls` section is used in combination with the
+`wells` section, which is also deprecated. The `type` section will removed
+together with the `wells` field in the future. It is an optional field now and
+may be removed from your configuration if no `wells` section is defined.
+"""

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -191,7 +191,6 @@ class EverestConfig(BaseModelWithContextSupport):
             ```yaml
             controls:
               - name: point
-                type: generic_control
                 min: -1.0
                 max: 1.0
                 initial_guess: 0.1
@@ -228,7 +227,6 @@ class EverestConfig(BaseModelWithContextSupport):
                 min: -1.0
                 initial_guess: 0.25
                 perturbation_magnitude: 0.001
-                type: generic_control
                 variables:
                   - name: x
                     index: 1
@@ -254,7 +252,6 @@ class EverestConfig(BaseModelWithContextSupport):
                 max: 1.0
                 min: -1.0
                 perturbation_magnitude: 0.001
-                type: generic_control
                 variables:
                   - name: x
                     initial_guess: [0.25, 0.25, 0.25]

--- a/test-data/everest/eightcells/everest/model/config.yml
+++ b/test-data/everest/eightcells/everest/model/config.yml
@@ -4,7 +4,6 @@ definitions:
 controls:
   -
     name: well_rate
-    type: generic_control
     perturbation_magnitude: 50
     variables:
       -

--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -5,7 +5,6 @@ controls:
     scaled_range: [-1, 1]
     initial_guess: 0.25
     perturbation_magnitude: 0.005
-    type: generic_control
     variables:
       - name: x
         index: 0

--- a/test-data/everest/math_func/config_minimal.yml
+++ b/test-data/everest/math_func/config_minimal.yml
@@ -1,6 +1,5 @@
 controls:
   - name: point
-    type: generic_control
     min: -1.0
     max: 1.0
     scaled_range: [-1, 1]

--- a/test-data/everest/math_func/config_multiobj.yml
+++ b/test-data/everest/math_func/config_multiobj.yml
@@ -1,7 +1,6 @@
 controls:
   -
     name: point
-    type: generic_control
     min: -1.0
     max: 1.0
     scaled_range: [-1, 1]

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -57,7 +57,6 @@ def copy_testdata_tmpdir(
 def control_data_no_variables() -> dict[str, str | float]:
     return {
         "name": "group_0",
-        "type": "well_control",
         "min": 0.0,
         "max": 0.1,
         "perturbation_magnitude": 0.005,
@@ -96,7 +95,6 @@ def setup_minimal_everest_case(tmp_path) -> AbstractContextManager[str]:
                     "controls": [
                         {
                             "name": "the_control",
-                            "type": "generic_control",
                             "min": -1,
                             "max": 1,
                             "initial_guess": 0,

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -123,7 +123,6 @@ def test_that_duplicate_control_names_raise_error():
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -133,7 +132,6 @@ def test_that_duplicate_control_names_raise_error():
                 },
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -151,7 +149,6 @@ def test_that_dot_not_in_control_names():
             controls=[
                 {
                     "name": "group_0.2",
-                    "type": "well_control",
                     "min": 0,
                     "max": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -172,7 +169,6 @@ def test_that_scaled_range_is_valid_range():
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -229,7 +225,6 @@ def test_that_invalid_control_initial_guess_outside_bounds(
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "perturbation_magnitude": 0.01,
                     "variables": variables,
                 }
@@ -282,7 +277,6 @@ def test_that_invalid_control_unique_entry(variables, unique_key):
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "max": 0,
                     "min": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -301,7 +295,6 @@ def test_that_perturbation_magnitude_is_required_when_one_variables_does_not_set
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 1,
                     "initial_guess": 0,
@@ -323,7 +316,6 @@ def test_that_perturbation_magnitude_is_required():
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 1,
                     "initial_guess": 0,
@@ -340,7 +332,6 @@ def test_that_perturbation_magnitude_can_be_set_per_variable():
         controls=[
             {
                 "name": "group_0",
-                "type": "well_control",
                 "min": 0,
                 "max": 1,
                 "initial_guess": 0,
@@ -357,7 +348,6 @@ def test_that_perturbation_magnitude_can_be_set_for_all_variables():
         controls=[
             {
                 "name": "group_0",
-                "type": "well_control",
                 "min": 0,
                 "max": 1,
                 "initial_guess": 0,
@@ -379,7 +369,6 @@ def test_that_invalid_control_undefined_fields():
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "perturbation_magnitude": 0.01,
                     "variables": [
                         {"name": "w00"},
@@ -397,7 +386,6 @@ def test_that_control_variables_index_is_defined_for_all_variables():
             controls=[
                 {
                     "name": "group_0",
-                    "type": "well_control",
                     "min": 0,
                     "max": 0.1,
                     "perturbation_magnitude": 0.01,
@@ -626,7 +614,6 @@ def test_install_data_with_invalid_templates(
             controls=[
                 {
                     "name": "initial_control",
-                    "type": "well_control",
                     "min": 0,
                     "max": 1,
                     "perturbation_magnitude": 0.01,
@@ -735,7 +722,8 @@ def test_that_install_data_with_inline_data_generates_a_file(
             }
         ],
     }
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     runtime_plugins = get_site_plugins()
     run_model = EverestRunModel.create(config, runtime_plugins=runtime_plugins)
     run_model.run_experiment(EvaluatorServerConfig())
@@ -1209,7 +1197,6 @@ def test_load_file_with_errors(capsys):
             [
                 {
                     "name": "test",
-                    "type": "generic_control",
                     "initial_guess": 0.5,
                     "perturbation_magnitude": 0.01,
                     "variables": [
@@ -1371,7 +1358,6 @@ def test_that_nested_extra_types_are_validated_correctly(change_to_tmpdir):
 
         controls:
           - name: my_control
-            type: generic_control
             min: 0
             max: 1
             initial_guess: 0.5
@@ -1394,7 +1380,7 @@ def test_that_nested_extra_types_are_validated_correctly(change_to_tmpdir):
         EverestConfig.load_file("everest_config.yml")
 
     assert "ctx" in err.value.errors[0]
-    assert err.value.errors[0]["ctx"] == {"line_number": 18}
+    assert err.value.errors[0]["ctx"] == {"line_number": 17}
     assert err.value.errors[0]["type"] == "extra_forbidden"
 
 

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -20,7 +20,6 @@ def test_that_duplicate_control_group_name_is_invalid(min_config):
     min_config["controls"].append(
         {
             "name": existing_name,
-            "type": "generic_control",
             "perturbation_magnitude": 0.01,
             "variables": [{"name": "var_b", "min": 0, "max": 1, "initial_guess": 0.9}],
         }
@@ -36,7 +35,6 @@ def test_that_duplicate_control_group_names_without_index_is_invalid():
     ):
         ControlConfig(
             name="group",
-            type="generic_control",
             initial_guess=0.5,
             variables=[
                 ControlVariableConfig(name="w00", min=0, max=1),
@@ -53,7 +51,6 @@ def test_that_partial_use_of_index_in_control_variables_is_invalid():
     ):
         ControlConfig(
             name="group",
-            type="generic_control",
             initial_guess=0.5,
             variables=[
                 ControlVariableConfig(name="w00", min=0, max=1),
@@ -68,7 +65,6 @@ def test_that_duplicate_control_variable_name_and_index_is_invalid():
     ):
         ControlConfig(
             name="group",
-            type="generic_control",
             initial_guess=0.5,
             perturbation_magnitude=0.01,
             variables=[
@@ -88,7 +84,6 @@ def test_that_unmatched_weight_name_due_to_missing_index_is_invalid():
             controls=[
                 ControlConfig(
                     name="group",
-                    type="generic_control",
                     initial_guess=0.5,
                     perturbation_magnitude=0.01,
                     variables=[
@@ -115,7 +110,6 @@ def test_that_input_constraint_with_deprecated_indexed_name_format_warns():
             controls=[
                 ControlConfig(
                     name="group",
-                    type="generic_control",
                     initial_guess=0.5,
                     perturbation_magnitude=0.01,
                     variables=[
@@ -140,7 +134,6 @@ def test_that_control_variable_with_initial_guess_below_min_is_invalid():
     with pytest.raises(ValidationError, match="initial_guess"):
         ControlConfig(
             name="my_control",
-            type="well_control",
             perturbation_magnitude=0.01,
             variables=[
                 ControlVariableConfig(name="w00", min=0.5, max=1.0, initial_guess=0.3)
@@ -152,7 +145,6 @@ def test_that_control_variable_with_initial_guess_above_max_is_invalid():
     with pytest.raises(ValidationError, match="initial_guess"):
         ControlConfig(
             name="my_control",
-            type="well_control",
             perturbation_magnitude=0.01,
             variables=[
                 ControlVariableConfig(name="w00", min=0.5, max=1.0, initial_guess=1.3)
@@ -178,12 +170,13 @@ def test_that_control_variable_without_too_many_dots_does_not_raise(min_config):
 
 
 def test_that_control_variables_not_matching_any_well_name_is_invalid(min_config):
-    illegal_name = "nowell4sure"
-    min_config["controls"][0]["variables"][0]["name"] = illegal_name
     min_config["controls"][0]["type"] = "well_control"
-    with pytest.raises(
-        ValidationError,
-        match="Variable name does not match any well name",
+    with (
+        pytest.raises(
+            ValidationError,
+            match="Variable name does not match any well name",
+        ),
+        pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"),
     ):
         everest_config_with_defaults(**(min_config | {"wells": [{"name": "a"}]}))
 
@@ -191,7 +184,6 @@ def test_that_control_variables_not_matching_any_well_name_is_invalid(min_config
 def test_that_controls_ordering_is_the_same_for_ropt_and_everest_control():
     index_wise = ControlConfig(
         name="well_priorities",
-        type="well_control",
         variables=[
             {"name": "WELL-1", "initial_guess": [0.58, 0.54, 0.5, 0.52]},
             {"name": "WELL-2", "initial_guess": [0.5, 0.58, 0.56, 0.54]},
@@ -209,7 +201,6 @@ def test_that_controls_ordering_is_the_same_for_ropt_and_everest_control():
 
     var_wise = ControlConfig(
         name="well_priorities",
-        type="well_control",
         variables=[
             {"name": "WELL-1", "initial_guess": 0.58, "index": 1},
             {"name": "WELL-1", "initial_guess": 0.54, "index": 2},
@@ -289,7 +280,6 @@ def test_that_controls_ordering_is_the_same_for_ropt_and_everest_control():
 def test_that_controls_ordering_disregards_index():
     var_wise = ControlConfig(
         name="well_priorities",
-        type="well_control",
         variables=[
             {"name": "WELL-1", "initial_guess": 0.54, "index": 2},
             {"name": "WELL-1", "initial_guess": 0.58, "index": 1},
@@ -345,7 +335,6 @@ def test_that_controls_ordering_disregards_index():
 def test_that_setting_initial_guess_in_a_list_is_the_same_as_one_per_index():
     controls1 = ControlConfig(
         name="controls",
-        type="generic_control",
         variables=[
             {"name": "var", "initial_guess": [0.1, 0.2, 0.3]},
         ],
@@ -360,7 +349,6 @@ def test_that_setting_initial_guess_in_a_list_is_the_same_as_one_per_index():
 
     controls2 = ControlConfig(
         name="controls",
-        type="generic_control",
         variables=[
             {"name": "var", "initial_guess": 0.1, "index": 1},
             {"name": "var", "initial_guess": 0.2, "index": 2},
@@ -431,3 +419,11 @@ def get_yaml_examples_from_pydantic_model_field_description(
 def test_controls_documentation_has_valid_examples(yaml_example, min_config):
     partial_config = yaml.safe_load(yaml_example)
     EverestConfig(**(min_config | partial_config))
+
+
+def test_that_control_types_is_deprecated(min_config, monkeypatch, tmp_path):
+    min_config["controls"][0]["type"] = "well_control"
+    min_config["controls"][0]["variables"] = [{"name": "test", "initial_guess": 0.1}]
+    monkeypatch.chdir(tmp_path)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        EverestConfig(**min_config)

--- a/tests/everest/test_cvar.py
+++ b/tests/everest/test_cvar.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigWarning
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
@@ -27,7 +28,8 @@ def test_mathfunc_cvar(copy_math_func_test_data_to_tmp):
             )
         ],
     }
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     # Act
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -13,6 +13,7 @@ import yaml
 
 import ert
 from ert import plugin
+from ert.config import ConfigWarning
 from ert.config.queue_config import (
     LocalQueueOptions,
     LsfQueueOptions,
@@ -299,7 +300,8 @@ async def test_starting_not_in_folder(tmp_path, monkeypatch):
         **everest_config.model_dump(exclude_none=True),
         "config_path": str(Path("minimal_config.yml").absolute()),
     }
-    everest_config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        everest_config = EverestConfig.model_validate(config_dict)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PATH", f".:{os.environ['PATH']}")
     everserver_path = Path("everserver")

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -24,7 +24,6 @@ def test_discrete_optimizer(copy_math_func_test_data_to_tmp):
         "controls": [
             {
                 "name": "point",
-                "type": "generic_control",
                 "min": 0,
                 "max": 10,
                 "control_type": "integer",

--- a/tests/everest/test_domain_transforms.py
+++ b/tests/everest/test_domain_transforms.py
@@ -13,7 +13,6 @@ def ever_config() -> EverestConfig:
         controls=[
             {
                 "name": "default",
-                "type": "generic_control",
                 "min": 0,
                 "max": 1.0,
                 "scaled_range": [0.3, 0.7],

--- a/tests/everest/test_everest_config.py
+++ b/tests/everest/test_everest_config.py
@@ -43,7 +43,6 @@ def test_that_str_type_failures_are_propagated(tmp_path, monkeypatch):
 def test_that_control_config_is_initialized_with_control_variables():
     controls_dict = {
         "name": "hello",
-        "type": "generic_control",
         "min": 0,
         "max": 1,
         "perturbation_magnitude": 0.01,
@@ -91,7 +90,6 @@ def test_that_get_output_dir_returns_same_for_old_and_new():
         "controls": [
             {
                 "name": "group_0",
-                "type": "well_control",
                 "min": 0,
                 "max": 0.1,
                 "perturbation_magnitude": 0.01,
@@ -130,8 +128,7 @@ def test_that_invalid_keys_are_linted():
         "controls": [
             {
                 "name": "group_0",
-                "type": "well_control",
-                "inital_guss": "well_control",
+                "inital_guss": "foo",
                 "min": 0,
                 "max": 0.1,
                 "perturbation_magnitude": 0.01,
@@ -141,8 +138,7 @@ def test_that_invalid_keys_are_linted():
             },
             {
                 "name": "group_0",
-                "type": "well_control",
-                "initial_guess": "well_control",
+                "initial_guess": "bar",
                 "min": 0,
                 "max": 0.1,
                 "perturbation_magnitude": 0.01,
@@ -266,7 +262,6 @@ def test_that_log_level_property_is_consistent_with_environment_log_level():
         "controls": [
             {
                 "name": "group_0",
-                "type": "well_control",
                 "min": 0,
                 "max": 0.1,
                 "perturbation_magnitude": 0.01,

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
 import ert
+from ert.config import ConfigWarning
 from ert.dark_storage.app import app
 from ert.ensemble_evaluator import EndEvent
 from ert.scheduler.event import FinishedEvent
@@ -138,7 +139,8 @@ async def test_status_max_batch_num(copy_math_func_test_data_to_tmp):
         "optimization": {"algorithm": "optpp_q_newton", "max_batch_num": 1},
         "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
 
     await wait_for_server_to_complete(config)
 
@@ -171,7 +173,8 @@ async def test_status_too_few_realizations_succeeded(copy_math_func_test_data_to
         {"name": "fail_simulation", "executable": "jobs/fail_simulation.py"}
     )
     config_dict["forward_model"].append("fail_simulation --fail realization_0")
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
 
     await wait_for_server_to_complete(config)
 
@@ -197,7 +200,8 @@ async def test_status_all_realizations_failed(copy_math_func_test_data_to_tmp):
     }
     config_dict["install_jobs"].append({"name": "fail", "executable": which("false")})
     config_dict["forward_model"].append("fail")
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
 
     await wait_for_server_to_complete(config)
 

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -11,7 +11,6 @@ def test_input_constraint_control_references(tmp_path, capsys, monkeypatch):
     controls_config = [
         {
             "name": "dummy",
-            "type": "generic_control",
             "min": 0,
             "max": 1,
             "initial_guess": 0,

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigWarning
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
@@ -150,7 +151,8 @@ def test_math_func_auto_scaled_controls(copy_math_func_test_data_to_tmp):
         ],
         "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
 
     # Act
     site_plugins = get_site_plugins()
@@ -184,7 +186,8 @@ def test_math_func_auto_scaled_objectives(copy_math_func_test_data_to_tmp):
     del config_dict["objective_functions"][0]["scale"]
 
     config_dict["environment"]["output_folder"] = "output_no_auto_scale"
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -194,7 +197,8 @@ def test_math_func_auto_scaled_objectives(copy_math_func_test_data_to_tmp):
 
     config_dict["environment"]["output_folder"] = "output_auto_scale"
     config_dict["optimization"]["auto_scale"] = True
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -216,7 +220,8 @@ def test_math_func_auto_scaled_constraints(copy_math_func_test_data_to_tmp):
     del config_dict["output_constraints"][0]["scale"]
 
     config_dict["environment"]["output_folder"] = "output_no_auto_scale"
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -226,7 +231,8 @@ def test_math_func_auto_scaled_constraints(copy_math_func_test_data_to_tmp):
 
     config_dict["environment"]["output_folder"] = "output_auto_scale"
     config_dict["optimization"]["auto_scale"] = True
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -261,7 +267,8 @@ def test_that_math_func_violating_output_constraints_has_no_result(
     config_dict["optimization"]["max_batch_num"] = 1
     config_dict["controls"][0]["initial_guess"] = 0.05
 
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -285,7 +292,8 @@ def test_that_math_func_violating_output_constraints_has_a_result(
     config_dict["optimization"]["max_batch_num"] = 2
     config_dict["controls"][0]["initial_guess"] = 0.05
 
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -309,7 +317,8 @@ def test_that_math_func_violating_input_constraints_has_no_result(
     config_dict["optimization"]["max_batch_num"] = 1
     config_dict["controls"][0]["initial_guess"] = 0.5
 
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
@@ -333,7 +342,8 @@ def test_that_math_func_violating_input_constraints_has_a_result(
     config_dict["optimization"]["max_batch_num"] = 2
     config_dict["controls"][0]["initial_guess"] = 0.5
 
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)

--- a/tests/everest/test_objective_type.py
+++ b/tests/everest/test_objective_type.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigWarning
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
@@ -32,7 +33,8 @@ def test_objective_type(copy_math_func_test_data_to_tmp):
         ],
         "simulator": {"queue_system": {"name": "local", "max_running": 2}},
     }
-    config = EverestConfig.model_validate(config_dict)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
     # Act
     runtime_plugins = get_site_plugins()
     with use_runtime_plugins(runtime_plugins):

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -49,7 +49,6 @@ def test_default_installed_jobs(tmp_path, monkeypatch):
         dedent("""
     controls:
       - name: my_control
-        type: well_control
         initial_guess: 0.1
         perturbation_magnitude: 0.01
         variables:

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -17,7 +17,6 @@ def ever_config() -> EverestConfig:
         controls=[
             {
                 "name": "default",
-                "type": "generic_control",
                 "min": 0,
                 "max": 0.1,
                 "perturbation_magnitude": 0.01,

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -8,7 +8,6 @@ from ruamel.yaml import YAML
 
 import everest
 from ert.base_model_context import use_runtime_plugins
-from ert.config import ConfigWarning
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.plugins import get_site_plugins
 from ert.run_models.everest_run_model import EverestRunModel
@@ -18,14 +17,9 @@ from tests.ert.utils import SOURCE_DIR
 from tests.everest.utils import everest_config_with_defaults
 
 CONFIG = {
-    "wells": [
-        {"name": "PROD1", "drill_time": 30},
-        {"name": "PROD2", "drill_time": 60},
-    ],
     "controls": [
         {
             "name": "well_drill",
-            "type": "well_control",
             "min": 0,
             "max": 1,
             "perturbation_magnitude": 0.01,
@@ -163,8 +157,7 @@ def test_install_template(change_to_tmpdir):
     Path("the_optimal_template.tmpl").write_text(
         THE_OPTIMAL_TEMPLATE_TMPL, encoding="utf-8"
     )
-    with pytest.warns(ConfigWarning, match="The `wells` section is deprecated"):
-        config = EverestConfig.load_file("config.yml")
+    config = EverestConfig.load_file("config.yml")
     site_plugins = get_site_plugins()
     with use_runtime_plugins(get_site_plugins()):
         run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)

--- a/tests/everest/test_wells.py
+++ b/tests/everest/test_wells.py
@@ -99,8 +99,10 @@ def test_well_config_to_wells_json(min_config, monkeypatch, tmp_path, config):
 )
 def test_controls_config_to_wells_json(min_config, monkeypatch, tmp_path, variables):
     monkeypatch.chdir(tmp_path)
+    min_config["controls"][0]["type"] = "well_control"
     min_config["controls"][0]["variables"] = variables
-    ever_config = EverestConfig(**min_config)
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        ever_config = EverestConfig(**min_config)
     for datafile, data in _get_internal_files(ever_config).items():
         datafile.parent.mkdir(exist_ok=True, parents=True)
         datafile.write_text(data, encoding="utf-8")

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -13,7 +13,6 @@ def test_read_file(tmp_path, monkeypatch):
     controls:
       -
         name: my_control
-        type: well_control
         min: 0
         max: 0.1
         perturbation_magnitude: 0.01

--- a/tests/everest/utils/utils.py
+++ b/tests/everest/utils/utils.py
@@ -16,7 +16,6 @@ MIN_CONFIG = dedent(
     controls:
       -
         name: my_control
-        type: well_control
         min: 0
         max: 0.1
         perturbation_magnitude: 0.01


### PR DESCRIPTION
**Issue**
Resolves #11765
Resolves #11720
Resolves #10651


**Approach**
Makes the `type` field optional and prints a deprecation message when used. Updated the documentation of `type` to clarify the current usage of the `type` field in the controls section of the Everest configuration. It notifies that `type` is deprecated and will be removed at the same time as the deprecated `wells` section.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
