### PR TITLE
Increase timeout of flaky GUI experiment test

### DIFF
--- a/tests/ert/ui_tests/gui/test_setting_random_seeds.py
+++ b/tests/ert/ui_tests/gui/test_setting_random_seeds.py
@@ -5,9 +5,10 @@ from textwrap import dedent
 
 import pytest
 
+from ert.gui.experiments import RunDialog
 from ert.run_models import EnsembleExperiment, SingleTestRun
 
-from .conftest import _open_main_window
+from .conftest import _open_main_window, get_children
 
 
 @pytest.mark.parametrize("experiment_type", [SingleTestRun, EnsembleExperiment])
@@ -33,6 +34,7 @@ def test_that_gui_uses_config_random_seed_when_specified(
     assert "'random_seed': 12345" in seed_logs[0]
 
 
+@pytest.mark.timeout(700)
 @pytest.mark.parametrize("experiment_type", [SingleTestRun, EnsembleExperiment])
 def test_that_gui_generates_different_seeds_for_consecutive_runs(
     run_experiment, use_tmpdir, qtbot, caplog, experiment_type
@@ -45,18 +47,34 @@ def test_that_gui_generates_different_seeds_for_consecutive_runs(
     )
     Path("config.ert").write_text(config_text, encoding="utf-8")
 
+    def wait_for_experiment_completion(gui):
+        qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=10000)
+        run_dialog = get_children(gui, RunDialog)[-1]
+        qtbot.waitUntil(
+            lambda dialog=run_dialog: dialog.is_experiment_done() is True,
+            timeout=300000,
+        )
+        qtbot.waitUntil(
+            lambda: run_dialog._tab_widget.currentWidget() is not None, timeout=10000
+        )
+
     with (
         caplog.at_level(logging.INFO),
         _open_main_window("config.ert") as (gui, _, _),
     ):
-        run_experiment(experiment_type, gui)
+        qtbot.addWidget(gui)
+        run_experiment(experiment_type, gui, click_done=False)
+        wait_for_experiment_completion(gui)
+
         seed_logs = [line for line in caplog.text.splitlines() if "RANDOM_SEED" in line]
         first_seed_from_log = seed_logs[-1]
 
         # run_experiment expects the runpath to not exist
         shutil.rmtree("gui_random_seed")
 
-        run_experiment(experiment_type, gui)
+        run_experiment(experiment_type, gui, click_done=False)
+        wait_for_experiment_completion(gui)
+
         seed_logs = [line for line in caplog.text.splitlines() if "RANDOM_SEED" in line]
         second_seed_from_log = seed_logs[-1]
 


### PR DESCRIPTION
We observed flaky behavior when this test is run during a Komodo build. The test is reproducible when putting load on a developer machine, but in that case it is possible to hit almost any timeout. This might be partially related to the fact that `fm_dispatch` sets the process nice value to 19 (=low priority).

We move some of the logic to run the test into the test such that we can increase the timeout for individual test runs. The test runs two experiments with individual timeouts increased to 250 s. The global pytest timeout is 360 s so we increase it to 600 s.

**Issue**
Resolves https://github.com/equinor/ert/issues/13101


**Approach**
Extend the test timeout to see if this reduces flakiness.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
