### PR TITLE
Fix PermissionError handling on Python 3.14 for ert_server

### DIFF
--- a/src/ert/services/ert_server.py
+++ b/src/ert/services/ert_server.py
@@ -444,15 +444,18 @@ def create_ert_server_controller(
         t = -1
         while t < timeout:
             storage_server_path = path / _ERT_SERVER_CONNECTION_INFO_FILE
-            if storage_server_path.exists() and storage_server_path.stat().st_size > 0:
-                with (path / _ERT_SERVER_CONNECTION_INFO_FILE).open() as f:
-                    storage_server_content = json.load(f)
+            try:
+                if storage_server_path.stat().st_size > 0:
+                    with storage_server_path.open() as f:
+                        storage_server_content = json.load(f)
 
-                return ErtServerController(
-                    storage_path=str(path),
-                    connection_info=storage_server_content,
-                    logging_config=logging_config,
-                )
+                    return ErtServerController(
+                        storage_path=str(path),
+                        connection_info=storage_server_content,
+                        logging_config=logging_config,
+                    )
+            except FileNotFoundError:
+                pass
 
             sleep(1)
             t += 1

--- a/tests/ert/unit_tests/services/test_ert_server.py
+++ b/tests/ert/unit_tests/services/test_ert_server.py
@@ -232,13 +232,6 @@ os.write(fd, b'{"authtoken": "test123", "urls": ["url"]}')
 os.close(fd)
 """
 )
-@pytest.mark.skipif(
-    sys.version_info[0:2] == (3, 14),
-    reason="""
-        On python 3.14, PermissionError is not raised from
-        pathlib.Path.exists()
-        """,
-)
 def test_that_connect_logs_permission_error(tmp_path, caplog):
     tmp_path.chmod(0o000)
     caplog.clear()


### PR DESCRIPTION
**Issue**
Resolves #13064 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
