### PR TITLE
Update total progress to account for inactive realizations

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -538,29 +538,74 @@ class RunModel(RunModelConfig, ABC):
 
     def calculate_current_progress(self) -> float:
         current_iter = max(list(self._iter_snapshot.keys()))
-        done_realizations = self.active_realizations.count(False)
         all_realizations = self._iter_snapshot[current_iter].reals
         current_progress = 0.0
 
+        filtered_active_realizations = [
+            active
+            for active, initial in zip(
+                self.active_realizations,
+                self._initial_realizations_mask,
+                strict=False,
+            )
+            if initial
+        ]
+
+        initial_active_indices = np.flatnonzero(self._initial_realizations_mask)
+        total_initial = len(initial_active_indices)
+        if total_initial == 0:
+            return current_progress
+
         if all_realizations:
-            for real in all_realizations.values():
-                if real["status"] in {
-                    REALIZATION_STATE_FINISHED,
-                    REALIZATION_STATE_FAILED,
-                }:
-                    done_realizations += 1
+            initial_id_str = {str(i) for i in initial_active_indices}
+            done_realizations = [
+                (real_id in initial_id_str)
+                and (
+                    real.get("status")
+                    in {REALIZATION_STATE_FINISHED, REALIZATION_STATE_FAILED}
+                )
+                for real_id, real in all_realizations.items()
+            ].count(True)
 
-            realization_progress = float(done_realizations) / len(
-                self.active_realizations
-            )
+            if self._total_iterations != 1:
+                start_iter = min(self._iter_snapshot)
 
-            current_it_offset = current_iter - min(list(self._iter_snapshot.keys()))
+                completed_realizations = 0
+                for it in range(start_iter, current_iter):
+                    iter_reals = self._iter_snapshot[it].reals
+                    if iter_reals:
+                        completed_realizations += [
+                            (real_id in initial_id_str) for real_id in iter_reals
+                        ].count(True)
+                    else:
+                        completed_realizations += total_initial
 
-            current_progress = (
-                (current_it_offset + realization_progress) / self._total_iterations
-                if self._total_iterations != 1
-                else realization_progress
-            )
+                current_iter_attempted = [
+                    (real_id in initial_id_str) for real_id in all_realizations
+                ].count(True)
+
+                current_iter_active = [
+                    (real_id in initial_id_str)
+                    and (real.get("status") != REALIZATION_STATE_FAILED)
+                    for real_id, real in all_realizations.items()
+                ].count(True)
+
+                remaining_iters = start_iter + self._total_iterations - current_iter - 1
+                total_realizations = (
+                    completed_realizations
+                    + current_iter_attempted
+                    + remaining_iters * current_iter_active
+                )
+
+                if total_realizations == 0:
+                    current_progress = 1.0
+                else:
+                    current_done = completed_realizations + done_realizations
+                    current_progress = float(current_done) / float(total_realizations)
+            else:
+                num_active = filtered_active_realizations.count(True)
+                if num_active > 0:
+                    current_progress = float(done_realizations) / float(num_active)
 
         return current_progress
 

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -480,6 +480,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
         "start_iteration",
         "total_iterations",
         "expected_result",
+        "initial_active_mask",
     ),
     [
         pytest.param(
@@ -488,6 +489,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             1,
             1,
             0.67,
+            None,
             id="progress_with_single_offset_iteration",
         ),
         pytest.param(
@@ -496,6 +498,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             0,
             1,
             0.33,
+            None,
             id="progress_with_partial_completed",
         ),
         pytest.param(
@@ -504,6 +507,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             0,
             1,
             0.0,
+            None,
             id="progress_with_none_finished",
         ),
         pytest.param(
@@ -512,6 +516,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             0,
             1,
             1.0,
+            None,
             id="progress_with_all_completed",
         ),
         pytest.param(
@@ -520,6 +525,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             2,
             3,
             0.22,
+            None,
             id="progress_with_extended_offset_iterations",
         ),
         pytest.param(
@@ -528,6 +534,7 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             2,
             3,
             0.55,
+            None,
             id="progress_with_extended_offset_iterations",
         ),
         pytest.param(
@@ -536,7 +543,17 @@ async def test_terminate_in_post_evaluation(evaluator, use_tmpdir):
             3,
             7,
             0.38,
+            None,
             id="progress_with_another_extended_offset_iterations",
+        ),
+        pytest.param(
+            {"0": "Running", "1": "Finished", "2": "Finished", "3": "Finished"},
+            0,
+            0,
+            1,
+            0.5,
+            [True, True, False, False],
+            id="progress_uses_initial_active_mask_ignores_non_active_reals",
         ),
     ],
 )
@@ -546,12 +563,20 @@ def test_progress_calculations(
     start_iteration: int,
     total_iterations: int,
     expected_result: float,
+    initial_active_mask: list | None,
     use_tmpdir,
 ):
+    # If an explicit initial mask is provided, use it; otherwise, default to all-True
+    initial_mask = (
+        initial_active_mask
+        if initial_active_mask is not None
+        else [True] * len(real_status_dict)
+    )
+
     brm = create_run_model(
         start_iteration=start_iteration,
         _total_iterations=total_iterations,
-        active_realizations=[True] * len(real_status_dict),
+        active_realizations=initial_mask,
     )
 
     for i in range(start_iteration, start_iteration + total_iterations):


### PR DESCRIPTION
**Issue**
Resolves #13018 


**Approach**
Instead of progress of all realiztions in the setup, we instead check progress compared only to active realizations
Meaning if you had NUM_REALIZATIONS set to 100, but use a custom mask of 0-4 reals, then you would start at 95% complete with the old way. Pictures before and after of said experiment: 

BEFORE:
<img width="1380" height="332" alt="bilde" src="https://github.com/user-attachments/assets/77089e75-e86b-41aa-bcac-2d1a7bafb1af" />


AFTER:
<img width="1395" height="388" alt="bilde" src="https://github.com/user-attachments/assets/d120d3c3-029f-4039-9acc-e6153b3cfda1" />




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
