### PR TITLE
Run GUI random seed test on LOCAL queue

### DIFF
--- a/tests/ert/ui_tests/gui/test_setting_random_seeds.py
+++ b/tests/ert/ui_tests/gui/test_setting_random_seeds.py
@@ -18,6 +18,8 @@ def test_that_gui_uses_config_random_seed_when_specified(
         """
         NUM_REALIZATIONS 1
         RANDOM_SEED 12345
+
+        QUEUE_SYSTEM LOCAL
         """
     )
     Path("config.ert").write_text(config_text, encoding="utf-8")
@@ -41,6 +43,8 @@ def test_that_gui_generates_different_seeds_for_consecutive_runs(
         """
         NUM_REALIZATIONS 1
         RUNPATH gui_random_seed/realization-<IENS>/iter-<ITER>
+
+        QUEUE_SYSTEM LOCAL
         """
     )
     Path("config.ert").write_text(config_text, encoding="utf-8")


### PR DESCRIPTION
Investigations show that tests running EnsembleExperiments sometimes fail on the GitHub runners of `komodo-releases` repository for `onprem` and `azure` jobs. This seems to be related to the queues used in komodo-releases (LSF and OpenPBS/Torque) compared to the "LOCAL" queue used in other cases.

Update the tests to ignore the site config such that the tests always use the "LOCAL" queue to reduce the flakiness of the test.

Replaces PR https://github.com/equinor/ert/pull/13107

Note: The fixup commit is to switch between explicitly defining the QUEUE_SYSTEM and ignoring the site configuration via a fixture to ensure using the "LOCAL" queue. Waiting for feedback to figure out which way is the canonical.

**Issue**
Resolves https://github.com/equinor/ert/issues/13101


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
