### PR TITLE
Remove ambigous restart message

### DIFF
--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -681,26 +681,12 @@ class RunDialog(QFrame):
             )
 
     def rerun_failed_realizations(self) -> None:
-        msg = QMessageBox(self)
-        msg.setIcon(QMessageBox.Icon.Information)
-        msg.setText(
-            "Note that workflows will only be executed on the restarted "
-            "realizations and that this might have unexpected consequences."
-        )
-        msg.setWindowTitle("Restart failed realizations")
-        msg.setStandardButtons(
-            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
-        )
-        msg.setObjectName("restart_prompt")
-        result = msg.exec()
-
-        if result == QMessageBox.StandardButton.Ok:
-            self.rerun_button.setEnabled(False)
-            self.kill_button.setEnabled(True)
-            self.post_experiment_warnings.clear()
-            self._is_rerunning_failed_realizations = True
-            self.rerun_failed_realizations_experiment.emit()
-            self.set_show_warning_button_to_initial_state()
+        self.rerun_button.setEnabled(False)
+        self.kill_button.setEnabled(True)
+        self.post_experiment_warnings.clear()
+        self._is_rerunning_failed_realizations = True
+        self.rerun_failed_realizations_experiment.emit()
+        self.set_show_warning_button_to_initial_state()
 
     @override
     def hideEvent(self, event: QHideEvent | None) -> None:

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -82,12 +82,7 @@ def test_rerun_failed_all_realizations(opened_main_window_poly, qtbot):
     # Check that all realizations failed
     assert all(run_model._create_mask_from_failed_realizations())
 
-    def handle_dialog():
-        message_box = gui.findChildren(QMessageBox, name="restart_prompt")[-1]
-        qtbot.mouseClick(message_box.buttons()[0], Qt.MouseButton.LeftButton)
-
     write_poly_eval(failing_reals=False)
-    QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(run_dialog.rerun_button, Qt.MouseButton.LeftButton)
 
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)
@@ -192,13 +187,8 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
 
     assert set(failed_realizations) == failing_reals_first_try
 
-    def handle_dialog():
-        message_box = gui.findChildren(QMessageBox, name="restart_prompt")[-1]
-        qtbot.mouseClick(message_box.buttons()[0], Qt.MouseButton.LeftButton)
-
     failing_reals_second_try = {*random.sample(list(failing_reals_first_try), 3)}
     write_poly_eval(failing_reals=failing_reals_second_try)
-    QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(run_dialog.rerun_button, Qt.MouseButton.LeftButton)
 
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)
@@ -229,7 +219,6 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
         failing_reals_second_try.union(failing_reals_second_try)
     )
 
-    QTimer.singleShot(500, handle_dialog)
     failing_reals_third_try = {*random.sample(list(failing_reals_second_try), 2)}
     write_poly_eval(failing_reals=failing_reals_third_try)
     qtbot.mouseClick(run_dialog.rerun_button, Qt.MouseButton.LeftButton)
@@ -358,13 +347,8 @@ def test_rerun_failed_realizations_evaluate_ensemble(
 
     assert set(failed_realizations) == failing_reals_first_try
 
-    def handle_dialog():
-        message_box = gui.findChildren(QMessageBox, name="restart_prompt")[-1]
-        qtbot.mouseClick(message_box.buttons()[0], Qt.MouseButton.LeftButton)
-
     failing_reals_second_try = {*random.sample(list(failing_reals_first_try), 5)}
     write_poly_eval(failing_reals=failing_reals_second_try)
-    QTimer.singleShot(500, handle_dialog)
     qtbot.mouseClick(run_dialog.rerun_button, Qt.MouseButton.LeftButton)
 
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=60000)


### PR DESCRIPTION
**Issue**
Resolves #7877 


**Approach**
I just yoinked the msg 😎 
There is now no dialog when you press restart

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
