### PR TITLE
Solve and enforce ruff PLW rules (pylint warnings)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ select = [
     "PIE",   # flake8-pie
     "PL",    # pylint
     "PLE",
-    "PLW2901",
+    "PLW",
     "PT",    # pytest
     "PYI",
     "Q",
@@ -242,6 +242,7 @@ select = [
 preview = true
 ignore = [
     "G004",    # logging-f-string
+    "PLW1641", # eq-without-hash
     "PLR2004", # magic-value-comparison
     "PLR0915", # too-many-statements
     "PLR0912", # too-many-branches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ select = [
     "PIE",   # flake8-pie
     "PL",    # pylint
     "PLE",
+    "PLW2901",
     "PT",    # pytest
     "PYI",
     "Q",
@@ -241,7 +242,6 @@ select = [
 preview = true
 ignore = [
     "G004",    # logging-f-string
-    "PLW2901", # redefined-loop-name
     "PLR2004", # magic-value-comparison
     "PLR0915", # too-many-statements
     "PLR0912", # too-many-branches

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -107,6 +107,7 @@ class ForwardModelRunner:
     def _set_environment(self) -> None:
         if self.global_environment:
             for key, value in self.global_environment.items():
+                expanded_value = value
                 for env_key, env_val in os.environ.items():
-                    value = value.replace(f"${env_key}", env_val)
-                os.environ[key] = value
+                    expanded_value = expanded_value.replace(f"${env_key}", env_val)
+                os.environ[key] = expanded_value

--- a/src/ert/config/analysis_config.py
+++ b/src/ert/config/analysis_config.py
@@ -130,19 +130,19 @@ class AnalysisConfig:
                 continue
             if var_name == "ENKF_FORCE_NCOMP":
                 continue
-            if var_name == "INVERSION":
-                if value in inversion_str_map[module_name]:
-                    new_value = inversion_str_map[module_name][value]
-                    ConfigWarning.warn(
-                        f"Using {value} is deprecated, use:\n"
-                        f"ANALYSIS_SET_VAR {module_name} INVERSION {new_value}"
-                    )
-                    value = new_value
+            if var_name == "INVERSION" and value in inversion_str_map[module_name]:
+                new_value = inversion_str_map[module_name][value]
+                ConfigWarning.warn(
+                    f"Using {value} is deprecated, use:\n"
+                    f"ANALYSIS_SET_VAR {module_name} INVERSION {new_value}"
+                )
+                value_to_store = new_value
+            else:
+                value_to_store = value
 
-                var_name = "inversion"
             key = var_name.lower()
             try:
-                options[module_name][key] = value
+                options[module_name][key] = value_to_store
             except KeyError:
                 all_errors.append(
                     ConfigValidationError(

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -574,10 +574,10 @@ def installed_forward_model_steps_from_dict(
     for name, (fm_step_config_file, config_contents) in config_dict.get(
         ConfigKeys.INSTALL_JOB, []
     ):
-        fm_step_config_file = path.abspath(fm_step_config_file)
+        fm_step_config_abspath = path.abspath(fm_step_config_file)
         try:
             new_fm_step = forward_model_step_from_config_contents(
-                config_contents, name=name, config_file=fm_step_config_file
+                config_contents, name=name, config_file=fm_step_config_abspath
             )
         except ConfigValidationError as e:
             errors.append(e)
@@ -585,7 +585,7 @@ def installed_forward_model_steps_from_dict(
         if name in fm_steps:
             ConfigWarning.warn(
                 f"Duplicate forward model step with name {name!r}, choosing "
-                f"{fm_step_config_file!r} over {fm_steps[name].executable!r}",
+                f"{fm_step_config_abspath!r} over {fm_steps[name].executable!r}",
                 name,
             )
         fm_steps[name] = new_fm_step
@@ -1240,8 +1240,8 @@ class ErtConfig(BaseModel):
         but the easy ones are filtered out.
         """
         config_context = ""
-        for line in config_file_contents.split("\n"):
-            line = line.strip()
+        for unstripped_line in config_file_contents.split("\n"):
+            line = unstripped_line.strip()
             if not line or line.startswith("--"):
                 continue
             if "--" in line and not any(x in line for x in ['"', "'"]):

--- a/src/ert/config/gen_kw_config.py
+++ b/src/ert/config/gen_kw_config.py
@@ -161,8 +161,10 @@ class GenKwConfig(ParameterConfig):
             )
 
         distributions_spec: list[list[str]] = []
-        for line_number, item in enumerate(parsed.parameter_file_contents.splitlines()):
-            item = item.split("--")[0]  # remove comments
+        for line_number, item_with_comments in enumerate(
+            parsed.parameter_file_contents.splitlines()
+        ):
+            item = item_with_comments.split("--")[0]  # remove comments
             if item.strip():  # only lines with content
                 items = item.split()
                 if len(items) < 2:

--- a/src/ert/dark_storage/endpoints/observations.py
+++ b/src/ert/dark_storage/endpoints/observations.py
@@ -104,13 +104,14 @@ def _get_observations(
 ) -> list[dict[str, Any]]:
     observations = []
 
-    for stored_response_type, df in experiment.observations.items():
+    for stored_response_type, stored_df in experiment.observations.items():
         if (
             requested_response_type is not None
             and stored_response_type != requested_response_type
         ):
             continue
 
+        df = stored_df
         if observation_keys is not None:
             df = df.filter(pl.col("observation_key").is_in(observation_keys))
 

--- a/src/ert/gui/ertwidgets/listeditbox.py
+++ b/src/ert/gui/ertwidgets/listeditbox.py
@@ -139,8 +139,8 @@ class ListEditBox(QWidget):
             return self._possible_items_dict
 
         result = {}
-        for item in items:
-            item = item.strip()
+        for unstripped_item in items:
+            item = unstripped_item.strip()
             for uuid, name in self._possible_items_dict.items():
                 if name == item:
                     result[uuid] = name

--- a/src/ert/gui/experiments/experiment_panel.py
+++ b/src/ert/gui/experiments/experiment_panel.py
@@ -49,9 +49,9 @@ EXPERIMENT_IS_MANUAL_UPDATE_MESSAGE = "Execute Selected"
 
 
 def create_md_table(kv: dict[str, str], output: str) -> str:
-    for k, v in kv.items():
-        v = v.replace("_", r"\_")
-        output += f"| {k} | {v} |\n"
+    for key, unescaped_value in kv.items():
+        value = unescaped_value.replace("_", r"\_")
+        output += f"| {key} | {value} |\n"
     output += "\n"
     return output
 

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -462,8 +462,8 @@ class PlotWindow(QMainWindow):
             if key_def.response is not None and key_def.response.type == "breakthrough":
                 plot_context.flip_observation_axis = True
 
-            for data in ensemble_to_data_map.values():
-                data = data.T
+            for untransposed_data in ensemble_to_data_map.values():
+                data = untransposed_data.T
 
                 if not data.empty and data.index.inferred_type == "datetime64":
                     self._preferred_ensemble_x_axis_format = PlotContext.DATE_AXIS

--- a/src/ert/gui/tools/plot/plottery/plots/cesp.py
+++ b/src/ert/gui/tools/plot/plottery/plots/cesp.py
@@ -91,18 +91,18 @@ def plotCrossEnsembleStatistics(
         std_dev_factor = config.getStandardDeviationFactor()
 
         if not data.empty:
-            data = _assertNumeric(data)
-            if data is not None:
+            numeric_data = _assertNumeric(data)
+            if numeric_data is not None:
                 ccs["index"].append(ensemble_index)
-                ccs["mean"][ensemble_index] = data.mean()
-                ccs["min"][ensemble_index] = data.min()
-                ccs["max"][ensemble_index] = data.max()
-                ccs["std"][ensemble_index] = data.std() * std_dev_factor
-                ccs["p10"][ensemble_index] = data.quantile(0.1)
-                ccs["p33"][ensemble_index] = data.quantile(0.33)
-                ccs["p50"][ensemble_index] = data.quantile(0.5)
-                ccs["p67"][ensemble_index] = data.quantile(0.67)
-                ccs["p90"][ensemble_index] = data.quantile(0.9)
+                ccs["mean"][ensemble_index] = numeric_data.mean()
+                ccs["min"][ensemble_index] = numeric_data.min()
+                ccs["max"][ensemble_index] = numeric_data.max()
+                ccs["std"][ensemble_index] = numeric_data.std() * std_dev_factor
+                ccs["p10"][ensemble_index] = numeric_data.quantile(0.1)
+                ccs["p33"][ensemble_index] = numeric_data.quantile(0.33)
+                ccs["p50"][ensemble_index] = numeric_data.quantile(0.5)
+                ccs["p67"][ensemble_index] = numeric_data.quantile(0.67)
+                ccs["p90"][ensemble_index] = numeric_data.quantile(0.9)
 
                 _plotCrossEnsembleStatistics(axes, config, ccs, ensemble_index)
 

--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -41,12 +41,12 @@ class EnsemblePlot:
         plot_context.x_axis = plot_context.DATE_AXIS
         draw_style = "steps-pre" if is_rate(plot_context.key()) else None
         zorder = 0
-        for (ensemble, data), color_index in zip(
+        for (ensemble, untransposed_data), color_index in zip(
             ensemble_to_data_map.items(),
             plot_context.ensembles_color_indexes(),
             strict=False,
         ):
-            data = data.T
+            data = untransposed_data.T
 
             if not data.empty:
                 if data.index.inferred_type != "datetime64":

--- a/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
+++ b/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
@@ -62,10 +62,9 @@ def plotGaussianKDE(
         config.setCurrentColor(color_index)
         if data.empty:
             continue
-        data = data[0]
-        if not _array_is_constant(data):
+        if not _array_is_constant(data[0]):
             _plotGaussianKDE(
-                axes, config, data, f"{ensemble.experiment_name} : {ensemble.name}"
+                axes, config, data[0], f"{ensemble.experiment_name} : {ensemble.name}"
             )
 
     if plot_context.log_scale:

--- a/src/ert/gui/tools/plot/plottery/plots/statistics.py
+++ b/src/ert/gui/tools/plot/plottery/plots/statistics.py
@@ -42,13 +42,13 @@ class StatisticsPlot:
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.DATE_AXIS
 
-        for (ensemble, data), color_index in zip(
+        for (ensemble, untransposed_data), color_index in zip(
             ensemble_to_data_map.items(),
             plot_context.ensembles_color_indexes(),
             strict=False,
         ):
             config.setCurrentColor(color_index)
-            data = data.T
+            data = untransposed_data.T
             if not data.empty:
                 if data.index.inferred_type != "datetime64":
                     plot_context.deactivateDateSupport()

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -333,10 +333,10 @@ def _create_one_run_path(
     param_substituter = _make_param_substituter(real_iter_substituter, param_data)
     for (
         source_file_content,
-        target_file,
+        unsubstituted_target_file,
     ) in ensemble.experiment.templates_configuration:
         start_time = time.perf_counter()
-        target_file = real_iter_substituter.substitute(target_file)
+        target_file = real_iter_substituter.substitute(unsubstituted_target_file)
         timings["substitute_real_iter"] += time.perf_counter() - start_time
 
         start_time = time.perf_counter()

--- a/src/ert/shared/_doc_utils/ert_jobs.py
+++ b/src/ert/shared/_doc_utils/ert_jobs.py
@@ -45,7 +45,7 @@ class _ErtDocumentation(SphinxDirective):
                 continue
 
             if isinstance(docs, ForwardModelStepDocumentation):
-                docs = {
+                docs = {  # noqa: PLW2901
                     "description": docs.description,
                     "examples": docs.examples,
                     "config_file": docs.config_file,

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -714,12 +714,15 @@ class LocalExperiment(BaseMode):
                     if set(all_controls).issubset(set(bdf_.columns)) and set(
                         all_controls
                     ).issubset(set(batch_df_.columns)):
-                        bdf_ = bdf_.drop(all_controls)
-
-                    batch_df_ = batch_df_.join(
-                        bdf_,
-                        on=on,
-                    )
+                        batch_df_ = batch_df_.join(
+                            bdf_.drop(all_controls),
+                            on=on,
+                        )
+                    else:
+                        batch_df_ = batch_df_.join(
+                            bdf_,
+                            on=on,
+                        )
 
                 dfs_to_concat_.append(batch_df_)
 

--- a/src/ert/validation/number_list_string_argument.py
+++ b/src/ert/validation/number_list_string_argument.py
@@ -33,8 +33,8 @@ class NumberListStringArgument(ArgumentDefinition):
             else:
                 groups = token.split(",")
 
-                for group in groups:
-                    group = group.strip()
+                for unstripped_group in groups:
+                    group = unstripped_group.strip()
 
                     if len(group) > 0:
                         try:

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -92,17 +92,17 @@ def plot_figure(
                 case_selection.slot_toggle_plot(item)
 
         found_selected_key = False
-        for i in range(key_model.rowCount()):
-            to_select = data_types.model.itemAt(data_types.model.index(i, 0))
+        for key_index in range(key_model.rowCount()):
+            to_select = data_types.model.itemAt(data_types.model.index(key_index, 0))
             assert to_select is not None
             if to_select.key == key:
-                index = key_model.index(i, 0)
+                index = key_model.index(key_index, 0)
                 key_list.setCurrentIndex(index)
                 selected_key = to_select
-                for i, tab in enumerate(plot_window._plot_widgets):
+                for widget_index, tab in enumerate(plot_window._plot_widgets):
                     if tab.name == plot_name:
                         found_selected_key = True
-                        if central_tab.isTabEnabled(i):
+                        if central_tab.isTabEnabled(widget_index):
                             central_tab.setCurrentWidget(tab)
                             assert (
                                 selected_key.dimensionality

--- a/tests/ert/ui_tests/gui/test_rft_visualizations.py
+++ b/tests/ert/ui_tests/gui/test_rft_visualizations.py
@@ -155,17 +155,17 @@ def plot_figure(qtbot: QtBot, request, rft_config: ErtConfig):
                 case_selection.slot_toggle_plot(item)
 
         found_selected_key = False
-        for i in range(key_model.rowCount()):
-            to_select = data_types.model.itemAt(data_types.model.index(i, 0))
+        for key_index in range(key_model.rowCount()):
+            to_select = data_types.model.itemAt(data_types.model.index(key_index, 0))
             assert to_select is not None
             if to_select.key == key:
-                index = key_model.index(i, 0)
+                index = key_model.index(key_index, 0)
                 key_list.setCurrentIndex(index)
                 selected_key = to_select
-                for i, tab in enumerate(plot_window._plot_widgets):
+                for widget_index, tab in enumerate(plot_window._plot_widgets):
                     if tab.name == plot_name:
                         found_selected_key = True
-                        if central_tab.isTabEnabled(i):
+                        if central_tab.isTabEnabled(widget_index):
                             central_tab.setCurrentWidget(tab)
                             assert (
                                 selected_key.dimensionality


### PR DESCRIPTION
**Issue**
Resolves ruff PLW (pylint warning) issues

**Approach**
PLW2901 solved by hand, this makes sense to enforce.

Skipping PLW1641 (eq without hash), this seems not as important to solve, lets add hash methods when
we need these objects in dicts.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
