### PR TITLE
fix: use monotonic clocks for scheduler duration measurements

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -47,7 +47,7 @@ class Driver(ABC):
         self._poll_period = _POLL_PERIOD
 
         self._polling_timeout_period = Driver.POLLING_TIMEOUT_PERIOD
-        self._last_successful_poll = time.time()
+        self._last_successful_poll = time.monotonic()
         self._last_polling_error_message: str | None = None
         self._has_warned_evaluator_of_polling_error = False
 
@@ -192,7 +192,10 @@ class Driver(ABC):
 
     async def _warn_evaluator_if_polling_has_failed_for_some_time(self) -> None:
         if (
-            (self._last_successful_poll < time.time() - self._polling_timeout_period)
+            (
+                self._last_successful_poll
+                < time.monotonic() - self._polling_timeout_period
+            )
             and self._last_polling_error_message
             and not self._has_warned_evaluator_of_polling_error
         ):

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -84,6 +84,8 @@ class Job:
         self._requested_max_submit: int | None = None
         self._start_time: float | None = None
         self._end_time: float | None = None
+        self._start_monotonic: float | None = None
+        self._end_monotonic: float | None = None
         self._remaining_file_verification_time = self.DEFAULT_FILE_VERIFICATION_TIMEOUT
         self._previous_file_verification_time = self._remaining_file_verification_time
         self._started_killing_by_evaluator: bool = False
@@ -123,10 +125,10 @@ class Job:
 
     @property
     def running_duration(self) -> float:
-        if self._start_time:
-            if self._end_time:
-                return self._end_time - self._start_time
-            return time.time() - self._start_time
+        if self._start_monotonic is not None:
+            if self._end_monotonic is not None:
+                return self._end_monotonic - self._start_monotonic
+            return time.monotonic() - self._start_monotonic
         return 0
 
     async def _submit_and_run_once(self, sem: asyncio.BoundedSemaphore) -> None:
@@ -161,6 +163,7 @@ class Job:
             await self._send(JobState.PENDING)
             await self.started.wait()
             self._start_time = time.time()
+            self._start_monotonic = time.monotonic()
             pending_time = self._start_time - self.submit_time
             logger.info(
                 f"Pending time for realization {self.iens} "
@@ -439,6 +442,7 @@ class Job:
             case JobState.COMPLETED:
                 event = RealizationSuccess(real=str(self.iens))
                 self._end_time = time.time()
+                self._end_monotonic = time.monotonic()
                 await self._scheduler.completed_jobs.put(self.iens)
             case default:
                 assert_never(default)

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -302,7 +302,7 @@ class LsfDriver(Driver):
         self._bhist_cmd = Path(bhist_cmd or shutil.which("bhist") or "bhist")
         self._bhist_cache: dict[str, dict[str, int]] | None = None
         self._bhist_required_cache_age: float = 4
-        self._bhist_cache_timestamp: float = time.time()
+        self._bhist_cache_timestamp: float = time.monotonic()
 
         self._submit_locks: MutableMapping[int, asyncio.Lock] = {}
 
@@ -523,7 +523,7 @@ class LsfDriver(Driver):
                     "bhist did not give status for job_ids "
                     f"{missing_in_bhist_and_bjobs}, giving up for now."
                 )
-            self._last_successful_poll = time.time()
+            self._last_successful_poll = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_state: AnyJob) -> None:
@@ -620,7 +620,10 @@ class LsfDriver(Driver):
     async def _poll_once_by_bhist(
         self, missing_job_ids: Iterable[str]
     ) -> dict[str, AnyJob]:
-        if time.time() - self._bhist_cache_timestamp < self._bhist_required_cache_age:
+        if (
+            time.monotonic() - self._bhist_cache_timestamp
+            < self._bhist_required_cache_age
+        ):
             return {}
 
         try:
@@ -672,7 +675,7 @@ class LsfDriver(Driver):
             ):
                 jobs[job_id] = "PEND"
         self._bhist_cache = data
-        self._bhist_cache_timestamp = time.time()
+        self._bhist_cache_timestamp = time.monotonic()
         return _parse_jobs_dict(jobs)
 
     def update_and_log_exec_hosts(self, bjobs_exec_hosts: dict[str, str]) -> None:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -349,7 +349,7 @@ class OpenPBSDriver(Driver):
                 for job_id, job in parsed_jobs_dict.items():
                     await self._process_job_update(job_id, job)
 
-            self._last_successful_poll = time.time()
+            self._last_successful_poll = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_state: AnyJob) -> None:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -49,11 +49,11 @@ class SubmitSleeper:
     def __init__(self, submit_sleep: float) -> None:
         self._submit_sleep = submit_sleep
         self._last_started = (
-            time.time() - submit_sleep
+            time.monotonic() - submit_sleep
         )  # Allow the first to start immediately
 
     async def sleep_until_we_can_submit(self) -> None:
-        now = time.time()
+        now = time.monotonic()
         next_start_time = max(self._last_started + self._submit_sleep, now)
         self._last_started = next_start_time
         await asyncio.sleep(max(0, next_start_time - now))

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -323,7 +323,7 @@ class SlurmDriver(Driver):
                     "scontrol did not give status for job_ids "
                     f"{missing_in_squeue_and_scontrol}, giving up for now."
                 )
-            self._last_successful_poll = time.time()
+            self._last_successful_poll = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_info: JobInfo) -> None:
@@ -378,7 +378,7 @@ class SlurmDriver(Driver):
 
     async def _poll_once_by_scontrol(self, missing_job_id: str) -> ScontrolInfo | None:
         if (
-            time.time() - self._scontrol_cache_timestamp
+            time.monotonic() - self._scontrol_cache_timestamp
             < self._scontrol_required_cache_age
         ) and missing_job_id in self._scontrol_cache:
             return self._scontrol_cache[missing_job_id]
@@ -394,7 +394,7 @@ class SlurmDriver(Driver):
             info.exit_code = SLURM_TERMINATED_EXIT_CODE
 
         self._scontrol_cache[missing_job_id] = info
-        self._scontrol_cache_timestamp = time.time()
+        self._scontrol_cache_timestamp = time.monotonic()
         return info
 
     async def _run_scontrol(self, missing_job_id: str) -> ScontrolInfo | None:


### PR DESCRIPTION
## Bug
Fixes #13111. Duration calculations used `time.time()` in scheduler timing paths, which can jump backwards/forwards with wall-clock adjustments (DST/NTP).

## Fix
- Switched elapsed-time tracking to `time.monotonic()` in scheduler pacing (`SubmitSleeper`)
- Switched driver polling timeout bookkeeping to monotonic time
- Updated LSF/Slurm/OpenPBS poll success timestamps to match monotonic timeout logic
- Switched cache age checks in LSF/Slurm scheduler helpers to monotonic time
- Kept wall-clock timestamps where epoch time is still needed (e.g. submission timestamp used for file-based checks)
- Added monotonic start/end tracking in `Job` for `running_duration` while preserving existing wall-clock fields

## Testing
- Code-path review for all elapsed-time comparisons in scheduler drivers
- Verified all touched comparisons now use a single monotonic clock source
- Local test execution was not possible in this environment because `pytest` is not installed

Happy to address any feedback.

Greetings, saschabuehrle
