### PR TITLE
Do not emit config warnings from the everest experiment server

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -7,6 +7,7 @@ import queue
 import time
 import traceback
 import uuid
+import warnings
 from base64 import b64decode
 from queue import SimpleQueue
 from typing import Annotated
@@ -27,7 +28,7 @@ from starlette.responses import PlainTextResponse, Response
 from starlette.websockets import WebSocket
 
 from ert.base_model_context import use_runtime_plugins
-from ert.config import QueueSystem
+from ert.config import ConfigWarning, QueueSystem
 from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig
 from ert.ensemble_evaluator.event import FullSnapshotEvent, SnapshotUpdateEvent
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
@@ -192,7 +193,11 @@ async def start_experiment(
     _check_user(credentials)
     if shared_data.status.status == ExperimentState.pending:
         request_data = await request.json()
-        config = EverestConfig.with_plugins(request_data)
+        # The output of warnings is the task of the user interface, not
+        # of everserver. Therefore we suppress them here:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=ConfigWarning)
+            config = EverestConfig.with_plugins(request_data)
         runner = ExperimentRunner(config)
         try:
             background_tasks.add_task(runner.run)


### PR DESCRIPTION
**Issue**
Resolves #13124


**Approach**
Suppress `ConfigWarning` while validating the configuration when starting via the experiment server



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
