### PR TITLE
Preserve active sub-tab when switching ensembles in Manage Experiments panel

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -462,7 +462,11 @@ class _EnsembleWidget(QWidget):
         self._name_label.setText(f"Name: {ensemble.name!s}")
         self._uuid_label.setText(f"UUID: {ensemble.id!s}")
 
-        self._tab_widget.setCurrentIndex(0)
+        current_index = self._tab_widget.currentIndex()
+        if current_index > 0:
+            self._currentTabChanged(current_index)
+        else:
+            self._tab_widget.setCurrentIndex(0)
 
     @Slot()
     def onClickExportMisfit(self) -> None:

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -628,6 +628,64 @@ def test_that_parameters_pane_is_populated_correctly(
     assert triggers == QAbstractItemView.EditTrigger.NoEditTriggers
 
 
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_sub_tab_persists_when_switching_ensembles(qtbot):
+    config = ErtConfig.from_file("poly.ert")
+    notifier = ErtNotifier()
+    notifier.set_storage(config.ens_path)
+
+    with notifier.write_storage() as storage:
+        exp = storage.create_experiment(
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json")
+                    for pc in config.ensemble_config.parameter_configuration
+                ],
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in config.ensemble_config.response_configuration
+                ],
+            },
+            name="my-experiment",
+        )
+        exp.create_ensemble(
+            ensemble_size=config.runpath_config.num_realizations, name="prior"
+        )
+        exp.create_ensemble(
+            ensemble_size=config.runpath_config.num_realizations, name="posterior"
+        )
+
+    tool = ManageExperimentsPanel(
+        config, notifier, config.runpath_config.num_realizations
+    )
+
+    storage_widget = tool.findChild(StorageWidget)
+    storage_widget._tree_view.expandAll()
+    experiment_index = storage_widget._tree_view.model().index(0, 0)
+
+    # Select first ensemble
+    first_ensemble_index = storage_widget._tree_view.model().index(
+        0, 0, experiment_index
+    )
+    storage_widget._tree_view.setCurrentIndex(first_ensemble_index)
+
+    ensemble_widget = tool._storage_info_widget._content_layout.currentWidget()
+    assert isinstance(ensemble_widget, _EnsembleWidget)
+
+    # Switch to STATE_TAB
+    ensemble_widget._tab_widget.setCurrentIndex(_EnsembleWidgetTabs.STATE_TAB)
+    assert ensemble_widget._tab_widget.currentIndex() == _EnsembleWidgetTabs.STATE_TAB
+
+    # Select second ensemble
+    second_ensemble_index = storage_widget._tree_view.model().index(
+        1, 0, experiment_index
+    )
+    storage_widget._tree_view.setCurrentIndex(second_ensemble_index)
+
+    # Tab should remain on STATE_TAB, not reset to ENSEMBLE_TAB
+    assert ensemble_widget._tab_widget.currentIndex() == _EnsembleWidgetTabs.STATE_TAB
+
+
 def test_that_export_parameters_button_opens_the_export_dialog(
     qtbot, snake_oil_case_storage: ErtConfig, snake_oil_storage: Storage
 ):


### PR DESCRIPTION
**Issue**
Resolves #12573 

**Approach**
When switching ensembles, `setEnsemble()` was unconditionally calling `setCurrentIndex(0)`, resetting the active sub-tab back to "Ensemble" every time. Now, the current tab index is preserved and its content is reloaded for the newly selected ensemble.

https://github.com/user-attachments/assets/498a395c-a52a-4e7d-8123-fd1082be2215

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
