### PR TITLE
Replace int rounding with round in breakthrough observation misfit endpoint

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/observations.py
+++ b/src/ert/gui/tools/plot/plottery/plots/observations.py
@@ -63,7 +63,10 @@ def _plotObservations(
         # np.timedelta64 requires int input. To achieve hourly resolution (ERROR = 1.5),
         # we convert the std to an hourly timedelta
         xerr = np.array(
-            [np.timedelta64(int(time * 24), "h") for time in data.loc["STD"].to_list()]
+            [
+                np.timedelta64(round(time * 24), "h")
+                for time in data.loc["STD"].to_list()
+            ]
         )
         errorbar_data = {
             "x": np.array(

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -32,6 +32,8 @@ from ert.config.parsing.observations_parser import (
     ObservationType,
 )
 from ert.config.rft_config import RFTConfig
+from ert.gui.tools.plot.plottery import PlotConfig
+from ert.gui.tools.plot.plottery.plots.observations import _plotObservations
 from ert.namespace import Namespace
 
 pytestmark = pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
@@ -2097,3 +2099,35 @@ def test_that_extract_localization_values_raises_error_given_non_float():
             r'Failed to validate "Not a float"',
         ):
             extract_localization_values(values)
+
+
+def test_that_hours_are_rounded_to_closest_int_in_plot_observations():
+    unrounded_days = 10.7 / 24  # 10.7 hours converted to days
+    expected_rounded_hours = 11
+
+    def assertion_mock(**kwargs):
+        assert kwargs["xerr"] == [expected_rounded_hours]
+
+    axes_mock = MagicMock()
+    axes_mock.errorbar = assertion_mock
+
+    config = PlotConfig()
+    config.flip_observation_axis = True
+
+    data = DataFrame(
+        [
+            [
+                datetime.fromisoformat("2025-01-02"),
+            ],
+            [unrounded_days],
+            [0],
+        ],
+        index=["key_index", "STD", "OBS"],
+    )
+
+    _plotObservations(
+        axes_mock,
+        config,
+        data=data,
+        value_column="foo",
+    )


### PR DESCRIPTION
Realized I made a mistake in a previous PR as int() always rounds down.