### PR TITLE
Use monotonic() instead of time() for measuring duration

### DIFF
--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -47,7 +47,7 @@ class Driver(ABC):
         self._poll_period = _POLL_PERIOD
 
         self._polling_timeout_period = Driver.POLLING_TIMEOUT_PERIOD
-        self._last_successful_poll = time.time()
+        self._last_successful_poll_monotonic = time.monotonic()
         self._last_polling_error_message: str | None = None
         self._has_warned_evaluator_of_polling_error = False
 
@@ -192,7 +192,10 @@ class Driver(ABC):
 
     async def _warn_evaluator_if_polling_has_failed_for_some_time(self) -> None:
         if (
-            (self._last_successful_poll < time.time() - self._polling_timeout_period)
+            (
+                self._last_successful_poll_monotonic
+                < time.monotonic() - self._polling_timeout_period
+            )
             and self._last_polling_error_message
             and not self._has_warned_evaluator_of_polling_error
         ):

--- a/src/ert/scheduler/job.py
+++ b/src/ert/scheduler/job.py
@@ -82,8 +82,8 @@ class Job:
         self._scheduler: Scheduler = scheduler
         self._message: str = ""
         self._requested_max_submit: int | None = None
-        self._start_time: float | None = None
-        self._end_time: float | None = None
+        self._start_time_monotonic: float | None = None
+        self._end_time_monotonic: float | None = None
         self._remaining_file_verification_time = self.DEFAULT_FILE_VERIFICATION_TIMEOUT
         self._previous_file_verification_time = self._remaining_file_verification_time
         self._started_killing_by_evaluator: bool = False
@@ -123,10 +123,10 @@ class Job:
 
     @property
     def running_duration(self) -> float:
-        if self._start_time:
-            if self._end_time:
-                return self._end_time - self._start_time
-            return time.monotonic() - self._start_time
+        if self._start_time_monotonic:
+            if self._end_time_monotonic:
+                return self._end_time_monotonic - self._start_time_monotonic
+            return time.monotonic() - self._start_time_monotonic
         return 0
 
     async def _submit_and_run_once(self, sem: asyncio.BoundedSemaphore) -> None:
@@ -160,8 +160,8 @@ class Job:
 
             await self._send(JobState.PENDING)
             await self.started.wait()
-            self._start_time = time.monotonic()
-            pending_time = self._start_time - self.submit_time
+            self._start_time_monotonic = time.monotonic()
+            pending_time = self._start_time_monotonic - self.submit_time
             logger.info(
                 f"Pending time for realization {self.iens} "
                 f"was {pending_time:.2f} seconds "
@@ -438,7 +438,7 @@ class Job:
                 await self._handle_aborted()
             case JobState.COMPLETED:
                 event = RealizationSuccess(real=str(self.iens))
-                self._end_time = time.monotonic()
+                self._end_time_monotonic = time.monotonic()
                 await self._scheduler.completed_jobs.put(self.iens)
             case default:
                 assert_never(default)

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -523,7 +523,7 @@ class LsfDriver(Driver):
                     "bhist did not give status for job_ids "
                     f"{missing_in_bhist_and_bjobs}, giving up for now."
                 )
-            self._last_successful_poll = time.time()
+            self._last_successful_poll_monotonic = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_state: AnyJob) -> None:

--- a/src/ert/scheduler/openpbs_driver.py
+++ b/src/ert/scheduler/openpbs_driver.py
@@ -349,7 +349,7 @@ class OpenPBSDriver(Driver):
                 for job_id, job in parsed_jobs_dict.items():
                     await self._process_job_update(job_id, job)
 
-            self._last_successful_poll = time.time()
+            self._last_successful_poll_monotonic = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_state: AnyJob) -> None:

--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -44,17 +44,19 @@ class _JobsJson:
 
 class SubmitSleeper:
     _submit_sleep: float
-    _last_started: float
+    _last_started_monotonic: float
 
     def __init__(self, submit_sleep: float) -> None:
         self._submit_sleep = submit_sleep
-        self._last_started = time.monotonic() - submit_sleep
+        self._last_started_monotonic = time.monotonic() - submit_sleep
 
     async def sleep_until_we_can_submit(self) -> None:
-        now = time.monotonic()
-        next_start_time = max(self._last_started + self._submit_sleep, now)
-        self._last_started = next_start_time
-        await asyncio.sleep(max(0.0, next_start_time - now))
+        monotonic_now = time.monotonic()
+        next_start_time = max(
+            self._last_started_monotonic + self._submit_sleep, monotonic_now
+        )
+        self._last_started_monotonic = next_start_time
+        await asyncio.sleep(max(0.0, next_start_time - monotonic_now))
 
 
 class Scheduler:

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -323,7 +323,7 @@ class SlurmDriver(Driver):
                     "scontrol did not give status for job_ids "
                     f"{missing_in_squeue_and_scontrol}, giving up for now."
                 )
-            self._last_successful_poll = time.time()
+            self._last_successful_poll_monotonic = time.monotonic()
             await asyncio.sleep(self._poll_period)
 
     async def _process_job_update(self, job_id: str, new_info: JobInfo) -> None:


### PR DESCRIPTION
**Issue**
Resolves #13111

**Approach**
Switch to using `monotonic()` when measuring duration as this clock only moves forward and is not affected by system clock updates.