### PR TITLE
Backport: Fix ert using incorrect gen_kw when exporting to runpath if name is s…

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -541,7 +541,7 @@ class LocalEnsemble(BaseMode):
                 for col in df.columns:
                     if col == "realization":
                         continue
-                    if col.startswith(key):
+                    if col == key:
                         tmp_configuration[col] = (
                             self.experiment.parameter_configuration[key]
                         )

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -1,5 +1,7 @@
+import json
 import math
 import re
+from itertools import permutations
 from pathlib import Path
 from textwrap import dedent
 
@@ -911,3 +913,58 @@ def test_that_init_files_option_raises_removal_error(tmp_path):
                 {"INIT_FILES": "init_%d"},
             ]
         )
+
+
+@pytest.mark.parametrize("order", list(permutations([("A", 1), ("AA", 2), ("AAA", 3)])))
+def test_that_gen_kw_substitutes_correctly(order, tmpdir, storage, run_args):
+    """This is a regression test to check that the substitution mechanism
+    works correctly when there are multiple parameters with similar names."""
+    with tmpdir.as_cwd():
+        config = dedent(
+            """
+        JOBNAME my_name%d
+        NUM_REALIZATIONS 1
+        GEN_KW KW_NAME prior.txt
+        """
+        )
+        Path("config.ert").write_text(config, encoding="utf-8")
+        Path("prior.txt").write_text(
+            "\n".join(
+                f"{param_name} CONST {param_value}"
+                for (param_name, param_value) in order
+            ),
+            encoding="utf-8",
+        )
+
+        ert_config = ErtConfig.from_file("config.ert")
+
+        experiment_id = storage.create_experiment(
+            experiment_config={
+                "parameter_configuration": (
+                    ert_config.ensemble_config.parameter_configuration
+                )
+            }
+        )
+        prior_ensemble = storage.create_ensemble(
+            experiment_id, name="prior", ensemble_size=1
+        )
+        sample_prior(prior_ensemble, [0], 123, 1)
+        create_run_path(
+            run_args=run_args(ert_config, prior_ensemble),
+            ensemble=prior_ensemble,
+            runpaths=Runpaths.from_config(ert_config),
+            user_config_file=ert_config.user_config_file,
+            forward_model_steps=ert_config.forward_model_steps,
+            env_vars=ert_config.env_vars,
+            env_pr_fm_step=ert_config.env_pr_fm_step,
+            substitutions=ert_config.substitutions,
+            parameters_file="parameters",
+        )
+
+        param_json = json.loads(
+            Path("simulations/realization-0/iter-0/parameters.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for param_name, param_value in order:
+            assert int(param_json[f"{param_name}"]["value"]) == param_value


### PR DESCRIPTION
…ubstring

This commit fixes the issue where two gen kw parameters where one of the names is a substring of the other one would be overwritten.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
