### PR TITLE
Fix inverted variance-reduction assertion in distance localization test

### DIFF
--- a/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
@@ -26,10 +26,13 @@ def assert_variance_in_field(
         x=no_upd_pos[0], y=no_upd_pos[1]
     )
 
-    assert (
-        posterior_var_obs.mean() - prior_var_obs.mean()
-        > posterior_var_no_obs.mean() - prior_var_no_obs.mean()
-    ), f"Expecting stronger update on observation location than outside on {field_name}"
+    obs_reduction = prior_var_obs.mean() - posterior_var_obs.mean()
+    no_obs_reduction = prior_var_no_obs.mean() - posterior_var_no_obs.mean()
+
+    assert obs_reduction > no_obs_reduction, (
+        f"Expecting stronger variance reduction at observation location "
+        f"than outside on {field_name}"
+    )
 
 
 @pytest.mark.timeout(600)


### PR DESCRIPTION
The test compared (posterior - prior) deltas with >, which passes when variance *increases* more near the observation which is the opposite of the intended check.
Replace with explicit variance reductions (prior - posterior) and assert the reduction is larger at the observation location than away from it.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
