### PR TITLE
Fix flaky test_design_matrix.py

### DIFF
--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -293,7 +293,13 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
             "--experiment-name",
             "test-experiment",
         )
-    warning_messages = [str(warning.message) for warning in all_warnings]
+    warning_messages = [
+        str(warning.message)
+        for warning in all_warnings
+        if not str(warning.message).startswith(
+            "Use of legacy_ertscript_workflow is deprecated"
+        )
+    ]
     # there are two warnings, where one is about NUM_REALIZATIONS begin greater than
     # the number of realizations in the design matrix
     assert len(warning_messages) == 2


### PR DESCRIPTION
**Issue**
Resolves #13139


**Approach**
This commit fixes the flaky test
ui_tests/cli/analysis/test_design_matrix.py::test_run_poly_example_with_multiple_design_matrix_instances by filtering out `Ùse of legacy_ertscript_workflow` warnings.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
