### PR TITLE
Partly isolate observations related code in rft read_from_file

### DIFF
--- a/docs/ert/reference/glossary.rst
+++ b/docs/ert/reference/glossary.rst
@@ -129,4 +129,9 @@ It is not about being correct, it is about being relevant and coherent.
     MD
         The length (along the well path) for a point along a well borehole.
 
+    well connection
+        A well connection is a single (i,j,k) grid cell that a well intersects in the
+        simulation grid. A well typically has multiple such connections, one for each
+        grid cell along its path.
+
 .. _OPM Flow manual: https://opm-project.org/wp-content/uploads/2023/06/OPM_Flow_Reference_Manual_2023-04_Rev-0_Reduced.pdf

--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -18,7 +18,7 @@ from .parsing import (
     ErrorInfo,
     ObservationConfigError,
 )
-from .rft_config import RFTConfig
+from .rft_config import Point, RFTConfig, ZoneName
 
 DEFAULT_LOCALIZATION_RADIUS = 2000
 
@@ -149,11 +149,12 @@ def _handle_rft_observation(
 ) -> pl.DataFrame:
     location = (rft_observation.east, rft_observation.north, rft_observation.tvd)
     localization_radius = rft_observation.radius
-    if location not in rft_config.locations:
-        if (zone := rft_observation.zone) is not None:
-            rft_config.locations.append((location, zone))
-        else:
-            rft_config.locations.append(location)
+
+    location_arg: Point | tuple[Point, ZoneName] = location
+    if (zone := rft_observation.zone) is not None:
+        location_arg = (location, zone)
+    if location_arg not in rft_config.locations:
+        rft_config.locations.append(location_arg)
 
     data_to_read = rft_config.data_to_read
     if rft_observation.well not in data_to_read:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -104,6 +104,34 @@ class RFTConfig(ResponseConfig):
 
         return [f"{base}.RFT"]
 
+    @staticmethod
+    def _rft_filepath(base_name: str, run_path: str, iens: int, iter_: int) -> str:
+        base_name = substitute_runpath_name(base_name, iens, iter_)
+        if base_name.upper().endswith(".DATA"):
+            # For backwards compatibility, it is
+            # allowed to give REFCASE and ECLBASE both
+            # with and without .DATA extensions
+            base_name = base_name[:-5]
+
+        return f"{run_path}/{base_name}"
+
+    @staticmethod
+    def _ergrid_filepath(rft_filepath: str) -> str:
+        grid_filepath = rft_filepath
+        if grid_filepath.upper().endswith(".RFT"):
+            grid_filepath = grid_filepath[:-4]
+        grid_filepath += ".EGRID"
+        return grid_filepath
+
+    @staticmethod
+    def _zonemap_filepath(
+        base_path: Path, run_path: str, iens: int, iter_: int
+    ) -> Path:
+        zonemap_filepath = Path(substitute_runpath_name(str(base_path), iens, iter_))
+        if not base_path.is_absolute():
+            zonemap_filepath = Path(run_path) / zonemap_filepath
+        return zonemap_filepath
+
     def _find_indices(
         self, egrid_file: str | os.PathLike[str] | IO[Any]
     ) -> dict[GridIndex | None, set[_ZonedPoint]]:
@@ -163,32 +191,22 @@ class RFTConfig(ResponseConfig):
         Points which were constrained to be in a given zone, but were not contained
         in that zone, is not labeled, and instead a warning is emitted.
         """
-        filename = substitute_runpath_name(self.input_files[0], iens, iter_)
+        rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
+        grid_filepath = self._ergrid_filepath(rft_filepath)
+
         if self.zonemap:
-            zonemap_filename = Path(
-                substitute_runpath_name(str(self.zonemap), iens, iter_)
-            )
-            if not self.zonemap.is_absolute():
-                zonemap_filename = Path(run_path) / zonemap_filename
-            zonemap = parse_zonemap(str(zonemap_filename), zonemap_filename.read_text())
+            zonemap_path = self._zonemap_filepath(self.zonemap, run_path, iens, iter_)
+            zonemap = parse_zonemap(str(zonemap_path), zonemap_path.read_text())
         else:
             zonemap = {}
-        if filename.upper().endswith(".DATA"):
-            # For backwards compatibility, it is
-            # allowed to give REFCASE and ECLBASE both
-            # with and without .DATA extensions
-            filename = filename[:-5]
-        grid_filename = f"{run_path}/{filename}"
-        if grid_filename.upper().endswith(".RFT"):
-            grid_filename = grid_filename[:-4]
-        grid_filename += ".EGRID"
+
         fetched: dict[
             tuple[WellName, datetime.date], dict[RFTProperty, npt.NDArray[np.float32]]
         ] = defaultdict(dict)
         indices = {}
         if self.locations:
             indices = self._filter_zones(
-                self._find_indices(grid_filename), iens, iter_, zonemap
+                self._find_indices(grid_filepath), iens, iter_, zonemap
             )
         if None in indices:
             raise InvalidResponseFile(
@@ -244,7 +262,7 @@ class RFTConfig(ResponseConfig):
         locations = {}
         connections = {}
         try:
-            with RFTReader.open(f"{run_path}/{filename}") as rft:
+            with RFTReader.open(rft_filepath) as rft:
                 for entry in rft:
                     date = entry.date
                     well = entry.well
@@ -268,7 +286,7 @@ class RFTConfig(ResponseConfig):
                                 if num_values != num_conns:
                                     raise InvalidResponseFile(
                                         "Could not read RFT from "
-                                        f"{run_path}/{filename}: "
+                                        f"{rft_filepath}: "
                                         f"RFT property {rft_property} for well {well} "
                                         f"at {date.isoformat()} has {num_values} "
                                         f"value{'s' if num_values != 1 else ''} "
@@ -278,7 +296,7 @@ class RFTConfig(ResponseConfig):
                                 fetched[well, date][rft_property] = values
         except (FileNotFoundError, InvalidRFTError) as err:
             raise InvalidResponseFile(
-                f"Could not read RFT from {run_path}/{filename}: {err}"
+                f"Could not read RFT from {rft_filepath}: {err}"
             ) from err
 
         if not fetched:
@@ -351,7 +369,7 @@ class RFTConfig(ResponseConfig):
             )
         except KeyError as err:
             raise InvalidResponseFile(
-                f"Could not find {err.args[0]} in RFTFile {filename}"
+                f"Could not find {err.args[0]} in RFTFile {rft_filepath}"
             ) from err
 
         return df.with_columns(

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -178,6 +178,13 @@ class RFTConfig(ResponseConfig):
                             locs.remove(loc)
         return indices
 
+    @staticmethod
+    def _assert_schema(df: pl.DataFrame, schema: dict[str, Any]) -> pl.DataFrame:
+        if df.schema != schema:
+            msg = f"Expected schema {schema}, got {df.schema}."
+            raise AssertionError(msg)
+        return df
+
     @dataclass(frozen=True)
     class ValidRFTEntry:
         property_values: dict[RFTProperty, npt.NDArray[np.float32]]
@@ -286,44 +293,32 @@ class RFTConfig(ResponseConfig):
         Points which were constrained to be in a given zone, but were not contained
         in that zone, is not labeled, and instead a warning is emitted.
         """
-        rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
+        schema: dict[str, Any] = {
+            "response_key": pl.String,
+            "well": pl.String,
+            "date": pl.String,
+            "property": pl.String,
+            "time": pl.Date,
+            "depth": pl.Float32,
+            "values": pl.Float32,
+            "zone": pl.String,
+            "east": pl.Float32,
+            "north": pl.Float32,
+            "tvd": pl.Float32,
+            "i": pl.Int64,
+            "j": pl.Int64,
+            "k": pl.Int64,
+        }
 
         if not self.data_to_read:
-            return pl.DataFrame(
-                {
-                    "response_key": [],
-                    "time": [],
-                    "depth": [],
-                    "values": [],
-                    "east": [],
-                    "north": [],
-                    "tvd": [],
-                    "zone": [],
-                }
-            )
+            return pl.DataFrame(schema=schema)
 
+        rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]
         rft_data = self._scan_rft(rft_filepath)
 
         if not rft_data:
-            return pl.DataFrame(
-                {
-                    "response_key": [],
-                    "well": [],
-                    "date": [],
-                    "property": [],
-                    "time": [],
-                    "depth": [],
-                    "values": [],
-                    "east": [],
-                    "north": [],
-                    "tvd": [],
-                    "i": [],
-                    "j": [],
-                    "k": [],
-                    "zone": [],
-                }
-            )
+            return pl.DataFrame(schema=schema)
 
         locations = self._obtain_locations(run_path, iens, iter_, rft_data)
 
@@ -384,14 +379,18 @@ class RFTConfig(ResponseConfig):
                 f"Could not find {err.args[0]} in RFTFile {rft_filepath}"
             ) from err
 
-        return df.with_columns(
-            east=pl.col("location").arr.get(0),
-            north=pl.col("location").arr.get(1),
-            tvd=pl.col("location").arr.get(2),
-            i=pl.col("well_connection_cell").list.get(0),
-            j=pl.col("well_connection_cell").list.get(1),
-            k=pl.col("well_connection_cell").list.get(2),
-        ).drop("location", "well_connection_cell")
+        return (
+            df.with_columns(
+                east=pl.col("location").arr.get(0),
+                north=pl.col("location").arr.get(1),
+                tvd=pl.col("location").arr.get(2),
+                i=pl.col("well_connection_cell").list.get(0),
+                j=pl.col("well_connection_cell").list.get(1),
+                k=pl.col("well_connection_cell").list.get(2),
+            )
+            .drop("location", "well_connection_cell")
+            .pipe(self._assert_schema, schema)
+        )
 
     def _obtain_locations(
         self,

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -287,23 +287,6 @@ class RFTConfig(ResponseConfig):
         in that zone, is not labeled, and instead a warning is emitted.
         """
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
-        grid_filepath = self._ergrid_filepath(rft_filepath)
-
-        if self.zonemap:
-            zonemap_path = self._zonemap_filepath(self.zonemap, run_path, iens, iter_)
-            zonemap = parse_zonemap(str(zonemap_path), zonemap_path.read_text())
-        else:
-            zonemap = {}
-
-        indices = {}
-        if self.locations:
-            indices = self._filter_zones(
-                self._find_indices(grid_filepath), iens, iter_, zonemap
-            )
-        if None in indices:
-            raise InvalidResponseFile(
-                f"Did not find grid coordinate for location(s) {indices[None]}"
-            )
 
         if not self.data_to_read:
             return pl.DataFrame(
@@ -321,18 +304,6 @@ class RFTConfig(ResponseConfig):
 
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]
         rft_data = self._scan_rft(rft_filepath)
-
-        locations = {}
-        for (well, date), rft_entry in rft_data.items():
-            locations[well, date] = [
-                list(
-                    indices.get(
-                        (c[0] - 1, c[1] - 1, c[2] - 1),
-                        [_ZonedPoint()],
-                    )
-                )
-                for c in rft_entry.well_connection_cells
-            ]
 
         if not rft_data:
             return pl.DataFrame(
@@ -353,6 +324,8 @@ class RFTConfig(ResponseConfig):
                     "zone": [],
                 }
             )
+
+        locations = self._obtain_locations(run_path, iens, iter_, rft_data)
 
         try:
             df = pl.concat(
@@ -419,6 +392,45 @@ class RFTConfig(ResponseConfig):
             j=pl.col("well_connection_cell").list.get(1),
             k=pl.col("well_connection_cell").list.get(2),
         ).drop("location", "well_connection_cell")
+
+    def _obtain_locations(
+        self,
+        run_path: str,
+        iens: int,
+        iter_: int,
+        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.RFTEntryExtract],
+    ) -> dict[tuple[WellName, datetime.date], list[list[_ZonedPoint]]]:
+        rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
+        grid_filepath = self._ergrid_filepath(rft_filepath)
+
+        if self.zonemap:
+            zonemap_path = self._zonemap_filepath(self.zonemap, run_path, iens, iter_)
+            zonemap = parse_zonemap(str(zonemap_path), zonemap_path.read_text())
+        else:
+            zonemap = {}
+
+        indices = {}
+        if self.locations:
+            indices = self._filter_zones(
+                self._find_indices(grid_filepath), iens, iter_, zonemap
+            )
+        if None in indices:
+            raise InvalidResponseFile(
+                f"Did not find grid coordinate for location(s) {indices[None]}"
+            )
+
+        locations = {}
+        for (well, date), rft_entry in rft_data.items():
+            locations[well, date] = [
+                list(
+                    indices.get(
+                        (c[0] - 1, c[1] - 1, c[2] - 1),
+                        [_ZonedPoint()],
+                    )
+                )
+                for c in rft_entry.well_connection_cells
+            ]
+        return locations
 
     @property
     def response_type(self) -> str:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -132,51 +132,63 @@ class RFTConfig(ResponseConfig):
             zonemap_filepath = Path(run_path) / zonemap_filepath
         return zonemap_filepath
 
-    def _find_indices(
-        self, egrid_file: str | os.PathLike[str] | IO[Any]
-    ) -> dict[GridIndex | None, set[_ZonedPoint]]:
-        indices: dict[GridIndex | None, set[_ZonedPoint]] = defaultdict(set)
-        if not self._zoned_locations:
-            return indices
+    @staticmethod
+    def _map_locations_to_cells(
+        egrid_file: str | os.PathLike[str] | IO[Any], zoned_locations: list[_ZonedPoint]
+    ) -> dict[_ZonedPoint, GridIndex]:
+        """
+        For each location, find the corresponding connected grid cell, if it exists.
+        """
+
+        location_cell_map: dict[_ZonedPoint, GridIndex] = {}
+        if not zoned_locations:
+            return location_cell_map
         try:
             grid = CornerpointGrid.read_egrid(egrid_file)
         except (OSError, InvalidEgridFileError) as err:
             raise InvalidResponseFile(f"Could not read grid file: {err}") from err
-        for a, b in zip(
+
+        for zoned_location, cell in zip(
+            zoned_locations,
             grid.find_cell_containing_point(
-                [cast(Point, loc.point) for loc in self._zoned_locations]
+                [cast(Point, loc.point) for loc in zoned_locations]
             ),
-            self._zoned_locations,
             strict=True,
         ):
-            indices[a].add(b)
-        return indices
+            if cell is None:
+                raise InvalidResponseFile(
+                    f"Did not find grid coordinate for location(s) {zoned_location}"
+                )
+            # cells returned by grid are 0-based, while zonemap
+            # and RFTEntry.connections are 1-based, so unifying
+            location_cell_map[zoned_location] = (cell[0] + 1, cell[1] + 1, cell[2] + 1)
+        return location_cell_map
 
+    @staticmethod
     def _filter_zones(
-        self,
-        indices: dict[GridIndex | None, set[_ZonedPoint]],
+        location_cell_map: dict[_ZonedPoint, GridIndex],
         iens: int,
         iter_: int,
         zonemap: Mapping[int, Container[str]],
-    ) -> dict[GridIndex | None, set[_ZonedPoint]]:
-        for idx, locs in indices.items():
-            if idx is not None:
-                for loc in list(locs):
-                    if loc.has_zone():
-                        zone = cast(ZoneName, loc.zone_name)
-                        # zonemap is 1-indexed so +1
-                        if zone not in zonemap.get(idx[-1] + 1, []):
-                            warnings.warn(
-                                PostExperimentWarning(
-                                    f"An RFT observation with location {loc.point}, "
-                                    f"in iteration {iter_}, realization {iens} did "
-                                    f"not match expected zone {zone}. The observation "
-                                    "was deactivated",
-                                ),
-                                stacklevel=2,
-                            )
-                            locs.remove(loc)
-        return indices
+    ) -> dict[_ZonedPoint, GridIndex | None]:
+        filtered_map: dict[_ZonedPoint, GridIndex | None] = {}
+        for loc, cell in location_cell_map.items():
+            filtered_map[loc] = cell
+            if cell is not None and loc.has_zone():
+                zone = cast(ZoneName, loc.zone_name)
+                # zone is supposed to correspond to cell k index
+                if zone not in zonemap.get(cell[-1], []):
+                    warnings.warn(
+                        PostExperimentWarning(
+                            f"An RFT observation with location {loc.point}, "
+                            f"in iteration {iter_}, realization {iens} did "
+                            f"not match expected zone {zone}. The observation "
+                            "was deactivated",
+                        ),
+                        stacklevel=2,
+                    )
+                    filtered_map[loc] = None
+        return filtered_map
 
     @staticmethod
     def _assert_schema(df: pl.DataFrame, schema: dict[str, Any]) -> pl.DataFrame:
@@ -399,6 +411,8 @@ class RFTConfig(ResponseConfig):
         iter_: int,
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.RFTEntryExtract],
     ) -> dict[tuple[WellName, datetime.date], list[list[_ZonedPoint]]]:
+        zoned_locations = self._zoned_locations
+
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
         grid_filepath = self._ergrid_filepath(rft_filepath)
 
@@ -408,27 +422,26 @@ class RFTConfig(ResponseConfig):
         else:
             zonemap = {}
 
-        indices = {}
-        if self.locations:
-            indices = self._filter_zones(
-                self._find_indices(grid_filepath), iens, iter_, zonemap
-            )
-        if None in indices:
-            raise InvalidResponseFile(
-                f"Did not find grid coordinate for location(s) {indices[None]}"
+        location_cell_map = {}
+        if zoned_locations:
+            location_cell_map = self._filter_zones(
+                self._map_locations_to_cells(grid_filepath, zoned_locations),
+                iens,
+                iter_,
+                zonemap,
             )
 
-        locations = {}
+        locations: dict[tuple[WellName, datetime.date], list[list[_ZonedPoint]]] = {}
         for (well, date), rft_entry in rft_data.items():
-            locations[well, date] = [
-                list(
-                    indices.get(
-                        (c[0] - 1, c[1] - 1, c[2] - 1),
-                        [_ZonedPoint()],
-                    )
-                )
-                for c in rft_entry.well_connection_cells
-            ]
+            locations[well, date] = []
+            for c in rft_entry.well_connection_cells:
+                locations_for_cell = []
+                for location, cell in location_cell_map.items():
+                    if cell == tuple(c):
+                        locations_for_cell.append(location)
+                if not locations_for_cell:
+                    locations_for_cell = [_ZonedPoint()]
+                locations[well, date].append(locations_for_cell)
         return locations
 
     @property

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -7,7 +7,6 @@ import os
 import re
 import warnings
 from collections import defaultdict
-from collections.abc import Container, Mapping
 from dataclasses import InitVar, dataclass
 from pathlib import Path
 from typing import IO, Any, Literal, TypeAlias, cast
@@ -165,32 +164,6 @@ class RFTConfig(ResponseConfig):
         return location_cell_map
 
     @staticmethod
-    def _filter_zones(
-        location_cell_map: dict[_ZonedPoint, GridIndex],
-        iens: int,
-        iter_: int,
-        zonemap: Mapping[int, Container[str]],
-    ) -> dict[_ZonedPoint, GridIndex | None]:
-        filtered_map: dict[_ZonedPoint, GridIndex | None] = {}
-        for loc, cell in location_cell_map.items():
-            filtered_map[loc] = cell
-            if cell is not None and loc.has_zone():
-                zone = cast(ZoneName, loc.zone_name)
-                # zone is supposed to correspond to cell k index
-                if zone not in zonemap.get(cell[-1], []):
-                    warnings.warn(
-                        PostExperimentWarning(
-                            f"An RFT observation with location {loc.point}, "
-                            f"in iteration {iter_}, realization {iens} did "
-                            f"not match expected zone {zone}. The observation "
-                            "was deactivated",
-                        ),
-                        stacklevel=2,
-                    )
-                    filtered_map[loc] = None
-        return filtered_map
-
-    @staticmethod
     def _assert_schema(df: pl.DataFrame, schema: dict[str, Any]) -> pl.DataFrame:
         if df.schema != schema:
             msg = f"Expected schema {schema}, got {df.schema}."
@@ -332,7 +305,7 @@ class RFTConfig(ResponseConfig):
         if not rft_data:
             return pl.DataFrame(schema=schema)
 
-        locations = self._obtain_locations(run_path, iens, iter_, rft_data)
+        location_metadata = self._obtain_location_metadata(run_path, iens, iter_)
 
         try:
             df = pl.concat(
@@ -346,41 +319,12 @@ class RFTConfig(ResponseConfig):
                             "time": [time],
                             "depth": [rft_data[well, time].property_values["DEPTH"]],
                             "values": [vals],
-                            "location": pl.Series(
-                                [
-                                    [
-                                        [loc.point for loc in locs]
-                                        for locs in locations.get(
-                                            (well, time),
-                                            [[_ZonedPoint()]] * len(vals),
-                                        )
-                                    ]
-                                ],
-                                dtype=pl.Array(
-                                    pl.List(pl.Array(pl.Float32, 3)), len(vals)
-                                ),
-                            ),
-                            "well_connection_cell": [
-                                rft_data[well, time].well_connection_cells.tolist()
-                            ],
-                            "zone": pl.Series(
-                                [
-                                    [
-                                        [loc.zone_name for loc in locs]
-                                        for locs in locations.get(
-                                            (well, time),
-                                            [[_ZonedPoint()]] * len(vals),
-                                        )
-                                    ]
-                                ],
-                                dtype=pl.Array(pl.List(pl.String), len(vals)),
+                            "well_connection_cell": pl.Series(
+                                [rft_data[well, time].well_connection_cells.tolist()],
+                                dtype=pl.List(pl.Array(pl.Int64, 3)),
                             ),
                         }
-                    )
-                    .explode(
-                        "depth", "values", "location", "well_connection_cell", "zone"
-                    )
-                    .explode("location", "zone")
+                    ).explode("depth", "values", "well_connection_cell")
                     for (well, time), inner_dict in rft_data.items()
                     for prop, vals in inner_dict.property_values.items()
                     if prop != "DEPTH" and len(vals) > 0
@@ -391,26 +335,26 @@ class RFTConfig(ResponseConfig):
                 f"Could not find {err.args[0]} in RFTFile {rft_filepath}"
             ) from err
 
-        return (
-            df.with_columns(
-                east=pl.col("location").arr.get(0),
-                north=pl.col("location").arr.get(1),
-                tvd=pl.col("location").arr.get(2),
-                i=pl.col("well_connection_cell").list.get(0),
-                j=pl.col("well_connection_cell").list.get(1),
-                k=pl.col("well_connection_cell").list.get(2),
-            )
-            .drop("location", "well_connection_cell")
-            .pipe(self._assert_schema, schema)
+        combined = self._combine_response_and_location_metadata(
+            df, location_metadata, iens, iter_
         )
 
-    def _obtain_locations(
+        return combined.pipe(self._assert_schema, schema)
+
+    def _obtain_location_metadata(
         self,
         run_path: str,
         iens: int,
         iter_: int,
-        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.RFTEntryExtract],
-    ) -> dict[tuple[WellName, datetime.date], list[list[_ZonedPoint]]]:
+    ) -> pl.DataFrame:
+        """
+        Obtains location metadata for the observations from provided simulation run.
+        'location' and 'expected_zone' is data provided by the observations. 'location'
+        is a primary key, while 'expected_zone' is added for completeness.
+        'actual_zones' is a list of zones that the location belongs to according to the
+        zonemap, and 'actual_cell' is the grid cell that the location belongs to in
+        current simulation.
+        """
         zoned_locations = self._zoned_locations
 
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
@@ -422,27 +366,83 @@ class RFTConfig(ResponseConfig):
         else:
             zonemap = {}
 
-        location_cell_map = {}
-        if zoned_locations:
-            location_cell_map = self._filter_zones(
-                self._map_locations_to_cells(grid_filepath, zoned_locations),
-                iens,
-                iter_,
-                zonemap,
+        location_cell_map = self._map_locations_to_cells(grid_filepath, zoned_locations)
+
+        return pl.DataFrame(
+            {
+                "location": pl.Series(
+                    [loc.point for loc in zoned_locations],
+                    dtype=pl.Array(pl.Float32, 3),
+                ),
+                "expected_zone": pl.Series(
+                    [loc.zone_name for loc in zoned_locations], dtype=pl.String
+                ),
+                "actual_zones": pl.Series(
+                    [
+                        zonemap.get(location_cell_map[loc][-1], [])
+                        for loc in zoned_locations
+                    ],
+                    dtype=pl.List(pl.String),
+                ),
+                "actual_cell": pl.Series(
+                    [location_cell_map[loc] for loc in zoned_locations],
+                    dtype=pl.Array(pl.Int64, 3),
+                ),
+            }
+        )
+
+    @staticmethod
+    def _combine_response_and_location_metadata(
+        responses: pl.DataFrame,
+        location_metadata: pl.DataFrame,
+        iens: int,
+        iter_: int,
+    ) -> pl.DataFrame:
+        result = responses.join(
+            location_metadata,
+            left_on="well_connection_cell",
+            right_on="actual_cell",
+            how="left",
+        )
+
+        is_zone_valid = pl.col("expected_zone").is_null() | pl.col(
+            "expected_zone"
+        ).is_in(pl.col("actual_zones"))
+
+        disabled_due_to_zone_mismatch = result.filter(
+            pl.col("expected_zone").is_not_null() & ~is_zone_valid
+        )
+        for row in disabled_due_to_zone_mismatch.iter_rows(named=True):
+            warnings.warn(
+                PostExperimentWarning(
+                    f"An RFT observation with location {row['location']}, "
+                    f"in iteration {iter_}, realization {iens} did "
+                    f"not match expected zone {row['expected_zone']}. The observation "
+                    "was deactivated",
+                ),
+                stacklevel=2,
+            )
+        result = result.filter(is_zone_valid)
+
+        def location_to_coordinate(index: int, name: str) -> pl.Expr:
+            return (
+                pl.when(pl.col("location").is_null())
+                .then(None)
+                .otherwise(pl.col("location").arr.get(index))
+                .alias(name)
             )
 
-        locations: dict[tuple[WellName, datetime.date], list[list[_ZonedPoint]]] = {}
-        for (well, date), rft_entry in rft_data.items():
-            locations[well, date] = []
-            for c in rft_entry.well_connection_cells:
-                locations_for_cell = []
-                for location, cell in location_cell_map.items():
-                    if cell == tuple(c):
-                        locations_for_cell.append(location)
-                if not locations_for_cell:
-                    locations_for_cell = [_ZonedPoint()]
-                locations[well, date].append(locations_for_cell)
-        return locations
+        return result.with_columns(
+            [
+                pl.col("expected_zone").alias("zone"),
+                location_to_coordinate(0, "east"),
+                location_to_coordinate(1, "north"),
+                location_to_coordinate(2, "tvd"),
+                pl.col("well_connection_cell").arr.get(0).alias("i"),
+                pl.col("well_connection_cell").arr.get(1).alias("j"),
+                pl.col("well_connection_cell").arr.get(2).alias("k"),
+            ]
+        ).drop(["location", "well_connection_cell", "expected_zone", "actual_zones"])
 
     @property
     def response_type(self) -> str:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -260,7 +260,7 @@ class RFTConfig(ResponseConfig):
             )
         )
         locations = {}
-        connections = {}
+        well_connection_cells = {}
         try:
             with RFTReader.open(rft_filepath) as rft:
                 for entry in rft:
@@ -270,16 +270,6 @@ class RFTConfig(ResponseConfig):
                         key = f"{well}{sep}{date}{sep}{rft_property}"
                         if matcher.fullmatch(key) is not None:
                             values = entry[rft_property]
-                            locations[well, date] = [
-                                list(
-                                    indices.get(
-                                        (c[0] - 1, c[1] - 1, c[2] - 1),
-                                        [_ZonedPoint()],
-                                    )
-                                )
-                                for c in entry.connections
-                            ]
-                            connections[well, date] = entry.connections
                             if np.isdtype(values.dtype, np.float32):
                                 num_values = len(values)
                                 num_conns = len(entry.connections)
@@ -294,10 +284,25 @@ class RFTConfig(ResponseConfig):
                                         f"connection{'s' if num_conns != 1 else ''}"
                                     )
                                 fetched[well, date][rft_property] = values
+
+                    if (well, date) in fetched:
+                        well_connection_cells[well, date] = entry.connections
+
         except (FileNotFoundError, InvalidRFTError) as err:
             raise InvalidResponseFile(
                 f"Could not read RFT from {rft_filepath}: {err}"
             ) from err
+
+        for (well, date), cells in well_connection_cells.items():
+            locations[well, date] = [
+                list(
+                    indices.get(
+                        (c[0] - 1, c[1] - 1, c[2] - 1),
+                        [_ZonedPoint()],
+                    )
+                )
+                for c in cells
+            ]
 
         if not fetched:
             return pl.DataFrame(
@@ -345,7 +350,9 @@ class RFTConfig(ResponseConfig):
                                     pl.List(pl.Array(pl.Float32, 3)), len(vals)
                                 ),
                             ),
-                            "connection": [connections[well, time].tolist()],
+                            "well_connection_cell": [
+                                well_connection_cells[well, time].tolist()
+                            ],
                             "zone": pl.Series(
                                 [
                                     [
@@ -360,7 +367,9 @@ class RFTConfig(ResponseConfig):
                             ),
                         }
                     )
-                    .explode("depth", "values", "location", "connection", "zone")
+                    .explode(
+                        "depth", "values", "location", "well_connection_cell", "zone"
+                    )
                     .explode("location", "zone")
                     for (well, time), inner_dict in fetched.items()
                     for prop, vals in inner_dict.items()
@@ -376,10 +385,10 @@ class RFTConfig(ResponseConfig):
             east=pl.col("location").arr.get(0),
             north=pl.col("location").arr.get(1),
             tvd=pl.col("location").arr.get(2),
-            i=pl.col("connection").list.get(0),
-            j=pl.col("connection").list.get(1),
-            k=pl.col("connection").list.get(2),
-        ).drop("location", "connection")
+            i=pl.col("well_connection_cell").list.get(0),
+            j=pl.col("well_connection_cell").list.get(1),
+            k=pl.col("well_connection_cell").list.get(2),
+        ).drop("location", "well_connection_cell")
 
     @property
     def response_type(self) -> str:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -203,6 +203,76 @@ class RFTConfig(ResponseConfig):
                         f"connection{'s' if num_conns != 1 else ''}"
                     )
 
+    def _scan_rft(
+        self, filepath: str
+    ) -> dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]:
+        # This is a somewhat complicated optimization in order to
+        # support wildcards in well names, dates and properties
+        # A python for loop is too slow so we use a compiled regex
+        # instead
+
+        sep = "\x31"
+
+        def _translate(pat: str) -> str:
+            """Translates fnmatch pattern to match anywhere"""
+            return fnmatch.translate(pat).replace("\\z", "").replace("\\Z", "")
+
+        def _props_matcher(props: list[str]) -> str:
+            """Regex for matching given props _and_ DEPTH"""
+            pattern = f"({'|'.join(_translate(p) for p in props)})"
+            if re.fullmatch(pattern, "DEPTH") is None:
+                return f"({'|'.join(_translate(p) for p in [*props, 'DEPTH'])})"
+            else:
+                return pattern
+
+        matcher = re.compile(
+            "|".join(
+                "("
+                + re.escape(sep).join(
+                    (
+                        _translate(well),
+                        _translate(time),
+                        _props_matcher(props),
+                    )
+                )
+                + ")"
+                for well, inner_dict in self.data_to_read.items()
+                for time, props in inner_dict.items()
+            )
+        )
+
+        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry] = {}
+        try:
+            with RFTReader.open(filepath) as rft:
+                for entry in rft:
+                    date = entry.date
+                    well = entry.well
+
+                    property_values: dict[str, np.ndarray] = {}
+                    for rft_property in entry:
+                        key = f"{well}{sep}{date}{sep}{rft_property}"
+                        if matcher.fullmatch(key) is not None:
+                            values = entry[rft_property]
+                            if np.isdtype(values.dtype, np.float32):
+                                property_values[rft_property] = values
+
+                    if property_values:
+                        valid_entry = RFTConfig.ValidRFTEntry(
+                            property_values=property_values,
+                            well_connection_cells=entry.connections,
+                            filepath=filepath,
+                            well=well,
+                            date=date,
+                        )
+                        rft_data[well, date] = valid_entry
+
+        except (FileNotFoundError, InvalidRFTError) as err:
+            raise InvalidResponseFile(
+                f"Could not read RFT from {filepath}: {err}"
+            ) from err
+
+        return rft_data
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         """Reads the RFT values from <RUNPATH>/<ECLBASE>.RFT
 
@@ -234,10 +304,7 @@ class RFTConfig(ResponseConfig):
             raise InvalidResponseFile(
                 f"Did not find grid coordinate for location(s) {indices[None]}"
             )
-        # This is a somewhat complicated optimization in order to
-        # support wildcards in well names, dates and properties
-        # A python for loop is too slow so we use a compiled regex
-        # instead
+
         if not self.data_to_read:
             return pl.DataFrame(
                 {
@@ -252,68 +319,10 @@ class RFTConfig(ResponseConfig):
                 }
             )
 
-        sep = "\x31"
+        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]
+        rft_data = self._scan_rft(rft_filepath)
 
-        def _translate(pat: str) -> str:
-            """Translates fnmatch pattern to match anywhere"""
-            return fnmatch.translate(pat).replace("\\z", "").replace("\\Z", "")
-
-        def _props_matcher(props: list[str]) -> str:
-            """Regex for matching given props _and_ DEPTH"""
-            pattern = f"({'|'.join(_translate(p) for p in props)})"
-            if re.fullmatch(pattern, "DEPTH") is None:
-                return f"({'|'.join(_translate(p) for p in [*props, 'DEPTH'])})"
-            else:
-                return pattern
-
-        matcher = re.compile(
-            "|".join(
-                "("
-                + re.escape(sep).join(
-                    (
-                        _translate(well),
-                        _translate(time),
-                        _props_matcher(props),
-                    )
-                )
-                + ")"
-                for well, inner_dict in self.data_to_read.items()
-                for time, props in inner_dict.items()
-            )
-        )
         locations = {}
-
-        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry] = {}
-        try:
-            with RFTReader.open(rft_filepath) as rft:
-                for entry in rft:
-                    date = entry.date
-                    well = entry.well
-
-                    property_values: dict[str, np.ndarray] = {}
-                    for rft_property in entry:
-                        key = f"{well}{sep}{date}{sep}{rft_property}"
-                        if matcher.fullmatch(key) is not None:
-                            values = entry[rft_property]
-                            if np.isdtype(values.dtype, np.float32):
-                                property_values[rft_property] = values
-
-                    if property_values:
-                        valid_entry = RFTConfig.ValidRFTEntry(
-                            property_values=property_values,
-                            well_connection_cells=entry.connections,
-                            filepath=rft_filepath,
-                            well=well,
-                            date=date,
-                        )
-
-                        rft_data[well, date] = valid_entry
-
-        except (FileNotFoundError, InvalidRFTError) as err:
-            raise InvalidResponseFile(
-                f"Could not read RFT from {rft_filepath}: {err}"
-            ) from err
-
         for (well, date), rft_entry in rft_data.items():
             locations[well, date] = [
                 list(

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -8,7 +8,7 @@ import re
 import warnings
 from collections import defaultdict
 from collections.abc import Container, Mapping
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from pathlib import Path
 from typing import IO, Any, Literal, TypeAlias, cast
 
@@ -178,6 +178,31 @@ class RFTConfig(ResponseConfig):
                             locs.remove(loc)
         return indices
 
+    @dataclass(frozen=True)
+    class ValidRFTEntry:
+        property_values: dict[RFTProperty, npt.NDArray[np.float32]]
+        # See :term:`well connection` in glossary
+        well_connection_cells: npt.NDArray[np.integer]
+
+        filepath: InitVar[str]
+        well: InitVar[str]
+        date: InitVar[datetime.date]
+
+        def __post_init__(self, filepath: str, well: str, date: datetime.date) -> None:
+            num_conns = len(self.well_connection_cells)
+            for rft_property, values in self.property_values.items():
+                num_values = len(values)
+                if num_values != num_conns:
+                    raise InvalidResponseFile(
+                        "Could not read RFT from "
+                        f"{filepath}: "
+                        f"RFT property {rft_property} for well {well} "
+                        f"at {date.isoformat()} has {num_values} "
+                        f"value{'s' if num_values != 1 else ''} "
+                        f"but {num_conns} well "
+                        f"connection{'s' if num_conns != 1 else ''}"
+                    )
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         """Reads the RFT values from <RUNPATH>/<ECLBASE>.RFT
 
@@ -200,9 +225,6 @@ class RFTConfig(ResponseConfig):
         else:
             zonemap = {}
 
-        fetched: dict[
-            tuple[WellName, datetime.date], dict[RFTProperty, npt.NDArray[np.float32]]
-        ] = defaultdict(dict)
         indices = {}
         if self.locations:
             indices = self._filter_zones(
@@ -260,40 +282,39 @@ class RFTConfig(ResponseConfig):
             )
         )
         locations = {}
-        well_connection_cells = {}
+
+        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry] = {}
         try:
             with RFTReader.open(rft_filepath) as rft:
                 for entry in rft:
                     date = entry.date
                     well = entry.well
+
+                    property_values: dict[str, np.ndarray] = {}
                     for rft_property in entry:
                         key = f"{well}{sep}{date}{sep}{rft_property}"
                         if matcher.fullmatch(key) is not None:
                             values = entry[rft_property]
                             if np.isdtype(values.dtype, np.float32):
-                                num_values = len(values)
-                                num_conns = len(entry.connections)
-                                if num_values != num_conns:
-                                    raise InvalidResponseFile(
-                                        "Could not read RFT from "
-                                        f"{rft_filepath}: "
-                                        f"RFT property {rft_property} for well {well} "
-                                        f"at {date.isoformat()} has {num_values} "
-                                        f"value{'s' if num_values != 1 else ''} "
-                                        f"but {num_conns} well "
-                                        f"connection{'s' if num_conns != 1 else ''}"
-                                    )
-                                fetched[well, date][rft_property] = values
+                                property_values[rft_property] = values
 
-                    if (well, date) in fetched:
-                        well_connection_cells[well, date] = entry.connections
+                    if property_values:
+                        valid_entry = RFTConfig.ValidRFTEntry(
+                            property_values=property_values,
+                            well_connection_cells=entry.connections,
+                            filepath=rft_filepath,
+                            well=well,
+                            date=date,
+                        )
+
+                        rft_data[well, date] = valid_entry
 
         except (FileNotFoundError, InvalidRFTError) as err:
             raise InvalidResponseFile(
                 f"Could not read RFT from {rft_filepath}: {err}"
             ) from err
 
-        for (well, date), cells in well_connection_cells.items():
+        for (well, date), rft_entry in rft_data.items():
             locations[well, date] = [
                 list(
                     indices.get(
@@ -301,10 +322,10 @@ class RFTConfig(ResponseConfig):
                         [_ZonedPoint()],
                     )
                 )
-                for c in cells
+                for c in rft_entry.well_connection_cells
             ]
 
-        if not fetched:
+        if not rft_data:
             return pl.DataFrame(
                 {
                     "response_key": [],
@@ -334,7 +355,7 @@ class RFTConfig(ResponseConfig):
                             "date": [time.isoformat()],
                             "property": [prop],
                             "time": [time],
-                            "depth": [fetched[well, time]["DEPTH"]],
+                            "depth": [rft_data[well, time].property_values["DEPTH"]],
                             "values": [vals],
                             "location": pl.Series(
                                 [
@@ -351,7 +372,7 @@ class RFTConfig(ResponseConfig):
                                 ),
                             ),
                             "well_connection_cell": [
-                                well_connection_cells[well, time].tolist()
+                                rft_data[well, time].well_connection_cells.tolist()
                             ],
                             "zone": pl.Series(
                                 [
@@ -371,8 +392,8 @@ class RFTConfig(ResponseConfig):
                         "depth", "values", "location", "well_connection_cell", "zone"
                     )
                     .explode("location", "zone")
-                    for (well, time), inner_dict in fetched.items()
-                    for prop, vals in inner_dict.items()
+                    for (well, time), inner_dict in rft_data.items()
+                    for prop, vals in inner_dict.property_values.items()
                     if prop != "DEPTH" and len(vals) > 0
                 ]
             )

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -413,6 +413,53 @@ def test_that_multiple_locations_in_the_same_cell_creates_multiple_rows(
     assert sorted(data["tvd"].to_list()) == [1.25, 1.5]
 
 
+def test_that_connection_mismatch_leads_to_nullified_location(mock_resfo_file, egrid):
+    config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "ECLBASE<IENS>",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "NAME",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.0,
+                        "EAST": 1.0,
+                        "TVD": 1.5,
+                    },
+                ],
+            ),
+        }
+    )
+
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.EGRID",
+        egrid,
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name="WELL",
+                ijks=[(5, 1, 1), (5, 1, 2), (5, 1, 3)],
+            ),
+            ("PRESSURE", float_arr([0.0, 1.0, 2.0])),
+            ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
+        ],
+    )
+
+    res = config.ensemble_config.response_configs["rft"].read_from_file(
+        "/tmp/does_not_exist", 1, 1
+    )
+    assert res["tvd"].to_list() == [None] * 3
+
+
 def test_that_handle_rft_observations_adds_defaulted_radius_column_to_dataframe():
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -120,11 +120,17 @@ def test_that_rft_with_empty_data_to_read_returns_empty_df(mock_resfo_file):
     assert df.is_empty()
     assert set(df.columns) == {
         "response_key",
+        "date",
+        "well",
+        "property",
         "time",
         "depth",
         "values",
         "east",
         "north",
+        "i",
+        "j",
+        "k",
         "tvd",
         "zone",
     }

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -462,6 +462,51 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
     assert df["radius"].dtype == pl.Float32
 
 
+@pytest.mark.parametrize(
+    ("zones"),
+    [
+        pytest.param(
+            [None, "zone1"],
+            id="Location with no zone followed by location with zone",
+        ),
+        pytest.param(
+            ["zone1", None],
+            id="Location with zone followed by location without zone",
+        ),
+        pytest.param(
+            ["zone1", "zone2"],
+            id="Location with zone followed by location with another zone",
+        ),
+    ],
+)
+def test_that_handle_rft_observations_adds_locations_both_with_zone_and_without(zones):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={"*": {"*": ["*"]}},
+    )
+
+    def make_observation(zone):
+        return RFTObservation(
+            name="NAME[0]",
+            well="WELL1",
+            date="2013-03-31",
+            value=294.0,
+            error=10.0,
+            property="PRESSURE",
+            north=71.0,
+            east=30.0,
+            tvd=2000.0,
+            radius=2400,
+            zone=zone,
+        )
+
+    for zone in zones:
+        rft_observation = make_observation(zone)
+        _handle_rft_observation(rft_config, rft_observation)
+
+    assert len(rft_config.locations) == 2
+
+
 def test_that_if_an_rft_observation_is_outside_the_zone_then_it_is_deactivated(
     mock_resfo_file, egrid, mocked_files
 ):

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -780,6 +780,78 @@ def test_that_when_the_zonemap_is_an_absolute_path_then_the_runpath_is_not_prepe
         )
 
 
+@pytest.mark.parametrize(
+    ("zonemap_path"),
+    [
+        pytest.param(
+            "zonemap<IENS>-<ITER>.txt",
+            id="when path is relative",
+        ),
+        pytest.param(
+            "/tmp/does_not_exist/zonemap<IENS>-<ITER>.txt",
+            id="when path is absolute",
+        ),
+    ],
+)
+def test_that_substitutions_are_applied_to_zonemap_filename(
+    mocked_files, mock_resfo_file, egrid, zonemap_path
+):
+    iens = 5
+    iter_ = 2
+    mocked_files[f"/tmp/does_not_exist/zonemap{iens}-{iter_}.txt"] = StringIO(
+        "zonemap_file_is_picked_correctly zone1"
+    )
+
+    mock_resfo_file(
+        f"/tmp/does_not_exist/ECLBASE{iens}.EGRID",
+        egrid,
+    )
+    mock_resfo_file(
+        f"/tmp/does_not_exist/ECLBASE{iens}.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name="WELL",
+                ijks=[(1, 1, 1), (1, 1, 2), (1, 1, 3)],
+            ),
+            ("PRESSURE", float_arr([0.0, 1.0, 2.0])),
+            ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
+        ],
+    )
+
+    config = ErtConfig.from_dict(
+        {
+            "ZONEMAP": zonemap_path,
+            "ECLBASE": "ECLBASE<IENS>",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "NAME",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.0,
+                        "EAST": 1.0,
+                        "TVD": 0.5,
+                        "ZONE": "zone1",
+                    },
+                ],
+            ),
+        }
+    )
+    with pytest.raises(
+        ConfigValidationError,
+        match="must be an integer, was zonemap_file_is_picked_correctly",
+    ):
+        config.ensemble_config.response_configs["rft"].read_from_file(
+            "/tmp/does_not_exist", iens, iter_
+        )
+
+
 def test_that_missing_egrid_with_locations_raises_invalid_response_file(
     mock_resfo_file,
 ):

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -568,11 +568,11 @@ def test_that_if_an_rft_observation_is_outside_the_zone_then_it_is_deactivated(
                     {
                         "type": ObservationType.RFT,
                         "name": "NAME",
-                        "WELL": "well",
+                        "WELL": "WELL2",
                         "VALUE": "700",
                         "ZONE": "zone2",
                         "ERROR": "0.1",
-                        "DATE": "2013-03-31",
+                        "DATE": "2000-01-01",
                         "PROPERTY": "PRESSURE",
                         "NORTH": 1.0,
                         "EAST": 1.0,
@@ -788,10 +788,26 @@ def test_that_observation_without_zones_are_not_disabled_by_zone_check(
 
 
 def test_that_when_the_zonemap_is_an_absolute_path_then_the_runpath_is_not_prepended(
-    mocked_files,
+    mock_resfo_file, egrid, mocked_files
 ):
     mocked_files["/tmp/does_not_exist/zonemap.txt"] = StringIO(
         "this_is_an_invalid_zonemap zone1"
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.EGRID",
+        egrid,
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name="WELL",
+                ijks=[(1, 1, 1), (1, 1, 2), (1, 1, 3)],
+            ),
+            ("PRESSURE", float_arr([0.0, 1.0, 2.0])),
+            ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
+        ],
     )
 
     config = ErtConfig.from_dict(

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -466,6 +466,55 @@ def test_that_connection_mismatch_leads_to_nullified_location(mock_resfo_file, e
     assert res["tvd"].to_list() == [None] * 3
 
 
+def test_that_location_outside_of_the_grid_raises_invalid_response_file(
+    mock_resfo_file, egrid
+):
+    config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "ECLBASE<IENS>",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "NAME",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1000.0,
+                        "EAST": 1000.0,
+                        "TVD": 1500.0,
+                    },
+                ],
+            ),
+        }
+    )
+
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.EGRID",
+        egrid,
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/ECLBASE1.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name="WELL",
+                ijks=[(1, 1, 1), (1, 1, 2), (1, 1, 3)],
+            ),
+            ("PRESSURE", float_arr([0.0, 1.0, 2.0])),
+            ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
+        ],
+    )
+
+    with pytest.raises(InvalidResponseFile, match="Did not find grid coordinate"):
+        config.ensemble_config.response_configs["rft"].read_from_file(
+            "/tmp/does_not_exist", 1, 1
+        )
+
+
 def test_that_handle_rft_observations_adds_defaulted_radius_column_to_dataframe():
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],


### PR DESCRIPTION
**Issue**
Does not resolve anything, but brings us a step closer to resolving #12787 


**Approach**
Currently RFT observation can be disabled for several reasons and in several places:
- in update on key mismatch (there are no responses matching `DATE` used in the observation)
- on zone mismatch during response creation (which issues a warning that is lost after application restart)
- silently on grid cell mismatch between well and observed location during response creation

So to know why observation is disabled we need to postpone all mismatch validations until update step.

To do this we need to untangle RFT's `read_from_file` which creates our response dataframe.
Now the dataframe contains combined information: data requested by user via RFT propery and quality assurance data for observation as in current realization.

So idea is to create two separate dataframes - one with responses (data requested by user via RFT property) and another with quality assurance data for observations.

This PR only deals with separating responses from observations metadata in `read_from_file` as much as possible.
It does not actually try to use those in the update step yet (so don't know how it will go in practice, maybe some additional changes will be needed :woman_shrugging: ). Instead for now it just recreates the original dataframe.

---

Note the following:
- in theory, we don't want to know anything about observations during simulation step. As with the new discussed design, we then can apply different sets of observations to the same simulated ensemble without rerunning whole simulation for each observation set.
- however to perform quality assurance on observations, we need data from simulation related to those observations (which zone and grid cell does the location belong to in this simulation?). The `.EGRID` file containing this data can be large and for the moment is lost after simulation step is finished.
- due to this restriction observations currently are a part of the RFTConfig.

---

I tried to make as small refactoring commits as possible.
Don't know what we prefer to do in the `refactoring+small related fixes` PRs: merge those as separate commits or just squash.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
