### PR TITLE
Solve and enforce selected ruff PTH rules

### DIFF
--- a/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_more_observations/poly_eval.py
@@ -2,7 +2,7 @@
 import json
 from pathlib import Path
 
-with open("parameters.json", encoding="utf-8") as f:
+with Path("parameters.json").open(encoding="utf-8") as f:
     coeffs = json.load(f)
 
 

--- a/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_observations/poly_eval.py
@@ -2,7 +2,7 @@
 import json
 from pathlib import Path
 
-with open("parameters.json", encoding="utf-8") as f:
+with Path("parameters.json").open(encoding="utf-8") as f:
     coeffs = json.load(f)
 
 

--- a/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
+++ b/docs/ert/getting_started/configuration/poly_new/with_results/poly_eval.py
@@ -2,7 +2,7 @@
 import json
 from pathlib import Path
 
-with open("parameters.json", encoding="utf-8") as f:
+with Path("parameters.json").open(encoding="utf-8") as f:
     coeffs = json.load(f)
 
 

--- a/docs/everest/conf.py
+++ b/docs/everest/conf.py
@@ -54,7 +54,7 @@ config = GenerationConfiguration(
     markdown_options={"breaks": {"on_newline": False}},
     deprecated_from_description=True,
 )
-with open("config_schema.json", "w", encoding="utf-8") as fout:
+with Path("config_schema.json").open("w", encoding="utf-8") as fout:
     json.dump(EverestConfig.model_json_schema(), fout)
 
 generate_from_filename("config_schema.json", "config_schema.html", config=config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ select = [
     "PLW",
     "PT",    # pytest
     "PTH109",
+    "PTH110",
     "PTH123",
     "PYI",
     "Q",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ select = [
     "PLE",
     "PLW",
     "PT",    # pytest
+    "PTH101",
     "PTH109",
     "PTH110",
     "PTH123",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ select = [
     "PLE",
     "PLW",
     "PT",    # pytest
+    "PTH123",
     "PYI",
     "Q",
     "RSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ select = [
     "PLE",
     "PLW",
     "PT",    # pytest
+    "PTH109",
     "PTH123",
     "PYI",
     "Q",

--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -196,7 +196,7 @@ def fm_dispatch(args: list[str]) -> None:
 
     # If run_path is defined, enter into that directory
     if parsed_args.run_path is not None:
-        if not os.path.exists(parsed_args.run_path):
+        if not Path(parsed_args.run_path).exists():
             sys.exit(f"No such directory: {parsed_args.run_path}")
         os.chdir(parsed_args.run_path)
 

--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -247,7 +247,9 @@ class ForwardModelStep:
             return exited_message
 
         exited_message = Exited(self, exit_code)
-        if (error_file := self.step_data.get("error_file")) and path.exists(error_file):
+        if (error_file := self.step_data.get("error_file")) and Path(
+            error_file
+        ).exists():
             return exited_message.with_error(
                 f"Found the error file:{error_file} - step failed."
             )
@@ -337,15 +339,19 @@ class ForwardModelStep:
         of failed checks.
         """
         errors = []
-        if (stdin_file := self.step_data.get("stdin")) and not path.exists(stdin_file):
+        if (stdin_file := self.step_data.get("stdin")) and not Path(
+            stdin_file
+        ).exists():
             errors.append(f"Could not locate stdin file: {stdin_file}")
 
-        if (start_file := self.step_data.get("start_file")) and not path.exists(
+        if (start_file := self.step_data.get("start_file")) and not Path(
             start_file
-        ):
+        ).exists():
             errors.append(f"Could not locate start_file:{start_file}")
 
-        if (error_file := self.step_data.get("error_file")) and path.exists(error_file):
+        if (error_file := self.step_data.get("error_file")) and Path(
+            error_file
+        ).exists():
             os.unlink(error_file)
 
         if executable_error := check_executable(self.step_data.get("executable")):
@@ -363,7 +369,7 @@ class ForwardModelStep:
 
         start_time = time.time()
         while True:
-            if path.exists(target_file):
+            if Path(target_file).exists():
                 stat = os.stat(target_file)
                 if stat.st_mtime_ns > (existing_target_file_mtime or 0):
                     return None
@@ -374,7 +380,7 @@ class ForwardModelStep:
 
         # We have gone out of the loop via the break statement,
         # i.e. on a timeout.
-        if path.exists(target_file):
+        if Path(target_file).exists():
             stat = os.stat(target_file)
             return (
                 f"The target file:{target_file} has not been updated; "
@@ -386,7 +392,7 @@ class ForwardModelStep:
 
 def _get_existing_target_file_mtime(file: str | None) -> int | None:
     mtime = None
-    if file and path.exists(file):
+    if file and Path(file).exists():
         stat = os.stat(file)
         mtime = stat.st_mtime_ns
     return mtime

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -194,7 +194,7 @@ class File(Reporter):
                 if os.path.exists(fm_step.std_err):
                     stderr = Path(fm_step.std_err).read_text(encoding="utf-8")
                     if stderr:
-                        stderr_file = os.path.join(os.getcwd(), fm_step.std_err)
+                        stderr_file = os.path.join(Path.cwd(), fm_step.std_err)
                     else:
                         stderr = f"Empty stderr from {fm_step.name()}\n"
                 else:

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -132,7 +132,7 @@ class File(Reporter):
 
     @staticmethod
     def _write_status_file(msg: str) -> None:
-        with open(STATUS_file, "a", encoding="utf-8") as status_file:
+        with Path(STATUS_file).open("a", encoding="utf-8") as status_file:
             status_file.write(msg)
 
     def _init_status_file(self) -> None:
@@ -174,7 +174,7 @@ class File(Reporter):
 
     @staticmethod
     def _add_log_line(step: "ForwardModelStep") -> None:
-        with open(LOG_file, "a", encoding="utf-8") as f:
+        with Path(LOG_file).open("a", encoding="utf-8") as f:
             assert step.step_data["argList"] is not None
             args = " ".join(step.step_data["argList"])
             time_str = time.strftime(TIME_FORMAT, time.localtime())
@@ -182,7 +182,7 @@ class File(Reporter):
 
     @staticmethod
     def _dump_error_file(fm_step: "ForwardModelStep", error_msg: str | None) -> None:
-        with open(ERROR_file, "w", encoding="utf-8") as file:
+        with Path(ERROR_file).open("w", encoding="utf-8") as file:
             file.write("<error>\n")
             file.write(
                 f"  <time>{time.strftime(TIME_FORMAT, time.localtime())}</time>\n"

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -191,7 +191,7 @@ class File(Reporter):
             file.write(f"  <reason>{error_msg}</reason>\n")
             stderr_file = None
             if fm_step.std_err:
-                if os.path.exists(fm_step.std_err):
+                if Path(fm_step.std_err).exists():
                     stderr = Path(fm_step.std_err).read_text(encoding="utf-8")
                     if stderr:
                         stderr_file = os.path.join(Path.cwd(), fm_step.std_err)

--- a/src/_ert/forward_model_runner/runner.py
+++ b/src/_ert/forward_model_runner/runner.py
@@ -94,14 +94,14 @@ class ForwardModelRunner:
             for status_update in step.run():
                 yield status_update
                 if not status_update.success():
-                    yield Checksum(checksum_dict={}, run_path=os.getcwd())
+                    yield Checksum(checksum_dict={}, run_path=str(Path.cwd()))
                     yield Finish().with_error(
                         "Not all forward model steps completed successfully."
                     )
                     return
 
         checksum_dict = self._populate_checksums(self._read_manifest())
-        yield Checksum(checksum_dict=checksum_dict, run_path=os.getcwd())
+        yield Checksum(checksum_dict=checksum_dict, run_path=str(Path.cwd()))
         yield Finish()
 
     def _set_environment(self) -> None:

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -712,7 +712,7 @@ def main() -> None:
         site_plugins = get_site_plugins()
         setup_site_logging(logging.getLogger())
         with use_runtime_plugins(site_plugins):
-            logger.info(f"Running ert with {args} in {os.getcwd()}")
+            logger.info(f"Running ert with {args} in {Path.cwd()}")
             args.func(args, site_plugins)
     except ErtStoragePermissionError as err:
         logger.error(str(err))

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -49,7 +49,7 @@ class DataSection:
         f_path = output_path / fname
         f_path.parent.mkdir(parents=True, exist_ok=True)
         df = pd.DataFrame(self.data, columns=self.header)
-        with open(f_path.with_suffix(".report"), "w", encoding="utf-8") as fout:
+        with Path(f_path.with_suffix(".report")).open("w", encoding="utf-8") as fout:
             if self.extra:
                 fout.writelines(f"{k}: {v}\n" for k, v in self.extra.items())
             fout.write(df.to_markdown(tablefmt="simple_outline", floatfmt=".4f"))

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -49,7 +49,7 @@ class DataSection:
         f_path = output_path / fname
         f_path.parent.mkdir(parents=True, exist_ok=True)
         df = pd.DataFrame(self.data, columns=self.header)
-        with Path(f_path.with_suffix(".report")).open("w", encoding="utf-8") as fout:
+        with f_path.with_suffix(".report").open("w", encoding="utf-8") as fout:
             if self.extra:
                 fout.writelines(f"{k}: {v}\n" for k, v in self.extra.items())
             fout.write(df.to_markdown(tablefmt="simple_outline", floatfmt=".4f"))

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -158,7 +158,7 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
     with contextlib.ExitStack() as exit_stack:
         out: TextIO
         if args.disable_monitoring:
-            out = exit_stack.enter_context(open(os.devnull, "w", encoding="utf-8"))
+            out = exit_stack.enter_context(Path(os.devnull).open("w", encoding="utf-8"))
         else:
             out = sys.stderr
         monitor = Monitor(out=out, color_always=args.color_always)

--- a/src/ert/config/_get_num_cpu.py
+++ b/src/ert/config/_get_num_cpu.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 from typing import TypeVar, overload
 
 from .parsing import ConfigWarning
@@ -77,7 +78,7 @@ def get_num_cpu_from_data_file(data_file: str) -> int | None:
 
     """
     try:
-        with open(data_file, encoding="utf-8") as file:
+        with Path(data_file).open(encoding="utf-8") as file:
             return _get_num_cpu(iter(file), data_file)
     except (OSError, UnicodeDecodeError) as err:
         ConfigWarning.warn(

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import pathlib
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import StrEnum
@@ -385,7 +386,7 @@ class RFTObservation(BaseModel):
         """
         if not os.path.isabs(filename):
             filename = os.path.join(directory, filename)
-        if not os.path.exists(filename):
+        if not pathlib.Path(filename).exists():
             raise ObservationConfigError.with_context(
                 f"The CSV file ({filename}) does not exist or is not accessible.",
                 filename,
@@ -794,7 +795,7 @@ def _missing_value_error(name_token: str, value_key: str) -> ObservationConfigEr
 def _resolve_path(directory: str, filename: str) -> str:
     if not os.path.isabs(filename):
         filename = os.path.join(directory, filename)
-    if not os.path.exists(filename):
+    if not pathlib.Path(filename).exists():
         raise ObservationConfigError.with_context(
             f"The following keywords did not resolve to a valid path:\n {filename}",
             filename,

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -784,7 +784,7 @@ class ErtConfig(BaseModel):
         self.config_path = (
             path.dirname(path.abspath(self.user_config_file))
             if self.user_config_file
-            else os.getcwd()
+            else str(Path.cwd())
         )
         return self
 
@@ -1455,7 +1455,7 @@ def _substitutions_from_dict(config_dict: ConfigDict) -> dict[str, str]:
     substitutions = dict(config_dict.get("DEFINE", []))
 
     if "<CONFIG_PATH>" not in substitutions:
-        substitutions["<CONFIG_PATH>"] = os.getcwd()
+        substitutions["<CONFIG_PATH>"] = str(Path.cwd())
 
     substitutions.update(dict(config_dict.get("DATA_KW", [])))
 

--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -418,7 +418,7 @@ class LegacyGeneralObservation(_LegacyGeneralObservation):
                     filename = value
                     if not os.path.isabs(filename):
                         filename = os.path.join(directory, filename)
-                    if not os.path.exists(filename):
+                    if not Path(filename).exists():
                         raise ObservationConfigError.with_context(
                             "The following keywords did not"
                             f" resolve to a valid path:\n {key}",

--- a/src/ert/config/parsing/_read_file.py
+++ b/src/ert/config/parsing/_read_file.py
@@ -21,7 +21,7 @@ def read_file(file: str, token: FileContextToken | None = None) -> str:
 
         # Find the first line in the file with decode error
         bad_byte_lines: list[int] = []
-        with open(file, "rb") as f:
+        with Path(file).open("rb") as f:
             all_lines = list(f)
 
         for i, line in enumerate(all_lines):

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import shutil
 from collections.abc import Callable, Mapping, Sequence
 from enum import EnumType
@@ -183,7 +184,7 @@ class SchemaItem:
                             f"{self.kw} {token} is not a file.",
                             token,
                         )
-                    if not os.path.exists(str(path)):
+                    if not pathlib.Path(str(path)).exists():
                         err = f'Cannot find file or directory "{token.value}". '
                         if path != token:
                             err += f"The configured value was {path!r} "
@@ -214,7 +215,7 @@ class SchemaItem:
                     absolute_path = os.path.abspath(os.path.join(cwd, token))
                 else:
                     absolute_path = token
-                if not os.path.exists(absolute_path):
+                if not pathlib.Path(absolute_path).exists():
                     absolute_path = shutil.which(token)
                     is_command = True
 

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -4,6 +4,7 @@ import datetime
 import os
 import os.path
 from collections.abc import Iterator, Sequence
+from pathlib import Path
 from typing import Any, Self
 
 from lark import (
@@ -334,7 +335,7 @@ def _handle_includes(
             constraints = define_keyword()
             args = constraints.join_args(args)
             args = _substitute_args(args, constraints, defines)  # type: ignore
-            args = constraints.apply_constraints(args, kw, os.getcwd())  # type: ignore
+            args = constraints.apply_constraints(args, kw, Path.cwd())  # type: ignore
             defines.append(args)  # type: ignore
         if kw == "INCLUDE":
             if len(args) > 1:

--- a/src/ert/field_utils/field_utils.py
+++ b/src/ert/field_utils/field_utils.py
@@ -67,7 +67,7 @@ def get_shape(
     grid_path: _PathLike,
 ) -> Shape | None:
     shape = None
-    with open(grid_path, "rb") as f:
+    with Path(grid_path).open("rb") as f:
         for entry in resfo.lazy_read(f):
             keyword = str(entry.read_keyword()).strip()
             if keyword == "GRIDHEAD":

--- a/src/ert/field_utils/grdecl_io.py
+++ b/src/ert/field_utils/grdecl_io.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import reduce
+from pathlib import Path
 from typing import Any, TextIO
 
 import numpy as np
@@ -177,7 +178,7 @@ def open_grdecl(
         if keyword is not None:
             raise ValueError(f"Reached end of stream while reading {keyword}")
 
-    with open(grdecl_file, encoding="utf-8") as stream:
+    with Path(grdecl_file).open(encoding="utf-8") as stream:
         yield read_grdecl(stream)
 
 
@@ -230,7 +231,7 @@ def import_bgrdecl(
     dimensions: tuple[int, int, int],
 ) -> npt.NDArray[np.float32]:
     field_name = field_name.strip()
-    with open(file_path, "rb") as f:
+    with Path(file_path).open("rb") as f:
         for entry in resfo.lazy_read(f):
             keyword = str(entry.read_keyword()).strip()
             if keyword == field_name:
@@ -282,7 +283,7 @@ def export_grdecl(
         fmt = " ".join(["%3e"] * per_line)
         fmt = "\n".join([fmt] * iters) + "\n"
         with (
-            open(file_path, "wb+", 0) as fh,
+            Path(file_path).open("wb+", 0) as fh,
             io.BufferedWriter(fh, _BUFFER_SIZE) as bw,
             io.TextIOWrapper(bw, write_through=True, encoding="utf-8") as tw,
         ):

--- a/src/ert/field_utils/grdecl_io.py
+++ b/src/ert/field_utils/grdecl_io.py
@@ -33,7 +33,7 @@ class GridFieldMismatchError(InvalidParameterFile):
         field_size = len(field_values)
         msg = (
             f"The FIELD '{field_name}' from file "
-            f"{os.path.relpath(file_path, os.getcwd())} "
+            f"{os.path.relpath(file_path, Path.cwd())} "
             f"is of size ({field_size}) which does not match the "
             f"size of the GRID ({grid_size}) - "
             f"derived from dimensions: {tuple(grid_dimensions)}."

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -69,7 +69,7 @@ class PathChooser(QWidget):
 
     def isPathValid(self, path: str) -> tuple[bool, str]:
         path = path.strip()
-        path_exists = os.path.exists(path)
+        path_exists = Path(path).exists()
         is_file = os.path.isfile(path)
         is_directory = os.path.isdir(path)
         is_executable = os.access(path, os.X_OK)

--- a/src/ert/gui/ertwidgets/pathchooser.py
+++ b/src/ert/gui/ertwidgets/pathchooser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QSize
@@ -53,7 +54,7 @@ class PathChooser(QWidget):
             self._path_line.backgroundRole()
         )
 
-        self._path_line.setText(os.getcwd())
+        self._path_line.setText(str(Path.cwd()))
         self._editing = False
 
         self._model = model
@@ -144,8 +145,8 @@ class PathChooser(QWidget):
 
         if current_directory:
             if not self._model.pathMustBeAbsolute():
-                cwd = os.getcwd()
-                match = re.match(cwd + "/(.*)", current_directory)
+                cwd = Path.cwd()
+                match = re.match(str(cwd) + "/(.*)", current_directory)
                 if match:
                     current_directory = match.group(1)
 

--- a/src/ert/gui/tools/file/file_dialog.py
+++ b/src/ert/gui/tools/file/file_dialog.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from PyQt6.QtCore import Qt, QThread
 from PyQt6.QtGui import (
     QClipboard,
@@ -40,7 +42,7 @@ class FileDialog(QDialog):
 
         try:
             # We take care to close this file in _quit_thread()
-            self._file = open(file_name, encoding="utf-8")  # noqa: SIM115
+            self._file = Path(file_name).open(encoding="utf-8")  # noqa: SIM115
         except OSError as error:
             self._mb = QMessageBox(
                 QMessageBox.Icon.Critical,

--- a/src/ert/plugins/hook_implementations/workflows/csv_export.py
+++ b/src/ert/plugins/hook_implementations/workflows/csv_export.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -76,7 +77,7 @@ class CSVExportJob(ErtScript):
             ensembles.append(ensemble)
 
         if design_matrix_path is not None:
-            if not os.path.exists(design_matrix_path):
+            if not pathlib.Path(design_matrix_path).exists():
                 raise UserWarning("The design matrix file does not exist!")
 
             if not os.path.isfile(design_matrix_path):

--- a/src/ert/resources/__init__.py
+++ b/src/ert/resources/__init__.py
@@ -1,9 +1,9 @@
 import os
-import pathlib
+from pathlib import Path
 
 all_shell_script_fm_steps = [
     x.split(".py")[0]
-    for x in os.listdir(pathlib.Path(__file__).resolve().parent / "shell_scripts")
+    for x in os.listdir(Path(__file__).resolve().parent / "shell_scripts")
     if not x.startswith("__")
 ]
 

--- a/src/ert/resources/forward_models/run_reservoirsimulator.py
+++ b/src/ert/resources/forward_models/run_reservoirsimulator.py
@@ -335,7 +335,7 @@ class RunReservoirSimulator:
 
         errors = None
         bugs = None
-        with open(report_file, encoding="utf-8", errors="ignore") as filehandle:
+        with Path(report_file).open(encoding="utf-8", errors="ignore") as filehandle:
             for line in filehandle:
                 error_match = re.match(error_regexp, line)
                 if error_match:
@@ -378,7 +378,7 @@ class RunReservoirSimulator:
 def tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with open(file_path, encoding="utf-8", errors="ignore") as file:
+    with Path(file_path).open(encoding="utf-8", errors="ignore") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)

--- a/src/ert/resources/shell_scripts/careful_copy_file.py
+++ b/src/ert/resources/shell_scripts/careful_copy_file.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import pathlib
 import shutil
 import sys
 
@@ -7,7 +8,7 @@ import sys
 def careful_copy_file(src: str, target: str | None = None) -> None:
     if target is None:
         target = os.path.basename(src)
-    if os.path.exists(target):
+    if pathlib.Path(target).exists():
         print(f"File: {target} already present - not updated")
         return
     if os.path.isfile(src):

--- a/src/ert/resources/shell_scripts/delete_directory.py
+++ b/src/ert/resources/shell_scripts/delete_directory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import pathlib
 import sys
 
 
@@ -41,7 +42,7 @@ def delete_directory(path: str) -> None:
     """
     Will ignore if you are not owner.
     """
-    if os.path.exists(path):
+    if pathlib.Path(path).exists():
         if os.path.isdir(path):
             for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
                 if not os.path.islink(root):

--- a/src/ert/resources/shell_scripts/delete_file.py
+++ b/src/ert/resources/shell_scripts/delete_file.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 import os
+import pathlib
 import sys
 
 
 def delete_file(filename: str) -> None:
-    if os.path.exists(filename):
+    if pathlib.Path(filename).exists():
         if os.path.isfile(filename):
             stat_info = os.stat(filename)
             uid = stat_info.st_uid

--- a/src/ert/resources/shell_scripts/move_directory.py
+++ b/src/ert/resources/shell_scripts/move_directory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import pathlib
 import shutil
 import sys
 
@@ -10,7 +11,7 @@ def move_directory(src_dir: str, target: str) -> None:
 
     """
     if os.path.isdir(src_dir):
-        if os.path.exists(target):
+        if pathlib.Path(target).exists():
             shutil.rmtree(target)
         shutil.move(src_dir, target)
     else:

--- a/src/ert/resources/shell_scripts/symlink.py
+++ b/src/ert/resources/shell_scripts/symlink.py
@@ -21,7 +21,7 @@ def symlink(target: str, link_name: str) -> None:
             os.makedirs(link_path)
         target_check = os.path.join(link_path, target)
 
-    if not os.path.exists(target_check):
+    if not Path(target_check).exists():
         raise OSError(
             f"{target} (target) and {link_name} (link_name) requested, "
             f"which implies that {target_check} must exist, but it does not."

--- a/src/ert/resources/shell_scripts/symlink.py
+++ b/src/ert/resources/shell_scripts/symlink.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+from pathlib import Path
 
 
 def symlink(target: str, link_name: str) -> None:
@@ -29,7 +30,7 @@ def symlink(target: str, link_name: str) -> None:
     if os.path.islink(link_name):
         os.unlink(link_name)
     os.symlink(target, link_name)
-    print(f"Linking '{link_name}' -> '{target}' [ cwd:{os.getcwd()} ]")
+    print(f"Linking '{link_name}' -> '{target}' [ cwd:{Path.cwd()} ]")
 
 
 if __name__ == "__main__":

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -181,7 +181,7 @@ def _generate_parameter_files(
                         f"{scalar_value} as it is invalid"
                     )
         else:
-            export_values = param.write_to_runpath(Path(run_path), iens, fs)
+            export_values = param.write_to_runpath(run_path, iens, fs)
 
         if export_values:
             for group, vals in export_values.items():
@@ -197,7 +197,7 @@ def _generate_parameter_files(
     # Write aggregated EverestControl JSON files
     start_time = time.perf_counter()
     for output_file, controls in everest_controls_by_file.items():
-        file_path: Path = Path(run_path) / substitute_runpath_name(
+        file_path: Path = run_path / substitute_runpath_name(
             output_file, iens, iteration
         )
         file_path.parent.mkdir(exist_ok=True, parents=True)
@@ -369,7 +369,7 @@ def _create_one_run_path(
         iens=run_arg.iens,
         itr=ensemble.iteration,
     )
-    Path(run_path / "jobs.json").write_bytes(
+    (run_path / "jobs.json").write_bytes(
         orjson.dumps(
             forward_model_output,
             option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
@@ -380,7 +380,7 @@ def _create_one_run_path(
     # Write MANIFEST file to runpath use to avoid NFS sync issues
     start_time = time.perf_counter()
     data = _manifest_to_json(ensemble, run_arg.iens, run_arg.itr)
-    Path(run_path / "manifest.json").write_bytes(
+    (run_path / "manifest.json").write_bytes(
         orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2)
     )
     timings["manifest_to_json"] = time.perf_counter() - start_time

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -1310,7 +1310,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
         return objectives, constraints if constraint_names else None
 
     def check_if_runpath_exists(self) -> bool:
-        return os.path.exists(self.simulation_dir) and any(
+        return Path(self.simulation_dir).exists() and any(
             os.listdir(self.simulation_dir)
         )
 

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -115,7 +115,7 @@ class TooFewRealizationsSucceeded(ErtRunError):
 
 
 def delete_runpath(run_path: str) -> None:
-    if os.path.exists(run_path):
+    if Path(run_path).exists():
         shutil.rmtree(run_path)
 
 

--- a/src/ert/runpaths.py
+++ b/src/ert/runpaths.py
@@ -98,7 +98,7 @@ class Runpaths:
         :param realization_numbers: The list of realizations to write entries for
         """
         Path(self.runpath_list_filename).parent.mkdir(parents=True, exist_ok=True)
-        with open(self.runpath_list_filename, "w", encoding="utf-8") as filehandle:
+        with Path(self.runpath_list_filename).open("w", encoding="utf-8") as filehandle:
             for iteration in iteration_numbers:
                 for realization in realization_numbers:
                     real_iter_substituter = self.substitutions.real_iter_substituter(

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -713,7 +713,7 @@ class LsfDriver(Driver):
 def tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with open(file_path, encoding="utf-8") as file:
+    with Path(file_path).open(encoding="utf-8") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)

--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -713,7 +713,7 @@ class LsfDriver(Driver):
 def tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with Path(file_path).open(encoding="utf-8") as file:
+    with file_path.open(encoding="utf-8") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -477,7 +477,7 @@ class SlurmDriver(Driver):
 def _tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with Path(file_path).open(encoding="utf-8") as file:
+    with file_path.open(encoding="utf-8") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)

--- a/src/ert/scheduler/slurm_driver.py
+++ b/src/ert/scheduler/slurm_driver.py
@@ -477,7 +477,7 @@ class SlurmDriver(Driver):
 def _tail_textfile(file_path: Path, num_chars: int) -> str:
     if not file_path.exists():
         return f"No output file {file_path}"
-    with open(file_path, encoding="utf-8") as file:
+    with Path(file_path).open(encoding="utf-8") as file:
         file.seek(0, 2)
         file_end_position = file.tell()
         seek_position = max(0, file_end_position - num_chars)

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -621,7 +621,7 @@ class LocalStorage(BaseMode):
         with NamedTemporaryFile(dir=self._swap_path, delete=False) as f:
             f.write(data)
             f.flush()
-            os.chmod(f.name, 0o660)
+            Path(f.name).chmod(0o660)
             os.rename(f.name, filename)
 
     def _to_netcdf_transaction(
@@ -636,7 +636,7 @@ class LocalStorage(BaseMode):
         self._swap_path.mkdir(parents=True, exist_ok=True)
         with NamedTemporaryFile(dir=self._swap_path, delete=False) as f:
             dataset.to_netcdf(f, engine="scipy")
-            os.chmod(f.name, 0o660)
+            Path(f.name).chmod(0o660)
             os.rename(f.name, filename)
 
     def _to_parquet_transaction(
@@ -651,7 +651,7 @@ class LocalStorage(BaseMode):
         self._swap_path.mkdir(parents=True, exist_ok=True)
         with NamedTemporaryFile(dir=self._swap_path, delete=False) as f:
             dataframe.write_parquet(f.name)
-            os.chmod(f.name, 0o660)
+            Path(f.name).chmod(0o660)
             os.rename(f.name, filename)
 
 

--- a/src/ert/storage/migration/to10.py
+++ b/src/ert/storage/migration/to10.py
@@ -31,10 +31,10 @@ def migrate(path: Path) -> None:
                 param.pop("forward_init_file", None)
                 param.pop("template_file", None)
                 param.pop("output_file", None)
-        Path(experiment / "parameter.json").write_text(
+        (experiment / "parameter.json").write_text(
             json.dumps(parameters_json, indent=4), encoding="utf-8"
         )
 
-        Path(experiment / "templates.json").write_text(
+        (experiment / "templates.json").write_text(
             json.dumps(templates_abs), encoding="utf-8"
         )

--- a/src/ert/storage/migration/to13.py
+++ b/src/ert/storage/migration/to13.py
@@ -111,7 +111,7 @@ def migrate_genkw(path: Path) -> None:
         )
 
         new_parameter_configs = migrate_gen_kw_param(parameters_json)
-        Path(experiment / "parameter.json").write_text(
+        (experiment / "parameter.json").write_text(
             json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
         )
 

--- a/src/ert/storage/migration/to14.py
+++ b/src/ert/storage/migration/to14.py
@@ -34,7 +34,7 @@ def migrate_fields(path: Path) -> None:
             (experiment / "parameter.json").read_text(encoding="utf-8")
         )
         new_parameter_configs = migrate_field_param(parameters_json)
-        Path(experiment / "parameter.json").write_text(
+        (experiment / "parameter.json").write_text(
             json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
         )
 

--- a/src/ert/storage/migration/to16.py
+++ b/src/ert/storage/migration/to16.py
@@ -22,7 +22,7 @@ def delete_mask_file(experiment: Path) -> None:
 
 
 def migrate_fields(experiment: Path) -> None:
-    with open(experiment / "parameter.json", encoding="utf-8") as fin:
+    with Path(experiment / "parameter.json").open(encoding="utf-8") as fin:
         parameters_json = json.load(fin)
 
     new_parameter_configs = migrate_field_param(parameters_json)

--- a/src/ert/storage/migration/to16.py
+++ b/src/ert/storage/migration/to16.py
@@ -22,11 +22,11 @@ def delete_mask_file(experiment: Path) -> None:
 
 
 def migrate_fields(experiment: Path) -> None:
-    with Path(experiment / "parameter.json").open(encoding="utf-8") as fin:
+    with (experiment / "parameter.json").open(encoding="utf-8") as fin:
         parameters_json = json.load(fin)
 
     new_parameter_configs = migrate_field_param(parameters_json)
-    Path(experiment / "parameter.json").write_text(
+    (experiment / "parameter.json").write_text(
         json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
     )
 

--- a/src/ert/storage/migration/to19.py
+++ b/src/ert/storage/migration/to19.py
@@ -20,11 +20,11 @@ def migrate_param(parameters_json: dict[str, Any]) -> dict[str, Any]:
 
 
 def migrate_parameters_for_experiment(experiment: Path) -> None:
-    with open(experiment / "parameter.json", encoding="utf-8") as fin:
+    with (experiment / "parameter.json").open(encoding="utf-8") as fin:
         parameters_json = json.load(fin)
 
     new_parameter_configs = migrate_param(parameters_json)
-    Path(experiment / "parameter.json").write_text(
+    (experiment / "parameter.json").write_text(
         json.dumps(new_parameter_configs, indent=2), encoding="utf-8"
     )
 

--- a/src/ert/storage/migration/to6.py
+++ b/src/ert/storage/migration/to6.py
@@ -33,6 +33,6 @@ def migrate(path: Path) -> None:
                         transform_function_definitions.append(tfd)
 
                 param["transform_function_definitions"] = transform_function_definitions
-        Path(experiment / "parameter.json").write_text(
+        (experiment / "parameter.json").write_text(
             json.dumps(parameters_json, indent=4), encoding="utf-8"
         )

--- a/src/ert/storage/migration/to7.py
+++ b/src/ert/storage/migration/to7.py
@@ -114,7 +114,7 @@ def _migrate_response_datasets(path: Path) -> None:
                         ).expand_dims(name=[gendata_name], axis=1),
                     )
                     for gendata_name in gendata_keys
-                    if os.path.exists(real_dir / f"{gendata_name}.nc")
+                    if (real_dir / f"{gendata_name}.nc").exists()
                 ]
 
                 if gen_data_datasets:

--- a/src/ert/storage/migration/to8.py
+++ b/src/ert/storage/migration/to8.py
@@ -122,7 +122,7 @@ def _migrate_responses_from_netcdf_to_parquet(path: Path) -> None:
 
 def _migrate_observations_to_grouped_parquet(path: Path) -> None:
     for experiment in path.glob("experiments/*"):
-        if not os.path.exists(experiment / "observations"):
+        if not (experiment / "observations").exists():
             os.makedirs(experiment / "observations")
 
         obs_keys = os.listdir(os.path.join(experiment, "observations"))

--- a/src/ert/storage/migration/to9.py
+++ b/src/ert/storage/migration/to9.py
@@ -19,7 +19,7 @@ def _write_transaction(filename: str | os.PathLike[str], data: bytes) -> None:
     Path("./swp").mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(dir="./swp", delete=False) as f:
         f.write(data)
-        os.chmod(f.name, 0o660)
+        Path(f.name).chmod(0o660)
         os.rename(f.name, filename)
 
 

--- a/src/ert/storage/migration/to9.py
+++ b/src/ert/storage/migration/to9.py
@@ -28,8 +28,8 @@ def migrate(path: Path) -> None:
         ensembles = [*path.glob("ensembles/*")]
 
         with (
-            open(experiment / "index.json", encoding="utf-8") as f_experiment,
-            open(experiment / "responses.json", encoding="utf-8") as f_responses,
+            (experiment / "index.json").open(encoding="utf-8") as f_experiment,
+            (experiment / "responses.json").open(encoding="utf-8") as f_responses,
         ):
             exp_index = json.load(f_experiment)
             experiment_id = exp_index["id"]

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -466,7 +466,7 @@ def show_scaled_controls_warning() -> None:
         case "y":
             everest_pref["show_scaling_warning"] = False
             try:
-                with open(user_info_path, mode="w", encoding="utf-8") as f:
+                with Path(user_info_path).open(mode="w", encoding="utf-8") as f:
                     json.dump(user_info, f, ensure_ascii=False, indent=4)
             except Exception as e:
                 logging.getLogger(EVEREST).error(str(e))

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -936,7 +936,7 @@ to read summary data from forward model, do:
     @classmethod
     def validate_config_path_exists(cls, config_path):
         expanded_path = os.path.realpath(config_path)
-        if not os.path.exists(expanded_path):
+        if not Path(expanded_path).exists():
             raise ValueError(f"no such file or directory {expanded_path}")
         return config_path
 

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -24,7 +24,7 @@ def _is_dir_all_model(source: str, model_realizations: list[int]) -> bool:
     is_dir = []
     for model_realization in model_realizations:
         model_source = source.replace("<REALIZATION_ID>", str(model_realization))
-        if not os.path.exists(model_source):
+        if not Path(model_source).exists():
             msg = (
                 "Expected source to exist for data installation, "
                 f"did not find: {model_source}"

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -83,7 +83,7 @@ class InstallDataContext:
             source = source.replace("<REALIZATION_ID>", str(realization))
             target = target.replace("<REALIZATION_ID>", str(realization))
 
-        tmp_target = Path(self._temp_dir.name) / Path(target)
+        tmp_target = Path(self._temp_dir.name) / target
         if tmp_target.exists():
             if tmp_target.is_dir() and not tmp_target.is_symlink():
                 raise ValueError(

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -280,7 +280,7 @@ def check_path_exists(
     for exp_path in [as_abs_path(p, str(config_dir)) for p in expanded_paths]:
         if os.path.ismount(exp_path):
             raise ValueError(f"'{exp_path}' is a mount point and can't be handled")
-        if not os.path.exists(exp_path):
+        if not Path(exp_path).exists():
             raise ValueError(f"No such file or directory {exp_path}")
 
 

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -49,7 +49,7 @@ class InstallDataContext:
     ) -> None:
         self._install_data = install_data or []
         self._config_dir = str(config_path.parent)
-        self._cwd = os.getcwd()
+        self._cwd = Path.cwd()
 
     def __enter__(self) -> Self:
         self._temp_dir = tempfile.TemporaryDirectory()

--- a/test-data/ert/heat_equation/heat_equation.py
+++ b/test-data/ert/heat_equation/heat_equation.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 import sys
+from pathlib import Path
 
 import geostat
 import numpy as np
@@ -129,7 +130,7 @@ def sample_prior_conductivity(ensemble_size, nx, rng, corr_length):
 
 
 def load_parameters(filename):
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -167,7 +168,7 @@ if __name__ == "__main__":
 
     index = sorted((obs.x, obs.y) for obs in obs_coordinates)
     for time_step in obs_times:
-        with open(f"gen_data_{time_step}.out", "w", encoding="utf-8") as f:
+        with Path(f"gen_data_{time_step}.out").open("w", encoding="utf-8") as f:
             f.writelines(f"{response[time_step][i]}\n" for i in index)
 
     time_map = []

--- a/test-data/ert/poly_example/poly_eval.py
+++ b/test-data/ert/poly_example/poly_eval.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def _load_coeffs(filename):
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/test-data/ert/snake_oil/forward_models/snake_oil_npv.py
+++ b/test-data/ert/snake_oil/forward_models/snake_oil_npv.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from resdata.summary import Summary
 
 OIL_PRICES = {
@@ -89,7 +91,7 @@ if __name__ == "__main__":
         production_value = oil_price * production_sum
         npv += production_value
 
-    with open("snake_oil_npv.txt", "w", encoding="utf-8") as output_file:
+    with Path("snake_oil_npv.txt").open("w", encoding="utf-8") as output_file:
         output_file.write(f"NPV {npv}\n")
 
         if npv < 80000:

--- a/test-data/ert/snake_oil/forward_models/snake_oil_simulator.py
+++ b/test-data/ert/snake_oil/forward_models/snake_oil_simulator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import datetime
+from pathlib import Path
 
 import numpy as np
 import resfo
@@ -12,7 +13,7 @@ def globalIndex(i, j, k, nx=10, ny=10, nz=10):
 
 def readParameters(filename):
     params = {}
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         for line in f:
             key, value = line.split(":", 1)
             params[key] = value.strip()
@@ -213,5 +214,5 @@ if __name__ == "__main__":
     report_step_count = 200
     time_map = runSimulator(simulator, history_simulator, report_step_count)
 
-    with open("time_map.txt", "w", encoding="utf-8") as f:
+    with Path("time_map.txt").open("w", encoding="utf-8") as f:
         f.writelines(f"{t}\n" for t in time_map)

--- a/test-data/ert/snake_oil_field/forward_models/snake_oil_npv.py
+++ b/test-data/ert/snake_oil_field/forward_models/snake_oil_npv.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from resdata.summary import Summary
 
 OIL_PRICES = {
@@ -89,7 +91,7 @@ if __name__ == "__main__":
         production_value = oil_price * production_sum
         npv += production_value
 
-    with open("snake_oil_npv.txt", "w", encoding="utf-8") as output_file:
+    with Path("snake_oil_npv.txt").open("w", encoding="utf-8") as output_file:
         output_file.write(f"NPV {npv}\n")
 
         if npv < 80000:

--- a/test-data/ert/snake_oil_field/forward_models/snake_oil_simulator.py
+++ b/test-data/ert/snake_oil_field/forward_models/snake_oil_simulator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import datetime
+from pathlib import Path
 
 import numpy as np
 import resfo
@@ -12,7 +13,7 @@ def globalIndex(i, j, k, nx=10, ny=10):
 
 def read_seed(filename):
     params = {}
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         for line in f:
             key, value = line.split(":")
             params[key] = value.strip()
@@ -22,7 +23,7 @@ def read_seed(filename):
 
 def read_parameters(filename):
     params = {}
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         for line in f:
             key, value = line.split(" ")
             _, name = key.split(":")
@@ -224,5 +225,5 @@ if __name__ == "__main__":
     report_step_count = 200
     time_map = runSimulator(simulator, history_simulator, report_step_count)
 
-    with open("time_map.txt", "w", encoding="utf-8") as f:
+    with Path("time_map.txt").open("w", encoding="utf-8") as f:
         f.writelines(f"{t}\n" for t in time_map)

--- a/test-data/everest/math_func/jobs/adv_dump_controls.py
+++ b/test-data/everest/math_func/jobs/adv_dump_controls.py
@@ -13,7 +13,7 @@ def main(argv):
     arg_parser.add_argument("--out-suffix", type=str, default="")
     opts, _ = arg_parser.parse_known_args(args=argv)
 
-    with open(opts.controls_file, encoding="utf-8") as f:
+    with Path(opts.controls_file).open(encoding="utf-8") as f:
         controls = json.load(f)
 
     for name, indices in controls.items():

--- a/test-data/everest/math_func/jobs/discrete.py
+++ b/test-data/everest/math_func/jobs/discrete.py
@@ -11,7 +11,7 @@ def compute_func(x, y):
 
 
 def read_point(filename):
-    with open(filename, encoding="utf-8") as f:
+    with Path(filename).open(encoding="utf-8") as f:
         point = json.load(f)
     return point["x"], point["y"]
 

--- a/test-data/everest/math_func/jobs/fail_simulation.py
+++ b/test-data/everest/math_func/jobs/fail_simulation.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import argparse
-import os
 import sys
 import time
+from pathlib import Path
 
 
 def main(argv):
@@ -19,7 +19,7 @@ def main(argv):
     arg_parser.add_argument("--fail", type=str)
     options, _ = arg_parser.parse_known_args(args=argv)
 
-    if options.fail in os.getcwd():
+    if options.fail in str(Path.cwd()):
         raise Exception(f"Failing {options.fail} by request!")
 
     time.sleep(1)

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -423,7 +423,7 @@ def _shared_snake_oil_case(request, monkeypatch, source_root):
         "snake_oil_data" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
     monkeypatch.chdir(snake_path)
-    if not Path(snake_path / "test_data").exists():
+    if not (snake_path / "test_data").exists():
         _run_snake_oil(source_root)
     else:
         monkeypatch.chdir("test_data")

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -197,7 +197,7 @@ def _create_design_matrix(filename, design_sheet_df, default_sheet_df=None):
 @pytest.fixture
 def copy_poly_case(copy_case):
     copy_case("poly_example")
-    with open("poly.ert", "a", encoding="utf-8") as fh:
+    with Path("poly.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
 
 
@@ -266,21 +266,21 @@ def copy_poly_case_with_design_matrix(copy_case):
 @pytest.fixture
 def copy_snake_oil_field(copy_case):
     copy_case("snake_oil_field")
-    with open("snake_oil_field.ert", "a", encoding="utf-8") as fh:
+    with Path("snake_oil_field.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
 
 
 @pytest.fixture
 def copy_snake_oil_case(copy_case):
     copy_case("snake_oil")
-    with open("snake_oil.ert", "a", encoding="utf-8") as fh:
+    with Path("snake_oil.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
 
 
 @pytest.fixture
 def copy_heat_equation(copy_case):
     copy_case("heat_equation")
-    with open("config.ert", "a", encoding="utf-8") as fh:
+    with Path("config.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
 
 
@@ -402,7 +402,7 @@ def _run_heat_equation(source_root, run_mode):
         os.path.join(source_root, "test-data", "ert", "heat_equation"), "test_data"
     )
     os.chdir("test_data")
-    with open("config.ert", "a", encoding="utf-8") as fh:
+    with Path("config.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
     parser = ArgumentParser(prog="test_main")
     parsed = ert_parser(

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -252,12 +252,8 @@ def copy_poly_case_with_design_matrix(copy_case):
             encoding="utf-8",
         )
 
-        os.chmod(
-            "poly_eval.py",
-            os.stat("poly_eval.py").st_mode
-            | stat.S_IXUSR
-            | stat.S_IXGRP
-            | stat.S_IXOTH,
+        Path("poly_eval.py").chmod(
+            os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
 
     return _create_poly_design_case

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -432,7 +432,7 @@ def _shared_snake_oil_case(request, monkeypatch, source_root):
     else:
         monkeypatch.chdir("test_data")
 
-    return os.getcwd()
+    return Path.cwd()
 
 
 @pytest.fixture
@@ -450,7 +450,7 @@ def _shared_heat_equation_es(request, monkeypatch, source_root):
     else:
         monkeypatch.chdir("test_data")
 
-    return os.getcwd()
+    return Path.cwd()
 
 
 @pytest.fixture
@@ -468,7 +468,7 @@ def _shared_heat_equation_esmda(request, monkeypatch, source_root):
     else:
         monkeypatch.chdir("test_data")
 
-    return os.getcwd()
+    return Path.cwd()
 
 
 @pytest.fixture
@@ -486,7 +486,7 @@ def _shared_heat_equation_enif(request, monkeypatch, source_root):
     else:
         monkeypatch.chdir("test_data")
 
-    return os.getcwd()
+    return Path.cwd()
 
 
 @pytest.fixture

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -427,7 +427,7 @@ def _shared_snake_oil_case(request, monkeypatch, source_root):
         "snake_oil_data" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
     monkeypatch.chdir(snake_path)
-    if not os.path.exists(snake_path / "test_data"):
+    if not Path(snake_path / "test_data").exists():
         _run_snake_oil(source_root)
     else:
         monkeypatch.chdir("test_data")

--- a/tests/ert/performance_tests/performance_utils.py
+++ b/tests/ert/performance_tests/performance_utils.py
@@ -101,7 +101,7 @@ def make_poly_example(folder, source, **kwargs):
             **kwargs,
         )
 
-    if not os.path.exists(folder / "refcase"):
+    if not Path(folder / "refcase").exists():
         os.mkdir(folder / "refcase")
 
     use_resfo = True

--- a/tests/ert/performance_tests/performance_utils.py
+++ b/tests/ert/performance_tests/performance_utils.py
@@ -101,7 +101,7 @@ def make_poly_example(folder, source, **kwargs):
             **kwargs,
         )
 
-    if not Path(folder / "refcase").exists():
+    if not (folder / "refcase").exists():
         os.mkdir(folder / "refcase")
 
     use_resfo = True

--- a/tests/ert/performance_tests/performance_utils.py
+++ b/tests/ert/performance_tests/performance_utils.py
@@ -92,7 +92,7 @@ def make_poly_example(folder, source, **kwargs):
     render_template(
         folder, env.get_template("poly_eval.py.j2"), "poly_eval.py", **kwargs
     )
-    os.chmod(folder / "poly_eval.py", 0o775)
+    (folder / "poly_eval.py").chmod(0o775)
     for r in range(gen_obs_count):
         render_template(
             folder,

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -275,9 +275,8 @@ if __name__ == "__main__":
         encoding="utf-8",
     )
 
-    os.chmod(
-        "forward_model",
-        os.stat("forward_model").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("forward_model").chmod(
+        os.stat("forward_model").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
     Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
     Path("observations").write_text(

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -247,7 +247,7 @@ def create_poly_with_field(field_dim: tuple[int, int, int], realisations: int):
             FORWARD_MODEL poly_eval
             """
     )
-    with open("config.ert", "w", encoding="utf-8") as fh:
+    with Path("config.ert").open("w", encoding="utf-8") as fh:
         fh.writelines(config)
 
     grid = xtgeo.create_box_grid(dimension=field_dim)

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -42,12 +42,12 @@ def test_that_adaptive_localization_with_cutoff_1_equals_ensemble_prior():
         """
     )
 
-    with open("poly.ert", "r+", encoding="utf-8") as f:
+    with Path("poly.ert").open("r+", encoding="utf-8") as f:
         lines = f.readlines()
         lines.insert(2, random_seed_line)
         lines.insert(9, set_adaptive_localization_1)
 
-    with open("poly_localization_1.ert", "w", encoding="utf-8") as f:
+    with Path("poly_localization_1.ert").open("w", encoding="utf-8") as f:
         f.writelines(lines)
     prior_ensemble_id, posterior_ensemble_id, storage_path = run_cli_ES_with_case(
         "poly_localization_1.ert", "test_experiment"
@@ -77,7 +77,7 @@ def test_that_adaptive_localization_works_with_a_single_observation():
         """
     )
 
-    with open("poly.ert", "r+", encoding="utf-8") as f:
+    with Path("poly.ert").open("r+", encoding="utf-8") as f:
         lines = f.readlines()
         lines.insert(9, set_adaptive_localization_0)
 
@@ -239,16 +239,16 @@ def test_that_adaptive_localization_with_cutoff_0_equals_ESupdate():
         """
     )
 
-    with open("poly.ert", "r+", encoding="utf-8") as f:
+    with Path("poly.ert").open("r+", encoding="utf-8") as f:
         lines = f.readlines()
         lines.insert(2, random_seed_line)
 
-    with open("poly_no_localization.ert", "w", encoding="utf-8") as f:
+    with Path("poly_no_localization.ert").open("w", encoding="utf-8") as f:
         f.writelines(lines)
 
     lines.insert(9, set_adaptive_localization_0)
 
-    with open("poly_localization_0.ert", "w", encoding="utf-8") as f:
+    with Path("poly_localization_0.ert").open("w", encoding="utf-8") as f:
         f.writelines(lines)
 
     _, posterior_ensemble_loc0_id, storage_loc = run_cli_ES_with_case(
@@ -291,16 +291,16 @@ def test_that_posterior_generalized_variance_increases_in_cutoff():
         """
     )
 
-    with open("poly.ert", "r+", encoding="utf-8") as f:
+    with Path("poly.ert").open("r+", encoding="utf-8") as f:
         lines = f.readlines()
         lines.insert(2, random_seed_line)
         lines.insert(9, set_adaptive_localization_cutoff1)
-    with open("poly_localization_cutoff1.ert", "w", encoding="utf-8") as f:
+    with Path("poly_localization_cutoff1.ert").open("w", encoding="utf-8") as f:
         f.writelines(lines)
 
     lines.remove(set_adaptive_localization_cutoff1)
     lines.insert(9, set_adaptive_localization_cutoff2)
-    with open("poly_localization_cutoff2.ert", "w", encoding="utf-8") as f:
+    with Path("poly_localization_cutoff2.ert").open("w", encoding="utf-8") as f:
         f.writelines(lines)
 
     prior_ensemble_cutoff1_id, posterior_ensemble_cutoff1_id, storage_cutoff1 = (

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -67,7 +67,9 @@ def test_run_poly_example_with_design_matrix(copy_poly_case_with_design_matrix, 
         Path(config_path) / "poly_out" / "realization-0" / "iter-0" / "parameters.json"
     )
     assert real_0_iter_0_parameters_json_path.exists()
-    with open(real_0_iter_0_parameters_json_path, mode="r+", encoding="utf-8") as fs:
+    with Path(real_0_iter_0_parameters_json_path).open(
+        mode="r+", encoding="utf-8"
+    ) as fs:
         parameters_contents = json.load(fs)
     assert isinstance(parameters_contents, dict)
     for k, v in parameters_contents.items():
@@ -122,7 +124,7 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
 
     # This adds a dummy category and big_numbers parameter to COEFFS GENKW
     # which will be overridden by the design matrix entries
-    with open("coeff_priors", "a", encoding="utf-8") as f:
+    with Path("coeff_priors").open("a", encoding="utf-8") as f:
         f.write("category UNIFORM 0 1\n")
         f.write("big_numbers UNIFORM 0 1\n")
 
@@ -195,14 +197,14 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         )
         np.testing.assert_array_equal(params["b"].to_list(), 10 * [1])
         np.testing.assert_array_equal(params["c"].to_list(), 10 * [2])
-    with open("poly_out/realization-0/iter-0/my_output", encoding="utf-8") as f:
+    with Path("poly_out/realization-0/iter-0/my_output").open(encoding="utf-8") as f:
         output = [line.strip() for line in f]
         assert output[0] == "a: 0"
         assert output[1] == "b: 1"
         assert output[2] == "c: 2"
         assert output[3] == "category: cat1"
         assert output[4] == "big_integer: 10000000000"
-    with open("poly_out/realization-5/iter-0/my_output", encoding="utf-8") as f:
+    with Path("poly_out/realization-5/iter-0/my_output").open(encoding="utf-8") as f:
         output = [line.strip() for line in f]
         assert output[0] == "a: 5"
         assert output[1] == "b: 1"
@@ -497,7 +499,7 @@ def test_design_matrix_on_esmda_fail_without_updateable_parameters(
         [["b", 1], ["c", 2]],
     )
 
-    with open("poly.ert", "a", encoding="utf-8") as f:
+    with Path("poly.ert").open("a", encoding="utf-8") as f:
         f.write(
             dedent(
                 """\
@@ -567,7 +569,7 @@ def test_run_poly_example_with_different_realization_count_chooses_smaller_and_w
     }
     default_list = [["b", 1], ["c", 2]]
     copy_poly_case_with_design_matrix(design_dict, default_list)
-    with open("poly.ert", "a+", encoding="utf-8") as f:
+    with Path("poly.ert").open("a+", encoding="utf-8") as f:
         f.write(f"\nNUM_REALIZATIONS {num_realizations_in_user_config}")
     with pytest.warns(ConfigWarning, match=expected_message):
         run_cli(
@@ -614,7 +616,7 @@ def test_run_poly_example_with_specified_realizations_finds_intersection_and_war
     }
     default_list = [["b", 1], ["c", 2]]
     copy_poly_case_with_design_matrix(design_dict, default_list)
-    with open("poly.ert", "a+", encoding="utf-8") as f:
+    with Path("poly.ert").open("a+", encoding="utf-8") as f:
         f.write("\nNUM_REALIZATIONS 20")
     if intersected_realizations_count > 0:
         run_cli(

--- a/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
+++ b/tests/ert/ui_tests/cli/analysis/test_design_matrix.py
@@ -165,9 +165,8 @@ def test_run_poly_example_with_design_matrix_and_genkw_merge(default_values):
         encoding="utf-8",
     )
 
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("poly_eval.py").chmod(
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     with warnings.catch_warnings():
@@ -282,9 +281,8 @@ def test_run_poly_example_with_multiple_design_matrix_instances():
         encoding="utf-8",
     )
 
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("poly_eval.py").chmod(
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     with warnings.catch_warnings(record=True) as all_warnings:
@@ -406,9 +404,8 @@ def test_design_matrix_on_esmda(experiment_mode, ensemble_name, iterations):
         encoding="utf-8",
     )
 
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("poly_eval.py").chmod(
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     Path("coeff_priors_a").write_text("a UNIFORM 0 1", encoding="utf-8")

--- a/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ert.config import ErtConfig
@@ -39,7 +41,7 @@ def assert_variance_in_field(
 @pytest.mark.usefixtures("copy_snake_oil_field")
 @pytest.mark.integration_test
 def test_that_distance_localization_works_with_a_single_observation():
-    with open("snake_oil_field.ert", "r+", encoding="utf-8") as f:
+    with Path("snake_oil_field.ert").open("r+", encoding="utf-8") as f:
         lines = f.readlines()
 
     config_content = [
@@ -52,7 +54,7 @@ def test_that_distance_localization_works_with_a_single_observation():
         ]
     )
 
-    with open("snake_oil_field_dl.ert", "w", encoding="utf-8") as f:
+    with Path("snake_oil_field_dl.ert").open("w", encoding="utf-8") as f:
         f.writelines(config_content)
 
     run_cli(
@@ -77,7 +79,7 @@ def test_that_distance_localization_works_with_a_single_observation():
 @pytest.mark.usefixtures("copy_heat_equation")
 @pytest.mark.integration_test
 def test_that_distance_localization_runs_on_heat_equation():
-    with open("config.ert", encoding="utf-8") as fh:
+    with Path("config.ert").open(encoding="utf-8") as fh:
         lines = fh.readlines()
 
     config_content = [
@@ -89,7 +91,7 @@ def test_that_distance_localization_runs_on_heat_equation():
             "ENSPATH heat_storage_dl\n",
         ]
     )
-    with open("heat_dl.ert", "w", encoding="utf-8") as fh:
+    with Path("heat_dl.ert").open("w", encoding="utf-8") as fh:
         fh.writelines(config_content)
 
     run_cli(

--- a/tests/ert/ui_tests/cli/analysis/test_es_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_es_update.py
@@ -206,9 +206,8 @@ def test_that_reals_with_load_failure_in_prior_become_parent_failure_in_posterio
         encoding="utf-8",
     )
 
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("poly_eval.py").chmod(
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     run_cli(

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -96,7 +96,7 @@ def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
 def test_field_init_file_not_readable():
     config_file_name = "snake_oil_field.ert"
     field_file_rel_path = "fields/permx0.grdecl"
-    os.chmod(field_file_rel_path, 0o000)
+    Path(field_file_rel_path).chmod(0o000)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=ConfigWarning)
@@ -144,7 +144,7 @@ def test_that_unopenable_observation_config_fails_gracefully():
     line_with_observation_config = content_lines[index_line_with_observation_config]
     observation_config_rel_path = line_with_observation_config.split(" ")[1]
     observation_config_abs_path = os.path.join(Path.cwd(), observation_config_rel_path)
-    os.chmod(observation_config_abs_path, 0o000)
+    Path(observation_config_abs_path).chmod(0o000)
 
     with pytest.raises(
         ConfigValidationError,
@@ -188,7 +188,7 @@ def test_that_successful_realizations_less_than_minimum_realizations_fails_grace
     Path("failing_fm.py").write_text(
         "#!/usr/bin/env python3\nraise RuntimeError('fm failed')", encoding="utf-8"
     )
-    os.chmod("failing_fm.py", 0o755)
+    Path("failing_fm.py").chmod(0o755)
 
     with pytest.raises(
         ErtCliError,
@@ -225,7 +225,7 @@ def setenv_config(tmp_path):
         'print(os.environ["FOURTH"])\n',
         encoding="utf-8",
     )
-    os.chmod(run_script, 0o755)
+    Path(run_script).chmod(0o755)
 
     (tmp_path / "ECHO.txt").write_text(
         dedent(
@@ -479,7 +479,7 @@ def test_that_stop_on_fail_workflow_jobs_stop_ert(
 
     Path(script_name).write_text(script_content, encoding="utf-8")
 
-    os.chmod(script_name, os.stat(script_name).st_mode | 0o111)
+    Path(script_name).chmod(os.stat(script_name).st_mode | 0o111)
 
     Path("dump_failing_workflow").write_text("failjob", encoding="utf-8")
 
@@ -812,7 +812,7 @@ def test_that_a_custom_eclrun_can_be_activated_through_setenv():
         ).strip(),
         encoding="utf-8",
     )
-    os.chmod(eclrun, os.stat(eclrun).st_mode | stat.S_IEXEC)
+    Path(eclrun).chmod(os.stat(eclrun).st_mode | stat.S_IEXEC)
 
     Path("FOO.DATA").touch()
     config_file = Path("config.ert")

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -143,7 +143,7 @@ def test_that_unopenable_observation_config_fails_gracefully():
     )
     line_with_observation_config = content_lines[index_line_with_observation_config]
     observation_config_rel_path = line_with_observation_config.split(" ")[1]
-    observation_config_abs_path = os.path.join(os.getcwd(), observation_config_rel_path)
+    observation_config_abs_path = os.path.join(Path.cwd(), observation_config_rel_path)
     os.chmod(observation_config_abs_path, 0o000)
 
     with pytest.raises(

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -55,8 +55,8 @@ def test_test_run_on_lsf_configuration_works_with_no_errors(tmp_path):
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
     with (
-        open("poly.ert", encoding="utf-8") as fin,
-        open("poly-no-gen-kw.ert", "w", encoding="utf-8") as fout,
+        Path("poly.ert").open(encoding="utf-8") as fin,
+        Path("poly-no-gen-kw.ert").open("w", encoding="utf-8") as fout,
     ):
         for line in fin:
             if "GEN_KW" not in line:
@@ -166,8 +166,8 @@ def test_that_successful_realizations_less_than_minimum_realizations_fails_grace
     mode,
 ):
     with (
-        open("poly.ert", encoding="utf-8") as fin,
-        open("failing_realizations.ert", "w", encoding="utf-8") as fout,
+        Path("poly.ert").open(encoding="utf-8") as fin,
+        Path("failing_realizations.ert").open("w", encoding="utf-8") as fout,
     ):
         for line in fin:
             if "MIN_REALIZATIONS" in line:
@@ -263,7 +263,7 @@ def test_that_setenv_sets_environment_variables_in_steps(setenv_config):
     )
 
     # Then the environment variables are put into jobs.json
-    with open("simulations/realization-0/iter-0/jobs.json", encoding="utf-8") as f:
+    with Path("simulations/realization-0/iter-0/jobs.json").open(encoding="utf-8") as f:
         data = json.load(f)
         global_env = data.get("global_environment")
         for key in ["_ERT_ENSEMBLE_ID", "_ERT_EXPERIMENT_ID"]:
@@ -277,7 +277,9 @@ def test_that_setenv_sets_environment_variables_in_steps(setenv_config):
     path = os.environ["PATH"]
 
     # and then fm_dispatch should expand the variables on the compute side
-    with open("simulations/realization-0/iter-0/ECHO.stdout.0", encoding="utf-8") as f:
+    with Path("simulations/realization-0/iter-0/ECHO.stdout.0").open(
+        encoding="utf-8"
+    ) as f:
         lines = f.readlines()
         assert len(lines) == 4
         # the compute-nodes path is the same since it's running locally,
@@ -481,7 +483,7 @@ def test_that_stop_on_fail_workflow_jobs_stop_ert(
 
     Path("dump_failing_workflow").write_text("failjob", encoding="utf-8")
 
-    with open("poly.ert", mode="a", encoding="utf-8") as fh:
+    with Path("poly.ert").open(mode="a", encoding="utf-8") as fh:
         fh.write(
             dedent(
                 """
@@ -688,7 +690,7 @@ def test_that_prior_is_not_overwritten_in_ensemble_experiment(
 @pytest.mark.usefixtures("copy_poly_case")
 def test_failing_step_cli_error_message():
     # modify poly_eval.py
-    with open("poly_eval.py", mode="a", encoding="utf-8") as poly_script:
+    with Path("poly_eval.py").open(mode="a", encoding="utf-8") as poly_script:
         poly_script.writelines(["    raise RuntimeError('Argh')"])
 
     expected_substrings = [
@@ -715,7 +717,7 @@ def test_exclude_parameter_from_update():
             if "GEN_KW" in line:
                 print("GEN_KW ANOTHER_KW distribution.txt UPDATE:FALSE")
             print(line, end="")
-    with open("distribution.txt", mode="w", encoding="utf-8") as fh:
+    with Path("distribution.txt").open(mode="w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD NORMAL 0 1")
 
     run_cli(
@@ -766,8 +768,10 @@ def test_that_log_is_cleaned_up_from_repeated_forward_model_steps(caplog):
     there are repeated forward models
     """
     with (
-        open("poly.ert", encoding="utf-8") as fin,
-        open("poly_repeated_forward_model_steps.ert", "w", encoding="utf-8") as fout,
+        Path("poly.ert").open(encoding="utf-8") as fin,
+        Path("poly_repeated_forward_model_steps.ert").open(
+            "w", encoding="utf-8"
+        ) as fout,
     ):
         forward_model_steps = ["FORWARD_MODEL poly_eval\n"] * 5
         lines = fin.readlines() + forward_model_steps

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -322,12 +322,11 @@ if __name__ == "__main__":
             encoding="utf-8",
         )
 
-        os.chmod(
-            "forward_model",
+        Path("forward_model").chmod(
             os.stat("forward_model").st_mode
             | stat.S_IXUSR
             | stat.S_IXGRP
-            | stat.S_IXOTH,
+            | stat.S_IXOTH
         )
         Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
         Path("observations").write_text(

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -285,7 +285,7 @@ def test_field_parameter_persistence_to_grdecl(tmpdir):
             FORWARD_MODEL poly_eval
         """
         )
-        with open("config.ert", "w", encoding="utf-8") as fh:
+        with Path("config.ert").open("w", encoding="utf-8") as fh:
             fh.writelines(config)
 
         realizations = 5

--- a/tests/ert/ui_tests/cli/test_local_driver.py
+++ b/tests/ert/ui_tests/cli/test_local_driver.py
@@ -36,7 +36,7 @@ def create_ert_config(path: Path):
     )
 
 
-async def test_that_forward_model_subprocesses_live_on_after_ert_dies(tmp_path):
+async def test_that_forward_model_subprocesses_live_on_after_ert_dies(tmp_path: Path):
     # Have ERT run a forward model that writes in PID to a file, then sleeps
     # Forcefully terminate ERT and assert that the child process is not terminated
     create_ert_config(tmp_path)
@@ -45,7 +45,7 @@ async def test_that_forward_model_subprocesses_live_on_after_ert_dies(tmp_path):
         "ert", "test_run", "ert_config.ert", cwd=tmp_path
     )
     check_path_retry, check_path_max_retries = 0, 200
-    expected_path = Path(tmp_path, "test_out/realization-0/iter-0/forward_model_pid")
+    expected_path = tmp_path / "test_out/realization-0/iter-0/forward_model_pid"
     while not expected_path.exists() and check_path_retry < check_path_max_retries:
         check_path_retry += 1
         await asyncio.sleep(0.5)

--- a/tests/ert/ui_tests/cli/test_local_driver.py
+++ b/tests/ert/ui_tests/cli/test_local_driver.py
@@ -6,9 +6,9 @@ from textwrap import dedent
 
 
 def create_ert_config(path: Path):
-    ert_config_path = Path(path / "ert_config.ert")
-    Path(path / "TEST_JOB").write_text("EXECUTABLE test_script.sh", encoding="utf-8")
-    Path(path / "test_script.sh").write_text(
+    ert_config_path = path / "ert_config.ert"
+    (path / "TEST_JOB").write_text("EXECUTABLE test_script.sh", encoding="utf-8")
+    (path / "test_script.sh").write_text(
         dedent(
             """\
             #!/bin/sh
@@ -18,7 +18,7 @@ def create_ert_config(path: Path):
         ),
         encoding="utf-8",
     )
-    os.chmod(path / "test_script.sh", 0o755)
+    (path / "test_script.sh").chmod(0o755)
     ert_config_path.write_text(
         dedent(
             r"""

--- a/tests/ert/ui_tests/cli/test_parameter_sample_types.py
+++ b/tests/ert/ui_tests/cli/test_parameter_sample_types.py
@@ -74,12 +74,11 @@ if __name__ == "__main__":
             encoding="utf-8",
         )
 
-        os.chmod(
-            "forward_model",
+        Path("forward_model").chmod(
             os.stat("forward_model").st_mode
             | stat.S_IXUSR
             | stat.S_IXGRP
-            | stat.S_IXOTH,
+            | stat.S_IXOTH
         )
         Path("POLY_EVAL").write_text("EXECUTABLE forward_model", encoding="utf-8")
         Path("observations").write_text(

--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -174,7 +174,7 @@ def test_update_lowers_generalized_variance_or_deactivates_observations(
         os.chmod(py, mode.st_mode | stat.S_IEXEC)
 
         for i in range(num_groups):
-            with open("observations", mode="a", encoding="utf-8") as f:
+            with Path("observations").open(mode="a", encoding="utf-8") as f:
                 f.write(observation.format(i=i))
             Path(f"poly_obs_{i}.txt").write_text(
                 "\n".join(

--- a/tests/ert/ui_tests/cli/test_update.py
+++ b/tests/ert/ui_tests/cli/test_update.py
@@ -171,7 +171,7 @@ def test_update_lowers_generalized_variance_or_deactivates_observations(
         py = Path("poly_eval.py")
         py.write_text(poly_eval.format(num_points=num_points), encoding="utf-8")
         mode = os.stat(py)
-        os.chmod(py, mode.st_mode | stat.S_IEXEC)
+        Path(py).chmod(mode.st_mode | stat.S_IEXEC)
 
         for i in range(num_groups):
             with Path("observations").open(mode="a", encoding="utf-8") as f:

--- a/tests/ert/ui_tests/cli/test_update_with_rft_observations.py
+++ b/tests/ert/ui_tests/cli/test_update_with_rft_observations.py
@@ -39,7 +39,7 @@ def test_that_rft_example_with_rft_observation_keyword_yelds_same_result_as_gend
     if bool(request.config.getoption("--snapshot-update")):
         snapshot.assert_match(json.dumps(pressure, indent=2) + "\n", FILE_NAME)
 
-    with open(Path(snapshot.snapshot_dir, FILE_NAME), encoding="utf-8") as file:
+    with Path(snapshot.snapshot_dir, FILE_NAME).open(encoding="utf-8") as file:
         pressure_snapshot = json.load(file)
 
     assert isinstance(pressure, dict)

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -190,12 +190,11 @@ def _ensemble_experiment_run(
                 encoding="utf-8",
             )
 
-            os.chmod(
-                "poly_eval.py",
+            Path("poly_eval.py").chmod(
                 os.stat("poly_eval.py").st_mode
                 | stat.S_IXUSR
                 | stat.S_IXGRP
-                | stat.S_IXOTH,
+                | stat.S_IXOTH
             )
         run_experiment(EnsembleExperiment, gui)
 

--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -279,7 +279,7 @@ def clean_up_diplayed_runpath(gui: QWidget):
     single_test_run_panel = get_child(experiment_panel, SingleTestRunPanel)
     runpath_label = get_child(single_test_run_panel, CopyableLabel)
 
-    current_directory = os.getcwd()
+    current_directory = str(Path.cwd())
     label_text = runpath_label.label.text()
     runpath_label.label.setText(label_text.replace(current_directory, "&lt;cwd&gt;"))
 

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -148,8 +148,8 @@ def test_gui_shows_a_warning_and_disables_update_when_there_are_no_observations(
 @pytest.mark.usefixtures("copy_poly_case")
 def test_gui_shows_a_warning_and_disables_update_when_parameters_are_missing(qapp):
     with (
-        open("poly.ert", encoding="utf-8") as fin,
-        open("poly-no-gen-kw.ert", "w", encoding="utf-8") as fout,
+        Path("poly.ert").open(encoding="utf-8") as fin,
+        Path("poly-no-gen-kw.ert").open("w", encoding="utf-8") as fout,
     ):
         for line in fin:
             if "GEN_KW" not in line:
@@ -211,7 +211,7 @@ def test_that_the_run_workflow_tool_is_disabled_when_there_are_no_workflows(qapp
 def test_that_the_run_workflow_tool_is_enabled_when_there_are_workflows(qapp, tmp_path):
     config_file = tmp_path / "config.ert"
 
-    with open(config_file, "a+", encoding="utf-8") as ert_file:
+    with Path(config_file).open("a+", encoding="utf-8") as ert_file:
         ert_file.write("NUM_REALIZATIONS 1\n")
         ert_file.write("LOAD_WORKFLOW_JOB workflows/UBER_PRINT print_uber\n")
         ert_file.write("LOAD_WORKFLOW workflows/MAGIC_PRINT magic_print\n")

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -208,7 +208,9 @@ def test_that_the_run_workflow_tool_is_disabled_when_there_are_no_workflows(qapp
 
 
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
-def test_that_the_run_workflow_tool_is_enabled_when_there_are_workflows(qapp, tmp_path):
+def test_that_the_run_workflow_tool_is_enabled_when_there_are_workflows(
+    qapp, tmp_path: Path
+):
     config_file = tmp_path / "config.ert"
 
     with Path(config_file).open("a+", encoding="utf-8") as ert_file:
@@ -218,12 +220,8 @@ def test_that_the_run_workflow_tool_is_enabled_when_there_are_workflows(qapp, tm
 
     os.mkdir(tmp_path / "workflows")
 
-    Path(tmp_path / "workflows/MAGIC_PRINT").write_text(
-        "print_uber\n", encoding="utf-8"
-    )
-    Path(tmp_path / "workflows/UBER_PRINT").write_text(
-        "EXECUTABLE ls\n", encoding="utf-8"
-    )
+    (tmp_path / "workflows/MAGIC_PRINT").write_text("print_uber\n", encoding="utf-8")
+    (tmp_path / "workflows/UBER_PRINT").write_text("EXECUTABLE ls\n", encoding="utf-8")
 
     args = Mock()
     args.config = str(config_file)

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -596,9 +596,8 @@ def test_that_a_failing_job_shows_error_message_with_context(
         ),
         encoding="utf-8",
     )
-    os.chmod(
-        "poly_eval.py",
-        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path("poly_eval.py").chmod(
+        os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     with contextlib.suppress(FileNotFoundError):
@@ -990,9 +989,8 @@ warnings.warn('Foobar')"""
 
     Path(script_file).write_text(dedent(script_file_content), encoding="utf-8")
 
-    os.chmod(
-        script_file,
-        os.stat(script_file).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    Path(script_file).chmod(
+        os.stat(script_file).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
 
     config_file = "config.ert"

--- a/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
+++ b/tests/ert/ui_tests/gui/test_restart_ensemble_experiment.py
@@ -51,12 +51,8 @@ def test_rerun_failed_all_realizations(opened_main_window_poly, qtbot):
             encoding="utf-8",
         )
 
-        os.chmod(
-            "poly_eval.py",
-            os.stat("poly_eval.py").st_mode
-            | stat.S_IXUSR
-            | stat.S_IXGRP
-            | stat.S_IXOTH,
+        Path("poly_eval.py").chmod(
+            os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
 
     write_poly_eval(failing_reals=True)
@@ -130,12 +126,8 @@ def test_rerun_failed_realizations(opened_main_window_poly, qtbot, caplog):
             encoding="utf-8",
         )
 
-        os.chmod(
-            "poly_eval.py",
-            os.stat("poly_eval.py").st_mode
-            | stat.S_IXUSR
-            | stat.S_IXGRP
-            | stat.S_IXOTH,
+        Path("poly_eval.py").chmod(
+            os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
 
     experiment_panel = gui.findChild(ExperimentPanel)
@@ -292,12 +284,8 @@ def test_rerun_failed_realizations_evaluate_ensemble(
             encoding="utf-8",
         )
 
-        os.chmod(
-            "poly_eval.py",
-            os.stat("poly_eval.py").st_mode
-            | stat.S_IXUSR
-            | stat.S_IXGRP
-            | stat.S_IXOTH,
+        Path("poly_eval.py").chmod(
+            os.stat("poly_eval.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
 
     experiment_panel = gui.findChild(ExperimentPanel)

--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -60,7 +60,7 @@ def _open_main_window(
     INSTALL_JOB forward_model FORWARD_MODEL
     FORWARD_MODEL forward_model
     """)
-    with open("config.ert", "w", encoding="utf-8") as fh:
+    with Path("config.ert").open("w", encoding="utf-8") as fh:
         fh.writelines(config)
 
     config = ErtConfig.from_file(path / "config.ert")

--- a/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
+++ b/tests/ert/ui_tests/gui/test_restart_no_responses_and_parameters.py
@@ -42,12 +42,8 @@ def _open_main_window(
         encoding="utf-8",
     )
 
-    os.chmod(
-        "forward_model.py",
-        os.stat("forward_model.py").st_mode
-        | stat.S_IXUSR
-        | stat.S_IXGRP
-        | stat.S_IXOTH,
+    Path("forward_model.py").chmod(
+        os.stat("forward_model.py").st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
     Path("FORWARD_MODEL").write_text("EXECUTABLE forward_model.py", encoding="utf-8")
 

--- a/tests/ert/ui_tests/gui/test_update_runs.py
+++ b/tests/ert/ui_tests/gui/test_update_runs.py
@@ -1,5 +1,6 @@
 import fileinput
 import shutil
+from pathlib import Path
 
 import polars as pl
 import pytest
@@ -153,7 +154,7 @@ def poly_case_with_autoscale_observations_config(source_root, tmp_path, run_expe
 
     config_path = tmp_path / "poly.ert"
 
-    with open(config_path, "a", encoding="utf-8") as f:
+    with Path(config_path).open("a", encoding="utf-8") as f:
         f.write("\nANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE *\n")
 
     with open_gui_with_config(config_path) as gui:
@@ -197,7 +198,7 @@ def poly_case_with_one_missing_response(source_root, tmp_path, run_experiment):
     _new_poly_example(source_root, tmp_path, 2)
     config_path = tmp_path / "poly.ert"
     # ensures observations are not disabled due to unlucky responses
-    with open(config_path, "a", encoding="utf-8") as f:
+    with Path(config_path).open("a", encoding="utf-8") as f:
         f.write("\nRANDOM_SEED 1234\n")
 
     with open_gui_with_config(config_path) as gui:

--- a/tests/ert/unit_tests/cli/test_cli_workflow.py
+++ b/tests/ert/unit_tests/cli/test_cli_workflow.py
@@ -14,7 +14,7 @@ def test_executing_workflow(storage):
     Path("test_wf").write_text("CSV_EXPORT test_workflow_output.csv", encoding="utf-8")
 
     config_file = "poly.ert"
-    with open(config_file, "a", encoding="utf-8") as file_handle:
+    with Path(config_file).open("a", encoding="utf-8") as file_handle:
         file_handle.write("LOAD_WORKFLOW test_wf")
 
     rc = ErtConfig.with_plugins(get_site_plugins()).from_file(config_file)

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -683,7 +683,7 @@ def config_generators(draw, use_eclbase=booleans):
 
             def make_executable(filename):
                 current_mode = os.stat(filename).st_mode
-                os.chmod(filename, current_mode | stat.S_IEXEC)
+                Path(filename).chmod(current_mode | stat.S_IEXEC)
 
             for job_file, executable_file in should_exist_job_configs:
                 path = Path(job_file).parent

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -709,7 +709,7 @@ def config_generators(draw, use_eclbase=booleans):
 
 
 def to_config_file(filename, config_values):
-    config_dict = config_values.to_config_dict(filename, os.getcwd(), all_defines=False)
+    config_dict = config_values.to_config_dict(filename, Path.cwd(), all_defines=False)
     with Path(filename).open(mode="w+", encoding="utf-8") as config:
         config.write(
             f"{ConfigKeys.RUNPATH_FILE} {config_dict[ConfigKeys.RUNPATH_FILE]}\n"

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -3,7 +3,6 @@ import datetime
 import operator
 import os
 import os.path
-import pathlib
 import stat
 from collections import defaultdict
 from dataclasses import dataclass
@@ -56,8 +55,7 @@ words = st.text(
 
 
 def touch(filename):
-    with open(file=filename, mode="w", encoding="utf-8") as fh:
-        fh.write(" ")
+    Path(filename).write_text(" ", encoding="utf-8")
 
 
 file_names = words
@@ -343,7 +341,7 @@ class ErtConfigValues:
                     name,
                     (
                         fn,
-                        pathlib.Path(fn).read_text(encoding="utf-8"),
+                        Path(fn).read_text(encoding="utf-8"),
                     ),
                 )
                 for name, fn in self.install_job
@@ -678,7 +676,7 @@ def config_generators(draw, use_eclbase=booleans):
                 if not os.path.isfile(filename):
                     touch(filename)
 
-            with open(config_values.obs_config, "w", encoding="utf-8") as fh:
+            with Path(config_values.obs_config).open("w", encoding="utf-8") as fh:
                 for o in obs:
                     fh.write(as_obs_config_content(o))
                     fh.write("\n")
@@ -712,7 +710,7 @@ def config_generators(draw, use_eclbase=booleans):
 
 def to_config_file(filename, config_values):
     config_dict = config_values.to_config_dict(filename, os.getcwd(), all_defines=False)
-    with open(file=filename, mode="w+", encoding="utf-8") as config:
+    with Path(filename).open(mode="w+", encoding="utf-8") as config:
         config.write(
             f"{ConfigKeys.RUNPATH_FILE} {config_dict[ConfigKeys.RUNPATH_FILE]}\n"
         )

--- a/tests/ert/unit_tests/config/parsing/test_lark_parser.py
+++ b/tests/ert/unit_tests/config/parsing/test_lark_parser.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -219,7 +218,7 @@ def test_that_file_without_read_access_raises_config_validation_error(
     template_file = "file.txt"
 
     touch(template_file)
-    os.chmod(template_file, 0o000)  # Remove permissions
+    Path(template_file).chmod(0o000)  # Remove permissions
     Path(config_file_name).write_text(config_file_contents, encoding="utf-8")
     with pytest.raises(
         ConfigValidationError,

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -215,7 +215,7 @@ def validate_forward_model(forward_model, forward_model_config):
 def generate_step_from_dict(forward_model_config):
     forward_model_config = copy.deepcopy(forward_model_config)
     forward_model_config["executable"] = os.path.join(
-        os.getcwd(), forward_model_config["executable"]
+        Path.cwd(), forward_model_config["executable"]
     )
     forward_model = _generate_step(
         forward_model_config["name"],
@@ -593,7 +593,7 @@ def test_that_config_path_is_the_directory_of_the_main_ert_config():
         user_config_file=ert_config.user_config_file,
         run_id="",
     )
-    assert data["jobList"][0]["argList"] == [os.getcwd()]
+    assert data["jobList"][0]["argList"] == [str(Path.cwd())]
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -152,7 +152,7 @@ def _generate_step(
         elif val is not None:
             config_contents += f"{key} {val}\n"
 
-    with open(executable, "w", encoding="utf-8"):
+    with Path(executable).open("w", encoding="utf-8"):
         pass
     mode = os.stat(executable).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
@@ -701,7 +701,7 @@ def test_that_environment_variables_are_set_in_forward_model(
     monkeypatch.setenv("ENV", "env_value")
     Path("job_file").write_text(job, encoding="utf-8")
 
-    with open("config_file.ert", "w", encoding="utf-8") as fout:
+    with Path("config_file.ert").open("w", encoding="utf-8") as fout:
         # Write a minimal config file
         fout.write(
             dedent(

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -156,7 +156,7 @@ def _generate_step(
         pass
     mode = os.stat(executable).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
-    os.chmod(executable, stat.S_IMODE(mode))
+    Path(executable).chmod(stat.S_IMODE(mode))
 
     return forward_model_step_from_config_contents(config_contents, config_file, name)
 

--- a/tests/ert/unit_tests/config/test_ensemble_config.py
+++ b/tests/ert/unit_tests/config/test_ensemble_config.py
@@ -73,9 +73,9 @@ def test_that_empty_grid_file_raises(tmpdir):
         GRID grid.GRDECL
         """
         )
-        with open("config.ert", "w", encoding="utf-8") as fh:
+        with Path("config.ert").open("w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("grid.GRDECL", "w", encoding="utf-8") as fh:
+        with Path("grid.GRDECL").open("w", encoding="utf-8") as fh:
             fh.writelines("")
 
         with pytest.raises(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1543,8 +1543,10 @@ def test_that_removed_analysis_module_keywords_raises_error(
         )
 
 
-def test_ert_config_parser_fails_gracefully_on_unreadable_config_file(caplog, tmp_path):
-    config_file = Path(tmp_path) / "config.ert"
+def test_ert_config_parser_fails_gracefully_on_unreadable_config_file(
+    caplog, tmp_path: Path
+):
+    config_file = tmp_path / "config.ert"
     config_file.write_text("")
     Path(config_file).chmod(0o000)
     caplog.set_level(logging.WARNING)
@@ -2261,9 +2263,9 @@ def test_queue_options_are_joined_after_option_name():
     ],
 )
 def test_validation_error_on_invalid_parameter_name(
-    invalid_parameter_definition_name, tmp_path
+    invalid_parameter_definition_name, tmp_path: Path
 ):
-    Path(tmp_path / "coeffs_priors").write_text(
+    (tmp_path / "coeffs_priors").write_text(
         invalid_parameter_definition_name, encoding="utf-8"
     )
     with pytest.raises(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -125,7 +125,7 @@ def test_that_workflow_run_modes_can_be_selected(run_mode):
     my_script = Path("my_script").resolve()
     my_script.write_text("", encoding="utf-8")
     st = os.stat(my_script)
-    os.chmod(my_script, st.st_mode | stat.S_IEXEC)
+    Path(my_script).chmod(st.st_mode | stat.S_IEXEC)
     test_user_config = Path("user_config.ert")
     test_user_config.write_text(
         dedent(f"""JOBNAME Job%d
@@ -164,7 +164,7 @@ def test_custom_forward_models_are_logged(caplog):
     localhack = "localhack.sh"
     Path(localhack).write_text("", encoding="utf-8")
     st = os.stat(localhack)
-    os.chmod(localhack, st.st_mode | stat.S_IEXEC)
+    Path(localhack).chmod(st.st_mode | stat.S_IEXEC)
     Path("foo_fm").write_text(
         f"-- A comment\n   \nEXECUTABLE {localhack}\n\n\n", encoding="utf-8"
     )
@@ -1546,7 +1546,7 @@ def test_that_removed_analysis_module_keywords_raises_error(
 def test_ert_config_parser_fails_gracefully_on_unreadable_config_file(caplog, tmp_path):
     config_file = Path(tmp_path) / "config.ert"
     config_file.write_text("")
-    os.chmod(config_file, 0o000)
+    Path(config_file).chmod(0o000)
     caplog.set_level(logging.WARNING)
 
     with pytest.raises(ConfigValidationError, match="Permission"):

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -339,7 +339,7 @@ def test_data_file_with_non_utf_8_character_gives_error_message():
         ),
         encoding="utf-8",
     )
-    with open(data_file, "ab") as f:
+    with Path(data_file).open("ab") as f:
         f.write(b"\xff")
     data_file_path = str(Path.cwd() / data_file)
     with (
@@ -1571,10 +1571,10 @@ def test_that_context_types_are_json_serializable():
         "context_list": cl,
     }
 
-    with open("test.json", "w", encoding="utf-8") as f:
+    with Path("test.json").open("w", encoding="utf-8") as f:
         json.dump(payload, f, cls=ContextBoolEncoder)
 
-    with open("test.json", encoding="utf-8") as f:
+    with Path("test.json").open(encoding="utf-8") as f:
         r = json.load(f)
 
     assert isinstance(r["context_bool_false"], bool)
@@ -1647,15 +1647,15 @@ def test_that_empty_params_file_gives_reasonable_error(tmpdir, param_config):
         GEN_KW COEFFS """
         config += param_config
 
-        with open("config.ert", mode="w", encoding="utf-8") as fh:
+        with Path("config.ert").open(mode="w", encoding="utf-8") as fh:
             fh.writelines(config)
 
         # Create an empty file named 'coeffs_priors'
-        with open("coeffs_priors", mode="w", encoding="utf-8") as fh:
+        with Path("coeffs_priors").open(mode="w", encoding="utf-8") as fh:
             pass
 
         # Create an empty file named 'template.txt'
-        with open("template.txt", mode="w", encoding="utf-8") as fh:
+        with Path("template.txt").open(mode="w", encoding="utf-8") as fh:
             pass
 
         with pytest.raises(ConfigValidationError, match="No parameters specified in"):
@@ -2519,8 +2519,8 @@ def test_that_user_forward_models_overwrite_site_forward_models(
 def test_that_files_for_refcase_exists(existing_suffix, expected_suffix):
     refcase_file = "missing_refcase_file"
 
-    with open(
-        refcase_file + "." + existing_suffix, "w+", encoding="utf-8"
+    with Path(refcase_file + "." + existing_suffix).open(
+        "w+", encoding="utf-8"
     ) as refcase_writer:
         refcase_writer.write("")
 
@@ -2546,9 +2546,13 @@ _________________________________________     _____    ____________________
  |____|_  /_______  / \\___  /    \\______  /\\____|__  /_______  //_______  /
         \\/        \\/      \\/            \\/         \\/        \\/         \\/
 """
-    with open(refcase_file + ".UNSMRY", "w+", encoding="utf-8") as refcase_file_handler:
+    with Path(refcase_file + ".UNSMRY").open(
+        "w+", encoding="utf-8"
+    ) as refcase_file_handler:
         refcase_file_handler.write(refcase_file_content)
-    with open(refcase_file + ".SMSPEC", "w+", encoding="utf-8") as refcase_file_handler:
+    with Path(refcase_file + ".SMSPEC").open(
+        "w+", encoding="utf-8"
+    ) as refcase_file_handler:
         refcase_file_handler.write(refcase_file_content)
     with pytest.raises(expected_exception=ConfigValidationError, match=refcase_file):
         Refcase.from_config_dict(config_dict={ConfigKeys.REFCASE: refcase_file})

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -76,8 +76,8 @@ def test_that_config_path_substitution_is_the_name_of_the_configs_directory():
     Path("minimal_config.ert").write_text("NUM_REALIZATIONS 1", encoding="utf-8")
     ert_config = ErtConfig.from_file("minimal_config.ert")
 
-    assert ert_config.config_path == os.getcwd()
-    assert ert_config.substitutions["<CONFIG_PATH>"] == os.getcwd()
+    assert ert_config.config_path == str(Path.cwd())
+    assert ert_config.substitutions["<CONFIG_PATH>"] == str(Path.cwd())
 
 
 def test_runpath_file_is_absolute(monkeypatch, tmp_path):
@@ -210,7 +210,7 @@ SUMMARY *"""
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_parsing_workflows_gives_expected():
-    cwd = os.getcwd()
+    cwd = str(Path.cwd())
 
     config_dict = {
         ConfigKeys.LOAD_WORKFLOW_JOB: [
@@ -421,7 +421,7 @@ def test_that_creating_ert_config_from_dict_is_same_as_from_file(
     filename = "config.ert"
     with config_generator(tmp_path_factory, filename) as config_values:
         config_from_dict = ErtConfig.from_dict(
-            config_values.to_config_dict("config.ert", os.getcwd())
+            config_values.to_config_dict("config.ert", str(Path.cwd()))
         )
         config_from_file = ErtConfig.from_file(filename)
 
@@ -438,7 +438,7 @@ def test_that_ert_config_is_serializable(tmp_path_factory, config_generator):
     filename = "config.ert"
     with config_generator(tmp_path_factory, filename) as config_values:
         ert_config = ErtConfig.from_dict(
-            config_values.to_config_dict("config.ert", os.getcwd())
+            config_values.to_config_dict("config.ert", str(Path.cwd()))
         )
         config_json = RootModel[ErtConfig](ert_config).model_dump(mode="json")
         from_json = ErtConfig(**config_json)
@@ -465,7 +465,7 @@ def test_that_parsing_ert_config_result_in_expected_values(
         assert ert_config.random_seed == config_values.random_seed
         assert ert_config.queue_config.max_submit == config_values.max_submit
         assert ert_config.user_config_file == os.path.abspath(filename)
-        assert ert_config.config_path == os.getcwd()
+        assert ert_config.config_path == str(Path.cwd())
         assert str(ert_config.runpath_file) == os.path.abspath(
             config_values.runpath_file
         )
@@ -487,7 +487,7 @@ def test_default_ens_path():
     dict_set_ens_path = ErtConfig.from_dict(
         {
             ConfigKeys.NUM_REALIZATIONS: 1,
-            "ENSPATH": os.path.join(os.getcwd(), "storage"),
+            "ENSPATH": os.path.join(Path.cwd(), "storage"),
         }
     ).ens_path
 
@@ -669,8 +669,8 @@ def test_that_magic_strings_get_substituted_in_workflow():
         script <ZERO>
         """
     )
-    script_file_path = os.path.join(os.getcwd(), "script")
-    workflow_file_path = os.path.join(os.getcwd(), "workflow")
+    script_file_path = os.path.join(Path.cwd(), "script")
+    workflow_file_path = os.path.join(Path.cwd(), "workflow")
     Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
     Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
 
@@ -742,7 +742,7 @@ def test_that_if_field_is_given_and_grid_is_missing_you_get_error(
     tmp_path_factory, config_generator
 ):
     with config_generator(tmp_path_factory) as config_values:
-        config_dict = config_values.to_config_dict("test.ert", os.getcwd())
+        config_dict = config_values.to_config_dict("test.ert", Path.cwd())
         del config_dict[ConfigKeys.GRID]
         assume(len(config_dict.get(ConfigKeys.FIELD, [])) > 0)
         with pytest.raises(
@@ -1423,8 +1423,8 @@ def test_parsing_workflow_with_multiple_args():
         script <ZERO>
         """
     )
-    script_file_path = os.path.join(os.getcwd(), "script")
-    workflow_file_path = os.path.join(os.getcwd(), "workflow")
+    script_file_path = os.path.join(Path.cwd(), "script")
+    workflow_file_path = os.path.join(Path.cwd(), "workflow")
     Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
     Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
 
@@ -1885,9 +1885,9 @@ def test_parsing_define_within_workflow():
         """
     )
 
-    script_file_path = os.path.join(os.getcwd(), "script")
-    workflow_file_path = os.path.join(os.getcwd(), "workflow")
-    workflow2_file_path = os.path.join(os.getcwd(), "workflow2")
+    script_file_path = os.path.join(Path.cwd(), "script")
+    workflow_file_path = os.path.join(Path.cwd(), "workflow")
+    workflow2_file_path = os.path.join(Path.cwd(), "workflow2")
 
     Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
 
@@ -2113,7 +2113,7 @@ def test_run_template_raises_configvalidationerror_with_more_than_two_arguments(
 
 @pytest.fixture
 def setup_workflow_file():
-    workflow_file_path = os.path.join(os.getcwd(), "workflow")
+    workflow_file_path = os.path.join(Path.cwd(), "workflow")
     Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
 
     Path("config.ert").write_text(
@@ -2208,7 +2208,7 @@ def test_ert_script_hook_pre_experiment_essettings_fails():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_script_hook_valid_essettings_succeed():
-    workflow_file_path = os.path.join(os.getcwd(), "workflow")
+    workflow_file_path = os.path.join(Path.cwd(), "workflow")
     Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
 
     Path("config.ert").write_text(

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -36,7 +36,7 @@ def test_load_forward_model():
     Path(name).write_text("This is a script", encoding="utf-8")
     mode = os.stat(name).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
-    os.chmod(name, stat.S_IMODE(mode))
+    Path(name).chmod(stat.S_IMODE(mode))
     contents = """
         STDOUT null
         STDERR null
@@ -63,7 +63,7 @@ def test_load_forward_model_upgraded():
     Path(name).write_text("This is a script", encoding="utf-8")
     mode = os.stat(name).st_mode
     mode |= stat.S_IXUSR | stat.S_IXGRP
-    os.chmod(name, stat.S_IMODE(mode))
+    Path(name).chmod(stat.S_IMODE(mode))
     fm_step = forward_model_step_from_config_contents(
         """
         EXECUTABLE script.sh

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -47,7 +47,7 @@ def test_load_forward_model():
     assert fm_step.stdout_file is None
     assert fm_step.stderr_file is None
 
-    assert fm_step.executable == os.path.join(os.getcwd(), "script.sh")
+    assert fm_step.executable == os.path.join(Path.cwd(), "script.sh")
     assert os.access(fm_step.executable, os.X_OK)
 
     assert fm_step.min_arg is None
@@ -221,7 +221,7 @@ def test_ert_config_throws_on_missing_forward_model_step(
             expected_exception=ValueError, match="Could not find forward model step"
         ):
             _ = ErtConfig.from_dict(
-                config_values.to_config_dict("test.ert", os.getcwd())
+                config_values.to_config_dict("test.ert", Path.cwd())
             )
 
 

--- a/tests/ert/unit_tests/config/test_gen_data_config.py
+++ b/tests/ert/unit_tests/config/test_gen_data_config.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import suppress
 from pathlib import Path
 
@@ -147,7 +146,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(con
             keys=["something"],
             report_steps_list=[None],
             input_files=["output"],
-        ).read_from_file(os.getcwd(), 0, 0)
+        ).read_from_file(Path.cwd(), 0, 0)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -257,7 +257,7 @@ async def test_gen_kw_is_log_or_not(
 )
 def test_gen_kw_distribution_errors(tmpdir, distribution, mean, std, error):
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
 
         if distribution == "TRUNCATED_NORMAL":
@@ -468,7 +468,7 @@ def test_gen_kw_trans_func(tmpdir, params, xinput, expected):
 
 def test_gen_kw_objects_equal(tmpdir):
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
 
         g1 = GenKwConfig.from_config_list(
@@ -494,9 +494,9 @@ def test_gen_kw_objects_equal(tmpdir):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_gen_kw_pred_special_suggested_removal():
-    with open("coeff_priors.txt", "a", encoding="utf-8") as f:
+    with Path("coeff_priors.txt").open("a", encoding="utf-8") as f:
         f.write("a NORMAL 0 1")
-    with open("config.ert", "a", encoding="utf-8") as f:
+    with Path("config.ert").open("a", encoding="utf-8") as f:
         f.write(
             "NUM_REALIZATIONS 1\n"
             "GEN_KW PRED coeff_priors.txt coeff_priors.txt coeff_priors.txt\n"
@@ -603,7 +603,7 @@ def test_suggestion_on_empty_parameter_file():
 )
 def test_validation_unif_distribution(tmpdir, distribution, minimum, maximum, error):
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
         config_list = [
             "KW_NAME",
@@ -655,7 +655,7 @@ def test_validation_triangular_distribution(
     tmpdir, distribution, minimum, mode, maximum, error
 ):
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
         config_list = [
             "KW_NAME",
@@ -789,7 +789,7 @@ def test_validation_derrf_distribution(
     tmpdir, distribution, nbins, minimum, maximum, skew, width, error
 ):
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
         config_list = [
             "KW_NAME",
@@ -852,9 +852,9 @@ def test_that_const_keyword_sets_update_to_false(tmpdir):
         GEN_KW CONST_TEST prior.txt UPDATE:TRUE
         """
         )
-        with open("config.ert", "w", encoding="utf-8") as fh:
+        with Path("config.ert").open("w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("prior.txt", "w", encoding="utf-8") as fh:
+        with Path("prior.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("CONST_TEST CONST 1")
 
         ert_config = ErtConfig.from_file("config.ert")

--- a/tests/ert/unit_tests/config/test_model_config.py
+++ b/tests/ert/unit_tests/config/test_model_config.py
@@ -91,9 +91,9 @@ def test_model_config_jobname_and_eclbase(extra_config, expected):
     ],
 )
 def test_that_when_the_runpath_disk_is_full_a_warning_is_given(
-    tmp_path, recwarn, total_space, used_space, to_warn, expected_warning
+    tmp_path: Path, recwarn, total_space, used_space, to_warn, expected_warning
 ):
-    Path(tmp_path / "simulations").mkdir()
+    (tmp_path / "simulations").mkdir()
     runpath = f"{tmp_path!s}/simulations/realization-%d/iter-%d"
     with patch(
         "ert.config.model_config.shutil.disk_usage",

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -905,7 +905,7 @@ def test_that_non_numbers_in_obs_file_shows_informative_error_message(tmpdir):
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_the_number_of_columns_in_obs_file_cannot_change():
-    with open("obs_data.txt", "w", encoding="utf-8") as fh:
+    with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
         fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
         fh.writelines("0.1\n")
     with pytest.raises(
@@ -928,7 +928,7 @@ def test_that_the_number_of_columns_in_obs_file_cannot_change():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_the_number_of_values_in_obs_file_must_be_even():
-    with open("obs_data.txt", "w", encoding="utf-8") as fh:
+    with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
         fh.writelines(f"{float(i)} 0.1 0.1\n" for i in range(5))
     with pytest.raises(ConfigValidationError, match="Expected even number of values"):
         make_observations(
@@ -1236,7 +1236,7 @@ def test_that_obs_file_must_have_the_same_number_of_lines_as_the_length_of_index
     tmpdir,
 ):
     with tmpdir.as_cwd():
-        with open("obs_data.txt", "w", encoding="utf-8") as fh:
+        with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
             fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
 
         with pytest.raises(ConfigValidationError, match="must be of equal length"):

--- a/tests/ert/unit_tests/config/test_parser_error_collection.py
+++ b/tests/ert/unit_tests/config/test_parser_error_collection.py
@@ -38,7 +38,7 @@ class ExpectedErrorInfo:
 def write_files(files: dict[str, str | FileDetail] | None = None):
     if files is not None:
         for other_filename, content in files.items():
-            with open(other_filename, mode="w", encoding="utf-8") as fh:
+            with Path(other_filename).open(mode="w", encoding="utf-8") as fh:
                 if isinstance(content, FileDetail):
                     fh.writelines(content.contents)
 
@@ -668,7 +668,7 @@ def test_queue_option_max_running_negative():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_unicode_decode_error_is_localized_first_line():
-    with open("test.ert", "ab") as f:
+    with Path("test.ert").open("ab") as f:
         f.write(b"\xff")
         f.write(
             bytes(
@@ -718,10 +718,10 @@ def test_that_unicode_decode_error_is_localized_random_line_single_insert():
 
         Path("test.ert").write_text("\n".join(before) + "\n", encoding="utf-8")
 
-        with open("test.ert", "ab") as f:
+        with Path("test.ert").open("ab") as f:
             f.write(b"\xff")
 
-        with open("test.ert", "a", encoding="utf-8") as f:
+        with Path("test.ert").open("a", encoding="utf-8") as f:
             f.write("\n" + "\n".join(after))
 
         with pytest.raises(
@@ -772,14 +772,14 @@ def test_that_unicode_decode_error_is_localized_multiple_random_inserts(
 
     for i, info in enumerate(write_infos):
         if info["type"] == "utf-8":
-            with open("test.ert", "w" if i == 0 else "a", encoding="utf-8") as f:
+            with Path("test.ert").open("w" if i == 0 else "a", encoding="utf-8") as f:
                 f.write(info["content"])
         elif info["type"] == "bytes":
-            with open("test.ert", "wb" if i == 0 else "ab") as f:
+            with Path("test.ert").open("wb" if i == 0 else "ab") as f:
                 f.write(info["content"])
 
         if i < (len(write_infos) - 1):
-            with open("test.ert", "a", encoding="utf-8") as f:
+            with Path("test.ert").open("a", encoding="utf-8") as f:
                 f.write("\n")
 
     with pytest.raises(

--- a/tests/ert/unit_tests/config/test_parser_error_collection.py
+++ b/tests/ert/unit_tests/config/test_parser_error_collection.py
@@ -43,10 +43,10 @@ def write_files(files: dict[str, str | FileDetail] | None = None):
                     fh.writelines(content.contents)
 
                     if not content.is_executable:
-                        os.chmod(other_filename, stat.S_IREAD)
+                        Path(other_filename).chmod(stat.S_IREAD)
 
                     if not content.is_readable:
-                        os.chmod(other_filename, ~0o400)
+                        Path(other_filename).chmod(~0o400)
                 else:
                     fh.write(content)
 

--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -1,7 +1,6 @@
 from array import array
 from datetime import datetime, timedelta
 from itertools import zip_longest
-from pathlib import Path
 
 import hypothesis.strategies as st
 import pytest
@@ -109,12 +108,14 @@ def test_that_incorrect_summary_files_raises_informative_errors(
         read_summary(str(tmp_path / "test"), ["*"])
 
 
-def test_truncated_summary_file_raises_invalidresponsefile(tmp_path_factory):
+def test_truncated_summary_file_raises_invalidresponsefile(
+    tmp_path_factory: pytest.TempPathFactory,
+):
     tmp_path = tmp_path_factory.mktemp("summary")
     simple_unsmry().to_file(tmp_path / "TEST.UNSMRY")
     simple_smspec().to_file(tmp_path / "TEST.SMSPEC")
 
-    with Path(tmp_path / "TEST.UNSMRY").open("ba") as unsmry_file:
+    with (tmp_path / "TEST.UNSMRY").open("ba") as unsmry_file:
         unsmry_file.truncate(100)  # 112 bytes is the un-truncated size
 
     with pytest.raises(InvalidResponseFile, match="Unable to read summary data from"):

--- a/tests/ert/unit_tests/config/test_read_summary.py
+++ b/tests/ert/unit_tests/config/test_read_summary.py
@@ -1,6 +1,7 @@
 from array import array
 from datetime import datetime, timedelta
 from itertools import zip_longest
+from pathlib import Path
 
 import hypothesis.strategies as st
 import pytest
@@ -113,7 +114,7 @@ def test_truncated_summary_file_raises_invalidresponsefile(tmp_path_factory):
     simple_unsmry().to_file(tmp_path / "TEST.UNSMRY")
     simple_smspec().to_file(tmp_path / "TEST.SMSPEC")
 
-    with open(tmp_path / "TEST.UNSMRY", "ba") as unsmry_file:
+    with Path(tmp_path / "TEST.UNSMRY").open("ba") as unsmry_file:
         unsmry_file.truncate(100)  # 112 bytes is the un-truncated size
 
     with pytest.raises(InvalidResponseFile, match="Unable to read summary data from"):

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -1,4 +1,3 @@
-import os
 import re
 from contextlib import suppress
 from pathlib import Path
@@ -55,7 +54,7 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_invalid_file(
     with suppress(InvalidResponseFile):
         SummaryConfig(
             name="summary", input_files=["CASE"], keys=["FOPR"]
-        ).read_from_file(os.getcwd(), 1, 0)
+        ).read_from_file(Path.cwd(), 1, 0)
 
 
 def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_file(tmpdir):

--- a/tests/ert/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/conftest.py
@@ -109,7 +109,7 @@ def make_ensemble(queue_config):
                 )
             realizations = []
             for iens in range(num_reals):
-                run_path = Path(tmpdir / f"real_{iens}")
+                run_path = tmpdir / f"real_{iens}"
                 run_path.mkdir()
                 (run_path / "jobs.json").write_text(
                     json.dumps(

--- a/tests/ert/unit_tests/ensemble_evaluator/conftest.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/conftest.py
@@ -98,7 +98,7 @@ def make_ensemble(queue_config):
                 )
                 mode = os.stat(forward_model_exec).st_mode
                 mode |= stat.S_IXUSR | stat.S_IXGRP
-                os.chmod(forward_model_exec, stat.S_IMODE(mode))
+                Path(forward_model_exec).chmod(stat.S_IMODE(mode))
 
                 forward_model_list.append(
                     forward_model_step_from_config_contents(

--- a/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_scheduler.py
@@ -31,7 +31,7 @@ async def test_scheduler_receives_checksum_and_waits_for_disk_sync(
         Path("real_0/test").rename("real_0/job_test_file")
 
     def create_manifest_file():
-        with open("real_0/manifest.json", mode="w", encoding="utf-8") as f:
+        with Path("real_0/manifest.json").open(mode="w", encoding="utf-8") as f:
             json.dump({"file": "job_test_file"}, f)
 
     with tmpdir.as_cwd():

--- a/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_file_reporter.py
@@ -1,4 +1,5 @@
 import os.path
+from pathlib import Path
 
 import pytest
 
@@ -29,9 +30,9 @@ def test_report_with_init_message_argument(reporter):
 
     r.report(Init([fmstep1], 1, 19))
 
-    with open(STATUS_file, encoding="utf-8") as f:
+    with Path(STATUS_file).open(encoding="utf-8") as f:
         assert "Current host" in f.readline(), "STATUS file missing expected value"
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"name": "fmstep1"' in content, "status.json missing fmstep1"
         assert '"status": "Waiting"' in content, "status.json missing Waiting status"
@@ -55,14 +56,14 @@ def test_report_with_successful_start_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, encoding="utf-8") as f:
+    with Path(STATUS_file).open(encoding="utf-8") as f:
         assert "fmstep1" in f.readline(), "STATUS file missing fmstep1"
-    with open(LOG_file, encoding="utf-8") as f:
+    with Path(LOG_file).open(encoding="utf-8") as f:
         assert "Calling: /bin/sh --foo 1 --bar 2" in f.readline(), (
             """JOB_LOG file missing executable and arguments"""
         )
 
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Running"' in content, "status.json missing Running status"
         assert '"start_time": null' not in content, "start_time not set"
@@ -75,11 +76,11 @@ def test_report_with_failed_start_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, encoding="utf-8") as f:
+    with Path(STATUS_file).open(encoding="utf-8") as f:
         assert "EXIT: -10/massive_failure" in f.readline(), (
             "STATUS file missing EXIT message"
         )
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Failure"' in content, "status.json missing Failure status"
         assert '"error": "massive_failure"' in content, (
@@ -97,7 +98,7 @@ def test_report_with_successful_exit_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Success"' in content, "status.json missing Success status"
 
@@ -111,9 +112,9 @@ def test_report_with_failed_exit_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_file, encoding="utf-8") as f:
+    with Path(STATUS_file).open(encoding="utf-8") as f:
         assert "EXIT: 1/massive_failure" in f.readline()
-    with open(ERROR_file, encoding="utf-8") as f:
+    with Path(ERROR_file).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert "<step>fmstep1</step>" in content, "ERROR file missing fmstep"
         assert "<reason>massive_failure</reason>" in content, (
@@ -122,7 +123,7 @@ def test_report_with_failed_exit_message_argument(reporter):
         assert "stderr: Not redirected" in content, (
             "ERROR had invalid stderr information"
         )
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Failure"' in content, "status.json missing Failure status"
         assert '"error": "massive_failure"' in content, (
@@ -141,7 +142,7 @@ def test_report_with_running_message_argument(reporter):
 
     reporter.report(msg)
 
-    with open(STATUS_json, encoding="utf-8") as f:
+    with Path(STATUS_json).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert '"status": "Running"' in content, "status.json missing status"
         assert '"max_memory_usage": 100' in content, (
@@ -168,7 +169,7 @@ def test_dump_error_file_with_stderr(reporter):
     that constitutes the ERROR file.
     The report system is left out, since this was tested in the fail case.
     """
-    with open("stderr.out.0", "a", encoding="utf-8") as stderr:
+    with Path("stderr.out.0").open("a", encoding="utf-8") as stderr:
         stderr.write("Error:\n")
         stderr.write("E_MASSIVE_FAILURE\n")
 
@@ -177,7 +178,7 @@ def test_dump_error_file_with_stderr(reporter):
         "massive_failure",
     )
 
-    with open(ERROR_file, encoding="utf-8") as f:
+    with Path(ERROR_file).open(encoding="utf-8") as f:
         content = "".join(f.readlines())
         assert "E_MASSIVE_FAILURE" in content, "ERROR file missing stderr content"
         assert "<stderr_file>" in content, "ERROR missing stderr_file part"
@@ -187,7 +188,7 @@ def test_dump_error_file_with_stderr(reporter):
 def test_old_file_deletion(reporter):
     # touch all files that are to be removed
     for f in [ERROR_file, STATUS_file]:
-        with open(f, "a", encoding="utf-8"):
+        with Path(f).open("a", encoding="utf-8"):
             pass
 
     reporter._delete_old_status_files()
@@ -225,7 +226,7 @@ def test_status_file_is_correct(reporter):
         f"EXIT: {exited_j_2.exit_code}/{exited_j_2.error_message}\n"
     )
 
-    with open(STATUS_file, encoding="utf-8") as f:
+    with Path(STATUS_file).open(encoding="utf-8") as f:
         for expected in [
             "Current host",
             expected_j1_line,

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -121,9 +121,7 @@ def test_that_all_subprocesses_of_a_job_are_cleaned_up_on_fm_dispatch_terminatio
     )
 
     # (we wait for the process below)
-    fm_dispatch_process = Popen(
-        [os.getcwd() + "/setsid", "fm_dispatch.py", os.getcwd()]
-    )
+    fm_dispatch_process = Popen([Path.cwd() / "setsid", "fm_dispatch.py", Path.cwd()])
 
     p = psutil.Process(fm_dispatch_process.pid)
 
@@ -171,7 +169,7 @@ def test_memory_profile_is_logged_as_csv(
     monkeypatch.setattr(
         _ert.forward_model_runner.runner.ForwardModelStep, "MEMORY_POLL_PERIOD", 0.1
     )
-    fm_dispatch(["fm_dispatch", os.getcwd()])
+    fm_dispatch(["fm_dispatch", str(Path.cwd())])
     csv_files = glob.glob("logs/memory-profile*csv")
     mem_df = pd.read_csv(csv_files[0], parse_dates=True)
     assert mem_df["timestamp"].is_monotonic_increasing
@@ -209,7 +207,7 @@ def test_that_a_subset_of_jobs_to_run_can_be_specified_as_cmdline_arguments(
     )
 
     fm_dispatch_process = Popen(
-        [os.getcwd() + "/setsid", "fm_dispatch.py", os.getcwd(), "step_B", "step_C"]
+        [Path.cwd() / "setsid", "fm_dispatch.py", Path.cwd(), "step_B", "step_C"]
     )
     fm_dispatch_process.wait()
 
@@ -406,7 +404,7 @@ async def test_fm_dispatch_sends_exited_event_with_terminated_msg_on_sigterm(
         )
 
         fm_dispatch_process = Popen(  # noqa: ASYNC220
-            [os.getcwd() + "/setsid", "fm_dispatch.py", os.getcwd()]
+            [Path.cwd() / "setsid", "fm_dispatch.py", Path.cwd()]
         )
         p = psutil.Process(fm_dispatch_process.pid)
 
@@ -448,7 +446,7 @@ async def test_fm_dispatch_sends_exited_event_with_terminated_msg_on_terminate_m
         )
 
         fm_dispatch_process = Popen(  # noqa: ASYNC220
-            [os.getcwd() + "/setsid", "fm_dispatch.py", os.getcwd()]
+            [Path.cwd() / "setsid", "fm_dispatch.py", Path.cwd()]
         )
 
         await asyncio.wait_for(

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -49,7 +49,7 @@ def use_custom_setsid(use_tmpdir):
         ),
         encoding="utf-8",
     )
-    os.chmod("setsid", 0o755)
+    Path("setsid").chmod(0o755)
 
 
 def write_executable(
@@ -57,7 +57,7 @@ def write_executable(
 ) -> str:
     file_path = directory / basename
     file_path.write_text(contents, encoding="utf-8")
-    os.chmod(file_path, stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
+    file_path.chmod(stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
     return str(file_path.resolve())
 
 

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -197,7 +197,7 @@ def test_env_var_available_inside_step_context():
         name=None,
         config_file="RUN_ENV",
     )
-    with open("jobs.json", mode="w", encoding="utf-8") as fptr:
+    with Path("jobs.json").open(mode="w", encoding="utf-8") as fptr:
         ert_config = ErtConfig(forward_model_steps=[step])
         json.dump(
             create_forward_model_json(
@@ -210,7 +210,7 @@ def test_env_var_available_inside_step_context():
             fptr,
         )
 
-    with open("jobs.json", encoding="utf-8") as f:
+    with Path("jobs.json").open(encoding="utf-8") as f:
         jobs_json = json.load(f)
 
     # Check ENV variable not available outside of step context
@@ -243,7 +243,7 @@ def test_default_env_variables_available_inside_fm_step_context():
     step = forward_model_step_from_config_contents(
         "EXECUTABLE run_me.py", name=None, config_file="RUN_ENV"
     )
-    with open("jobs.json", mode="w", encoding="utf-8") as fptr:
+    with Path("jobs.json").open(mode="w", encoding="utf-8") as fptr:
         ert_config = ErtConfig(
             forward_model_steps=[step],
             substitutions={"<RUNPATH>": "./"},
@@ -259,7 +259,7 @@ def test_default_env_variables_available_inside_fm_step_context():
             fptr,
         )
 
-    with open("jobs.json", encoding="utf-8") as f:
+    with Path("jobs.json").open(encoding="utf-8") as f:
         jobs_json = json.load(f)
 
     # Check default ENV variable not available outside of step context

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -144,7 +144,7 @@ def test_when_manifest_file_is_not_created_by_fm_runner_checksum_contains_error(
     assert "md5sum" not in info
     assert "error" in info
     assert (
-        f"Expected file {os.getcwd()}/{file_name} not created by forward model!"
+        f"Expected file {Path.cwd()}/{file_name} not created by forward model!"
         in info["error"]
     )
 

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -187,7 +187,7 @@ def test_env_var_available_inside_step_context():
         ),
         encoding="utf-8",
     )
-    os.chmod("run_me.py", stat.S_IEXEC + stat.S_IREAD)
+    Path("run_me.py").chmod(stat.S_IEXEC + stat.S_IREAD)
 
     step = forward_model_step_from_config_contents(
         """
@@ -238,7 +238,7 @@ def test_default_env_variables_available_inside_fm_step_context():
         ),
         encoding="utf-8",
     )
-    os.chmod("run_me.py", stat.S_IEXEC + stat.S_IREAD)
+    Path("run_me.py").chmod(stat.S_IEXEC + stat.S_IREAD)
 
     step = forward_model_step_from_config_contents(
         "EXECUTABLE run_me.py", name=None, config_file="RUN_ENV"

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -174,7 +174,7 @@ def test_run_fails_using_exit_bash_builtin():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_but_missing():
-    executable = os.path.join(os.getcwd(), "this/is/not/a/file")
+    executable = os.path.join(Path.cwd(), "this/is/not/a/file")
     fmstep = ForwardModelStep(
         {
             "name": "TEST_EXECUTABLE_NOT_FOUND",
@@ -192,7 +192,7 @@ def test_run_with_defined_executable_but_missing():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_empty_executable():
-    empty_executable = os.path.join(os.getcwd(), "foo")
+    empty_executable = os.path.join(Path.cwd(), "foo")
     with Path(empty_executable).open("a", encoding="utf-8"):
         pass
     st = os.stat(empty_executable)
@@ -218,7 +218,7 @@ def test_run_with_empty_executable():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_no_exec_bit():
-    non_executable = os.path.join(os.getcwd(), "foo")
+    non_executable = os.path.join(Path.cwd(), "foo")
     with Path(non_executable).open("a", encoding="utf-8"):
         pass
 

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -1,10 +1,10 @@
 import contextlib
 import os
-import pathlib
 import stat
 import sys
 import textwrap
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -46,7 +46,7 @@ def test_run_with_process_failing(mock_process, mock_popen, mock_check_executabl
 def test_memory_usage_counts_grandchildren():
     scriptname = "recursive_memory_hog.py"
     blobsize = 1e7
-    pathlib.Path(scriptname).write_text(
+    Path(scriptname).write_text(
         textwrap.dedent(
             """\
             #!/usr/bin/env python
@@ -137,10 +137,10 @@ def test_cpu_seconds_for_process_with_children():
 
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="No oom_score on MacOS")
 def test_oom_score_is_max_over_processtree():
-    def read_text_side_effect(self: pathlib.Path, *args, **kwargs):
-        if self.absolute() == pathlib.Path("/proc/123/oom_score"):
+    def read_text_side_effect(self: Path, *args, **kwargs):
+        if self.absolute() == Path("/proc/123/oom_score"):
             return "234"
-        if self.absolute() == pathlib.Path("/proc/124/oom_score"):
+        if self.absolute() == Path("/proc/124/oom_score"):
             return "456"
 
     with patch("pathlib.Path.read_text", autospec=True) as mocked_read_text:
@@ -193,7 +193,7 @@ def test_run_with_defined_executable_but_missing():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_empty_executable():
     empty_executable = os.path.join(os.getcwd(), "foo")
-    with open(empty_executable, "a", encoding="utf-8"):
+    with Path(empty_executable).open("a", encoding="utf-8"):
         pass
     st = os.stat(empty_executable)
     os.chmod(empty_executable, st.st_mode | stat.S_IEXEC)
@@ -219,7 +219,7 @@ def test_run_with_empty_executable():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_no_exec_bit():
     non_executable = os.path.join(os.getcwd(), "foo")
-    with open(non_executable, "a", encoding="utf-8"):
+    with Path(non_executable).open("a", encoding="utf-8"):
         pass
 
     fmstep = ForwardModelStep(
@@ -351,7 +351,7 @@ def test_processtree_timer(
 def test_target_file_only_sets_error_if_specified_and_fm_step_succeeded(
     command, exit_code, expected_error_message, target_file_name
 ):
-    pathlib.Path("already_existing_file").touch()
+    Path("already_existing_file").touch()
     fmstep = ForwardModelStep(
         {
             "name": "target_file_test_fm_step ",

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -76,7 +76,7 @@ def test_memory_usage_counts_grandchildren():
         encoding="utf-8",
     )
     executable = os.path.realpath(scriptname)
-    os.chmod(scriptname, stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
+    Path(scriptname).chmod(stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
 
     def max_memory_per_subprocess_layer(layers: int) -> int:
         fmstep = ForwardModelStep(
@@ -196,7 +196,7 @@ def test_run_with_empty_executable():
     with Path(empty_executable).open("a", encoding="utf-8"):
         pass
     st = os.stat(empty_executable)
-    os.chmod(empty_executable, st.st_mode | stat.S_IEXEC)
+    Path(empty_executable).chmod(st.st_mode | stat.S_IEXEC)
 
     fmstep = ForwardModelStep(
         {

--- a/tests/ert/unit_tests/gui/experiments/test_run_path_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_path_dialog.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from unittest.mock import Mock, patch
 

--- a/tests/ert/unit_tests/gui/experiments/test_run_path_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_path_dialog.py
@@ -45,8 +45,8 @@ def test_run_path_deleted_error(snake_oil_case_storage: ErtConfig, qtbot: QtBot)
             "<IENS>", "0"
         ).replace("<ITER>", "0")
     )
-    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-        dummy_file.close()
+    dummy_file = run_path / "dummy"
+    dummy_file.touch()
 
     QTimer.singleShot(
         1000, lambda: handle_run_path_dialog(gui, qtbot, expect_error=True)
@@ -58,7 +58,7 @@ def test_run_path_deleted_error(snake_oil_case_storage: ErtConfig, qtbot: QtBot)
     run_dialog = gui.findChild(RunDialog)
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-    assert os.path.exists(run_path / dummy_file.name)
+    assert dummy_file.exists()
 
 
 @pytest.mark.integration_test
@@ -89,8 +89,8 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
             "<IENS>", "0"
         ).replace("<ITER>", "0")
     )
-    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-        dummy_file.close()
+    dummy_file = run_path / "dummy"
+    dummy_file.touch()
 
     QTimer.singleShot(
         1000, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
@@ -101,7 +101,7 @@ def test_run_path_is_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot):
     run_dialog = gui.findChild(RunDialog)
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-    assert not os.path.exists(run_path / dummy_file.name)
+    assert not dummy_file.exists()
 
 
 @pytest.mark.integration_test
@@ -130,8 +130,8 @@ def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot
     run_path = Path(
         snake_oil_case.runpath_config.runpath_format_string.replace("<IENS>", "0")
     ).parent
-    with open(run_path / "dummy", "w", encoding="utf-8") as dummy_file:
-        dummy_file.close()
+    dummy_file = run_path / "dummy"
+    dummy_file.touch()
 
     QTimer.singleShot(
         500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=False)
@@ -142,4 +142,4 @@ def test_run_path_is_not_deleted(snake_oil_case_storage: ErtConfig, qtbot: QtBot
     run_dialog = gui.findChild(RunDialog)
     qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=100000)
     qtbot.waitUntil(lambda: run_dialog._tab_widget.currentWidget() is not None)
-    assert os.path.exists(run_path / dummy_file.name)
+    assert dummy_file.exists()

--- a/tests/ert/unit_tests/plugins/test_misfit_preprocessor.py
+++ b/tests/ert/unit_tests/plugins/test_misfit_preprocessor.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
@@ -8,10 +10,10 @@ from ert.plugins import get_site_plugins
 def test_that_misfit_preprocessor_raises():
     # Warning is given on LOAD_WORKFLOW.
     # Since LOAD_WORKFLOW failed error is raised on HOOK_WORKFLOW
-    with open("poly.ert", "a", encoding="utf-8") as fh:
+    with Path("poly.ert").open("a", encoding="utf-8") as fh:
         fh.writelines("LOAD_WORKFLOW config\n")
         fh.writelines("HOOK_WORKFLOW config PRE_FIRST_UPDATE\n")
-    with open("config", "w", encoding="utf-8") as fh:
+    with Path("config").open("w", encoding="utf-8") as fh:
         fh.writelines("MISFIT_PREPROCESSOR")
     with (
         pytest.warns(
@@ -34,10 +36,10 @@ def test_that_misfit_preprocessor_raises():
 def test_that_misfit_preprocessor_raises_with_config():
     # Warning is given on LOAD_WORKFLOW.
     # Since LOAD_WORKFLOW failed error is raised on HOOK_WORKFLOW
-    with open("poly.ert", "a", encoding="utf-8") as fh:
+    with Path("poly.ert").open("a", encoding="utf-8") as fh:
         fh.writelines("LOAD_WORKFLOW config\n")
         fh.writelines("HOOK_WORKFLOW config PRE_FIRST_UPDATE\n")
-    with open("config", "w", encoding="utf-8") as fh:
+    with Path("config").open("w", encoding="utf-8") as fh:
         fh.writelines("MISFIT_PREPROCESSOR my_config")
     with (
         pytest.warns(

--- a/tests/ert/unit_tests/plugins/test_parameter_disable.py
+++ b/tests/ert/unit_tests/plugins/test_parameter_disable.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
@@ -8,15 +10,15 @@ from ert.plugins import get_site_plugins
 def test_that_removed_job_disable_parameters_gives_warning():
     # Warning is given on LOAD_WORKFLOW.
     # Since LOAD_WORKFLOW failed error is raised on HOOK_WORKFLOW
-    with open("poly.ert", "a", encoding="utf-8") as fh:
+    with Path("poly.ert").open("a", encoding="utf-8") as fh:
         fh.writelines("GEN_KW DONT_UPDATE_KW template.txt kw.txt prior.txt\n")
         fh.writelines("LOAD_WORKFLOW config\n")
         fh.writelines("HOOK_WORKFLOW config PRE_SIMULATION\n")
-    with open("config", "w", encoding="utf-8") as fh:
+    with Path("config").open("w", encoding="utf-8") as fh:
         fh.writelines("DISABLE_PARAMETERS DONT_UPDATE_KW")
-    with open("template.txt", "w", encoding="utf-8") as fh:
+    with Path("template.txt").open("w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-    with open("prior.txt", "w", encoding="utf-8") as fh:
+    with Path("prior.txt").open("w", encoding="utf-8") as fh:
         fh.writelines("MY_KEYWORD NORMAL 0 1")
     with (
         pytest.warns(ConfigWarning, match="use the UPDATE:FALSE option"),

--- a/tests/ert/unit_tests/plugins/test_plugin_context.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_context.py
@@ -1,4 +1,3 @@
-import os
 import stat
 import tempfile
 from pathlib import Path
@@ -16,13 +15,13 @@ def mock_dummy_plugins(target_dir: Path):
     fm_disapatch_path = target_dir / "fm_dispatch_dummy.py"
     fm_disapatch_path.write_text("echo helloworld")
 
-    os.chmod(fm_disapatch_path, fm_disapatch_path.stat().st_mode | stat.S_IEXEC)
+    Path(fm_disapatch_path).chmod(fm_disapatch_path.stat().st_mode | stat.S_IEXEC)
 
     Path.mkdir(target_dir / "dummy/path", exist_ok=True, parents=True)
     executable_path = target_dir / "dummy/path/dummy_exec.sh"
 
     executable_path.write_text("#!/usr/bin/env bash\necho 'hello world'")
-    os.chmod(executable_path, 0o775)
+    Path(executable_path).chmod(0o775)
 
     (target_dir / "dummy/path/job1").write_text("EXECUTABLE dummy_exec.sh")
     (target_dir / "dummy/path/job2").write_text("EXECUTABLE dummy_exec.sh")

--- a/tests/ert/unit_tests/resources/test_run_eclipse_simulator.py
+++ b/tests/ert/unit_tests/resources/test_run_eclipse_simulator.py
@@ -1,4 +1,3 @@
-import os
 import re
 import shutil
 import subprocess
@@ -531,11 +530,11 @@ def test_license_error_in_slave_is_caught():
  @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2000):
  @           STARTING SLAVE SLAVE1   RUNNING EIGHTCEL
  @           ON HOST localhost                        IN DIRECTORY
- @           {os.getcwd()}/slave1
+ @           {Path.cwd()}/slave1
  @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2000):
  @           STARTING SLAVE SLAVE2   RUNNING EIGHTCEL
  @           ON HOST localhost                        IN DIRECTORY
- @           {os.getcwd()}/slave2
+ @           {Path.cwd()}/slave2
 
 <various_output>
 
@@ -585,11 +584,11 @@ def test_crash_in_slave_is_not_mistaken_as_license():
  @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2000):
  @           STARTING SLAVE SLAVE1   RUNNING EIGHTCEL
  @           ON HOST localhost                        IN DIRECTORY
- @           {os.getcwd()}/slave1
+ @           {Path.cwd()}/slave1
  @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2000):
  @           STARTING SLAVE SLAVE2   RUNNING EIGHTCEL
  @           ON HOST localhost                        IN DIRECTORY
- @           {os.getcwd()}/slave2
+ @           {Path.cwd()}/slave2
 
 <various_output>
 
@@ -726,7 +725,7 @@ def test_slave_started_message_are_not_counted_as_errors():
  @--MESSAGE  AT TIME        0.0   DAYS    ( 1-JAN-2000):
  @           STARTING SLAVE SLAVE1   RUNNING EIGHTCEL
  @           ON HOST localhost                        IN DIRECTORY
- @           {os.getcwd()}/slave1"""
+ @           {Path.cwd()}/slave1"""
     eclend = """
  Error summary
  Comments               0

--- a/tests/ert/unit_tests/resources/test_run_flow_simulator.py
+++ b/tests/ert/unit_tests/resources/test_run_flow_simulator.py
@@ -40,12 +40,12 @@ def test_flow_can_produce_output():
     assert Path("EIGHTCELLS.UNSMRY").exists()
 
 
-def test_flowrun_can_be_bypassed_when_flow_is_available(tmp_path, monkeypatch):
+def test_flowrun_can_be_bypassed_when_flow_is_available(tmp_path: Path, monkeypatch):
     # Set FLOWRUN_PATH to a path guaranteed not to contain flowrun
     monkeypatch.setenv("FLOWRUN_PATH", str(tmp_path))
     # Add a mocked flow to PATH
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
-    mocked_flow = Path(tmp_path / "flow")
+    mocked_flow = tmp_path / "flow"
     mocked_flow.write_text("", encoding="utf-8")
     mocked_flow.chmod(mocked_flow.stat().st_mode | stat.S_IEXEC)
     (tmp_path / "DUMMY.DATA").write_text("", encoding="utf-8")
@@ -55,12 +55,12 @@ def test_flowrun_can_be_bypassed_when_flow_is_available(tmp_path, monkeypatch):
     assert runner.bypass_flowrun is True
 
 
-def test_flowrun_cannot_be_bypassed_for_parallel_runs(tmp_path, monkeypatch):
+def test_flowrun_cannot_be_bypassed_for_parallel_runs(tmp_path: Path, monkeypatch):
     # Set FLOWRUN_PATH to a path guaranteed not to contain flowrun
     monkeypatch.setenv("FLOWRUN_PATH", str(tmp_path))
     # Add a mocked flow to PATH
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
-    mocked_flow = Path(tmp_path / "flow")
+    mocked_flow = tmp_path / "flow"
     mocked_flow.write_text("", encoding="utf-8")
     mocked_flow.chmod(mocked_flow.stat().st_mode | stat.S_IEXEC)
 

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -18,7 +18,7 @@ from ._import_from_location import import_from_location
 
 @contextlib.contextmanager
 def pushd(path):
-    cwd0 = os.getcwd()
+    cwd0 = Path.cwd()
     os.chdir(path)
 
     yield

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -179,27 +179,27 @@ def test_move_directory():
     mkdir("dir1")
     Path("dir1/file").write_text("Hei!", encoding="utf-8")
     move_directory("dir1", "dir2")
-    assert os.path.exists("dir2")
-    assert os.path.exists("dir2/file")
-    assert not os.path.exists("dir1")
+    assert Path("dir2").exists()
+    assert Path("dir2/file").exists()
+    assert not Path("dir1").exists()
 
     # Test overwriting directory
     mkdir("dir1")
     Path("dir1/file2").write_text("Hei!", encoding="utf-8")
     move_directory("dir1", "dir2")
-    assert os.path.exists("dir2")
-    assert os.path.exists("dir2/file2")
-    assert not os.path.exists("dir2/file")
-    assert not os.path.exists("dir1")
+    assert Path("dir2").exists()
+    assert Path("dir2/file2").exists()
+    assert not Path("dir2/file").exists()
+    assert not Path("dir1").exists()
 
     # Test moving directory inside already existing direcotry
     mkdir("dir1")
     Path("dir1/file3").write_text("Hei!", encoding="utf-8")
     move_directory("dir1", "dir2/dir1")
-    assert os.path.exists("dir2/dir1")
-    assert os.path.exists("dir2/file2")
-    assert os.path.exists("dir2/dir1/file3")
-    assert not os.path.exists("dir1")
+    assert Path("dir2/dir1").exists()
+    assert Path("dir2/file2").exists()
+    assert Path("dir2/dir1/file3").exists()
+    assert not Path("dir1").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -297,8 +297,8 @@ def test_that_delete_directory_does_not_follow_symlinks():
 
     symlink("../link_target", "path/link")
     delete_directory("path")
-    assert not os.path.exists("path")
-    assert os.path.exists("link_target/link_file")
+    assert not Path("path").exists()
+    assert Path("link_target/link_file").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -307,8 +307,8 @@ def test_that_delete_directory_on_a_symlink_to_file_fails():
     symlink("link_target", "link")
     with pytest.raises(IOError, match="is not a directory"):
         delete_directory("link")
-    assert os.path.exists("link_target")
-    assert os.path.exists("link")
+    assert Path("link_target").exists()
+    assert Path("link").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -317,8 +317,8 @@ def test_that_delete_directory_on_a_symlink_to_a_directory_only_deletes_link():
     Path("link_target/file").write_text("hei", encoding="utf-8")
     symlink("link_target", "link")
     delete_directory("link")
-    assert os.path.exists("link_target/file")
-    assert not os.path.exists("link")
+    assert Path("link_target/file").exists()
+    assert not Path("link").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -344,19 +344,19 @@ def test_that_delete_directory_on_a_symlink_to_a_directory_is_conditionally_igno
         delete_directory(f"link{trailing}")
 
     if trailing:
-        assert not os.path.exists("link_target/file")
+        assert not Path("link_target/file").exists()
 
         if sys.platform.startswith("darwin"):
             # Mac will also delete the symlink, while Linux will not
-            assert not os.path.exists("link")
-            assert not os.path.exists("link_target")
+            assert not Path("link").exists()
+            assert not Path("link_target").exists()
         else:
-            assert os.path.exists("link")
-            assert os.path.exists("link_target")
+            assert Path("link").exists()
+            assert Path("link_target").exists()
     else:
-        assert os.path.exists("link_target/file")
-        assert os.path.exists("link_target")
-        assert not os.path.exists("link")
+        assert Path("link_target/file").exists()
+        assert Path("link_target").exists()
+        assert not Path("link").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/run_models/test_enif.py
+++ b/tests/ert/unit_tests/run_models/test_enif.py
@@ -38,7 +38,7 @@ def test_that_enif_update_does_not_update_design_matrix_parameters(
         ),
     )
 
-    with open(config_file, "a", encoding="utf-8") as fh:
+    with Path(config_file).open("a", encoding="utf-8") as fh:
         fh.write(f"NUM_REALIZATIONS {num_realizations}\n")
         fh.write("RANDOM_SEED 123456789\n")
         fh.write("DESIGN_MATRIX poly_design.xlsx\n")

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -1,4 +1,3 @@
-import os
 import queue
 import string
 import unittest
@@ -653,7 +652,7 @@ def _create_and_verify_runmodel_snapshot(config, snapshot, cli_args, case):
     serialized = runmodel.model_dump_json(indent=2) + "\n"
 
     # Trim off cwd to make snapshots general
-    cwd = str(os.getcwd())
+    cwd = str(Path.cwd())
     serialized = serialized.replace(cwd, f"test-data/ert/{case}")
 
     snapshot.assert_match(

--- a/tests/ert/unit_tests/run_models/test_manual_update.py
+++ b/tests/ert/unit_tests/run_models/test_manual_update.py
@@ -25,7 +25,7 @@ def test_that_manual_update_from_ensemble_experiment_supports_all_update_modes(
     Path("some_template.txt").write_text("<IENS>", encoding="utf-8")
 
     run_template = "RUN_TEMPLATE some_template.txt TEMPLATE_FILE:poly.tmpl"
-    with open(config_file, "a", encoding="utf-8") as fh:
+    with Path(config_file).open("a", encoding="utf-8") as fh:
         fh.write(f"\n{run_template}\n")
         fh.write("\nNUM_REALIZATIONS 2\n")
 

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -51,9 +51,9 @@ def ert_config(tmpdir):
         RANDOM_SEED 1234
         """
         )
-        with open("config.ert", "w", encoding="utf-8") as fh:
+        with Path("config.ert").open("w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("observations", "w", encoding="utf-8") as fh:
+        with Path("observations").open("w", encoding="utf-8") as fh:
             obs_config = dedent(
                 """
                 SUMMARY_OBSERVATION FOPR_1
@@ -73,9 +73,9 @@ def ert_config(tmpdir):
                 """
             )
             fh.writelines(obs_config)
-        with open("template.txt", mode="w", encoding="utf-8") as fh:
+        with Path("template.txt").open(mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", mode="w", encoding="utf-8") as fh:
+        with Path("prior.txt").open(mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD NORMAL 0 1")
         yield ErtConfig.from_file("config.ert")
 

--- a/tests/ert/unit_tests/scheduler/bin/sbatch.py
+++ b/tests/ert/unit_tests/scheduler/bin/sbatch.py
@@ -46,8 +46,8 @@ def main() -> None:
     subprocess.Popen(
         [str(Path(__file__).parent / "runner"), f"{jobdir}/mock_jobs/{jobid}"],
         start_new_session=True,
-        stdout=open(args.output, "w", encoding="utf-8"),  # noqa: SIM115
-        stderr=open(args.error, "w", encoding="utf-8"),  # noqa: SIM115
+        stdout=Path(args.output).open("w", encoding="utf-8"),  # noqa: SIM115
+        stderr=Path(args.error).open("w", encoding="utf-8"),  # noqa: SIM115
     )
 
     if args.parsable:

--- a/tests/ert/unit_tests/scheduler/test_local_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_local_driver.py
@@ -136,11 +136,11 @@ async def test_that_killing_killed_job_does_not_raise(use_tmpdir):
 
 
 @pytest.mark.timeout(10)
-async def test_path_as_argument_is_valid(tmp_path, monkeypatch):
+async def test_path_as_argument_is_valid(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     driver = LocalDriver()
 
-    await driver.submit(42, "/usr/bin/env", "touch", Path(tmp_path) / "testfile")
+    await driver.submit(42, "/usr/bin/env", "touch", str(tmp_path / "testfile"))
     assert await driver.event_queue.get() == StartedEvent(iens=42)
     assert await driver.event_queue.get() == FinishedEvent(iens=42, returncode=0)
 

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -230,7 +230,7 @@ async def test_submit_sets_stdout():
     driver = LsfDriver()
     driver._poll_period = 0.01
     await driver.submit(0, "sleep", name="myjobname")
-    expected_stdout_file = Path(os.getcwd()) / "myjobname.LSF-stdout"
+    expected_stdout_file = Path(Path.cwd()) / "myjobname.LSF-stdout"
     assert f"-o {expected_stdout_file}" in Path("captured_bsub_args").read_text(
         encoding="utf-8"
     )
@@ -240,7 +240,7 @@ async def test_submit_sets_stdout():
 async def test_submit_sets_stderr():
     driver = LsfDriver()
     await driver.submit(0, "sleep", name="myjobname")
-    expected_stderr_file = Path(os.getcwd()) / "myjobname.LSF-stderr"
+    expected_stderr_file = Path(Path.cwd()) / "myjobname.LSF-stderr"
     assert f"-e {expected_stderr_file}" in Path("captured_bsub_args").read_text(
         encoding="utf-8"
     )

--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -596,7 +596,7 @@ def test_openpbs_driver_with_poly_example_failing_submit_fails_ert_and_propagate
         return await mock_failure("Submit job failed", *args, **kwargs)
 
     monkeypatch.setattr(OpenPBSDriver, "submit", submit_that_fails)
-    with open("poly.ert", mode="a+", encoding="utf-8") as f:
+    with Path("poly.ert").open(mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
         f.write(queue_name_config)
     with pytest.raises(ErtCliError):
@@ -619,7 +619,7 @@ def test_openpbs_driver_with_poly_example_failing_poll_fails_ert_and_propagates_
         return await mock_failure("Status polling failed", *args, **kwargs)
 
     monkeypatch.setattr(OpenPBSDriver, "poll", poll_that_fails)
-    with open("poly.ert", mode="a+", encoding="utf-8") as f:
+    with Path("poly.ert").open(mode="a+", encoding="utf-8") as f:
         f.write("QUEUE_SYSTEM TORQUE\nNUM_REALIZATIONS 2")
         f.write(queue_name_config)
     with pytest.raises(ErtCliError):

--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -44,7 +44,7 @@ def create_jobs_json(realization: Realization) -> None:
     }
     realization_run_path = Path(realization.run_arg.runpath)
     realization_run_path.mkdir()
-    with Path(realization_run_path / "jobs.json").open(mode="w", encoding="utf-8") as f:
+    with (realization_run_path / "jobs.json").open(mode="w", encoding="utf-8") as f:
         json.dump(jobs, f)
 
 

--- a/tests/ert/unit_tests/scheduler/test_scheduler.py
+++ b/tests/ert/unit_tests/scheduler/test_scheduler.py
@@ -44,7 +44,7 @@ def create_jobs_json(realization: Realization) -> None:
     }
     realization_run_path = Path(realization.run_arg.runpath)
     realization_run_path.mkdir()
-    with open(realization_run_path / "jobs.json", mode="w", encoding="utf-8") as f:
+    with Path(realization_run_path / "jobs.json").open(mode="w", encoding="utf-8") as f:
         json.dump(jobs, f)
 
 

--- a/tests/ert/unit_tests/services/test_ert_server.py
+++ b/tests/ert/unit_tests/services/test_ert_server.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import signal
 import sys
 import threading
@@ -206,7 +205,7 @@ def test_json_deleted(server):
     server.fetch_connection_info()  # wait for it to start
     time.sleep(2)  # ensure subprocess is done before calling shutdown()
 
-    assert not os.path.exists(_ERT_SERVER_CONNECTION_INFO_FILE)
+    assert not Path(_ERT_SERVER_CONNECTION_INFO_FILE).exists()
 
 
 @pytest.mark.script(

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -241,9 +241,9 @@ def test_that_an_exception_is_raised_if_storage_server_file_has_no_permissions(
     file_path = Path("storage_server.json")
     file_path.write_text("{}", encoding="utf-8")
     mode = file_path.stat().st_mode
-    os.chmod(file_path, 0o000)  # no permissions
+    Path(file_path).chmod(0o000)  # no permissions
     try:
         with pytest.raises(PermissionError):
             ErtServerController.init_service(project=Path(".").absolute())
     finally:
-        os.chmod(file_path, mode)
+        Path(file_path).chmod(mode)

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -58,7 +58,7 @@ def test_that_service_can_be_started_with_existing_conn_info_json(change_to_tmpd
         "authtoken": "dummytoken",
     }
 
-    with open("storage_server.json", mode="w", encoding="utf-8") as f:
+    with Path("storage_server.json").open(mode="w", encoding="utf-8") as f:
         json.dump(connection_info, f)
     create_ert_server_controller(project=Path(".").absolute())
 
@@ -87,7 +87,7 @@ def test_that_service_can_be_started_with_missing_cert_in_conn_info_json(
         ],
         "authtoken": "dummytoken",
     }
-    with open("storage_server.json", mode="w", encoding="utf-8") as f:
+    with Path("storage_server.json").open(mode="w", encoding="utf-8") as f:
         json.dump(connection_info, f)
     ErtServerController.init_service(project=Path(".").absolute())
     start_server_mock.assert_called_once()
@@ -170,7 +170,7 @@ def test_storage_logging(change_to_tmpdir):
 
     logfiles = glob.glob("api-log-storage*.txt")
     assert len(logfiles) == 1, "Expected exactly one log file"
-    with open(logfiles[0], encoding="utf-8") as logfile:
+    with Path(logfiles[0]).open(encoding="utf-8") as logfile:
         contents = logfile.readlines()
 
     # check for duplicated log entries

--- a/tests/ert/unit_tests/shared/test_main_entry.py
+++ b/tests/ert/unit_tests/shared/test_main_entry.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import sys
 from unittest import mock
 from unittest.mock import MagicMock
@@ -59,7 +60,7 @@ def test_storage_exception_is_not_unexpected_error(caplog):
 def test_non_writable_log_directory_exits_with_message(monkeypatch, use_tmpdir):
     logs_dir = "logs_dir_without_write_access"
     os.mkdir(logs_dir)
-    os.chmod(logs_dir, 0o444)  # Read only access mode
+    pathlib.Path(logs_dir).chmod(0o444)  # Read only access mode
 
     expected_exit_messages = [
         "Could not configure log handler for files.",

--- a/tests/ert/unit_tests/storage/migration/test_to13.py
+++ b/tests/ert/unit_tests/storage/migration/test_to13.py
@@ -61,7 +61,7 @@ def setup_experiments_and_ensembles(
     ensemble_uuids: list[uuid.UUID],
     ensemble_mapping: dict[uuid.UUID, uuid.UUID] | None = None,
 ) -> None:
-    with open("index.json", "w", encoding="utf-8") as f:
+    with Path("index.json").open("w", encoding="utf-8") as f:
         json.dump({"version": 12, "migrations": []}, f, indent=2)
 
     os.mkdir("experiments")
@@ -70,7 +70,7 @@ def setup_experiments_and_ensembles(
     for i, exp_id in enumerate(experiment_uuids):
         exp_path = Path("experiments", str(exp_id))
         os.mkdir(exp_path)
-        with open(Path(exp_path, "index.json"), "w", encoding="utf-8") as f:
+        with (exp_path / "index.json").open("w", encoding="utf-8") as f:
             json.dump(
                 {
                     "id": str(exp_id),
@@ -90,7 +90,7 @@ def setup_experiments_and_ensembles(
 
         ens_path = Path("ensembles", str(ens_id))
         os.mkdir(ens_path)
-        with open(Path(ens_path) / "index.json", "w", encoding="utf-8") as f:
+        with (ens_path / "index.json").open("w", encoding="utf-8") as f:
             json.dump(
                 {
                     "id": str(ens_id),
@@ -116,11 +116,11 @@ def test_that_experiments_point_to_ensembles_after_migration_one_to_one(use_tmpd
 
     for ens_id, exp_id in zip(ensemble_uuids, experiment_uuids, strict=False):
         with (
-            open(
-                Path("ensembles") / str(ens_id) / "index.json", encoding="utf-8"
+            (Path("ensembles") / str(ens_id) / "index.json").open(
+                encoding="utf-8"
             ) as ens_f,
-            open(
-                Path("experiments") / str(exp_id) / "index.json", encoding="utf-8"
+            (Path("experiments") / str(exp_id) / "index.json").open(
+                encoding="utf-8"
             ) as exp_f,
         ):
             ens_data = json.load(ens_f)
@@ -149,14 +149,14 @@ def test_that_experiments_point_to_ensembles_after_migration_many_ensembles_per_
     point_experiments_to_ensembles(Path.cwd())
 
     for exp_id in experiment_uuids:
-        with open(
-            Path("experiments") / str(exp_id) / "index.json", encoding="utf-8"
+        with (Path("experiments") / str(exp_id) / "index.json").open(
+            encoding="utf-8"
         ) as exp_f:
             exp_data = json.load(exp_f)
             assert exp_data["ensembles"] == sorted(expected_exp_to_ens[str(exp_id)])
             for ensemble_id in exp_data["ensembles"]:
-                with open(
-                    Path("ensembles") / ensemble_id / "index.json", encoding="utf-8"
+                with (Path("ensembles") / ensemble_id / "index.json").open(
+                    encoding="utf-8"
                 ) as ens_check_f:
                     ens_check_data = json.load(ens_check_f)
                     assert ens_check_data["experiment_id"] == str(exp_id)
@@ -180,9 +180,8 @@ def test_that_experiments_point_to_ensembles_after_migration_for_empty_experimen
     setup_experiments_and_ensembles(experiment_uuids, ensemble_uuids, ensemble_mapping)
     point_experiments_to_ensembles(Path.cwd())
 
-    with open(
-        Path("experiments") / str(empty_experiment_uuid) / "index.json",
-        encoding="utf-8",
+    with (Path("experiments") / str(empty_experiment_uuid) / "index.json").open(
+        encoding="utf-8"
     ) as exp_f:
         exp_data = json.load(exp_f)
         assert exp_data["ensembles"] == []

--- a/tests/ert/unit_tests/storage/migration/test_to20.py
+++ b/tests/ert/unit_tests/storage/migration/test_to20.py
@@ -53,7 +53,7 @@ def test_that_name_is_removed_from_responses_json_file_for_all_experiments(use_t
         experiment_paths.append(experiment_path)
 
         # Add responses.json to each experiment
-        with open(experiment_path / "responses.json", "w", encoding="utf-8") as f:
+        with (experiment_path / "responses.json").open("w", encoding="utf-8") as f:
             json.dump(
                 {"gen_data": gendata_with_name, "summary": summary_with_name},
                 f,
@@ -64,7 +64,7 @@ def test_that_name_is_removed_from_responses_json_file_for_all_experiments(use_t
 
     # Validate responses.json files no longer contain 'name' field
     for experiment_path in experiment_paths:
-        with open(experiment_path / "responses.json", encoding="utf-8") as f:
+        with (experiment_path / "responses.json").open(encoding="utf-8") as f:
             migrated_responses = json.load(f)
 
         assert migrated_responses == {

--- a/tests/ert/unit_tests/storage/migration/test_to21.py
+++ b/tests/ert/unit_tests/storage/migration/test_to21.py
@@ -48,7 +48,7 @@ def test_that_name_is_removed_from_responses_json_file_for_all_experiments(use_t
         experiment_paths.append(experiment_path)
 
         # Add responses.json to each experiment
-        with open(experiment_path / "responses.json", "w", encoding="utf-8") as f:
+        with (experiment_path / "responses.json").open("w", encoding="utf-8") as f:
             json.dump(
                 {"gen_data": gendata, "summary": summary_with_refcase},
                 f,
@@ -59,7 +59,7 @@ def test_that_name_is_removed_from_responses_json_file_for_all_experiments(use_t
 
     # Validate responses.json files no longer contain 'name' field
     for experiment_path in experiment_paths:
-        with open(experiment_path / "responses.json", encoding="utf-8") as f:
+        with (experiment_path / "responses.json").open(encoding="utf-8") as f:
             migrated_responses = json.load(f)
 
         assert migrated_responses == {

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -60,10 +60,10 @@ def test_create_experiment(tmp_path):
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment(name="test-experiment")
 
-        experiment_path = Path(storage.path / "experiments" / str(experiment.id))
+        experiment_path = storage.path / "experiments" / str(experiment.id)
         assert experiment_path.exists()
 
-        with Path(experiment_path / "index.json").open(encoding="utf-8") as f:
+        with (experiment_path / "index.json").open(encoding="utf-8") as f:
             index = json.load(f)
             assert index["id"] == str(experiment.id)
             assert index["name"] == "test-experiment"
@@ -1259,7 +1259,7 @@ def test_that_permission_error_is_logged_in_load_ensembles(snake_oil_storage, ca
 
 
 def test_that_permission_error_is_logged_in_load_index(snake_oil_storage, caplog):
-    index_path = Path(snake_oil_storage.path / "index.json")
+    index_path = snake_oil_storage.path / "index.json"
     index_path.chmod(0o000)  # no permissions
     try:
         with caplog.at_level(logging.ERROR), pytest.raises(PermissionError):

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -356,7 +356,7 @@ def test_open_with_no_permissions(tmp_path):
         ensemble = storage.create_ensemble(experiment, name="foo", ensemble_size=1)
     path = Path(ensemble._path)
     mode = path.stat().st_mode
-    os.chmod(path, 0o000)  # no permissions
+    Path(path).chmod(0o000)  # no permissions
     try:
         with (
             pytest.raises(
@@ -367,7 +367,7 @@ def test_open_with_no_permissions(tmp_path):
         ):
             storage._load_experiments()
     finally:
-        os.chmod(path, mode)  # restore permissions
+        Path(path).chmod(mode)  # restore permissions
 
 
 def test_reload(tmp_path):

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -63,7 +63,7 @@ def test_create_experiment(tmp_path):
         experiment_path = Path(storage.path / "experiments" / str(experiment.id))
         assert experiment_path.exists()
 
-        with open(experiment_path / "index.json", encoding="utf-8") as f:
+        with Path(experiment_path / "index.json").open(encoding="utf-8") as f:
             index = json.load(f)
             assert index["id"] == str(experiment.id)
             assert index["name"] == "test-experiment"
@@ -1053,13 +1053,13 @@ def test_load_gen_kw_not_sorted(storage, tmpdir, snapshot):
         RANDOM_SEED 1234
         """
         )
-        with open("config.ert", mode="w", encoding="utf-8") as fh:
+        with Path("config.ert").open(mode="w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("template.txt", mode="w", encoding="utf-8") as fh:
+        with Path("template.txt").open(mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior1.txt", mode="w", encoding="utf-8") as fh:
+        with Path("prior1.txt").open(mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD1 LOGUNIF 0.1 1")
-        with open("prior2.txt", mode="w", encoding="utf-8") as fh:
+        with Path("prior2.txt").open(mode="w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD2 LOGUNIF 0.1 1")
 
         ert_config = ErtConfig.from_file("config.ert")

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -576,4 +576,4 @@ async def test_gen_kw_outfile_will_use_paths(
                 await create_runpath(storage, "config.ert")
         else:
             await create_runpath(storage, "config.ert")
-            assert os.path.exists(f"simulations/realization-0/iter-0/{relpath}kw.txt")
+            assert Path(f"simulations/realization-0/iter-0/{relpath}kw.txt").exists()

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -286,7 +286,7 @@ def test_that_sampling_is_fixed_from_name(
     only that name of the parameter and the global seed determine the values.
     """
     with tmpdir.as_cwd():
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines(template)
         fs = storage.create_ensemble(
             storage.create_experiment(
@@ -351,11 +351,11 @@ def test_that_sub_sample_maintains_order(tmpdir, storage, mask, expected):
         GEN_KW KW_NAME template.txt kw.txt prior.txt
         """
         )
-        with open("config.ert", "w", encoding="utf-8") as fh:
+        with Path("config.ert").open("w", encoding="utf-8") as fh:
             fh.writelines(config)
-        with open("template.txt", "w", encoding="utf-8") as fh:
+        with Path("template.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD <MY_KEYWORD>")
-        with open("prior.txt", "w", encoding="utf-8") as fh:
+        with Path("prior.txt").open("w", encoding="utf-8") as fh:
             fh.writelines("MY_KEYWORD NORMAL 0 1")
 
         ert_config = ErtConfig.from_file("config.ert")
@@ -414,7 +414,7 @@ async def test_gen_kw_optional_template(storage, tmpdir, config_str, expected):
 
 
 def write_file(fname, contents):
-    with open(fname, mode="w", encoding="utf-8") as fout:
+    with Path(fname).open(mode="w", encoding="utf-8") as fout:
         fout.writelines(contents)
 
 

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -279,7 +279,7 @@ def test_that_storage_works_with_missing_parameters_and_responses(
 
 
 @pytest.mark.integration_test
-def test_that_migrate_blockfs_creates_backup_folder(tmp_path, caplog):
+def test_that_migrate_blockfs_creates_backup_folder(tmp_path: Path, caplog):
     storage_path = tmp_path / "storage"
     storage_ensembles = storage_path / "ensembles"
     storage_experiments = storage_path / "experiments"

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -63,10 +63,10 @@ def test_migration_to_genkw_with_polars_and_design_matrix(
     local_storage_set_ert_config(ErtConfig.from_file_contents("NUM_REALIZATIONS 1\n"))
     storage_path = copy_shared_design / f"version-{ert_version}"
 
-    if LocalStorage.check_migration_needed(Path(storage_path)):
-        LocalStorage.perform_migration(Path(storage_path))
+    if LocalStorage.check_migration_needed(storage_path):
+        LocalStorage.perform_migration(storage_path)
 
-    with open_storage(Path(storage_path), "w") as storage:
+    with open_storage(storage_path, "w") as storage:
         experiments = list(storage.experiments)
         assert len(experiments) == 1
         experiment = experiments[0]
@@ -257,10 +257,10 @@ def test_that_storage_works_with_missing_parameters_and_responses(
     # To make sure all tests run against the same snapshot
     snapshot.snapshot_dir = snapshot.snapshot_dir.parent
 
-    if LocalStorage.check_migration_needed(Path(storage_path)):
-        LocalStorage.perform_migration(Path(storage_path))
+    if LocalStorage.check_migration_needed(storage_path):
+        LocalStorage.perform_migration(storage_path)
 
-    with open_storage(Path(storage_path), "w") as storage:
+    with open_storage(storage_path, "w") as storage:
         experiments = list(storage.experiments)
         assert len(experiments) == 1
         experiment = experiments[0]
@@ -285,17 +285,17 @@ def test_that_migrate_blockfs_creates_backup_folder(tmp_path, caplog):
     storage_experiments = storage_path / "experiments"
     storage_backup = storage_path / "_blockfs_backup"
 
-    with open(tmp_path / "config.ert", mode="w", encoding="utf-8") as f:
+    with (tmp_path / "config.ert").open(mode="w", encoding="utf-8") as f:
         f.writelines(["NUM_REALIZATIONS 1\n", "ENSPATH", str(storage_path)])
 
     for d in (storage_path, storage_ensembles, storage_experiments):
         os.makedirs(d, exist_ok=True)
 
-    with open(storage_path / "index.json", "w+", encoding="utf-8") as f:
+    with (storage_path / "index.json").open("w+", encoding="utf-8") as f:
         f.write("""{"version": 0}""")
 
-    Path(storage_experiments / "exp_dummy.txt").write_text("", encoding="utf-8")
-    Path(storage_ensembles / "ens_dummy.txt").write_text("", encoding="utf-8")
+    (storage_experiments / "exp_dummy.txt").write_text("", encoding="utf-8")
+    (storage_ensembles / "ens_dummy.txt").write_text("", encoding="utf-8")
 
     with caplog.at_level(level=logging.INFO):
         run_cli("test_run", str(tmp_path / "config.ert"))
@@ -303,12 +303,12 @@ def test_that_migrate_blockfs_creates_backup_folder(tmp_path, caplog):
     assert storage_backup.exists()
     assert "Blockfs storage backed up" in caplog.messages
 
-    with open(storage_path / "index.json", encoding="utf-8") as f:
+    with (storage_path / "index.json").open(encoding="utf-8") as f:
         index = json.load(f)
         assert index["version"] == _LOCAL_STORAGE_VERSION
         assert index["migrations"] == []
 
-    with open(storage_backup / "index.json", encoding="utf-8") as f:
+    with (storage_backup / "index.json").open(encoding="utf-8") as f:
         index = json.load(f)
         assert index["version"] == 0
 
@@ -475,10 +475,10 @@ def test_migrate_storage_with_no_responses(
 
     local_storage_set_ert_config(ert_config)
 
-    if LocalStorage.check_migration_needed(Path(storage_path)):
-        LocalStorage.perform_migration(Path(storage_path))
+    if LocalStorage.check_migration_needed(storage_path):
+        LocalStorage.perform_migration(storage_path)
 
-    open_storage(Path(storage_path), "w")
+    open_storage(storage_path, "w")
 
 
 @pytest.mark.integration_test
@@ -558,10 +558,10 @@ def test_that_storages_with_failed_realizations_are_migrated_without_errors(
 
     local_storage_set_ert_config(ert_config)
 
-    if LocalStorage.check_migration_needed(Path(storage_path)):
-        LocalStorage.perform_migration(Path(storage_path))
+    if LocalStorage.check_migration_needed(storage_path):
+        LocalStorage.perform_migration(storage_path)
 
-    with open_storage(Path(storage_path), "w") as storage:
+    with open_storage(storage_path, "w") as storage:
         ensemble = next(storage.ensembles)
         realization_states = ensemble.get_ensemble_state()
         for i, _, realization_state in failures:

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -210,8 +210,8 @@ async def test_that_when_gen_kw_is_in_the_config_then_parameters_txt_is_created(
         config_contents.format(parameters="GEN_KW GENKW genkw")
     )
     await make_run_path(ert_config)
-    assert os.path.exists("simulations/realization-0/iter-0")
-    assert os.path.exists("simulations/realization-0/iter-0/parameters.txt")
+    assert Path("simulations/realization-0/iter-0").exists()
+    assert Path("simulations/realization-0/iter-0/parameters.txt").exists()
     assert len(os.listdir("simulations")) == 1
     assert len(os.listdir("simulations/realization-0")) == 1
 
@@ -222,8 +222,8 @@ async def test_that_when_gen_kw_is_not_in_the_config_then_parameters_txt_is_not_
 ):
     ert_config = ErtConfig.from_file_contents(config_contents.format(parameters=""))
     await make_run_path(ert_config)
-    assert os.path.exists("simulations/realization-0/iter-0")
-    assert not os.path.exists("simulations/realization-0/iter-0/parameters.txt")
+    assert Path("simulations/realization-0/iter-0").exists()
+    assert not Path("simulations/realization-0/iter-0/parameters.txt").exists()
     assert len(os.listdir("simulations")) == 1
     assert len(os.listdir("simulations/realization-0")) == 1
 
@@ -235,7 +235,7 @@ async def test_that_jobs_json_is_backed_up_when_run_path_is_recreated(make_run_p
         config_contents.format(parameters="GEN_KW GENKW genkw")
     )
     await make_run_path(ert_config)
-    assert os.path.exists("simulations/realization-0/iter-0/jobs.json")
+    assert Path("simulations/realization-0/iter-0/jobs.json").exists()
     await make_run_path(ert_config)
     iter0_output_files = os.listdir("simulations/realization-0/iter-0/")
     assert len([f for f in iter0_output_files if f.startswith("jobs.json")]) > 1, (

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -722,7 +722,7 @@ async def test_assert_export(make_run_path):
     assert runpath_list_file.name == "test_runpath_list.txt"
     assert (
         runpath_list_file.read_text("utf-8")
-        == f"000  {os.getcwd()}/simulations/realization-0/iter-0  a_name_0  000\n"
+        == f"000  {Path.cwd()}/simulations/realization-0/iter-0  a_name_0  000\n"
     )
 
 
@@ -886,7 +886,7 @@ async def test_that_ertcase_is_replaced_in_runpath(placeholder, make_run_path):
     prior_ensemble, _, _ = await make_run_path(ert_config)
 
     runpath_file = (
-        f"{os.getcwd()}/simulations/{prior_ensemble.name}/realization-0/iter-0"
+        f"{Path.cwd()}/simulations/{prior_ensemble.name}/realization-0/iter-0"
     )
 
     assert (

--- a/tests/ert/unit_tests/test_tracking.py
+++ b/tests/ert/unit_tests/test_tracking.py
@@ -172,7 +172,7 @@ def test_tracking(
         extra_config,
     ]
 
-    with open("poly.ert", "a", encoding="utf-8") as fh:
+    with Path("poly.ert").open("a", encoding="utf-8") as fh:
         fh.writelines(config_lines)
 
     with fileinput.input("poly_eval.py", inplace=True) as fin:
@@ -369,7 +369,7 @@ def test_run_information_present_as_env_var_in_fm_context(
 
     # Check run information in job environment
     for path in model.paths:
-        with open(Path(path) / "jobs.json", encoding="utf-8") as f:
+        with Path(Path(path) / "jobs.json").open(encoding="utf-8") as f:
             jobs_data = json.load(f)
         for key in expected:
             assert key in jobs_data["global_environment"]

--- a/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
+++ b/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
@@ -1,4 +1,3 @@
-import os.path
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
@@ -199,22 +198,22 @@ def test_workflow_thread_cancel_ert_script():
         assert workflow_runner.workflowResult() is None
 
         wait_until(workflow_runner.isRunning)
-        wait_until(lambda: os.path.exists("wait_started_0"))
+        wait_until(lambda: Path("wait_started_0").exists())
 
-        wait_until(lambda: os.path.exists("wait_finished_0"))
+        wait_until(lambda: Path("wait_finished_0").exists())
 
-        wait_until(lambda: os.path.exists("wait_started_1"))
+        wait_until(lambda: Path("wait_started_1").exists())
 
         workflow_runner.cancel()
 
-        wait_until(lambda: os.path.exists("wait_cancelled_1"))
+        wait_until(lambda: Path("wait_cancelled_1").exists())
 
         assert workflow_runner.isCancelled()
 
-    assert not os.path.exists("wait_finished_1")
-    assert not os.path.exists("wait_started_2")
-    assert not os.path.exists("wait_cancelled_2")
-    assert not os.path.exists("wait_finished_2")
+    assert not Path("wait_finished_1").exists()
+    assert not Path("wait_started_2").exists()
+    assert not Path("wait_cancelled_2").exists()
+    assert not Path("wait_finished_2").exists()
 
 
 @pytest.mark.integration_test
@@ -236,16 +235,16 @@ def test_workflow_thread_cancel_external():
 
     with workflow_runner:
         wait_until(workflow_runner.isRunning)
-        wait_until(lambda: os.path.exists("wait_started_0"))
-        wait_until(lambda: os.path.exists("wait_finished_0"))
-        wait_until(lambda: os.path.exists("wait_started_1"))
+        wait_until(lambda: Path("wait_started_0").exists())
+        wait_until(lambda: Path("wait_finished_0").exists())
+        wait_until(lambda: Path("wait_started_1").exists())
         workflow_runner.cancel()
         assert workflow_runner.isCancelled()
 
-    assert not os.path.exists("wait_finished_1")
-    assert not os.path.exists("wait_started_2")
-    assert not os.path.exists("wait_cancelled_2")
-    assert not os.path.exists("wait_finished_2")
+    assert not Path("wait_finished_1").exists()
+    assert not Path("wait_started_2").exists()
+    assert not Path("wait_cancelled_2").exists()
+    assert not Path("wait_finished_2").exists()
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -300,13 +299,13 @@ def test_workflow_success():
     assert not workflow_runner.isRunning()
     with workflow_runner:
         workflow_runner.wait()
-    assert os.path.exists("wait_started_0")
-    assert not os.path.exists("wait_cancelled_0")
-    assert os.path.exists("wait_finished_0")
+    assert Path("wait_started_0").exists()
+    assert not Path("wait_cancelled_0").exists()
+    assert Path("wait_finished_0").exists()
 
-    assert os.path.exists("wait_started_1")
-    assert not os.path.exists("wait_cancelled_1")
-    assert os.path.exists("wait_finished_1")
+    assert Path("wait_started_1").exists()
+    assert not Path("wait_cancelled_1").exists()
+    assert Path("wait_finished_1").exists()
 
     assert workflow_runner.workflowResult()
 

--- a/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
+++ b/tests/ert/unit_tests/workflow_runner/test_workflow_runner.py
@@ -125,7 +125,7 @@ def test_deprecated_keywords(config, expected_result, monkeypatch, tmp_path):
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.filterwarnings("ignore:.*Deprecated keywords, SCRIPT and INTERNAL")
 def test_stop_on_fail_is_parsed_internal():
-    with open("fail_job", "w+", encoding="utf-8") as f:
+    with Path("fail_job").open("w+", encoding="utf-8") as f:
         f.write("INTERNAL True\n")
         f.write("SCRIPT fail_script.py\n")
         f.write("MIN_ARG 1\n")
@@ -133,7 +133,7 @@ def test_stop_on_fail_is_parsed_internal():
         f.write("ARG_TYPE 0 STRING\n")
         f.write("STOP_ON_FAIL True\n")
 
-    with open("fail_script.py", "w+", encoding="utf-8") as f:
+    with Path("fail_script.py").open("w+", encoding="utf-8") as f:
         f.write(
             """
 from ert import ErtScript
@@ -314,7 +314,7 @@ def test_workflow_success():
 @pytest.mark.usefixtures("use_tmpdir")
 def test_workflow_stops_with_stopping_job():
     WorkflowCommon.createExternalDumpJob()
-    with open("dump_failing_job", "a", encoding="utf-8") as f:
+    with Path("dump_failing_job").open("a", encoding="utf-8") as f:
         f.write("STOP_ON_FAIL True")
 
     Path("dump_failing_workflow").write_text("DUMP", encoding="utf-8")
@@ -332,7 +332,7 @@ def test_workflow_stops_with_stopping_job():
     with pytest.raises(RuntimeError, match="Workflow job dump_failing_job failed"):
         runner.run_blocking()
 
-    with open("dump_failing_job", "a", encoding="utf-8") as f:
+    with Path("dump_failing_job").open("a", encoding="utf-8") as f:
         f.write("\nSTOP_ON_FAIL False")
 
     job_successful_dump = workflow_job_from_file("dump_failing_job", origin="user")

--- a/tests/ert/unit_tests/workflow_runner/workflow_common.py
+++ b/tests/ert/unit_tests/workflow_runner/workflow_common.py
@@ -30,11 +30,11 @@ class WorkflowCommon:
             encoding="utf-8",
         )
         st = os.stat("dump.py")
-        os.chmod(
-            "dump.py", st.st_mode | stat.S_IEXEC
+        Path("dump.py").chmod(
+            st.st_mode | stat.S_IEXEC
         )  # | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         st = os.stat("dump_failing.py")
-        os.chmod("dump_failing.py", st.st_mode | stat.S_IEXEC)
+        Path("dump_failing.py").chmod(st.st_mode | stat.S_IEXEC)
 
         Path("dump_workflow").write_text(
             "DUMP dump1 dump_text_1\nDUMP dump2 dump_<PARAM>_2\n", encoding="utf-8"
@@ -97,8 +97,8 @@ class WorkflowCommon:
         )
 
         st = os.stat("external_wait_job.sh")
-        os.chmod(
-            "external_wait_job.sh", st.st_mode | stat.S_IEXEC
+        Path("external_wait_job.sh").chmod(
+            st.st_mode | stat.S_IEXEC
         )  # | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 
         Path("wait_job").write_text(

--- a/tests/ert/utils.py
+++ b/tests/ert/utils.py
@@ -42,7 +42,7 @@ def source_dir() -> Path:
             return current_path
         # This is to find root dir for git worktrees
         elif (current_path / ".git").is_file():
-            with open(current_path / ".git", encoding="utf-8") as f:
+            with Path(current_path / ".git").open(encoding="utf-8") as f:
                 for line in f:
                     if "gitdir:" in line:
                         return current_path

--- a/tests/ert/utils.py
+++ b/tests/ert/utils.py
@@ -42,7 +42,7 @@ def source_dir() -> Path:
             return current_path
         # This is to find root dir for git worktrees
         elif (current_path / ".git").is_file():
-            with Path(current_path / ".git").open(encoding="utf-8") as f:
+            with (current_path / ".git").open(encoding="utf-8") as f:
                 for line in f:
                     if "gitdir:" in line:
                         return current_path

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -88,7 +88,7 @@ def setup_minimal_everest_case(tmp_path) -> AbstractContextManager[str]:
                 """)
             )
 
-            os.chmod(job_path, job_path.stat().st_mode | stat.S_IEXEC)
+            Path(job_path).chmod(job_path.stat().st_mode | stat.S_IEXEC)
 
             config = EverestConfig.with_plugins(
                 {

--- a/tests/everest/entry_points/test_config_branch_entry.py
+++ b/tests/everest/entry_points/test_config_branch_entry.py
@@ -1,5 +1,4 @@
 import difflib
-from os.path import exists
 from pathlib import Path
 
 import pytest
@@ -17,7 +16,7 @@ def test_config_branch_entry(cached_example):
 
     config_branch_entry(["config_minimal.yml", "new_restart_config.yml", "-b", "1"])
 
-    assert exists("new_restart_config.yml")
+    assert Path("new_restart_config.yml").exists()
 
     old_config = load_yaml("config_minimal.yml")
     old_controls = old_config["controls"]
@@ -55,7 +54,7 @@ def test_config_branch_preserves_config_section_order(cached_example):
 
     config_branch_entry(["config_minimal.yml", "new_restart_config.yml", "-b", "1"])
 
-    assert exists("new_restart_config.yml")
+    assert Path("new_restart_config.yml").exists()
 
     diff_lines = []
     with (

--- a/tests/everest/entry_points/test_config_branch_entry.py
+++ b/tests/everest/entry_points/test_config_branch_entry.py
@@ -59,8 +59,8 @@ def test_config_branch_preserves_config_section_order(cached_example):
 
     diff_lines = []
     with (
-        open("config_minimal.yml", encoding="utf-8") as initial_config,
-        open("new_restart_config.yml", encoding="utf-8") as branch_config,
+        Path("config_minimal.yml").open(encoding="utf-8") as initial_config,
+        Path("new_restart_config.yml").open(encoding="utf-8") as branch_config,
     ):
         diff = difflib.unified_diff(
             initial_config.readlines(),

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -68,7 +67,7 @@ def test_everest_entry_debug(
     assert '"controls"' in logstream
     assert '"objective_functions"' in logstream
     assert '"name": "my_control"' in logstream
-    assert f'"config_path": "{os.getcwd()}/config.yml"' in logstream
+    assert f'"config_path": "{Path.cwd()}/config.yml"' in logstream
 
 
 @patch("everest.bin.everest_script.run_detached_monitor")

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -116,10 +116,10 @@ def test_everest_main_lint_entry(cached_example):
     assert "config_minimal.yml is valid" in out.getvalue()
 
     # Make the config invalid
-    with open(config_file, encoding="utf-8") as f:
+    with Path(config_file).open(encoding="utf-8") as f:
         raw_config = YAML(typ="safe", pure=True).load(f)
     raw_config["controls"][0]["initial_guess"] = "invalid"
-    with open(config_file, "w", encoding="utf-8") as f:
+    with Path(config_file).open("w", encoding="utf-8") as f:
         yaml = YAML(typ="safe", pure=True)
         yaml.indent = 2
         yaml.default_flow_style = False

--- a/tests/everest/test_config_file_loader.py
+++ b/tests/everest/test_config_file_loader.py
@@ -1,5 +1,6 @@
 import os
 import string
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -85,7 +86,7 @@ def test_load_config_as_yaml(tmp_path):
 
 def test_configpath_in_defs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    current_working_directory = os.getcwd()
+    current_working_directory = Path.cwd()
 
     definitions_for_yaml_creation = {
         "local_jobs_folder": "r{{ configpath }}/jobs",
@@ -107,7 +108,7 @@ def test_configpath_in_defs(tmp_path, monkeypatch):
 
 def test_dependent_definitions(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    current_working_directory = os.getcwd()
+    current_working_directory = str(Path.cwd())
 
     definitions_for_initial_config_object = {
         "numeric_key": 1,

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -840,7 +840,7 @@ def test_that_existing_install_job_with_non_executable_executable_errors_depreca
     with Path("non_executable").open("w+", encoding="utf-8") as f:
         f.write("bla")
 
-    os.chmod("non_executable", os.stat("non_executable").st_mode & ~0o111)
+    Path("non_executable").chmod(os.stat("non_executable").st_mode & ~0o111)
     assert not os.access("non_executable", os.X_OK)
 
     with pytest.warns(
@@ -875,7 +875,7 @@ def test_that_existing_install_job_with_non_executable_executable_errors(
     with Path("non_executable").open("w+", encoding="utf-8") as f:
         f.write("bla")
 
-    os.chmod("non_executable", os.stat("non_executable").st_mode & ~0o111)
+    Path("non_executable").chmod(os.stat("non_executable").st_mode & ~0o111)
     assert not os.access("non_executable", os.X_OK)
 
     with pytest.raises(ValidationError, match="File not executable"):

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -1,6 +1,5 @@
 import json
 import os
-import pathlib
 import re
 from argparse import ArgumentParser
 from contextlib import ExitStack as does_not_raise
@@ -788,12 +787,12 @@ def test_that_non_existing_install_job_errors_deprecated(
 def test_that_existing_install_job_with_malformed_executable_errors_deprecated(
     install_keyword, change_to_tmpdir
 ):
-    with open("malformed.ert", "w+", encoding="utf-8") as f:
+    with Path("malformed.ert").open("w+", encoding="utf-8") as f:
         f.write(
             """EXECUTABLE
         """
         )
-    with open("malformed2.ert", "w+", encoding="utf-8") as f:
+    with Path("malformed2.ert").open("w+", encoding="utf-8") as f:
         f.write(
             """EXECUTABLE 1 two 3
                EXECUTABLE one two
@@ -832,13 +831,13 @@ def test_that_existing_install_job_with_malformed_executable_errors_deprecated(
 def test_that_existing_install_job_with_non_executable_executable_errors_deprecated(
     install_keyword, change_to_tmpdir
 ):
-    with open("exec.ert", "w+", encoding="utf-8") as f:
+    with Path("exec.ert").open("w+", encoding="utf-8") as f:
         f.write(
             """EXECUTABLE non_executable
         """
         )
 
-    with open("non_executable", "w+", encoding="utf-8") as f:
+    with Path("non_executable").open("w+", encoding="utf-8") as f:
         f.write("bla")
 
     os.chmod("non_executable", os.stat("non_executable").st_mode & ~0o111)
@@ -873,7 +872,7 @@ def test_that_existing_install_job_with_non_executable_executable_errors_depreca
 def test_that_existing_install_job_with_non_executable_executable_errors(
     install_keyword, change_to_tmpdir
 ):
-    with open("non_executable", "w+", encoding="utf-8") as f:
+    with Path("non_executable").open("w+", encoding="utf-8") as f:
         f.write("bla")
 
     os.chmod("non_executable", os.stat("non_executable").st_mode & ~0o111)
@@ -903,7 +902,7 @@ def test_that_existing_install_job_with_non_executable_executable_errors(
 def test_that_existing_install_job_with_non_existing_executable_errors_deprecated(
     install_keyword, change_to_tmpdir
 ):
-    with open("exec.ert", "w+", encoding="utf-8") as f:
+    with Path("exec.ert").open("w+", encoding="utf-8") as f:
         f.write(
             """EXECUTABLE non_existing
         """
@@ -1038,7 +1037,7 @@ def test_that_objective_function_weights_sum_is_positive(values, expect_error):
 
 def test_that_install_templates_must_have_unique_names(change_to_tmpdir):
     for f in ["hey", "hesy", "heyyy"]:
-        pathlib.Path(f).write_text(f, encoding="utf-8")
+        Path(f).write_text(f, encoding="utf-8")
 
     with pytest.raises(
         ValueError,
@@ -1266,7 +1265,7 @@ def test_load_file_undefined_substitutions(min_config, change_to_tmpdir, capsys)
         }
     ]
 
-    with open("config.yml", mode="w", encoding="utf-8") as f:
+    with Path("config.yml").open(mode="w", encoding="utf-8") as f:
         yaml.dump(config, f)
 
     parser = ArgumentParser(prog="test")
@@ -1305,7 +1304,7 @@ def test_export_deprecated_keys(key, value, min_config, change_to_tmpdir):
     config = min_config
     config["export"] = {key: value}
 
-    with open("config.yml", mode="w", encoding="utf-8") as f:
+    with Path("config.yml").open(mode="w", encoding="utf-8") as f:
         yaml.dump(config, f)
 
     parser = ArgumentParser(prog="test")

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -106,7 +106,7 @@ def test_wait_for_server(mock_get_context, mock_is_running):
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 def test_detached_mode_config_base(min_config, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    with open("config.yml", "w", encoding="utf-8") as fout:
+    with Path("config.yml").open("w", encoding="utf-8") as fout:
         yaml.dump(min_config, fout)
     everest_config = EverestConfig.load_file("config.yml")
 

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -55,7 +55,7 @@ def test_save_running_config(
     everest_entry(["config.yml", "--skip-prompt"])
     saved_config_path = os.path.join(config.output_dir, "config.yml")
 
-    assert os.path.exists(saved_config_path)
+    assert Path(saved_config_path).exists()
     shutil.move(saved_config_path, os.path.join(Path.cwd(), "saved_config.yml"))
 
     new_config = EverestConfig.load_file("saved_config.yml")

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -56,7 +56,7 @@ def test_save_running_config(
     saved_config_path = os.path.join(config.output_dir, "config.yml")
 
     assert os.path.exists(saved_config_path)
-    shutil.move(saved_config_path, os.path.join(os.getcwd(), "saved_config.yml"))
+    shutil.move(saved_config_path, os.path.join(Path.cwd(), "saved_config.yml"))
 
     new_config = EverestConfig.load_file("saved_config.yml")
 

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -343,7 +343,7 @@ def test_undefined_substitution(min_config, change_to_tmpdir, target, expected):
         {"source": "r{{configpath}}/../model/file.txt", "target": target}
     ]
 
-    with open("config.yml", mode="w", encoding="utf-8") as f:
+    with Path("config.yml").open(mode="w", encoding="utf-8") as f:
         yaml.dump(config, f)
     if expected:
         with pytest.raises(ValueError, match=expected) as e:
@@ -362,7 +362,7 @@ def test_commented_out_substitution(min_config, change_to_tmpdir):
         "step3 abc",
     ]
 
-    with open("config.yml", mode="w", encoding="utf-8") as f:
+    with Path("config.yml").open(mode="w", encoding="utf-8") as f:
         yaml.dump(config, f)
 
     with fileinput.input("config.yml", inplace=True) as fin:
@@ -410,7 +410,7 @@ def test_that_geo_id_is_deprecated(min_config, change_to_tmpdir, caplog, capsys)
     config = min_config
     config["forward_model"] = ["step1 <GEO_ID>"]
 
-    with open("config.yml", mode="w", encoding="utf-8") as f:
+    with Path("config.yml").open(mode="w", encoding="utf-8") as f:
         yaml.dump(config, f)
 
     config_dict = yaml_file_to_substituted_config_dict("config.yml")

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from ruamel.yaml import YAML
 
@@ -48,7 +50,7 @@ def test_input_constraint_control_references(tmp_path, capsys, monkeypatch):
 
     yaml = YAML(typ="safe", pure=True)
 
-    with open("config_nowarns.yml", "w+", encoding="utf-8") as f:
+    with Path("config_nowarns.yml").open("w+", encoding="utf-8") as f:
         yaml.dump(
             {
                 "model": {"realizations": ["0", "2", "4"]},
@@ -59,7 +61,7 @@ def test_input_constraint_control_references(tmp_path, capsys, monkeypatch):
             f,
         )
 
-    with open("config_warns.yml", "w+", encoding="utf-8") as f:
+    with Path("config_warns.yml").open("w+", encoding="utf-8") as f:
         yaml.dump(
             {
                 "model": {"realizations": ["0", "2", "4"]},

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -51,11 +51,11 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     everest_log_path = os.path.join(everest_logs_dir_path, "everest.log")
     forward_model_log_path = os.path.join(everest_logs_dir_path, "forward_models.log")
 
-    assert os.path.exists(everest_output_path)
-    assert os.path.exists(everest_logs_dir_path)
-    assert os.path.exists(forward_model_log_path)
-    assert os.path.exists(everest_log_path)
-    assert os.path.exists(everserver_log_path)
+    assert Path(everest_output_path).exists()
+    assert Path(everest_logs_dir_path).exists()
+    assert Path(forward_model_log_path).exists()
+    assert Path(everest_log_path).exists()
+    assert Path(everserver_log_path).exists()
 
     assert "everest.detached.everserver INFO: Output directory:" in Path(
         everest_log_path

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -45,7 +45,7 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     everest_config.write_to_file("config_minimal.yml")
     start_everest(["everest", "run", "config_minimal.yml", "--skip-prompt"])
 
-    everest_output_path = os.path.join(os.getcwd(), "everest_output")
+    everest_output_path = os.path.join(Path.cwd(), "everest_output")
     everest_logs_dir_path = everest_config.log_dir
     everserver_log_path = os.path.join(everest_logs_dir_path, "everserver.log")
     everest_log_path = os.path.join(everest_logs_dir_path, "everest.log")

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -92,18 +92,20 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the failed simulation folder still exists
-    assert os.path.exists(
+    assert Path(
         os.path.join(simulation_dir, "batch_0/realization_0/perturbation_1")
-    ), "Simulation folder should be there, something went wrong and was removed!"
+    ).exists(), (
+        "Simulation folder should be there, something went wrong and was removed!"
+    )
 
     # Check the successful simulation folders do not exist
-    assert not os.path.exists(
+    assert not Path(
         os.path.join(simulation_dir, "batch_0/realization_0/evaluation_0")
-    ), "Simulation folder should not be there, something went wrong!"
+    ).exists(), "Simulation folder should not be there, something went wrong!"
 
-    assert not os.path.exists(
+    assert not Path(
         os.path.join(simulation_dir, "batch_0/realization_0/simulation_1")
-    ), "Simulation folder should not be there, something went wrong!"
+    ).exists(), "Simulation folder should not be there, something went wrong!"
 
     # Manually rolling the output folder between two runs
     makedirs_if_needed(Path(config.output_dir), roll_if_exists=True)
@@ -117,17 +119,23 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the all simulation folder exist when delete_run_path is set to False
-    assert os.path.exists(
+    assert Path(
         os.path.join(simulation_dir, "batch_0/realization_0/perturbation_1")
-    ), "Simulation folder should be there, something went wrong and was removed!"
+    ).exists(), (
+        "Simulation folder should be there, something went wrong and was removed!"
+    )
 
-    assert os.path.exists(
+    assert Path(
         os.path.join(simulation_dir, "batch_0/realization_0/evaluation_0")
-    ), "Simulation folder should be there, something went wrong and was removed"
+    ).exists(), (
+        "Simulation folder should be there, something went wrong and was removed"
+    )
 
-    assert os.path.exists(
+    assert Path(
         os.path.join(simulation_dir, "batch_0/realization_0/perturbation_0")
-    ), "Simulation folder should be there, something went wrong and was removed"
+    ).exists(), (
+        "Simulation folder should be there, something went wrong and was removed"
+    )
 
 
 @pytest.mark.integration_test

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -92,20 +91,18 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the failed simulation folder still exists
-    assert Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/perturbation_1")
-    ).exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_1").exists(), (
         "Simulation folder should be there, something went wrong and was removed!"
     )
 
     # Check the successful simulation folders do not exist
-    assert not Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/evaluation_0")
-    ).exists(), "Simulation folder should not be there, something went wrong!"
+    assert not (Path(simulation_dir) / "batch_0/realization_0/evaluation_0").exists(), (
+        "Simulation folder should not be there, something went wrong!"
+    )
 
-    assert not Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/simulation_1")
-    ).exists(), "Simulation folder should not be there, something went wrong!"
+    assert not (Path(simulation_dir) / "batch_0/realization_0/simulation_1").exists(), (
+        "Simulation folder should not be there, something went wrong!"
+    )
 
     # Manually rolling the output folder between two runs
     makedirs_if_needed(Path(config.output_dir), roll_if_exists=True)
@@ -119,21 +116,15 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the all simulation folder exist when delete_run_path is set to False
-    assert Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/perturbation_1")
-    ).exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_1").exists(), (
         "Simulation folder should be there, something went wrong and was removed!"
     )
 
-    assert Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/evaluation_0")
-    ).exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization_0/evaluation_0").exists(), (
         "Simulation folder should be there, something went wrong and was removed"
     )
 
-    assert Path(
-        os.path.join(simulation_dir, "batch_0/realization_0/perturbation_0")
-    ).exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_0").exists(), (
         "Simulation folder should be there, something went wrong and was removed"
     )
 

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -71,14 +71,14 @@ def test_math_func_advanced(cached_example):
 @pytest.mark.integration_test
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
 def test_remove_run_path(copy_math_func_test_data_to_tmp):
-    with open("config_minimal.yml", encoding="utf-8") as file:
+    with Path("config_minimal.yml").open(encoding="utf-8") as file:
         config_yaml = yaml.safe_load(file)
         config_yaml["simulator"] = {"delete_run_path": True}
         config_yaml["install_jobs"].append(
             {"name": "toggle_failure", "executable": "jobs/fail_simulation.py"}
         )
         config_yaml["forward_model"].append("toggle_failure --fail perturbation_1")
-    with open("config.yml", "w", encoding="utf-8") as fout:
+    with Path("config.yml").open("w", encoding="utf-8") as fout:
         yaml.dump(config_yaml, fout)
     config = EverestConfig.load_file("config.yml")
 

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -73,7 +73,7 @@ def test_render_invalid(change_to_tmpdir):
 
     prod_wells = {f"PROD{idx:d}": 0.3 * idx for idx in range(4)}
     prod_in = "well_drill_prod.json"
-    with open(prod_in, "w", encoding="utf-8") as fout:
+    with Path(prod_in).open("w", encoding="utf-8") as fout:
         json.dump(prod_wells, fout)
 
     wells_out = "wells.out"
@@ -103,13 +103,13 @@ def test_render(change_to_tmpdir):
     wells = {f"PROD{idx:d}": 0.2 * idx for idx in range(1, 5)}
     wells.update({f"INJ{idx:d}": 1 - 0.2 * idx for idx in range(1, 5)})
     wells_in = "well_drill.json"
-    with open(wells_in, "w", encoding="utf-8") as fout:
+    with Path(wells_in).open("w", encoding="utf-8") as fout:
         json.dump(wells, fout)
 
     wells_out = "wells.out"
     render(wells_in, template_file, wells_out)
 
-    with open(wells_out, encoding="utf-8") as fin:
+    with Path(wells_out).open(encoding="utf-8") as fin:
         output = fin.readlines()
 
     for idx, line in enumerate(output):
@@ -135,12 +135,12 @@ def test_render_multiple_input(change_to_tmpdir):
 
     wells_north = {f"PROD{idx:d}": 0.2 * idx for idx in range(1, 5)}
     wells_north_in = "well_drill_north.json"
-    with open(wells_north_in, "w", encoding="utf-8") as fout:
+    with Path(wells_north_in).open("w", encoding="utf-8") as fout:
         json.dump(wells_north, fout)
 
     wells_south = {f"PROD{idx:d}": 1 - 0.2 * idx for idx in range(1, 5)}
     wells_south_in = "well_drill_south.json"
-    with open(wells_south_in, "w", encoding="utf-8") as fout:
+    with Path(wells_south_in).open("w", encoding="utf-8") as fout:
         json.dump(wells_south, fout)
 
     wells_out = "sub_folder/wells.out"

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -57,14 +57,14 @@ def test_show_scaled_controls_warning_user_info_file_present(
 
     user_info = {EVEREST: {"show_scaling_warning": existing_value}}
 
-    with open(".ert", "w", encoding="utf-8") as f:
+    with Path(".ert").open("w", encoding="utf-8") as f:
         json.dump(user_info, f)
     if user_reply.lower() == "n":
         with pytest.raises(SystemExit):
             show_scaled_controls_warning()
     else:
         show_scaled_controls_warning()
-    with open(".ert", encoding="utf-8") as f:
+    with Path(".ert").open(encoding="utf-8") as f:
         user_info = json.load(f)
     assert user_info.get(EVEREST).get("show_scaling_warning") == result
 
@@ -96,7 +96,7 @@ def test_show_scaled_controls_warning_no_user_info_file_present(
 
     assert Path(".ert").exists()
 
-    with open(".ert", encoding="utf-8") as f:
+    with Path(".ert").open(encoding="utf-8") as f:
         user_info = json.load(f)
 
     assert user_info.get(EVEREST), "Expected everest key"
@@ -124,7 +124,7 @@ def test_show_scaled_controls_warning_error_reading_from_user_info(
 
     with (
         pytest.raises(json.decoder.JSONDecodeError),
-        open(".ert", encoding="utf-8") as f,
+        Path(".ert").open(encoding="utf-8") as f,
     ):
         json.load(f)
 
@@ -134,7 +134,7 @@ def test_show_scaled_controls_warning_error_reading_from_user_info(
     elif user_reply.lower() == "y":
         show_scaled_controls_warning()
 
-        with open(".ert", encoding="utf-8") as f:
+        with Path(".ert").open(encoding="utf-8") as f:
             user_info = json.load(f)
         assert user_info.get(EVEREST).get("show_scaling_warning") == result
     else:
@@ -189,7 +189,7 @@ def test_show_scaled_controls_warning_preserves_extra_keys(
         "ert": {"test_key": 42},
     }
 
-    with open(".ert", "w", encoding="utf-8") as f:
+    with Path(".ert").open("w", encoding="utf-8") as f:
         json.dump(user_info, f)
 
     if user_reply.lower() == "n":
@@ -198,7 +198,7 @@ def test_show_scaled_controls_warning_preserves_extra_keys(
     else:
         show_scaled_controls_warning()
 
-    with open(".ert", encoding="utf-8") as f:
+    with Path(".ert").open(encoding="utf-8") as f:
         user_info = json.load(f)
     assert user_info.get(EVEREST).get("show_scaling_warning") == result
     assert user_info.get("ert").get("test_key") == 42

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -1,5 +1,4 @@
 import json
-import os.path
 from pathlib import Path
 
 import pytest
@@ -159,7 +158,7 @@ def test_show_scaled_controls_warning_error_writing_user_info(
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     Path(".ert").touch()
-    os.chmod(Path(".ert"), 0o444)
+    Path(".ert").chmod(0o444)
     if user_reply.lower() == "n":
         with pytest.raises(SystemExit):
             show_scaled_controls_warning()

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -51,7 +51,7 @@ def test_get_values(change_to_tmpdir):
 def test_show_scaled_controls_warning_user_info_file_present(
     change_to_tmpdir, monkeypatch, user_reply, existing_value, result
 ):
-    monkeypatch.setenv("HOME", os.getcwd())
+    monkeypatch.setenv("HOME", Path.cwd())
     if existing_value:
         monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
@@ -83,7 +83,7 @@ def test_show_scaled_controls_warning_user_info_file_present(
 def test_show_scaled_controls_warning_no_user_info_file_present(
     change_to_tmpdir, monkeypatch, user_reply, result
 ):
-    monkeypatch.setenv("HOME", os.getcwd())
+    monkeypatch.setenv("HOME", Path.cwd())
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     assert not Path(".ert").exists()
@@ -117,7 +117,7 @@ def test_show_scaled_controls_warning_no_user_info_file_present(
 def test_show_scaled_controls_warning_error_reading_from_user_info(
     change_to_tmpdir, monkeypatch, user_reply, result
 ):
-    monkeypatch.setenv("HOME", os.getcwd())
+    monkeypatch.setenv("HOME", Path.cwd())
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     Path(".ert").write_text("{ not valid json ", encoding="utf-8")
@@ -155,7 +155,7 @@ def test_show_scaled_controls_warning_error_reading_from_user_info(
 def test_show_scaled_controls_warning_error_writing_user_info(
     change_to_tmpdir, monkeypatch, user_reply
 ):
-    monkeypatch.setenv("HOME", os.getcwd())
+    monkeypatch.setenv("HOME", Path.cwd())
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     Path(".ert").touch()
@@ -180,7 +180,7 @@ def test_show_scaled_controls_warning_error_writing_user_info(
 def test_show_scaled_controls_warning_preserves_extra_keys(
     change_to_tmpdir, monkeypatch, user_reply, existing_value, result
 ):
-    monkeypatch.setenv("HOME", os.getcwd())
+    monkeypatch.setenv("HOME", Path.cwd())
     if existing_value:
         monkeypatch.setattr("builtins.input", lambda _: user_reply)
 

--- a/tests/everest/test_wells.py
+++ b/tests/everest/test_wells.py
@@ -1,5 +1,6 @@
 import json
 from contextlib import ExitStack as does_not_raise
+from pathlib import Path
 
 import pytest
 
@@ -79,7 +80,7 @@ def test_well_config_to_wells_json(min_config, monkeypatch, tmp_path, config):
     for datafile, data in _get_internal_files(ever_config).items():
         datafile.parent.mkdir(exist_ok=True, parents=True)
         datafile.write_text(data, encoding="utf-8")
-    with open("everest_output/.internal_data/wells.json", encoding="utf-8") as fin:
+    with Path("everest_output/.internal_data/wells.json").open(encoding="utf-8") as fin:
         wells_json = json.load(fin)
     assert wells_json == config
 
@@ -106,7 +107,7 @@ def test_controls_config_to_wells_json(min_config, monkeypatch, tmp_path, variab
     for datafile, data in _get_internal_files(ever_config).items():
         datafile.parent.mkdir(exist_ok=True, parents=True)
         datafile.write_text(data, encoding="utf-8")
-    with open("everest_output/.internal_data/wells.json", encoding="utf-8") as fin:
+    with Path("everest_output/.internal_data/wells.json").open(encoding="utf-8") as fin:
         wells_json = json.load(fin)
     assert wells_json == [{"name": "test"}]
 


### PR DESCRIPTION
**Issue**
Resolve ruff PTH sub-rules

**Approach**
Automated ruff fixes as much as possible. 

Ruff chooses to import the entire `pathlib`, changed manually to only import `Path` from `pathlib`.

There are many possible refinements to the code to leverage `pathlib`, but want to leave that to future PRs. 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [x] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
