### PR TITLE
Everest Gradient Histogram and temp fix of Everest plots

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -77,43 +77,37 @@ class EverestGradientsPlot:
         combined = pd.concat(all_frames)
         batch_ids = sorted(combined["batch_id"].unique())
 
-        pos = np.arange(len(self.selected_controls))  # one position per control
-        n_batches = len(batch_ids)
-        bar_width = 0.8 / n_batches
+        pos = np.arange(len(batch_ids))
+        n_controls = len(self.selected_controls)
+        bar_width = 0.8 / n_controls
 
-        for i, batch_id in enumerate(batch_ids):
+        for i, control in enumerate(self.selected_controls):
             color = colors[i % len(colors)][0]
-            batch_data = combined[combined["batch_id"] == batch_id]
-
             values = []
-            for control in self.selected_controls:
+            for batch_id in batch_ids:
+                batch_data = combined[combined["batch_id"] == batch_id]
                 match = batch_data[batch_data["control_name"] == control]
                 values.append(match[response_key].values[0] if not match.empty else 0.0)
 
-            offsets = pos + (i - n_batches / 2) * bar_width + bar_width / 2
-            axes.bar(
+            offsets = pos + (i - n_controls / 2) * bar_width + bar_width / 2
+
+            bars = axes.bar(
                 offsets,
                 values,
                 width=bar_width,
                 color=color,
                 alpha=0.7,
-                label=f"Batch {batch_id}",
             )
+            config.addLegendItem(control, bars[0])
 
-        axes.legend()
-        figure.tight_layout()
-
-
-        axes.set_xticks(pos)
         rotation = 0
-        if len(self.selected_controls) > 3:
+        if len(batch_ids) > 3:
             rotation = 30
 
-        axes.set_xticklabels(self.selected_controls, rotation=rotation)
-        # Not sure if this is needed
+        axes.set_xticks(pos)
+        axes.set_xticklabels([str(b) for b in batch_ids], rotation=rotation)
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
 
-        
         PlotTools.finalizePlot(
-        plot_context, figure, axes, default_x_label="Control Variable", default_y_label="Gradient"
+            plot_context, figure, axes, default_x_label="Batch", default_y_label="Gradient"
         )

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -57,17 +57,16 @@ class EverestGradientsPlot:
         colors = config.lineColorCycle()
 
         # Collect all data into one frame
-        all_frames = []
-        for df in ensemble_to_data_map.values():
-            if (
-                not df.empty
-                and response_key in df.columns
-                and "control_name" in df.columns
-                and (
-                    filtered := df[df["control_name"].isin(self.selected_controls)]
-                ).shape[0]
-            ):
-                all_frames.append(filtered)
+        all_frames = [
+            filtered
+            for df in ensemble_to_data_map.values()
+            if not df.empty
+            and response_key in df.columns
+            and "control_name" in df.columns
+            and (filtered := df[df["control_name"].isin(self.selected_controls)]).shape[
+                0
+            ]
+        ]
 
         if not all_frames:
             axes.text(0.5, 0.5, "No data", ha="center", va="center")

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -35,8 +35,8 @@ class EverestGradientsPlot:
         obs_loc: npt.NDArray[np.float32] | None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
+        axes = figure.add_subplot(111)
         if not self.selected_controls:
-            axes = figure.add_subplot(111)
             axes.text(
                 0.5,
                 0.5,
@@ -47,7 +47,6 @@ class EverestGradientsPlot:
             return
 
         config = plot_context.plotConfig()
-        axes = figure.add_subplot(111)
 
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -100,12 +100,8 @@ class EverestGradientsPlot:
             )
             config.addLegendItem(control, bars[0])
 
-        rotation = 0
-        if len(batch_ids) > 3:
-            rotation = 30
-
         axes.set_xticks(pos)
-        axes.set_xticklabels([str(b) for b in batch_ids], rotation=rotation)
+        axes.set_xticklabels([str(b) for b in batch_ids], rotation=0)
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
 
         PlotTools.finalizePlot(

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -63,7 +63,9 @@ class EverestGradientsPlot:
                 not df.empty
                 and response_key in df.columns
                 and "control_name" in df.columns
-                and (filtered := df[df["control_name"].isin(self.selected_controls)]).shape[0]
+                and (
+                    filtered := df[df["control_name"].isin(self.selected_controls)]
+                ).shape[0]
             ):
                 all_frames.append(filtered)
 

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -109,5 +109,9 @@ class EverestGradientsPlot:
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
 
         PlotTools.finalizePlot(
-            plot_context, figure, axes, default_x_label="Batch", default_y_label="Gradient"
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Batch",
+            default_y_label="Gradient",
         )

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-
+import numpy as np
 import pandas as pd
 from matplotlib.ticker import MaxNLocator
+from .plot_tools import ConditionalAxisFormatter, PlotTools
 
 if TYPE_CHECKING:
     import numpy as np
@@ -34,8 +35,8 @@ class EverestGradientsPlot:
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         if not self.selected_controls:
-            ax = figure.add_subplot(111)
-            ax.text(
+            axes = figure.add_subplot(111)
+            axes.text(
                 0.5,
                 0.5,
                 "Select control(s) from the side panel to view gradients",
@@ -45,85 +46,74 @@ class EverestGradientsPlot:
             return
 
         config = plot_context.plotConfig()
-
-        n_controls = len(self.selected_controls)
-        axs = figure.subplots(n_controls, 1, sharex=True, squeeze=False)
+        axes = figure.add_subplot(111)
 
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS
         plot_context.deactivateDateSupport()
 
         response_key = key_def.key if key_def else "Response"
-        config.setTitle(f"Derivative of {response_key} wrt controls")
 
-        default_color = config.lineColorCycle()[0][0]
+        colors = config.lineColorCycle()
 
-        for i, control in enumerate(self.selected_controls):
-            ax = axs[i, 0]
-            ax.set_ylabel(control)
+        # Collect all data into one frame
+        all_frames = []
+        for df in ensemble_to_data_map.values():
+            if (
+                df.empty
+                or response_key not in df.columns
+                or "control_name" not in df.columns
+            ):
+                continue
+            filtered = df[df["control_name"].isin(self.selected_controls)]
 
-            ax.yaxis.grid(True, linestyle=":", linewidth=0.5, color="gray", alpha=0.5)
-            ax.xaxis.grid(False)
+            if not filtered.empty:
+                all_frames.append(filtered)
 
-            ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+        if not all_frames:
+            axes.text(0.5, 0.5, "No data", ha="center", va="center")
+            return
 
-            # (derivative is interesting to see go towards/away from 0)
-            # Hence thicker horizontal line at y=0
-            ax.axhline(0, color="black", linewidth=1.0, alpha=0.3)
+        combined = pd.concat(all_frames)
+        batch_ids = sorted(combined["batch_id"].unique())
 
-            ax.spines["top"].set_visible(False)
-            ax.spines["right"].set_visible(False)
+        pos = np.arange(len(self.selected_controls))  # one position per control
+        n_batches = len(batch_ids)
+        bar_width = 0.8 / n_batches
 
-            if i < n_controls - 1:
-                # Intermediate plots: thin gray line as separator
-                ax.spines["bottom"].set_visible(True)
-                ax.spines["bottom"].set_linewidth(0.5)
-                ax.spines["bottom"].set_color("lightgray")
-                ax.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
-            else:
-                ax.spines["bottom"].set_visible(True)
-                ax.tick_params(axis="x", which="both", bottom=True, labelbottom=True)
+        for i, batch_id in enumerate(batch_ids):
+            color = colors[i % len(colors)][0]
+            batch_data = combined[combined["batch_id"] == batch_id]
 
-            # For normalizing y-axis across controls
-            max_abs_val = 0.0
+            values = []
+            for control in self.selected_controls:
+                match = batch_data[batch_data["control_name"] == control]
+                values.append(match[response_key].values[0] if not match.empty else 0.0)
 
-            data_frames = []
-            for df in ensemble_to_data_map.values():
-                if (
-                    df.empty
-                    or response_key not in df.columns
-                    or "control_name" not in df.columns
-                ):
-                    continue
+            offsets = pos + (i - n_batches / 2) * bar_width + bar_width / 2
+            axes.bar(
+                offsets,
+                values,
+                width=bar_width,
+                color=color,
+                alpha=0.7,
+                label=f"Batch {batch_id}",
+            )
 
-                control_data = df[df["control_name"] == control]
-                if not control_data.empty:
-                    data_frames.append(control_data)
+        axes.legend()
+        figure.tight_layout()
 
-            if data_frames:
-                r_data = pd.concat(data_frames).sort_values("batch_id")
 
-                current_max_abs = r_data[response_key].abs().max()
-                max_abs_val = max(max_abs_val, current_max_abs)
+        axes.set_xticks(pos)
+        rotation = 0
+        if len(self.selected_controls) > 3:
+            rotation = 30
 
-                ax.plot(
-                    r_data["batch_id"].to_numpy(),
-                    r_data[response_key].to_numpy(),
-                    "-o",
-                    markersize=5,
-                    linewidth=2,
-                    color=default_color,
-                    markerfacecolor=default_color,
-                )
+        axes.set_xticklabels(self.selected_controls, rotation=rotation)
+        # Not sure if this is needed
+        axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
 
-                if max_abs_val > 0:
-                    limit = max_abs_val * 1.1  # Add some padding
-                    ax.set_ylim(-limit, limit)
-            else:
-                ax.text(0.5, 0.5, "No data", ha="center", va="center")
-
-        axs[-1, 0].set_xlabel("Iteration")
-
-        # Adjust layout to remove gaps if removing spines looks like 'sparklines'
-        figure.subplots_adjust(hspace=0.0)
-        figure.suptitle(f"Derivative of {response_key} wrt controls")
+        
+        PlotTools.finalizePlot(
+        plot_context, figure, axes, default_x_label="Control Variable", default_y_label="Gradient"
+        )

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
-from matplotlib.ticker import MaxNLocator
+
 from .plot_tools import ConditionalAxisFormatter, PlotTools
 
 if TYPE_CHECKING:
@@ -87,7 +88,9 @@ class EverestGradientsPlot:
             for batch_id in batch_ids:
                 batch_data = combined[combined["batch_id"] == batch_id]
                 match = batch_data[batch_data["control_name"] == control]
-                values.append(match[response_key].values[0] if not match.empty else 0.0)
+                values.append(
+                    match[response_key].to_numpy()[0] if not match.empty else 0.0
+                )
 
             offsets = pos + (i - n_controls / 2) * bar_width + bar_width / 2
 
@@ -99,7 +102,7 @@ class EverestGradientsPlot:
                 alpha=0.7,
             )
             config.addLegendItem(control, bars[0])
-
+        axes.axhline(0, color="black", linewidth=1.0, alpha=0.3)
         axes.set_xticks(pos)
         axes.set_xticklabels([str(b) for b in batch_ids], rotation=0)
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -60,14 +60,11 @@ class EverestGradientsPlot:
         all_frames = []
         for df in ensemble_to_data_map.values():
             if (
-                df.empty
-                or response_key not in df.columns
-                or "control_name" not in df.columns
+                not df.empty
+                and response_key in df.columns
+                and "control_name" in df.columns
+                and (filtered := df[df["control_name"].isin(self.selected_controls)]).shape[0]
             ):
-                continue
-            filtered = df[df["control_name"].isin(self.selected_controls)]
-
-            if not filtered.empty:
                 all_frames.append(filtered)
 
         if not all_frames:

--- a/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
@@ -82,9 +82,7 @@ class ValuesOverIterationsPlot:
             colors = [
                 "red" if not row.is_improvement else color for _, row in data.iterrows()
             ]
-            scatter = axes.scatter(
-                data["batch_id"], data[value_col], c=colors, s=20, zorder=5
-            )
+            axes.scatter(data["batch_id"], data[value_col], c=colors, s=20, zorder=5)
 
             config.addLegendItem("Accepted", lines[0])
             config.addLegendItem(
@@ -113,7 +111,8 @@ class ValuesOverIterationsPlot:
 
         realizations = sorted(combined["realization"].unique())
 
-        # This loop is the reason batch controls plot multiple identical plots for each realization.
+        # This loop is the reason batch controls
+        # plot multiple identical plots for each realization.
         for realization in realizations:
             data = combined[combined["realization"] == realization].sort_values(
                 "batch_id"

--- a/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from matplotlib.lines import Line2D
 from matplotlib.ticker import MaxNLocator
+
 from .plot_tools import PlotTools
 
 if TYPE_CHECKING:

--- a/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/values_over_iteration_plot.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from matplotlib.lines import Line2D
 from matplotlib.ticker import MaxNLocator
+from .plot_tools import PlotTools
 
 if TYPE_CHECKING:
     import numpy as np
@@ -69,46 +70,38 @@ class ValuesOverIterationsPlot:
             data = combined.sort_values("batch_id")
 
             color = config.nextColor()
-            axes.plot(
-                data["batch_id"],
-                data[value_col],
+            improvement_data = data[data["is_improvement"]]
+
+            lines = axes.plot(
+                improvement_data["batch_id"],
+                improvement_data[value_col],
                 "-",
                 color=color,
-                label=key_def.key if key_def else value_col,
             )
 
             colors = [
                 "red" if not row.is_improvement else color for _, row in data.iterrows()
             ]
-            axes.scatter(data["batch_id"], data[value_col], c=colors, s=20, zorder=5)
+            scatter = axes.scatter(
+                data["batch_id"], data[value_col], c=colors, s=20, zorder=5
+            )
 
-            axes.set_xlabel("Iteration")
-            axes.set_ylabel(value_col)
+            config.addLegendItem("Accepted", lines[0])
+            config.addLegendItem(
+                "Rejected",
+                Line2D(
+                    [0], [0], marker="o", color="w", markerfacecolor="red", markersize=8
+                ),
+            )
             axes.xaxis.set_major_locator(MaxNLocator(integer=True))
 
-            legend_elements = [
-                Line2D(
-                    [0],
-                    [0],
-                    marker="o",
-                    color="w",
-                    label="Accepted",
-                    markerfacecolor=color,
-                    markersize=8,
-                ),
-                Line2D(
-                    [0],
-                    [0],
-                    marker="o",
-                    color="w",
-                    label="Rejected",
-                    markerfacecolor="red",
-                    markersize=8,
-                ),
-            ]
-            axes.legend(handles=legend_elements, loc="best")
-
-            axes.grid(True)
+            PlotTools.finalizePlot(
+                plot_context,
+                figure,
+                axes,
+                default_x_label="Iteration",
+                default_y_label="Value",
+            )
             figure.tight_layout()
             return
 
@@ -120,6 +113,7 @@ class ValuesOverIterationsPlot:
 
         realizations = sorted(combined["realization"].unique())
 
+        # This loop is the reason batch controls plot multiple identical plots for each realization.
         for realization in realizations:
             data = combined[combined["realization"] == realization].sort_values(
                 "batch_id"
@@ -128,19 +122,21 @@ class ValuesOverIterationsPlot:
                 continue
 
             color = config.nextColor()
-            axes.plot(
+            lines = axes.plot(
                 data["batch_id"],
                 data[value_col],
                 "-o",
-                label=f"Realization {int(realization)}",
                 color=color,
                 markersize=4,
             )
+            config.addLegendItem(f"Realization {int(realization)}", lines[0])
 
-        axes.set_xlabel("Iteration")
-        axes.set_ylabel(value_col)
-        axes.legend(title="Realization")
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
-
-        axes.grid(True)
+        PlotTools.finalizePlot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Iteration",
+            default_y_label="Value",
+        )
         figure.tight_layout()


### PR DESCRIPTION
**Issue**
Resolves #13142 
Resolves #13119 
Resolves #13118
 
**Approach**
<img width="971" height="684" alt="image" src="https://github.com/user-attachments/assets/5c12d265-ff38-4b1a-9254-29c05c141ec8" />

- Changed Everest Gradient to be a single histogram rather than multiple line plots. Grouped by control variables as discussed in #13142 . 

<img width="973" height="687" alt="image" src="https://github.com/user-attachments/assets/194c6ba8-c0bc-4138-a9bf-3810b487a5cd" />

- Split the data in `ValuesOverIterationsPlot` during the `is_improvement` condition, so that the line is only on the "accepted" batches. 

<img width="973" height="684" alt="image" src="https://github.com/user-attachments/assets/3122e6b8-3be3-4091-bfa8-0a337e54e517" />

- Removed in-plot customization in the Everest plots and incorporated `PlotTools.finalizePlot()` so that grid, legend, title and axis can be customized. This matches the approach of Ert plots more closely. 
 
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
