### PR TITLE
Fix gaussian_kde plotter trying to plot non-numeric data

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
+++ b/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
@@ -60,7 +60,7 @@ def plotGaussianKDE(
         strict=False,
     ):
         config.setCurrentColor(color_index)
-        if data.empty:
+        if data.empty or not pd.api.types.is_numeric_dtype(data[0]):
             continue
         if not _array_is_constant(data[0]):
             _plotGaussianKDE(

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from matplotlib.figure import Figure
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
@@ -12,6 +13,8 @@ from ert.config.gen_kw_config import DataSource, GenKwConfig
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
 from ert.gui.tools.plot.plot_widget import PlotWidget
 from ert.gui.tools.plot.plot_window import PlotWindow, create_error_dialog
+from ert.gui.tools.plot.plottery import PlotConfig, PlotContext
+from ert.gui.tools.plot.plottery.plots.gaussian_kde import plotGaussianKDE
 from ert.services import ErtServerController
 
 
@@ -218,3 +221,27 @@ def test_that_plot_window_ignores_negative_check_for_non_numeric_columns(
 
     # This is the call that previously crashed with TypeError.
     plot_window.updatePlot()
+
+
+def test_that_gaussian_kde_plot_skips_categorical_data_without_raising():
+
+    ensemble = EnsembleObject(
+        "ensemble",
+        "ensemble",
+        False,
+        "experiment",
+        "2026-01-01T00:00:00",
+    )
+    categorical_df = pd.DataFrame({0: ["cat", "dog", "fish"], 1: [12, 12, 12]})
+
+    fig = Figure()
+    ctx = PlotContext(
+        PlotConfig(),
+        ensembles=[ensemble],
+        ensembles_color_indexes=[0],
+        key="animal_type",
+        layer=None,
+    )
+
+    # Should not raise (categorical data is simply skipped).
+    plotGaussianKDE(fig, ctx, {ensemble: categorical_df}, _observation_data=None)


### PR DESCRIPTION
**Issue**
Resolves #13163


**Approach**
This fixes the bug where it would crash with `unsupported operand type(s) for -: 'str' and 'str'`

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
