### PR TITLE
Fix test_create_run_path_performance benchmark

### DIFF
--- a/tests/ert/performance_tests/test_create_run_path_performance.py
+++ b/tests/ert/performance_tests/test_create_run_path_performance.py
@@ -1,3 +1,4 @@
+import asyncio
 import itertools
 import threading
 
@@ -56,7 +57,7 @@ from ert.storage import open_storage
         ),
     ],
 )
-async def test_create_run_path_load_scalar_keys_performance(
+def test_create_run_path_load_scalar_keys_performance(
     benchmark, tmp_path, distribution_settings
 ):
     reals = 100
@@ -118,10 +119,10 @@ async def test_create_run_path_load_scalar_keys_performance(
                 runpaths=runpaths,
             )
 
-        benchmark(run)
+        benchmark(lambda: asyncio.run(run()))
 
 
-async def test_create_run_path_surface_performance(tmp_path, benchmark):
+def test_create_run_path_surface_performance(tmp_path, benchmark):
     storage_path = tmp_path / "storage"
     reals = 2
     num_surfaces = 2
@@ -190,4 +191,4 @@ async def test_create_run_path_surface_performance(tmp_path, benchmark):
                 runpaths=runpaths,
             )
 
-        await benchmark(run)
+        benchmark(lambda: asyncio.run(run()))


### PR DESCRIPTION
We use pytest-benchmark for benchmarking our code, but it does not support running async functions. This commit changes the benchmark function to run asyncio.run(run()) instead of awaiting run() directly.

**Issue**
Benchmarking async functions with pytest-benchmark is not supported directly (https://github.com/ionelmc/pytest-benchmark/issues/66)

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
