### PR TITLE
Add per-parameter timing to update status messages

### DIFF
--- a/src/ert/analysis/_update_strategies/_adaptive.py
+++ b/src/ert/analysis/_update_strategies/_adaptive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, TypeVar
 
@@ -201,12 +202,16 @@ class AdaptiveLocalizationUpdate:
         num_params = param_ensemble.shape[0]
         batch_size = _calculate_adaptive_batch_size(num_params, self._num_obs)
         batches = _split_by_batchsize(np.arange(0, num_params), batch_size)
+        num_batches = len(batches)
 
+        batch_info = f" and {num_batches} batches" if num_batches > 1 else ""
         self._progress_callback(
             AnalysisStatusEvent(
-                msg=f"Running adaptive localization on {num_params} parameters, "
-                f"{self._num_obs} responses, {self._ensemble_size} realizations "
-                f"and {len(batches)} batches"
+                msg=f"Updating {param_config.name} ({param_config.type.upper()}) "
+                f"using adaptive localization, "
+                f"{self._num_obs} observations, "
+                f"{self._ensemble_size} realizations"
+                f"{batch_info}"
             )
         )
 
@@ -215,6 +220,7 @@ class AdaptiveLocalizationUpdate:
         ) -> TimedIterator[T]:
             return TimedIterator(iterable, self._progress_callback)
 
+        start_time = time.perf_counter()
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
             X_local = param_ensemble[update_idx, :]
@@ -231,5 +237,13 @@ class AdaptiveLocalizationUpdate:
                 progress_callback=progress_callback_wrapper,
                 n_jobs=NUM_JOBS_ADAPTIVE_LOC,
             )
+        elapsed = time.perf_counter() - start_time
+
+        self._progress_callback(
+            AnalysisStatusEvent(
+                msg=f"Updated {param_config.name} ({param_config.type.upper()}) "
+                f"in {elapsed:.2f}s"
+            )
+        )
 
         return param_ensemble

--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -65,22 +66,30 @@ class DistanceLocalizationUpdate:
         if self._obs_loc is None or self._smoother is None:
             raise RuntimeError("prepare() must be called before update()")
 
-        param_type_name = self._param_type.__name__
         self._progress_callback(
             AnalysisStatusEvent(
-                msg=f"Running distance localization on {param_type_name}"
-                f" with {param_ensemble.shape[0]} parameters,"
-                f" {self._obs_loc.xpos.shape[0]} observations,"
-                f" {self._ensemble_size} realizations"
+                msg=f"Updating {param_config.name} ({param_config.type.upper()}) "
+                f"using distance-based localization, "
+                f"{self._obs_loc.xpos.shape[0]} observations, "
+                f"{self._ensemble_size} realizations"
             )
         )
 
+        start_time = time.perf_counter()
         if self._param_type is Field:
             assert isinstance(param_config, Field)
             result = self._update_field(param_ensemble, param_config)
         else:
             assert isinstance(param_config, SurfaceConfig)
             result = self._update_surface(param_ensemble, param_config)
+        elapsed = time.perf_counter() - start_time
+
+        self._progress_callback(
+            AnalysisStatusEvent(
+                msg=f"Updated {param_config.name} ({param_config.type.upper()}) "
+                f"in {elapsed:.2f}s"
+            )
+        )
 
         return result
 

--- a/src/ert/analysis/_update_strategies/_standard.py
+++ b/src/ert/analysis/_update_strategies/_standard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -138,11 +139,22 @@ class StandardESUpdate:
 
         self._progress_callback(
             AnalysisStatusEvent(
-                msg=f"There are {self._num_obs} responses "
-                f"and {self._ensemble_size} realizations."
+                msg=f"Updating {param_config.name} ({param_config.type.upper()}) "
+                f"without localization, "
+                f"{self._num_obs} observations, "
+                f"{self._ensemble_size} realizations"
             )
         )
 
+        start_time = time.perf_counter()
         param_ensemble[non_zero_variance_mask] @= self._T.astype(param_ensemble.dtype)
+        elapsed = time.perf_counter() - start_time
+
+        self._progress_callback(
+            AnalysisStatusEvent(
+                msg=f"Updated {param_config.name} ({param_config.type.upper()}) "
+                f"in {elapsed:.2f}s"
+            )
+        )
 
         return param_ensemble

--- a/src/ert/gui/experiments/view/update.py
+++ b/src/ert/gui/experiments/view/update.py
@@ -5,7 +5,6 @@ import time
 from datetime import timedelta
 
 import humanize
-from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QColor, QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import (
@@ -15,13 +14,12 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
-    QListWidget,
-    QListWidgetItem,
     QMessageBox,
     QProgressBar,
     QTableWidget,
     QTableWidgetItem,
     QTabWidget,
+    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -159,8 +157,8 @@ class UpdateWidget(QWidget):
         msg_layout = QHBoxLayout()
         widget.setLayout(msg_layout)
 
-        self._msg_list = QListWidget()
-        self._msg_list.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        self._msg_list = QTextEdit()
+        self._msg_list.setReadOnly(True)
 
         msg_layout.addWidget(self._msg_list)
 
@@ -188,10 +186,10 @@ class UpdateWidget(QWidget):
         return self._iteration
 
     def _insert_status_message(self, message: str) -> None:
-        item = QListWidgetItem()
-        item.setText(message)
-        item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
-        self._msg_list.addItem(item)
+        if message.startswith("Updated "):
+            self._msg_list.append(f'<span style="color: gray;">{message}</span>')
+        else:
+            self._msg_list.append(message)
 
     def _insert_table_tab(
         self,

--- a/tests/ert/ui_tests/gui/test_update_runs.py
+++ b/tests/ert/ui_tests/gui/test_update_runs.py
@@ -4,7 +4,7 @@ import shutil
 import polars as pl
 import pytest
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QComboBox, QListWidget
+from PyQt6.QtWidgets import QComboBox, QTextEdit
 
 from ert.gui.experiments import ExperimentPanel
 from ert.gui.experiments.run_dialog import RunDialog
@@ -137,14 +137,11 @@ def test_that_report_table_is_displayed_on_no_active_observations(
     assert update_widget._tab_widget.tabText(0) == "Status"
     assert update_widget._tab_widget.tabText(1) == "Report"
 
-    status_list = update_widget._tab_widget.widget(0).findChild(QListWidget)
+    status_text = update_widget._tab_widget.widget(0).findChild(QTextEdit)
 
-    count = sum(
-        1
-        for i in range(status_list.count())
-        if "No active observations for update step" in status_list.item(i).text()
-    )
-    assert count == 1, "message is expected to appear just once on the list"
+    content = status_text.toPlainText()
+    count = content.count("No active observations for update step")
+    assert count == 1, "message is expected to appear just once"
 
 
 @pytest.fixture


### PR DESCRIPTION
Show parameter name, type, and localization strategy in analysis status messages for all three update strategies. Report elapsed time after each parameter group update.

Replace QListWidget with QTextEdit in the status tab to support styled text and allow copy-paste of messages. Render completion messages in gray to visually distinguish them from in-progress status lines.

**new:**

<img width="3224" height="2118" alt="image" src="https://github.com/user-attachments/assets/1bac0afd-2acb-4f1c-9cc9-1171705ae758" />

**old:**

<img width="3224" height="2118" alt="image" src="https://github.com/user-attachments/assets/e085a086-4e98-4af0-b16d-648068c95389" />

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
