### PR TITLE
Fix flaky does not hang test

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -9,6 +9,7 @@ from _ert.events import (
     ForwardModelStepSuccess,
     dispatcher_event_from_json,
 )
+from _ert.forward_model_runner.client import ClientConnectionError
 from _ert.forward_model_runner.forward_model_step import ForwardModelStep
 from _ert.forward_model_runner.reporting import Event
 from _ert.forward_model_runner.reporting.message import (
@@ -254,14 +255,19 @@ def test_event_reporter_does_not_hang_after_failed(
             {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
         )
 
-        reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
-        reporter.report(Start(fmstep1))
+        errored = False
         # May raise ClientConnectionError if connection retries already finished
         # in which case reporter._reporter_exception is set
-        if not reporter._reporter_exception:
+        try:
+            reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
+            reporter.report(Start(fmstep1))
             reporter.report(Finish())
+        except ClientConnectionError:
+            errored = True
 
         reporter._event_publisher_thread.join(timeout=10)
         assert not reporter._event_publisher_thread.is_alive(), (
             "Event publisher thread is hanging"
         )
+        if not errored:
+            assert expected_message in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #13110 


**Approach**
:brain: 

The test sometimes crashes with a connection error rather than having to join the thread. This is unproblematic as all we want is for the runner to not hang. 

This change removes the check for set exception, which could result in a race condition and rather just catches the exception.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
