### PR TITLE
Introduce shape registry for observation geometry

### DIFF
--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -1,4 +1,5 @@
 from ._observations import Observation
+from ._shapes import CircleShapeConfig, ShapeConfig, ShapeRegistry
 from .analysis_config import (
     AnalysisConfig,
     ObservationGroups,
@@ -83,6 +84,7 @@ __all__ = [
     "AnalysisModule",
     "BaseErtScriptWorkflow",
     "BreakthroughConfig",
+    "CircleShapeConfig",
     "ConfigValidationError",
     "ConfigWarning",
     "DataSource",
@@ -140,6 +142,8 @@ __all__ = [
     "RFTConfig",
     "ResponseConfig",
     "SamplerConfig",
+    "ShapeConfig",
+    "ShapeRegistry",
     "SiteInstalledForwardModelStep",
     "SiteOrUserForwardModelStep",
     "SummaryConfig",

--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -8,23 +8,21 @@ from typing import assert_never
 import polars as pl
 
 from ._observations import (
-    DEFAULT_LOCALIZATION_RADIUS,
     BreakthroughObservation,
     GeneralObservation,
     Observation,
     RFTObservation,
     SummaryObservation,
 )
-from .parsing import (
-    ErrorInfo,
-    ObservationConfigError,
-)
+from ._shapes import CircleShapeConfig, ShapeRegistry
+from .parsing import ErrorInfo, ObservationConfigError
 from .rft_config import Point, RFTConfig, ZoneName
 
 
 def create_observation_dataframes(
     observations: Sequence[Observation],
     rft_config: RFTConfig | None,
+    shape_registry: ShapeRegistry | None = None,
 ) -> dict[str, pl.DataFrame]:
     if not observations:
         return {}
@@ -39,6 +37,7 @@ def create_observation_dataframes(
                         _handle_summary_observation(
                             obs,
                             obs.name,
+                            shape_registry,
                         )
                     )
                 case GeneralObservation():
@@ -54,11 +53,19 @@ def create_observation_dataframes(
                             "create_observation_dataframes requires "
                             "rft_config is not None when using RFTObservation"
                         )
-                    grouped["rft"].append(_handle_rft_observation(rft_config, obs))
+                    if shape_registry is None:
+                        raise TypeError(
+                            "create_observation_dataframes requires "
+                            "shape_registry is not None when using RFTObservation"
+                        )
+                    grouped["rft"].append(
+                        _handle_rft_observation(rft_config, obs, shape_registry)
+                    )
                 case BreakthroughObservation():
                     grouped["breakthrough"].append(
                         _handle_breakthrough_observation(
                             obs,
+                            shape_registry,
                         )
                     )
                 case default:
@@ -82,24 +89,24 @@ def create_observation_dataframes(
     return datasets
 
 
-def _has_localization(summary_dict: SummaryObservation) -> bool:
-    return summary_dict.east is not None and summary_dict.north is not None
-
-
 def _handle_summary_observation(
     summary_dict: SummaryObservation,
     obs_key: str,
+    shape_registry: ShapeRegistry | None = None,
 ) -> pl.DataFrame:
     summary_key = summary_dict.key
     value = summary_dict.value
     std_dev = summary_dict.error
     date = datetime.datetime.fromisoformat(summary_dict.date)
 
-    localization_radius = (
-        summary_dict.radius or DEFAULT_LOCALIZATION_RADIUS
-        if _has_localization(summary_dict)
-        else None
-    )
+    east = None
+    north = None
+    radius = None
+    shape = summary_dict.shape(shape_registry) if shape_registry is not None else None
+    if shape is not None and isinstance(shape, CircleShapeConfig):
+        east = shape.east
+        north = shape.north
+        radius = shape.radius
 
     return pl.DataFrame(
         {
@@ -108,9 +115,9 @@ def _handle_summary_observation(
             "time": pl.Series([date]).dt.cast_time_unit("ms"),
             "observations": pl.Series([value], dtype=pl.Float32),
             "std": pl.Series([std_dev], dtype=pl.Float32),
-            "east": pl.Series([summary_dict.east], dtype=pl.Float32),
-            "north": pl.Series([summary_dict.north], dtype=pl.Float32),
-            "radius": pl.Series([localization_radius], dtype=pl.Float32),
+            "east": pl.Series([east], dtype=pl.Float32),
+            "north": pl.Series([north], dtype=pl.Float32),
+            "radius": pl.Series([radius], dtype=pl.Float32),
         }
     )
 
@@ -122,6 +129,9 @@ def _handle_general_observation(
     response_key = general_observation.data
     restart = general_observation.restart
 
+    east = None
+    north = None
+    radius = None
     if general_observation.error <= 0:
         raise ObservationConfigError.with_context(
             "Observation uncertainty must be strictly > 0", obs_key
@@ -135,9 +145,9 @@ def _handle_general_observation(
             "index": pl.Series([general_observation.index], dtype=pl.UInt16),
             "observations": pl.Series([general_observation.value], dtype=pl.Float32),
             "std": pl.Series([general_observation.error], dtype=pl.Float32),
-            "east": pl.Series([general_observation.east], dtype=pl.Float32),
-            "north": pl.Series([general_observation.north], dtype=pl.Float32),
-            "radius": pl.Series([general_observation.radius], dtype=pl.Float32),
+            "east": pl.Series([east], dtype=pl.Float32),
+            "north": pl.Series([north], dtype=pl.Float32),
+            "radius": pl.Series([radius], dtype=pl.Float32),
         }
     )
 
@@ -145,9 +155,16 @@ def _handle_general_observation(
 def _handle_rft_observation(
     rft_config: RFTConfig,
     rft_observation: RFTObservation,
+    shape_registry: ShapeRegistry,
 ) -> pl.DataFrame:
     location = (rft_observation.east, rft_observation.north, rft_observation.tvd)
-    localization_radius = rft_observation.radius
+    localization_radius = None
+    shape = rft_observation.shape(shape_registry)
+    localization_radius = (
+        shape.radius
+        if shape is not None and isinstance(shape, CircleShapeConfig)
+        else None
+    )
 
     location_arg: Point | tuple[Point, ZoneName] = location
     if (zone := rft_observation.zone) is not None:
@@ -189,16 +206,23 @@ def _handle_rft_observation(
             "zone": pl.Series([rft_observation.zone], dtype=pl.String),
             "observations": pl.Series([rft_observation.value], dtype=pl.Float32),
             "std": pl.Series([rft_observation.error], dtype=pl.Float32),
-            "radius": pl.Series(
-                [localization_radius or DEFAULT_LOCALIZATION_RADIUS], dtype=pl.Float32
-            ),
+            "radius": pl.Series([localization_radius], dtype=pl.Float32),
         }
     )
 
 
 def _handle_breakthrough_observation(
     obs_config: BreakthroughObservation,
+    shape_registry: ShapeRegistry | None = None,
 ) -> pl.DataFrame:
+    east = None
+    north = None
+    radius = None
+    shape = obs_config.shape(shape_registry) if shape_registry is not None else None
+    if shape is not None and isinstance(shape, CircleShapeConfig):
+        east = shape.east
+        north = shape.north
+        radius = shape.radius
     return pl.DataFrame(
         {
             "observation_key": obs_config.name,
@@ -207,8 +231,8 @@ def _handle_breakthrough_observation(
             "observations": pl.Series([0], dtype=pl.Float32),
             "threshold": obs_config.threshold,
             "std": pl.Series([obs_config.error], dtype=pl.Float32),
-            "east": pl.Series([obs_config.east], dtype=pl.Float32),
-            "north": pl.Series([obs_config.north], dtype=pl.Float32),
-            "radius": pl.Series([obs_config.radius], dtype=pl.Float32),
+            "east": pl.Series([east], dtype=pl.Float32),
+            "north": pl.Series([north], dtype=pl.Float32),
+            "radius": pl.Series([radius], dtype=pl.Float32),
         }
     )

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from ert.validation import rangestring_to_list
 
+from ._shapes import CircleShapeConfig, ShapeConfig, ShapeRegistry
 from .parsing import (
     ConfigWarning,
     ErrorInfo,
@@ -40,9 +41,7 @@ class _SummaryValues(BaseModel):
     error: float
     key: str  #: The :term:`summary key` in the summary response
     date: str
-    east: float | None = None
-    north: float | None = None
-    radius: float | None = None
+    shape_id: int | None = None
 
 
 def _parse_date(date_str: str) -> datetime:
@@ -68,7 +67,10 @@ def _parse_date(date_str: str) -> datetime:
 class SummaryObservation(_SummaryValues):
     @classmethod
     def from_obs_dict(
-        cls, directory: str, observation_dict: ObservationDict
+        cls,
+        directory: str,
+        observation_dict: ObservationDict,
+        shape_registry: ShapeRegistry,
     ) -> list[Self]:
         error_mode = ErrorModes.ABS
         summary_key = None
@@ -144,14 +146,24 @@ class SummaryObservation(_SummaryValues):
             case default:
                 assert_never(default)
 
+        # Register geometry if localization is present
+        shape_id = None
+        if east is not None and north is not None:
+            radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+            shape_id = shape_registry.register(
+                CircleShapeConfig(
+                    east=east,
+                    north=north,
+                    radius=radius,
+                )
+            )
+
         obs_instance = cls(
             name=observation_dict["name"],
             error=error,
             key=summary_key,
             value=value,
-            east=east,
-            north=north,
-            radius=radius,
+            shape_id=shape_id,
             date=standardized_date,
         )
         # Bypass pydantic discarding context
@@ -160,6 +172,11 @@ class SummaryObservation(_SummaryValues):
         obs_instance.name = observation_dict["name"]
 
         return [obs_instance]
+
+    def shape(self, shape_registry: ShapeRegistry) -> ShapeConfig | None:
+        if self.shape_id is not None:
+            return shape_registry.get(self.shape_id)
+        return None
 
 
 class _GeneralObservation(BaseModel):
@@ -170,15 +187,16 @@ class _GeneralObservation(BaseModel):
     error: float
     restart: int
     index: int
-    east: float | None = None
-    north: float | None = None
-    radius: float | None = None
+    shape_id: int | None = None
 
 
 class GeneralObservation(_GeneralObservation):
     @classmethod
     def from_obs_dict(
-        cls, directory: str, observation_dict: ObservationDict
+        cls,
+        directory: str,
+        observation_dict: ObservationDict,
+        shape_registry: ShapeRegistry,
     ) -> list[Self]:
         try:
             data = observation_dict["DATA"]
@@ -265,6 +283,7 @@ class GeneralObservation(_GeneralObservation):
                 ),
                 restart=restart,
                 index=0,
+                shape_id=None,
             )
             # Bypass pydantic discarding context
             # only relevant for ERT config surfacing validation errors
@@ -324,6 +343,7 @@ class GeneralObservation(_GeneralObservation):
                 error=float(std),
                 restart=restart,
                 index=int(idx),
+                shape_id=None,
             )
             # Bypass pydantic discarding context
             # only relevant for ERT config surfacing validation errors
@@ -331,6 +351,10 @@ class GeneralObservation(_GeneralObservation):
             inst.name = observation_dict["name"]
             obs_instances.append(inst)
         return obs_instances
+
+    def shape(self, shape_registry: ShapeRegistry) -> ShapeConfig | None:
+        # General observations do not support localization
+        return None
 
 
 class RFTObservation(BaseModel):
@@ -347,11 +371,11 @@ class RFTObservation(BaseModel):
     property: str
     value: float
     error: float
-    north: float
     east: float
+    north: float
     tvd: float
     md: float | None = None
-    radius: float | None
+    shape_id: int | None = None
     zone: str | None = None
 
     @classmethod
@@ -360,6 +384,7 @@ class RFTObservation(BaseModel):
         directory: str,
         observation_dict: ObservationDict,
         filename: str,
+        shape_registry: ShapeRegistry,
         observed_property: str = "PRESSURE",
         radius: float | None = None,
     ) -> list[Self]:
@@ -418,6 +443,18 @@ class RFTObservation(BaseModel):
         rft_observations = []
         invalid_observations = []
         for row in csv_file.itertuples(index=True):
+            east_val = validate_float(str(row.EAST), "EAST")
+            north_val = validate_float(str(row.NORTH), "NORTH")
+            radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+
+            shape_id = shape_registry.register(
+                CircleShapeConfig(
+                    east=east_val,
+                    north=north_val,
+                    radius=radius,
+                )
+            )
+
             rft_observation = cls(
                 name=f"{observation_dict['name']}[{row.Index}]",
                 well=str(row.WELL_NAME),
@@ -427,12 +464,16 @@ class RFTObservation(BaseModel):
                     str(getattr(row, observed_property)), observed_property
                 ),
                 error=validate_float(str(row.ERROR), "ERROR"),
-                north=validate_float(str(row.NORTH), "NORTH"),
-                east=validate_float(str(row.EAST), "EAST"),
-                radius=radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS,
+                east=east_val,
+                north=north_val,
+                shape_id=shape_id,
                 tvd=validate_float(str(row.TVD), "TVD"),
                 md=validate_float(str(row.MD), "MD") if "MD" in csv_file else None,
-                zone=row.ZONE if "ZONE" in csv_file else None,
+                zone=(
+                    str(row.ZONE)
+                    if "ZONE" in csv_file and row.ZONE is not None
+                    else None
+                ),
             )
             # A value of -1 and error of 0 is used by fmu.tools.rms create_rft_ertobs to
             # indicate missing data. If encountered in an rft observations csv file
@@ -461,7 +502,10 @@ class RFTObservation(BaseModel):
 
     @classmethod
     def from_obs_dict(
-        cls, directory: str, observation_dict: ObservationDict
+        cls,
+        directory: str,
+        observation_dict: ObservationDict,
+        shape_registry: ShapeRegistry,
     ) -> list[Self]:
         """Create RFT observations from an observation dictionary.
 
@@ -473,6 +517,7 @@ class RFTObservation(BaseModel):
         Args:
             directory: Base directory for resolving relative file paths.
             observation_dict: Dictionary containing the observation configuration.
+            shape_registry: ShapeRegistry for storing geometry.
 
         Returns:
             List of RFTObservation instances. Returns multiple observations when
@@ -522,6 +567,9 @@ class RFTObservation(BaseModel):
                 case "LOCALIZATION":
                     validate_rft_localization(value, observation_dict["name"])
                     east, north, radius = extract_localization_values(value)
+                    radius = (
+                        radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+                    )
                 case _:
                     raise _unknown_key_error(str(key), observation_dict["name"])
         if csv_filename is not None:
@@ -529,6 +577,7 @@ class RFTObservation(BaseModel):
                 directory,
                 observation_dict,
                 csv_filename,
+                shape_registry,
                 observed_property or "PRESSURE",
                 radius=radius,
             )
@@ -548,6 +597,16 @@ class RFTObservation(BaseModel):
             raise _missing_value_error(observation_dict["name"], "EAST")
         if tvd is None:
             raise _missing_value_error(observation_dict["name"], "TVD")
+
+        radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+        shape_id = shape_registry.register(
+            CircleShapeConfig(
+                east=east,
+                north=north,
+                radius=radius,
+            )
+        )
+
         obs_instance = cls(
             name=observation_dict["name"],
             well=well,
@@ -560,7 +619,7 @@ class RFTObservation(BaseModel):
             tvd=tvd,
             md=md,
             zone=zone,
-            radius=radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS,
+            shape_id=shape_id,
         )
 
         # Bypass pydantic discarding context
@@ -570,6 +629,11 @@ class RFTObservation(BaseModel):
 
         return [obs_instance]
 
+    def shape(self, shape_registry: ShapeRegistry) -> ShapeConfig | None:
+        if self.shape_id is not None:
+            return shape_registry.get(self.shape_id)
+        return None
+
 
 class BreakthroughObservation(BaseModel):
     type: Literal["breakthrough"] = "breakthrough"
@@ -578,12 +642,15 @@ class BreakthroughObservation(BaseModel):
     date: datetime
     error: float
     threshold: float
-    north: float | None
-    east: float | None
-    radius: float | None
+    shape_id: int | None = None
 
     @classmethod
-    def from_obs_dict(cls, directory: str, obs_dict: ObservationDict) -> list[Self]:
+    def from_obs_dict(
+        cls,
+        directory: str,
+        obs_dict: ObservationDict,
+        shape_registry: ShapeRegistry,
+    ) -> list[Self]:
         summary_key = None
         date = None
         error = None
@@ -618,6 +685,18 @@ class BreakthroughObservation(BaseModel):
         if threshold is None:
             raise _missing_value_error(obs_dict["name"], "THRESHOLD")
 
+        # Register shape if localization is present
+        shape_id = None
+        if east is not None and north is not None:
+            radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+            shape_id = shape_registry.register(
+                CircleShapeConfig(
+                    east=east,
+                    north=north,
+                    radius=radius,
+                )
+            )
+
         return [
             cls(
                 name=obs_dict["name"],
@@ -625,11 +704,14 @@ class BreakthroughObservation(BaseModel):
                 date=date,
                 error=error,
                 threshold=threshold,
-                north=north,
-                east=east,
-                radius=radius,
+                shape_id=shape_id,
             )
         ]
+
+    def shape(self, shape_registry: ShapeRegistry) -> ShapeConfig | None:
+        if self.shape_id is not None:
+            return shape_registry.get(self.shape_id)
+        return None
 
 
 Observation = Annotated[
@@ -653,14 +735,18 @@ LOCALIZATION_KEYS = Literal["east", "north", "radius"]
 
 
 def make_observations(
-    directory: str, observation_dicts: Sequence[ObservationDict]
+    directory: str,
+    observation_dicts: Sequence[ObservationDict],
+    shape_registry: ShapeRegistry,
 ) -> list[Observation]:
     """Takes observation dicts and returns validated observations.
 
     Param:
         directory: The name of the directory the observation config is located in.
             Used to disambiguate relative paths.
-        inp: The collection of statements to validate.
+        observation_dicts: The collection of observation dictionaries to validate.
+        shape_registry: ShapeRegistry for storing localization geometries.
+
     """
     result: list[Observation] = []
     error_list: list[ErrorInfo | ObservationConfigError] = []
@@ -677,7 +763,9 @@ def make_observations(
             continue
         try:
             result.extend(
-                _TYPE_TO_CLASS[obs_dict["type"]].from_obs_dict(directory, obs_dict)
+                _TYPE_TO_CLASS[obs_dict["type"]].from_obs_dict(
+                    directory, obs_dict, shape_registry=shape_registry
+                )
             )
         except KeyError as err:
             raise _unknown_observation_type_error(obs_dict) from err

--- a/src/ert/config/_shapes.py
+++ b/src/ert/config/_shapes.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ShapeConfig(BaseModel):
+    """Base class for all shape configurations models for observations."""
+
+    shape_id: int | None = None
+
+
+class CircleShapeConfig(ShapeConfig):
+    """Configuration for a circular (point-based) shape.
+
+    Attributes:
+        shape_id: Unique identifier for this shape, if registered.
+        east: X-coordinate of the circle center (meters).
+        north: Y-coordinate of the circle center (meters).
+        radius: Radius of localization in meters.
+    """
+
+    type: Literal["circle"] = "circle"
+    east: float
+    north: float
+    radius: float
+
+    def __eq__(self, other: object) -> bool:
+        """Compare two CircleShapeConfig instances by geometry."""
+        if not isinstance(other, CircleShapeConfig):
+            return False
+        return (
+            self.east == other.east
+            and self.north == other.north
+            and self.radius == other.radius
+        )
+
+
+Shape = Annotated[CircleShapeConfig, Field(discriminator="type")]
+
+
+class ShapeRegistry(BaseModel):
+    """Registry for reusable shape configurations.
+
+    Resolves identical geometries and assigns unique shape IDs.
+
+    Attributes:
+        shapes: Mapping from shape_id to ShapeConfig (serialized).
+    """
+
+    shapes: dict[int, Shape] = Field(default_factory=dict)
+
+    def register(self, shape: ShapeConfig) -> int:
+        """Register or find an existing shape.
+
+        Checks if a shape with identical geometry already exists.
+        If so, returns its shape_id. Otherwise, stores a copy with a new ID and
+        returns that ID.
+
+        Args:
+            shape: Shape configuration to register. The input shape may have
+                ``shape_id=None`` and will be copied with the assigned ID.
+
+        Returns:
+            Unique shape_id for this geometry.
+        """
+
+        if not isinstance(shape, CircleShapeConfig):
+            msg = f"Unsupported shape config type: {type(shape).__name__}"
+            raise TypeError(msg)
+
+        # Check for existing shape with same geometry
+        for existing_id, existing_shape in self.shapes.items():
+            if shape == existing_shape:
+                return existing_id
+
+        new_id = max(self.shapes.keys(), default=-1) + 1
+        self.shapes[new_id] = shape.model_copy(update={"shape_id": new_id})
+        return new_id
+
+    def get(self, shape_id: int) -> Shape | None:
+        """Retrieve a shape by its ID.
+
+        Args:
+            shape_id: The shape identifier.
+
+        Returns:
+            The ShapeConfig if found, None otherwise.
+        """
+        return self.shapes.get(shape_id)

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -29,6 +29,7 @@ from ._observations import (
     SummaryObservation,
     make_observations,
 )
+from ._shapes import ShapeRegistry
 from .analysis_config import AnalysisConfig
 from .breakthrough_config import BreakthroughConfig
 from .ensemble_config import EnsembleConfig
@@ -570,9 +571,11 @@ def workflows_from_dict(
 ]:
     workflow_jobs = workflow_jobs_from_dict(
         content_dict,
-        dict(copy.copy(site_installed_workflows_jobs))
-        if site_installed_workflows_jobs
-        else {},
+        (
+            dict(copy.copy(site_installed_workflows_jobs))
+            if site_installed_workflows_jobs
+            else {}
+        ),
     )
     workflows, hooked_workflows = create_and_hook_workflows(
         content_dict.get(ConfigKeys.HOOK_WORKFLOW, []),
@@ -817,6 +820,7 @@ class ErtConfig(BaseModel):
     random_seed_generator: RandomSeedGenerator = Field(
         default_factory=RandomSeedGenerator
     )
+    shape_registry: ShapeRegistry = Field(default_factory=ShapeRegistry)
 
     @model_validator(mode="after")
     def set_fields(self) -> Self:
@@ -1067,6 +1071,7 @@ class ErtConfig(BaseModel):
 
         obs_config_args = config_dict.get(ConfigKeys.OBS_CONFIG)
         obs_configs: list[Observation] = []
+        shape_registry = ShapeRegistry()
         try:
             if obs_config_args:
                 obs_config_file, obs_config_input = obs_config_args
@@ -1074,6 +1079,7 @@ class ErtConfig(BaseModel):
                 obs_configs = make_observations(
                     os.path.dirname(obs_config_file),
                     obs_config_input,
+                    shape_registry=shape_registry,
                 )
                 if not obs_configs:
                     raise ObservationConfigError.with_context(
@@ -1197,6 +1203,7 @@ class ErtConfig(BaseModel):
                 user_config_file=config_file_path,
                 observation_declarations=list(obs_configs),
                 zonemap=zonemap,
+                shape_registry=shape_registry,
             )
 
             # The observations are created here because create_observation_dataframes
@@ -1236,8 +1243,11 @@ class ErtConfig(BaseModel):
             # This mutates the rft config and is necessary for the moment
             # Consider changing this pattern
             _ = create_observation_dataframes(
-                obs_configs,
-                cast(RFTConfig | None, ensemble_config.response_configs.get("rft")),
+                observations=obs_configs,
+                rft_config=cast(
+                    RFTConfig | None, ensemble_config.response_configs.get("rft")
+                ),
+                shape_registry=shape_registry,
             )
 
             cls_config.random_seed_generator.user_defined_seed = config_dict.get(

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -221,6 +221,7 @@ class StorageWidget(QWidget):
                             ],
                             "ert_templates": self._ert_config.ert_templates,
                             "experiment_type": ExperimentType.MANUAL,
+                            "shape_registry": self._ert_config.shape_registry,
                         },
                         name=create_experiment_dialog.experiment_name,
                     ).create_ensemble(

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -37,6 +37,7 @@ from ert.config import (
     KnownQueueOptionsAdapter,
     QueueConfig,
     ResponseConfig,
+    ShapeRegistry,
     SummaryConfig,
     WorkflowJob,
 )
@@ -557,6 +558,8 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
             queue_config=queue_config,
             status_queue=status_queue,
             optimization_callback=optimization_callback,
+            shape_registry=ShapeRegistry(),  # this one is not expected to be used,
+            # but is needed for the observation localization
         )
 
     @property

--- a/src/ert/run_models/initial_ensemble_run_model.py
+++ b/src/ert/run_models/initial_ensemble_run_model.py
@@ -117,7 +117,11 @@ class InitialEnsembleRunModel(RunModel, InitialEnsembleRunModelConfig):
             None,
         )
 
+        shape_registry = self._storage.get_experiment_by_name(
+            self.experiment_name
+        ).shape_registry
         return create_observation_dataframes(
             observations=self.observations,
             rft_config=rft_config,
+            shape_registry=shape_registry,
         )

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -155,6 +155,7 @@ def _setup_single_test_run(
         storage_path=config.ens_path,
         queue_config=config.queue_config.create_local_copy(),
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
 
     return SingleTestRun(
@@ -215,6 +216,7 @@ def _setup_ensemble_experiment(
         storage_path=config.ens_path,
         queue_config=config.queue_config,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
 
     return EnsembleExperiment(
@@ -246,6 +248,7 @@ def _setup_evaluate_ensemble(
         substitutions=config.substitutions,
         hooked_workflows=config.hooked_workflows,
         log_path=config.analysis_config.log_path,
+        shape_registry=config.shape_registry,
     )
     return EvaluateEnsemble(**runmodel_config.model_dump(), status_queue=status_queue)
 
@@ -308,6 +311,7 @@ def _setup_manual_update(
         log_path=config.analysis_config.log_path,
         ert_templates=config.ert_templates,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
     return ManualUpdate(**runmodel_config.model_dump(), status_queue=status_queue)
 
@@ -347,6 +351,7 @@ def _setup_manual_update_enif(
         hooked_workflows=config.hooked_workflows,
         log_path=config.analysis_config.log_path,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
 
 
@@ -394,6 +399,7 @@ def _setup_ensemble_smoother(
         hooked_workflows=config.hooked_workflows,
         log_path=config.analysis_config.log_path,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
     return EnsembleSmoother(**runmodel_config.model_dump(), status_queue=status_queue)
 
@@ -441,6 +447,7 @@ def _setup_ensemble_information_filter(
         hooked_workflows=config.hooked_workflows,
         log_path=config.analysis_config.log_path,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
     return EnsembleInformationFilter(
         **runmodel_config.model_dump(), status_queue=status_queue
@@ -514,6 +521,7 @@ def _setup_multiple_data_assimilation(
         hooked_workflows=config.hooked_workflows,
         log_path=config.analysis_config.log_path,
         observations=config.observation_declarations,
+        shape_registry=config.shape_registry,
     )
     return MultipleDataAssimilation(
         **runmodel_config.model_dump(), status_queue=status_queue

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -48,6 +48,7 @@ from ert.config import (
     PostSimulationFixtures,
     PreSimulationFixtures,
     QueueConfig,
+    ShapeRegistry,
     SiteOrUserForwardModelStep,
     UserInstalledForwardModelStep,
     Workflow,
@@ -175,6 +176,7 @@ class RunModelConfig(BaseModelWithContextSupport):
     env_pr_fm_step: dict[str, dict[str, Any]]
     runpath_config: ModelConfig
     queue_config: QueueConfig
+    shape_registry: ShapeRegistry
     forward_model_steps: list[SiteOrUserForwardModelStep]
     substitutions: dict[str, str]
     hooked_workflows: defaultdict[HookRuntime, list[Workflow]]

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -26,12 +26,11 @@ from ert.config import (
     KnownResponseTypes,
     ParameterConfig,
     ResponseConfig,
+    ShapeRegistry,
     SurfaceConfig,
 )
 from ert.config import Field as FieldConfig
-from ert.config._create_observation_dataframes import (
-    create_observation_dataframes,
-)
+from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config._observations import Observation
 
 from .mode import BaseMode, Mode, require_write
@@ -190,7 +189,15 @@ class LocalExperiment(BaseMode):
                 obs_adapter.validate_python(od) for od in observation_declarations
             ]
 
-            datasets = create_observation_dataframes(obs_objs, rft_config)
+            shape_registry_data = experiment_config.get("shape_registry")
+            shape_registry = (
+                ShapeRegistry.model_validate(shape_registry_data)
+                if shape_registry_data
+                else ShapeRegistry()
+            )
+            datasets = create_observation_dataframes(
+                obs_objs, rft_config, shape_registry
+            )
             for response_type, df in datasets.items():
                 storage._to_parquet_transaction(output_path / response_type, df)
 
@@ -301,6 +308,16 @@ class LocalExperiment(BaseMode):
     @property
     def mount_point(self) -> Path:
         return self._path
+
+    @property
+    def shape_registry(self) -> ShapeRegistry:
+        shape_registry_data = self.experiment_config.get("shape_registry")
+        shape_registry = (
+            ShapeRegistry.model_validate(shape_registry_data)
+            if shape_registry_data
+            else ShapeRegistry()
+        )
+        return shape_registry
 
     @property
     def parameter_info(self) -> dict[str, Any]:
@@ -455,7 +472,7 @@ class LocalExperiment(BaseMode):
             obs_adapter.validate_python(od) for od in serialized_observations
         ]
 
-        datasets = create_observation_dataframes(obs_objs, rft_cfg)
+        datasets = create_observation_dataframes(obs_objs, rft_cfg, self.shape_registry)
         for response_type, df in datasets.items():
             self._storage._to_parquet_transaction(output_path / response_type, df)
 

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 26
+_LOCAL_STORAGE_VERSION = 27
 
 
 class _Migrations(BaseModel):
@@ -516,6 +516,7 @@ class LocalStorage(BaseMode):
             to24,
             to25,
             to26,
+            to27,
         )
 
         try:
@@ -571,6 +572,7 @@ class LocalStorage(BaseMode):
                     23: to24,
                     24: to25,
                     25: to26,
+                    26: to27,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to27.py
+++ b/src/ert/storage/migration/to27.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LOCALIZATION_RADIUS = 2000
+
+info = "Migrate observation localization (east/north/radius) into ShapeRegistry"
+
+
+def _register_shape(
+    shapes: dict[int, dict[str, Any]],
+    east: float,
+    north: float,
+    radius: float,
+) -> int:
+
+    for existing_id, existing_shape in shapes.items():
+        if (
+            existing_shape["east"] == east
+            and existing_shape["north"] == north
+            and existing_shape["radius"] == radius
+        ):
+            return existing_id
+
+    new_id = max(shapes.keys(), default=-1) + 1
+    shape = {
+        "type": "circle",
+        "east": east,
+        "north": north,
+        "radius": radius,
+        "shape_id": new_id,
+    }
+    shapes[new_id] = shape
+    return new_id
+
+
+def _migrate_observations(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
+        return
+
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
+            continue
+
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
+            continue
+
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+        observations = experiment_data.get("observations", [])
+
+        shapes: dict[int, dict[str, Any]] = {}
+
+        for obs in observations:
+            obs_type = obs.get("type")
+
+            if obs_type in {"summary_observation", "breakthrough"}:
+                east = obs.get("east")
+                north = obs.get("north")
+                if east is not None and north is not None:
+                    radius = obs.get("radius")
+                    radius = (
+                        radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+                    )
+                    shape_id = _register_shape(shapes, east, north, radius)
+                    obs["shape_id"] = shape_id
+                    obs.pop("east", None)
+                    obs.pop("north", None)
+                    obs.pop("radius", None)
+                else:
+                    obs.setdefault("shape_id", None)
+
+            elif obs_type == "rft_observation":
+                east = obs.get("east")
+                north = obs.get("north")
+                if east is not None and north is not None:
+                    radius = obs.pop("radius", None)
+                    radius = (
+                        radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+                    )
+                    shape_id = _register_shape(shapes, east, north, radius)
+                    obs["shape_id"] = shape_id
+                else:
+                    obs.setdefault("shape_id", None)
+
+            elif obs_type == "general_observation":
+                obs.setdefault("shape_id", None)
+
+        experiment_data["shape_registry"] = {"shapes": shapes}
+        index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+
+
+def migrate(path: Path) -> None:
+    _migrate_observations(path)

--- a/tests/ert/unit_tests/cli/test_model_hook_order.py
+++ b/tests/ert/unit_tests/cli/test_model_hook_order.py
@@ -18,6 +18,7 @@ from ert.config import (
     PreSimulationFixtures,
     PreUpdateFixtures,
     QueueConfig,
+    ShapeRegistry,
     fixtures_per_hook,
 )
 from ert.run_models import (
@@ -143,6 +144,7 @@ def test_hook_call_order(monkeypatch, use_tmpdir, cls, extra_args, expected_call
         log_path=Path(""),
         status_queue=queue.SimpleQueue(),
         observations=[],
+        shape_registry=ShapeRegistry(),
     )
 
     test_class.run_ensemble_evaluator = MagicMock(return_value=[0])

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2829,6 +2829,7 @@ def test_that_breakthrough_observations_can_be_internalized_in_ert_config():
     breakthrough_observations = create_observation_dataframes(
         config.observation_declarations,
         None,
+        config.shape_registry,
     )["breakthrough"]
     assert breakthrough_observations["observation_key"].to_list() == ["BRT_OBS"]
     assert breakthrough_observations["response_key"].to_list() == [

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -19,6 +19,7 @@ from ert.config._observations import (
     SummaryObservation,
     make_observations,
 )
+from ert.config._shapes import CircleShapeConfig, ShapeRegistry
 from ert.config.observation_config_migrations import HistoryObservation
 from ert.config.parsing import parse_observations
 from ert.config.parsing.observations_parser import (
@@ -32,8 +33,11 @@ observation_contents = stlark.from_lark(observations_parser)
 
 
 def make_and_parse_observations(contents, filename):
+    registry = ShapeRegistry()
     return make_observations(
-        os.path.dirname(filename), parse_observations(contents, filename)
+        os.path.dirname(filename),
+        parse_observations(contents, filename),
+        shape_registry=registry,
     )
 
 
@@ -147,7 +151,9 @@ def test_that_make_observations_migrates_observations():
     # Re-parse the migrated obs_config and build the observation objects
     migrated_contents = Path("obs_config").read_text(encoding="utf8")
     parsed = parse_observations(migrated_contents, "obs_config")
-    observations = make_observations(os.path.dirname("obs_config"), parsed)
+    observations = make_observations(
+        os.path.dirname("obs_config"), parsed, ShapeRegistry()
+    )
 
     # Validate migrated observations contain expected entries and values
     names = [getattr(o, "name", None) for o in observations]
@@ -186,7 +192,8 @@ def test_that_make_observations_migrates_observations():
 
 
 def test_rft_observation_declaration():
-    assert make_observations(
+    shape_registry = ShapeRegistry()
+    obs = make_observations(
         "",
         [
             {
@@ -202,7 +209,9 @@ def test_rft_observation_declaration():
                 "TVD": 2000,
             }
         ],
-    ) == [
+        shape_registry=shape_registry,
+    )
+    assert obs == [
         RFTObservation(
             name="NAME",
             well="well",
@@ -212,10 +221,15 @@ def test_rft_observation_declaration():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
+            shape_id=0,  # the first registered shape gets id 0
         )
     ]
+    shape = obs[0].shape(shape_registry)
+    assert isinstance(shape, CircleShapeConfig)
+    assert math.isclose(shape.east, 30.0)
+    assert math.isclose(shape.north, 71.0)
+    assert shape.radius == DEFAULT_LOCALIZATION_RADIUS
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -230,7 +244,8 @@ def test_rft_observation_csv_declaration():
         ),
         encoding="utf8",
     )
-    assert make_observations(
+    shape_registry = ShapeRegistry()
+    obs = make_observations(
         "",
         [
             {
@@ -239,7 +254,9 @@ def test_rft_observation_csv_declaration():
                 "CSV": "rft_observations.csv",
             }
         ],
-    ) == [
+        shape_registry=shape_registry,
+    )
+    assert obs == [
         RFTObservation(
             name="NAME[0]",
             well="WELL1",
@@ -249,10 +266,10 @@ def test_rft_observation_csv_declaration():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
             md=2500.0,
             zone="zone1",
+            shape_id=0,  # the first registered shape gets id 0
         ),
         RFTObservation(
             name="NAME[1]",
@@ -263,12 +280,23 @@ def test_rft_observation_csv_declaration():
             property="PRESSURE",
             north=72.0,
             east=31.0,
-            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2100.0,
             md=2600.0,
             zone="zone2",
+            shape_id=1,  # the second registered shape gets id 1
         ),
     ]
+    shape = obs[0].shape(shape_registry)
+    assert isinstance(shape, CircleShapeConfig)
+    assert math.isclose(shape.east, 30.0)
+    assert math.isclose(shape.north, 71.0)
+    assert shape.radius == DEFAULT_LOCALIZATION_RADIUS
+
+    shape = obs[1].shape(shape_registry)
+    assert isinstance(shape, CircleShapeConfig)
+    assert math.isclose(shape.east, 31.0)
+    assert math.isclose(shape.north, 72.0)
+    assert shape.radius == DEFAULT_LOCALIZATION_RADIUS
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -282,7 +310,8 @@ def test_that_rft_csv_without_radius_column_gets_defaulted():
         ),
         encoding="utf8",
     )
-    assert make_observations(
+    shape_registry = ShapeRegistry()
+    obs = make_observations(
         "",
         [
             {
@@ -291,7 +320,9 @@ def test_that_rft_csv_without_radius_column_gets_defaulted():
                 "CSV": "rft_observations.csv",
             }
         ],
-    ) == [
+        shape_registry=shape_registry,
+    )
+    assert obs == [
         RFTObservation(
             name="NAME[0]",
             well="WELL1",
@@ -301,12 +332,15 @@ def test_that_rft_csv_without_radius_column_gets_defaulted():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
             md=2500.0,
             zone="zone1",
+            shape_id=0,  # the first registered shape gets id 0
         ),
     ]
+    shape = obs[0].shape(shape_registry)
+    assert isinstance(shape, CircleShapeConfig)
+    assert shape.radius == DEFAULT_LOCALIZATION_RADIUS
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -325,6 +359,7 @@ def test_that_rft_observations_from_csv_with_no_rows_after_header_returns_empty_
                     "CSV": "rft_observations.csv",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
         == []
     )
@@ -357,6 +392,7 @@ def test_that_observation_type_rft_is_compatible_with_create_rft_ertobs_handling
                     "CSV": "rft_observations.csv",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
     assert dedent(
         """
@@ -389,6 +425,7 @@ def test_that_invalid_numeric_values_in_rft_observations_csv_raises_error():
                     "CSV": "rft_observations.csv",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
 
     assert (
@@ -409,6 +446,7 @@ def test_that_non_existent_rft_observations_csv_file_raises_error():
                     "CSV": "rft_observations.csv",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
 
     assert (
@@ -428,7 +466,8 @@ def test_that_property_can_be_specified_for_rft_observation_csv_declaration():
         ),
         encoding="utf8",
     )
-    assert make_observations(
+    shape_registry = ShapeRegistry()
+    obs = make_observations(
         "",
         [
             {
@@ -438,7 +477,9 @@ def test_that_property_can_be_specified_for_rft_observation_csv_declaration():
                 "PROPERTY": "SWAT",
             }
         ],
-    ) == [
+        shape_registry=shape_registry,
+    )
+    assert obs == [
         RFTObservation(
             name="NAME[0]",
             well="WELL1",
@@ -450,8 +491,8 @@ def test_that_property_can_be_specified_for_rft_observation_csv_declaration():
             east=30.0,
             tvd=2000.0,
             md=2500.0,
-            radius=DEFAULT_LOCALIZATION_RADIUS,
             zone="zone1",
+            shape_id=0,  # the first registered shape gets id 0
         )
     ]
 
@@ -478,6 +519,7 @@ def test_that_missing_user_specified_property_raises_error():
                     "PROPERTY": "SWAT",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
 
     assert (
@@ -507,6 +549,7 @@ def test_that_missing_columns_in_rft_observations_file_raises_error():
                     "CSV": "rft_observations.csv",
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
 
     assert (
@@ -562,16 +605,17 @@ def test_that_breakthrough_observation_can_be_instantiated_from_config():
 
     Path("obs_config.txt").write_text(obs_config_str, encoding="utf8")
     parsed_obs_dict = parse_observations(obs_config_str, "obs_config.txt")
-    brt_obs = BreakthroughObservation.from_obs_dict("", parsed_obs_dict[0]).pop()
+    shape_registry = ShapeRegistry()
+    brt_obs = BreakthroughObservation.from_obs_dict(
+        "", parsed_obs_dict[0], shape_registry=shape_registry
+    ).pop()
     assert brt_obs.type == "breakthrough"
     assert brt_obs.name == "name"
     assert brt_obs.key == "WWCT:OP_1"
     assert brt_obs.date == datetime.fromisoformat("2012-10-01")
     assert brt_obs.error == 3
     assert math.isclose(brt_obs.threshold, 0.1)
-    assert brt_obs.east is None
-    assert brt_obs.north is None
-    assert brt_obs.radius is None
+    assert brt_obs.shape_id is None
 
 
 @pytest.mark.parametrize("missing_keyword", ["KEY", "DATE", "ERROR", "THRESHOLD"])
@@ -594,10 +638,13 @@ def test_that_breakthrough_observation_raises_error_when_missing_required_keywor
     obs_config_str = "\n".join(obs_config_lines)
     Path("obs_config.txt").write_text(obs_config_str, encoding="utf8")
     parsed_obs_dict = parse_observations(obs_config_str, "obs_config.txt")
+    shape_registry = ShapeRegistry()
     with pytest.raises(
         ObservationConfigError, match=f'Missing item "{missing_keyword}" in BRT_OBS'
     ):
-        BreakthroughObservation.from_obs_dict("", parsed_obs_dict[0])
+        BreakthroughObservation.from_obs_dict(
+            "", parsed_obs_dict[0], shape_registry=shape_registry
+        )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -618,10 +665,17 @@ def test_that_breakthrough_observation_can_be_instantiated_with_localization():
 
     Path("obs_config.txt").write_text(obs_config_str, encoding="utf8")
     parsed_obs_dict = parse_observations(obs_config_str, "obs_config.txt")
-    brt_obs = BreakthroughObservation.from_obs_dict("", parsed_obs_dict[0]).pop()
-    assert brt_obs.east == 10
-    assert brt_obs.north == 20
-    assert brt_obs.radius == 2500
+    shape_registry = ShapeRegistry()
+    brt_obs = BreakthroughObservation.from_obs_dict(
+        "", parsed_obs_dict[0], shape_registry=shape_registry
+    ).pop()
+    assert brt_obs.shape_id is not None
+    shape = brt_obs.shape(shape_registry)
+    assert isinstance(shape, CircleShapeConfig)
+    assert shape is not None
+    assert math.isclose(shape.east, 10)
+    assert math.isclose(shape.north, 20)
+    assert math.isclose(shape.radius, 2500)
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -658,6 +712,7 @@ def test_that_rft_observation_raises_error_given_north_or_east_keys_in_config():
                     },
                 }
             ],
+            shape_registry=ShapeRegistry(),
         )
 
 
@@ -674,6 +729,7 @@ def test_that_rft_observation_can_be_provided_radius_localization_keyword():
         encoding="utf8",
     )
 
+    shape_registry = ShapeRegistry()
     obss = make_observations(
         "",
         [
@@ -686,6 +742,33 @@ def test_that_rft_observation_can_be_provided_radius_localization_keyword():
                 },
             }
         ],
+        shape_registry=shape_registry,
     )
     for obs in obss:
-        assert obs.radius == 2500
+        assert obs.shape_id is not None
+        shape = obs.shape(shape_registry)
+        assert shape is not None
+        assert isinstance(shape, CircleShapeConfig)
+        assert math.isclose(shape.radius, 2500)
+
+
+def test_that_shape_registry_reuses_identical_circle_shapes():
+    shape_registry = ShapeRegistry()
+    shape_id_1 = shape_registry.register(
+        CircleShapeConfig(east=10.0, north=20.0, radius=2500.0)
+    )
+    shape_id_2 = shape_registry.register(
+        CircleShapeConfig(east=10.0, north=20.0, radius=2500.0)
+    )
+    assert shape_id_1 == shape_id_2
+
+
+def test_that_shape_registry_assigns_new_id_for_different_shapes():
+    shape_registry = ShapeRegistry()
+    shape_id_1 = shape_registry.register(
+        CircleShapeConfig(east=10.0, north=20.0, radius=2500.0)
+    )
+    shape_id_2 = shape_registry.register(
+        CircleShapeConfig(east=10.0, north=20.0, radius=3000.0)
+    )
+    assert shape_id_1 != shape_id_2

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -16,16 +16,13 @@ from resdata.summary import Summary
 from resfo_utilities.testing import summaries
 
 from ert.__main__ import run_convert_observations
-from ert.config import (
-    ConfigValidationError,
-    ConfigWarning,
-    ErtConfig,
-)
-from ert.config._create_observation_dataframes import (
+from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, ShapeRegistry
+from ert.config._create_observation_dataframes import create_observation_dataframes
+from ert.config._observations import (
     DEFAULT_LOCALIZATION_RADIUS,
-    create_observation_dataframes,
+    extract_localization_values,
+    make_observations,
 )
-from ert.config._observations import extract_localization_values, make_observations
 from ert.config.parsing import parse_observations
 from ert.config.parsing.observations_parser import (
     ObservationConfigError,
@@ -118,7 +115,9 @@ def make_refcase_observations(
     run_convert_observations(Namespace(config="config.ert"))
 
     migrated_config = ErtConfig.from_file("config.ert")
-    return create_observation_dataframes(migrated_config.observation_declarations, None)
+    return create_observation_dataframes(
+        migrated_config.observation_declarations, None, migrated_config.shape_registry
+    )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -173,10 +172,10 @@ def test_date_parsing_in_observations(datestring, errors):
     ]
     if errors:
         with pytest.raises(ValueError, match="Please use ISO date format"):
-            make_observations("", obs)
+            make_observations("", obs, ShapeRegistry())
     else:
         with pytest.warns(ConfigWarning, match="Please use ISO date format"):
-            make_observations("", obs)
+            make_observations("", obs, ShapeRegistry())
 
 
 def test_that_using_summary_observations_without_eclbase_shows_user_error():
@@ -244,7 +243,9 @@ def test_that_summary_observations_can_use_restart_for_index_if_refcase_is_given
 
         migrated_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            migrated_config.observation_declarations, None
+            migrated_config.observation_declarations,
+            None,
+            migrated_config.shape_registry,
         )["summary"]
 
         assert len(observations["time"]) == 1
@@ -297,7 +298,7 @@ def test_that_summary_observations_can_use_restart_for_index_if_time_map_is_give
 
     migrated_config = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        migrated_config.observation_declarations, None
+        migrated_config.observation_declarations, None, migrated_config.shape_registry
     )["summary"]
 
     # RESTART is a 1-based index; Python lists are 0-based.
@@ -329,7 +330,7 @@ def test_that_rft_config_is_created_from_observations():
     )
     rft_config = cast(RFTConfig, ert_config.ensemble_config.response_configs["rft"])
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, rft_config
+        ert_config.observation_declarations, rft_config, ert_config.shape_registry
     )["rft"]
     assert_frame_equal(
         observations,
@@ -386,7 +387,7 @@ def test_that_the_date_keyword_sets_the_summary_index_without_time_map_or_refcas
 
     migrated = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        migrated.observation_declarations, None
+        migrated.observation_declarations, None, migrated.shape_registry
     )["summary"]
 
     assert list(observations["time"]) == [datetime.fromisoformat(date)]
@@ -421,6 +422,7 @@ def test_that_general_observations_can_use_restart_even_without_refcase_and_time
     observations = create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )
 
     assert list(observations["gen_data"]["report_step"]) == [restart]
@@ -456,8 +458,9 @@ def test_that_the_date_keyword_sets_the_general_index_by_looking_up_time_map():
     Path("config.ert").write_text(config_content, encoding="utf-8")
 
     run_convert_observations(Namespace(config="config.ert"))
+    ert_config = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        ErtConfig.from_file("config.ert").observation_declarations, None
+        ert_config.observation_declarations, None, ert_config.shape_registry
     )
     assert observations["gen_data"].to_dicts()[0]["report_step"] == restart
 
@@ -524,8 +527,9 @@ def test_that_the_date_keyword_sets_the_report_step_by_looking_up_refcase(
         )
         Path("config.ert").write_text(config_content, encoding="utf-8")
         run_convert_observations(Namespace(config="config.ert"))
+        ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ErtConfig.from_file("config.ert").observation_declarations, None
+            ert_config.observation_declarations, None, ert_config.shape_registry
         )
         assert observations["gen_data"].to_dicts()[0]["report_step"] == restart
 
@@ -547,6 +551,7 @@ def test_that_error_must_be_greater_than_zero_in_summary_observations(std):
                     "ERROR": str(std),
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -568,6 +573,7 @@ def test_that_computed_error_must_be_greater_than_zero_in_summary_observations()
                     "ERROR_MODE": "REL",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -642,6 +648,7 @@ def test_that_error_must_be_greater_than_zero_in_general_observations(std):
                     "ERROR": str(std),
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -665,6 +672,7 @@ def test_that_all_errors_in_general_observations_must_be_greater_than_zero(tmpdi
                         "OBS_FILE": "obs_data.txt",
                     }
                 ],
+                ShapeRegistry(),
             )
 
 
@@ -756,10 +764,13 @@ def test_that_indices_from_file_and_list_are_read(tmpdir, indices_type, indices_
                     "OBS_FILE": "obs_data.txt",
                 }
             ],
+            ShapeRegistry(),
         )
+
         observations = create_observation_dataframes(
             observations=obs,
             rft_config=None,
+            shape_registry=None,
         )
         assert list(observations["gen_data"]["index"]) == [0, 2, 4, 6, 8]
 
@@ -812,6 +823,7 @@ def test_that_non_existent_obs_file_is_invalid():
                     "OBS_FILE": "does_not_exist/at_all",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -866,6 +878,7 @@ def test_that_general_observation_cannot_contain_both_value_and_obs_file():
                     "ERROR": "0.1",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -883,6 +896,7 @@ def test_that_general_observation_must_contain_either_value_or_obs_file():
                     "RESTART": "1",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -906,6 +920,7 @@ def test_that_non_numbers_in_obs_file_shows_informative_error_message(tmpdir):
                         "OBS_FILE": "obs_data.txt",
                     }
                 ],
+                ShapeRegistry(),
             )
 
 
@@ -929,6 +944,7 @@ def test_that_the_number_of_columns_in_obs_file_cannot_change():
                     "OBS_FILE": "obs_data.txt",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -949,6 +965,7 @@ def test_that_the_number_of_values_in_obs_file_must_be_even():
                     "OBS_FILE": "obs_data.txt",
                 }
             ],
+            ShapeRegistry(),
         )
 
 
@@ -973,6 +990,7 @@ def test_that_giving_both_index_file_and_index_list_raises_an_exception(tmpdir):
                         "ERROR": "0.1",
                     }
                 ],
+                ShapeRegistry(),
             )
 
 
@@ -1200,8 +1218,9 @@ def test_that_history_observations_values_are_fetched_from_refcase(
         Path("config.ert").write_text(config_content, encoding="utf-8")
 
         run_convert_observations(Namespace(config="config.ert"))
+        ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ErtConfig.from_file("config.ert").observation_declarations, None
+            ert_config.observation_declarations, None, ert_config.shape_registry
         )["summary"]
 
         steps = len(unsmry.steps)
@@ -1381,8 +1400,9 @@ def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
         Path("config.ert").write_text(config_content, encoding="utf-8")
 
         run_convert_observations(Namespace(config="config.ert"))
+        ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ErtConfig.from_file("config.ert").observation_declarations, None
+            ert_config.observation_declarations, None, ert_config.shape_registry
         )["summary"]
 
         assert list(observations["response_key"]) == ["FGPR", "FOPR", "FWPR"]
@@ -1424,8 +1444,9 @@ def test_that_segment_defaults_are_applied(tmpdir):
         Path("config.ert").write_text(config_content, encoding="utf-8")
 
         run_convert_observations(Namespace(config="config.ert"))
+        ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ErtConfig.from_file("config.ert").observation_declarations, None
+            ert_config.observation_declarations, None, ert_config.shape_registry
         )["summary"]
 
         # default error_min is 0.1
@@ -1448,10 +1469,12 @@ def test_that_summary_default_error_min_is_applied():
                 "ERROR_MODE": "RELMIN",
             }
         ],
+        ShapeRegistry(),
     )
     observations = create_observation_dataframes(
         obs,
         rft_config=None,
+        shape_registry=None,
     )
 
     # default error_min is 0.1
@@ -1891,6 +1914,7 @@ def test_that_general_observations_are_instantiated_with_localization_attributes
     gen_obs = create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )["gen_data"]
     for loc_kw in ["east", "north", "radius"]:
         assert loc_kw in gen_obs.columns
@@ -1917,6 +1941,7 @@ def test_that_breakthrough_observations_df_have_obs_value_zero():
     brt_obs = create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )["breakthrough"]
     assert brt_obs["observations"].to_list() == [0]
 
@@ -1942,6 +1967,7 @@ def test_that_breakthrough_observations_appends_to_breakthrough_config_responses
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )
     breakthrough_config = ert_config.ensemble_config.derived_response_configs[
         "breakthrough"
@@ -1968,6 +1994,7 @@ def test_that_breakthrough_responses_are_derived_from_summary():
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )
 
     ensemble_mock = MagicMock()
@@ -2006,6 +2033,7 @@ def test_that_unreachable_breakthrough_thresholds_has_none_response():
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )
 
     ensemble_mock = MagicMock()
@@ -2050,6 +2078,7 @@ def test_that_combined_reachable_and_unreachable_breakthrough_thresholds_are_tur
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
         rft_config=None,
+        shape_registry=ert_config.shape_registry,
     )
 
     ensemble_mock = MagicMock()

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -8,14 +8,13 @@ import pytest
 import resfo
 
 from ert.config import (
+    CircleShapeConfig,
     ErtConfig,
     InvalidResponseFile,
     RFTConfig,
+    ShapeRegistry,
 )
-from ert.config._create_observation_dataframes import (
-    DEFAULT_LOCALIZATION_RADIUS,
-    _handle_rft_observation,
-)
+from ert.config._create_observation_dataframes import _handle_rft_observation
 from ert.config._observations import RFTObservation
 from ert.config.parsing import ConfigValidationError, ObservationType
 from ert.warnings import PostExperimentWarning
@@ -515,30 +514,6 @@ def test_that_location_outside_of_the_grid_raises_invalid_response_file(
         )
 
 
-def test_that_handle_rft_observations_adds_defaulted_radius_column_to_dataframe():
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["*"]}},
-        locations=[(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)],
-    )
-    rft_observation = RFTObservation(
-        name="NAME[0]",
-        well="WELL1",
-        date="2013-03-31",
-        value=294.0,
-        error=10.0,
-        property="PRESSURE",
-        north=71.0,
-        east=30.0,
-        tvd=2000.0,
-        radius=None,
-    )
-    df = _handle_rft_observation(rft_config, rft_observation)
-    assert "radius" in df.columns
-    assert df["radius"].to_list() == [DEFAULT_LOCALIZATION_RADIUS]
-    assert df["radius"].dtype == pl.Float32
-
-
 def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
     provided_radius = 2400
     rft_config = RFTConfig(
@@ -546,6 +521,14 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
         data_to_read={"*": {"*": ["*"]}},
         locations=[(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)],
     )
+    shape_registry = ShapeRegistry()
+    shape_id = shape_registry.register(
+        CircleShapeConfig(
+            east=30.0,
+            north=71.0,
+            radius=provided_radius,
+        )
+    )
     rft_observation = RFTObservation(
         name="NAME[0]",
         well="WELL1",
@@ -556,9 +539,9 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
         north=71.0,
         east=30.0,
         tvd=2000.0,
-        radius=provided_radius,
+        shape_id=shape_id,
     )
-    df = _handle_rft_observation(rft_config, rft_observation)
+    df = _handle_rft_observation(rft_config, rft_observation, shape_registry)
     assert "radius" in df.columns
     assert df["radius"].to_list() == [provided_radius]
     assert df["radius"].dtype == pl.Float32
@@ -598,13 +581,12 @@ def test_that_handle_rft_observations_adds_locations_both_with_zone_and_without(
             north=71.0,
             east=30.0,
             tvd=2000.0,
-            radius=2400,
             zone=zone,
         )
 
     for zone in zones:
         rft_observation = make_observation(zone)
-        _handle_rft_observation(rft_config, rft_observation)
+        _handle_rft_observation(rft_config, rft_observation, ShapeRegistry())
 
     assert len(rft_config.locations) == 2
 

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -15,10 +15,8 @@ from ert.config import (
     InvalidResponseFile,
     SummaryConfig,
 )
-from ert.config._create_observation_dataframes import (
-    DEFAULT_LOCALIZATION_RADIUS,
-    create_observation_dataframes,
-)
+from ert.config._create_observation_dataframes import create_observation_dataframes
+from ert.config._observations import DEFAULT_LOCALIZATION_RADIUS
 
 
 @settings(max_examples=10)
@@ -104,9 +102,9 @@ def create_summary_observation(loc_config_lines):
     Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
 
     ert_config = ErtConfig.from_file("config.ert")
-    return create_observation_dataframes(ert_config.observation_declarations, None)[
-        "summary"
-    ]
+    return create_observation_dataframes(
+        ert_config.observation_declarations, None, ert_config.shape_registry
+    )["summary"]
 
 
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
@@ -203,8 +201,9 @@ def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internal
         obs_lines.insert(observation_index + 2 + i, line)
     new_obs_content = "\n".join(obs_lines)
     Path("observations/observations.txt").write_text(new_obs_content, encoding="utf-8")
+    ert_config = ErtConfig.from_file("snake_oil.ert")
     summary = create_observation_dataframes(
-        ErtConfig.from_file("snake_oil.ert").observation_declarations, None
+        ert_config.observation_declarations, None, ert_config.shape_registry
     )["summary"]
     assert summary["east"].dtype == pl.Float32
     assert summary["north"].dtype == pl.Float32

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",
@@ -285,9 +331,7 @@
       "error": 0.16482328267562937,
       "key": "HEAT_5_3",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -296,9 +340,7 @@
       "error": 0.02019488439360088,
       "key": "HEAT_3_5",
       "date": "2010-01-11T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -307,9 +349,7 @@
       "error": 0.7711986689522445,
       "key": "HEAT_5_7",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -318,9 +358,7 @@
       "error": 1.1721378322073848,
       "key": "HEAT_7_5",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -329,9 +367,7 @@
       "error": 3.079730973727218e-7,
       "key": "HEAT_2_2",
       "date": "2010-01-11T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -340,9 +376,7 @@
       "error": 0.08703349479928242,
       "key": "HEAT_7_2",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -351,9 +385,7 @@
       "error": 0.2356693348137558,
       "key": "HEAT_5_3",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -362,9 +394,7 @@
       "error": 0.16236736528249898,
       "key": "HEAT_3_5",
       "date": "2010-03-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -373,9 +403,7 @@
       "error": 0.3651414263739366,
       "key": "HEAT_5_7",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -384,9 +412,7 @@
       "error": 0.241688861656198,
       "key": "HEAT_7_5",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -395,9 +421,7 @@
       "error": 0.006459468053108617,
       "key": "HEAT_2_2",
       "date": "2010-03-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -406,9 +430,7 @@
       "error": 0.09825818825456456,
       "key": "HEAT_7_2",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -417,9 +439,7 @@
       "error": 0.13250138129273847,
       "key": "HEAT_5_3",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -428,9 +448,7 @@
       "error": 0.15681634616330167,
       "key": "HEAT_3_5",
       "date": "2010-05-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -439,9 +457,7 @@
       "error": 0.16395530223185706,
       "key": "HEAT_5_7",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -450,9 +466,7 @@
       "error": 0.09892536429471738,
       "key": "HEAT_7_5",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -461,9 +475,7 @@
       "error": 0.022178937646389424,
       "key": "HEAT_2_2",
       "date": "2010-05-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -472,9 +484,7 @@
       "error": 0.04802326866273813,
       "key": "HEAT_7_2",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -483,9 +493,7 @@
       "error": 0.0852887062955658,
       "key": "HEAT_5_3",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -494,9 +502,7 @@
       "error": 0.12647358189561586,
       "key": "HEAT_3_5",
       "date": "2010-07-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -505,9 +511,7 @@
       "error": 0.09129362898615401,
       "key": "HEAT_5_7",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -516,9 +520,7 @@
       "error": 0.05481999368163665,
       "key": "HEAT_7_5",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -527,9 +529,7 @@
       "error": 0.03025694175733248,
       "key": "HEAT_2_2",
       "date": "2010-07-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -538,9 +538,7 @@
       "error": 0.029074626753866163,
       "key": "HEAT_7_2",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -549,9 +547,7 @@
       "error": 0.059704412976213254,
       "key": "HEAT_5_3",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -560,9 +556,7 @@
       "error": 0.09864794502197914,
       "key": "HEAT_3_5",
       "date": "2010-09-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -571,9 +565,7 @@
       "error": 0.0578912754007102,
       "key": "HEAT_5_7",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -582,9 +574,7 @@
       "error": 0.03513379960968278,
       "key": "HEAT_7_5",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -593,9 +583,7 @@
       "error": 0.030970706785202192,
       "key": "HEAT_2_2",
       "date": "2010-09-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -604,9 +592,7 @@
       "error": 0.019673050794904112,
       "key": "HEAT_7_2",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -615,9 +601,7 @@
       "error": 0.04439419910993733,
       "key": "HEAT_5_3",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -626,9 +610,7 @@
       "error": 0.07717531220547702,
       "key": "HEAT_3_5",
       "date": "2010-11-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -637,9 +619,7 @@
       "error": 0.04024385452889148,
       "key": "HEAT_5_7",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -648,9 +628,7 @@
       "error": 0.02474437100142805,
       "key": "HEAT_7_5",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -659,9 +637,7 @@
       "error": 0.028125076404487734,
       "key": "HEAT_2_2",
       "date": "2010-11-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -670,9 +646,7 @@
       "error": 0.014347799635254097,
       "key": "HEAT_7_2",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -681,9 +655,7 @@
       "error": 0.034056140511841845,
       "key": "HEAT_5_3",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -692,9 +664,7 @@
       "error": 0.06058558661201531,
       "key": "HEAT_3_5",
       "date": "2011-01-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -703,9 +673,7 @@
       "error": 0.029445994399171317,
       "key": "HEAT_5_7",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -714,9 +682,7 @@
       "error": 0.018328942601053527,
       "key": "HEAT_7_5",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -725,9 +691,7 @@
       "error": 0.024116728326928134,
       "key": "HEAT_2_2",
       "date": "2011-01-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -736,9 +700,7 @@
       "error": 0.010882878724937851,
       "key": "HEAT_7_2",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -747,9 +709,7 @@
       "error": 0.026578037415319125,
       "key": "HEAT_5_3",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -758,9 +718,7 @@
       "error": 0.04770972792113973,
       "key": "HEAT_3_5",
       "date": "2011-03-15T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -769,9 +727,7 @@
       "error": 0.02222651207493663,
       "key": "HEAT_5_7",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -780,9 +736,7 @@
       "error": 0.013980361433931335,
       "key": "HEAT_7_5",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -791,9 +745,7 @@
       "error": 0.02005330502035694,
       "key": "HEAT_2_2",
       "date": "2011-03-15T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -802,9 +754,7 @@
       "error": 0.008437608752033662,
       "key": "HEAT_7_2",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     }
   ],
   "experiment_type": "Ensemble Information Filter"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",
@@ -258,9 +261,7 @@
       "error": 0.6,
       "restart": 0,
       "index": 0,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -270,9 +271,7 @@
       "error": 1.4,
       "restart": 0,
       "index": 2,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -282,9 +281,7 @@
       "error": 3.0,
       "restart": 0,
       "index": 4,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -294,9 +291,7 @@
       "error": 5.4,
       "restart": 0,
       "index": 6,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -306,9 +301,7 @@
       "error": 8.6,
       "restart": 0,
       "index": 8,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "experiment_type": "Ensemble Information Filter"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",
@@ -361,9 +364,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2010-03-31T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -372,9 +373,7 @@
       "error": 0.07,
       "key": "WOPR:OP1",
       "date": "2010-12-26T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -383,9 +382,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2011-12-21T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -394,9 +391,7 @@
       "error": 0.075,
       "key": "WOPR:OP1",
       "date": "2012-12-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -405,9 +400,7 @@
       "error": 0.035,
       "key": "WOPR:OP1",
       "date": "2013-12-10T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -416,9 +409,7 @@
       "error": 0.01,
       "key": "WOPR:OP1",
       "date": "2015-03-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -428,9 +419,7 @@
       "error": 0.1,
       "restart": 199,
       "index": 400,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -440,9 +429,7 @@
       "error": 0.2,
       "restart": 199,
       "index": 800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -452,9 +439,7 @@
       "error": 0.15,
       "restart": 199,
       "index": 1200,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -464,9 +449,7 @@
       "error": 0.05,
       "restart": 199,
       "index": 1800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "experiment_type": "Ensemble Information Filter"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",
@@ -270,9 +316,7 @@
       "error": 0.16482328267562937,
       "key": "HEAT_5_3",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -281,9 +325,7 @@
       "error": 0.02019488439360088,
       "key": "HEAT_3_5",
       "date": "2010-01-11T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -292,9 +334,7 @@
       "error": 0.7711986689522445,
       "key": "HEAT_5_7",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -303,9 +343,7 @@
       "error": 1.1721378322073848,
       "key": "HEAT_7_5",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -314,9 +352,7 @@
       "error": 3.079730973727218e-7,
       "key": "HEAT_2_2",
       "date": "2010-01-11T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -325,9 +361,7 @@
       "error": 0.08703349479928242,
       "key": "HEAT_7_2",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -336,9 +370,7 @@
       "error": 0.2356693348137558,
       "key": "HEAT_5_3",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -347,9 +379,7 @@
       "error": 0.16236736528249898,
       "key": "HEAT_3_5",
       "date": "2010-03-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -358,9 +388,7 @@
       "error": 0.3651414263739366,
       "key": "HEAT_5_7",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -369,9 +397,7 @@
       "error": 0.241688861656198,
       "key": "HEAT_7_5",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -380,9 +406,7 @@
       "error": 0.006459468053108617,
       "key": "HEAT_2_2",
       "date": "2010-03-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -391,9 +415,7 @@
       "error": 0.09825818825456456,
       "key": "HEAT_7_2",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -402,9 +424,7 @@
       "error": 0.13250138129273847,
       "key": "HEAT_5_3",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -413,9 +433,7 @@
       "error": 0.15681634616330167,
       "key": "HEAT_3_5",
       "date": "2010-05-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -424,9 +442,7 @@
       "error": 0.16395530223185706,
       "key": "HEAT_5_7",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -435,9 +451,7 @@
       "error": 0.09892536429471738,
       "key": "HEAT_7_5",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -446,9 +460,7 @@
       "error": 0.022178937646389424,
       "key": "HEAT_2_2",
       "date": "2010-05-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -457,9 +469,7 @@
       "error": 0.04802326866273813,
       "key": "HEAT_7_2",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -468,9 +478,7 @@
       "error": 0.0852887062955658,
       "key": "HEAT_5_3",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -479,9 +487,7 @@
       "error": 0.12647358189561586,
       "key": "HEAT_3_5",
       "date": "2010-07-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -490,9 +496,7 @@
       "error": 0.09129362898615401,
       "key": "HEAT_5_7",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -501,9 +505,7 @@
       "error": 0.05481999368163665,
       "key": "HEAT_7_5",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -512,9 +514,7 @@
       "error": 0.03025694175733248,
       "key": "HEAT_2_2",
       "date": "2010-07-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -523,9 +523,7 @@
       "error": 0.029074626753866163,
       "key": "HEAT_7_2",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -534,9 +532,7 @@
       "error": 0.059704412976213254,
       "key": "HEAT_5_3",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -545,9 +541,7 @@
       "error": 0.09864794502197914,
       "key": "HEAT_3_5",
       "date": "2010-09-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -556,9 +550,7 @@
       "error": 0.0578912754007102,
       "key": "HEAT_5_7",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -567,9 +559,7 @@
       "error": 0.03513379960968278,
       "key": "HEAT_7_5",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -578,9 +568,7 @@
       "error": 0.030970706785202192,
       "key": "HEAT_2_2",
       "date": "2010-09-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -589,9 +577,7 @@
       "error": 0.019673050794904112,
       "key": "HEAT_7_2",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -600,9 +586,7 @@
       "error": 0.04439419910993733,
       "key": "HEAT_5_3",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -611,9 +595,7 @@
       "error": 0.07717531220547702,
       "key": "HEAT_3_5",
       "date": "2010-11-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -622,9 +604,7 @@
       "error": 0.04024385452889148,
       "key": "HEAT_5_7",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -633,9 +613,7 @@
       "error": 0.02474437100142805,
       "key": "HEAT_7_5",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -644,9 +622,7 @@
       "error": 0.028125076404487734,
       "key": "HEAT_2_2",
       "date": "2010-11-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -655,9 +631,7 @@
       "error": 0.014347799635254097,
       "key": "HEAT_7_2",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -666,9 +640,7 @@
       "error": 0.034056140511841845,
       "key": "HEAT_5_3",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -677,9 +649,7 @@
       "error": 0.06058558661201531,
       "key": "HEAT_3_5",
       "date": "2011-01-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -688,9 +658,7 @@
       "error": 0.029445994399171317,
       "key": "HEAT_5_7",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -699,9 +667,7 @@
       "error": 0.018328942601053527,
       "key": "HEAT_7_5",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -710,9 +676,7 @@
       "error": 0.024116728326928134,
       "key": "HEAT_2_2",
       "date": "2011-01-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -721,9 +685,7 @@
       "error": 0.010882878724937851,
       "key": "HEAT_7_2",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -732,9 +694,7 @@
       "error": 0.026578037415319125,
       "key": "HEAT_5_3",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -743,9 +703,7 @@
       "error": 0.04770972792113973,
       "key": "HEAT_3_5",
       "date": "2011-03-15T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -754,9 +712,7 @@
       "error": 0.02222651207493663,
       "key": "HEAT_5_7",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -765,9 +721,7 @@
       "error": 0.013980361433931335,
       "key": "HEAT_7_5",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -776,9 +730,7 @@
       "error": 0.02005330502035694,
       "key": "HEAT_2_2",
       "date": "2011-03-15T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -787,9 +739,7 @@
       "error": 0.008437608752033662,
       "key": "HEAT_7_2",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     }
   ],
   "target_ensemble": "the_experiment",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",
@@ -243,9 +246,7 @@
       "error": 0.6,
       "restart": 0,
       "index": 0,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -255,9 +256,7 @@
       "error": 1.4,
       "restart": 0,
       "index": 2,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -267,9 +266,7 @@
       "error": 3.0,
       "restart": 0,
       "index": 4,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -279,9 +276,7 @@
       "error": 5.4,
       "restart": 0,
       "index": 6,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -291,9 +286,7 @@
       "error": 8.6,
       "restart": 0,
       "index": 8,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "target_ensemble": "the_experiment",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",
@@ -346,9 +349,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2010-03-31T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -357,9 +358,7 @@
       "error": 0.07,
       "key": "WOPR:OP1",
       "date": "2010-12-26T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -368,9 +367,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2011-12-21T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -379,9 +376,7 @@
       "error": 0.075,
       "key": "WOPR:OP1",
       "date": "2012-12-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -390,9 +385,7 @@
       "error": 0.035,
       "key": "WOPR:OP1",
       "date": "2013-12-10T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -401,9 +394,7 @@
       "error": 0.01,
       "key": "WOPR:OP1",
       "date": "2015-03-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -413,9 +404,7 @@
       "error": 0.1,
       "restart": 199,
       "index": 400,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -425,9 +414,7 @@
       "error": 0.2,
       "restart": 199,
       "index": 800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -437,9 +424,7 @@
       "error": 0.15,
       "restart": 199,
       "index": 1200,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -449,9 +434,7 @@
       "error": 0.05,
       "restart": 199,
       "index": 1800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "target_ensemble": "the_experiment",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",
@@ -285,9 +331,7 @@
       "error": 0.16482328267562937,
       "key": "HEAT_5_3",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -296,9 +340,7 @@
       "error": 0.02019488439360088,
       "key": "HEAT_3_5",
       "date": "2010-01-11T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -307,9 +349,7 @@
       "error": 0.7711986689522445,
       "key": "HEAT_5_7",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -318,9 +358,7 @@
       "error": 1.1721378322073848,
       "key": "HEAT_7_5",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -329,9 +367,7 @@
       "error": 3.079730973727218e-7,
       "key": "HEAT_2_2",
       "date": "2010-01-11T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -340,9 +376,7 @@
       "error": 0.08703349479928242,
       "key": "HEAT_7_2",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -351,9 +385,7 @@
       "error": 0.2356693348137558,
       "key": "HEAT_5_3",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -362,9 +394,7 @@
       "error": 0.16236736528249898,
       "key": "HEAT_3_5",
       "date": "2010-03-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -373,9 +403,7 @@
       "error": 0.3651414263739366,
       "key": "HEAT_5_7",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -384,9 +412,7 @@
       "error": 0.241688861656198,
       "key": "HEAT_7_5",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -395,9 +421,7 @@
       "error": 0.006459468053108617,
       "key": "HEAT_2_2",
       "date": "2010-03-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -406,9 +430,7 @@
       "error": 0.09825818825456456,
       "key": "HEAT_7_2",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -417,9 +439,7 @@
       "error": 0.13250138129273847,
       "key": "HEAT_5_3",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -428,9 +448,7 @@
       "error": 0.15681634616330167,
       "key": "HEAT_3_5",
       "date": "2010-05-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -439,9 +457,7 @@
       "error": 0.16395530223185706,
       "key": "HEAT_5_7",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -450,9 +466,7 @@
       "error": 0.09892536429471738,
       "key": "HEAT_7_5",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -461,9 +475,7 @@
       "error": 0.022178937646389424,
       "key": "HEAT_2_2",
       "date": "2010-05-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -472,9 +484,7 @@
       "error": 0.04802326866273813,
       "key": "HEAT_7_2",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -483,9 +493,7 @@
       "error": 0.0852887062955658,
       "key": "HEAT_5_3",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -494,9 +502,7 @@
       "error": 0.12647358189561586,
       "key": "HEAT_3_5",
       "date": "2010-07-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -505,9 +511,7 @@
       "error": 0.09129362898615401,
       "key": "HEAT_5_7",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -516,9 +520,7 @@
       "error": 0.05481999368163665,
       "key": "HEAT_7_5",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -527,9 +529,7 @@
       "error": 0.03025694175733248,
       "key": "HEAT_2_2",
       "date": "2010-07-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -538,9 +538,7 @@
       "error": 0.029074626753866163,
       "key": "HEAT_7_2",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -549,9 +547,7 @@
       "error": 0.059704412976213254,
       "key": "HEAT_5_3",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -560,9 +556,7 @@
       "error": 0.09864794502197914,
       "key": "HEAT_3_5",
       "date": "2010-09-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -571,9 +565,7 @@
       "error": 0.0578912754007102,
       "key": "HEAT_5_7",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -582,9 +574,7 @@
       "error": 0.03513379960968278,
       "key": "HEAT_7_5",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -593,9 +583,7 @@
       "error": 0.030970706785202192,
       "key": "HEAT_2_2",
       "date": "2010-09-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -604,9 +592,7 @@
       "error": 0.019673050794904112,
       "key": "HEAT_7_2",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -615,9 +601,7 @@
       "error": 0.04439419910993733,
       "key": "HEAT_5_3",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -626,9 +610,7 @@
       "error": 0.07717531220547702,
       "key": "HEAT_3_5",
       "date": "2010-11-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -637,9 +619,7 @@
       "error": 0.04024385452889148,
       "key": "HEAT_5_7",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -648,9 +628,7 @@
       "error": 0.02474437100142805,
       "key": "HEAT_7_5",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -659,9 +637,7 @@
       "error": 0.028125076404487734,
       "key": "HEAT_2_2",
       "date": "2010-11-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -670,9 +646,7 @@
       "error": 0.014347799635254097,
       "key": "HEAT_7_2",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -681,9 +655,7 @@
       "error": 0.034056140511841845,
       "key": "HEAT_5_3",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -692,9 +664,7 @@
       "error": 0.06058558661201531,
       "key": "HEAT_3_5",
       "date": "2011-01-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -703,9 +673,7 @@
       "error": 0.029445994399171317,
       "key": "HEAT_5_7",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -714,9 +682,7 @@
       "error": 0.018328942601053527,
       "key": "HEAT_7_5",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -725,9 +691,7 @@
       "error": 0.024116728326928134,
       "key": "HEAT_2_2",
       "date": "2011-01-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -736,9 +700,7 @@
       "error": 0.010882878724937851,
       "key": "HEAT_7_2",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -747,9 +709,7 @@
       "error": 0.026578037415319125,
       "key": "HEAT_5_3",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -758,9 +718,7 @@
       "error": 0.04770972792113973,
       "key": "HEAT_3_5",
       "date": "2011-03-15T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -769,9 +727,7 @@
       "error": 0.02222651207493663,
       "key": "HEAT_5_7",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -780,9 +736,7 @@
       "error": 0.013980361433931335,
       "key": "HEAT_7_5",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -791,9 +745,7 @@
       "error": 0.02005330502035694,
       "key": "HEAT_2_2",
       "date": "2011-03-15T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -802,9 +754,7 @@
       "error": 0.008437608752033662,
       "key": "HEAT_7_2",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     }
   ],
   "experiment_type": "Ensemble Smoother"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",
@@ -258,9 +261,7 @@
       "error": 0.6,
       "restart": 0,
       "index": 0,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -270,9 +271,7 @@
       "error": 1.4,
       "restart": 0,
       "index": 2,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -282,9 +281,7 @@
       "error": 3.0,
       "restart": 0,
       "index": 4,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -294,9 +291,7 @@
       "error": 5.4,
       "restart": 0,
       "index": 6,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -306,9 +301,7 @@
       "error": 8.6,
       "restart": 0,
       "index": 8,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "experiment_type": "Ensemble Smoother"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",
@@ -361,9 +364,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2010-03-31T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -372,9 +373,7 @@
       "error": 0.07,
       "key": "WOPR:OP1",
       "date": "2010-12-26T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -383,9 +382,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2011-12-21T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -394,9 +391,7 @@
       "error": 0.075,
       "key": "WOPR:OP1",
       "date": "2012-12-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -405,9 +400,7 @@
       "error": 0.035,
       "key": "WOPR:OP1",
       "date": "2013-12-10T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -416,9 +409,7 @@
       "error": 0.01,
       "key": "WOPR:OP1",
       "date": "2015-03-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -428,9 +419,7 @@
       "error": 0.1,
       "restart": 199,
       "index": 400,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -440,9 +429,7 @@
       "error": 0.2,
       "restart": 199,
       "index": 800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -452,9 +439,7 @@
       "error": 0.15,
       "restart": 199,
       "index": 1200,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -464,9 +449,7 @@
       "error": 0.05,
       "restart": 199,
       "index": 1800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "experiment_type": "Ensemble Smoother"

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",
@@ -285,9 +331,7 @@
       "error": 0.16482328267562937,
       "key": "HEAT_5_3",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -296,9 +340,7 @@
       "error": 0.02019488439360088,
       "key": "HEAT_3_5",
       "date": "2010-01-11T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -307,9 +349,7 @@
       "error": 0.7711986689522445,
       "key": "HEAT_5_7",
       "date": "2010-01-11T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -318,9 +358,7 @@
       "error": 1.1721378322073848,
       "key": "HEAT_7_5",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -329,9 +367,7 @@
       "error": 3.079730973727218e-7,
       "key": "HEAT_2_2",
       "date": "2010-01-11T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -340,9 +376,7 @@
       "error": 0.08703349479928242,
       "key": "HEAT_7_2",
       "date": "2010-01-11T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -351,9 +385,7 @@
       "error": 0.2356693348137558,
       "key": "HEAT_5_3",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -362,9 +394,7 @@
       "error": 0.16236736528249898,
       "key": "HEAT_3_5",
       "date": "2010-03-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -373,9 +403,7 @@
       "error": 0.3651414263739366,
       "key": "HEAT_5_7",
       "date": "2010-03-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -384,9 +412,7 @@
       "error": 0.241688861656198,
       "key": "HEAT_7_5",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -395,9 +421,7 @@
       "error": 0.006459468053108617,
       "key": "HEAT_2_2",
       "date": "2010-03-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -406,9 +430,7 @@
       "error": 0.09825818825456456,
       "key": "HEAT_7_2",
       "date": "2010-03-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -417,9 +439,7 @@
       "error": 0.13250138129273847,
       "key": "HEAT_5_3",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -428,9 +448,7 @@
       "error": 0.15681634616330167,
       "key": "HEAT_3_5",
       "date": "2010-05-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -439,9 +457,7 @@
       "error": 0.16395530223185706,
       "key": "HEAT_5_7",
       "date": "2010-05-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -450,9 +466,7 @@
       "error": 0.09892536429471738,
       "key": "HEAT_7_5",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -461,9 +475,7 @@
       "error": 0.022178937646389424,
       "key": "HEAT_2_2",
       "date": "2010-05-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -472,9 +484,7 @@
       "error": 0.04802326866273813,
       "key": "HEAT_7_2",
       "date": "2010-05-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -483,9 +493,7 @@
       "error": 0.0852887062955658,
       "key": "HEAT_5_3",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -494,9 +502,7 @@
       "error": 0.12647358189561586,
       "key": "HEAT_3_5",
       "date": "2010-07-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -505,9 +511,7 @@
       "error": 0.09129362898615401,
       "key": "HEAT_5_7",
       "date": "2010-07-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -516,9 +520,7 @@
       "error": 0.05481999368163665,
       "key": "HEAT_7_5",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -527,9 +529,7 @@
       "error": 0.03025694175733248,
       "key": "HEAT_2_2",
       "date": "2010-07-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -538,9 +538,7 @@
       "error": 0.029074626753866163,
       "key": "HEAT_7_2",
       "date": "2010-07-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -549,9 +547,7 @@
       "error": 0.059704412976213254,
       "key": "HEAT_5_3",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -560,9 +556,7 @@
       "error": 0.09864794502197914,
       "key": "HEAT_3_5",
       "date": "2010-09-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -571,9 +565,7 @@
       "error": 0.0578912754007102,
       "key": "HEAT_5_7",
       "date": "2010-09-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -582,9 +574,7 @@
       "error": 0.03513379960968278,
       "key": "HEAT_7_5",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -593,9 +583,7 @@
       "error": 0.030970706785202192,
       "key": "HEAT_2_2",
       "date": "2010-09-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -604,9 +592,7 @@
       "error": 0.019673050794904112,
       "key": "HEAT_7_2",
       "date": "2010-09-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -615,9 +601,7 @@
       "error": 0.04439419910993733,
       "key": "HEAT_5_3",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -626,9 +610,7 @@
       "error": 0.07717531220547702,
       "key": "HEAT_3_5",
       "date": "2010-11-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -637,9 +619,7 @@
       "error": 0.04024385452889148,
       "key": "HEAT_5_7",
       "date": "2010-11-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -648,9 +628,7 @@
       "error": 0.02474437100142805,
       "key": "HEAT_7_5",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -659,9 +637,7 @@
       "error": 0.028125076404487734,
       "key": "HEAT_2_2",
       "date": "2010-11-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -670,9 +646,7 @@
       "error": 0.014347799635254097,
       "key": "HEAT_7_2",
       "date": "2010-11-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -681,9 +655,7 @@
       "error": 0.034056140511841845,
       "key": "HEAT_5_3",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -692,9 +664,7 @@
       "error": 0.06058558661201531,
       "key": "HEAT_3_5",
       "date": "2011-01-13T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -703,9 +673,7 @@
       "error": 0.029445994399171317,
       "key": "HEAT_5_7",
       "date": "2011-01-13T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -714,9 +682,7 @@
       "error": 0.018328942601053527,
       "key": "HEAT_7_5",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -725,9 +691,7 @@
       "error": 0.024116728326928134,
       "key": "HEAT_2_2",
       "date": "2011-01-13T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -736,9 +700,7 @@
       "error": 0.010882878724937851,
       "key": "HEAT_7_2",
       "date": "2011-01-13T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     },
     {
       "type": "summary_observation",
@@ -747,9 +709,7 @@
       "error": 0.026578037415319125,
       "key": "HEAT_5_3",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 3.5,
-      "radius": 15.0
+      "shape_id": 0
     },
     {
       "type": "summary_observation",
@@ -758,9 +718,7 @@
       "error": 0.04770972792113973,
       "key": "HEAT_3_5",
       "date": "2011-03-15T00:00:00",
-      "east": 3.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 1
     },
     {
       "type": "summary_observation",
@@ -769,9 +727,7 @@
       "error": 0.02222651207493663,
       "key": "HEAT_5_7",
       "date": "2011-03-15T00:00:00",
-      "east": 5.5,
-      "north": 7.5,
-      "radius": 15.0
+      "shape_id": 2
     },
     {
       "type": "summary_observation",
@@ -780,9 +736,7 @@
       "error": 0.013980361433931335,
       "key": "HEAT_7_5",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 5.5,
-      "radius": 15.0
+      "shape_id": 3
     },
     {
       "type": "summary_observation",
@@ -791,9 +745,7 @@
       "error": 0.02005330502035694,
       "key": "HEAT_2_2",
       "date": "2011-03-15T00:00:00",
-      "east": 2.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 4
     },
     {
       "type": "summary_observation",
@@ -802,9 +754,7 @@
       "error": 0.008437608752033662,
       "key": "HEAT_7_2",
       "date": "2011-03-15T00:00:00",
-      "east": 7.5,
-      "north": 2.5,
-      "radius": 15.0
+      "shape_id": 5
     }
   ],
   "restart_run": false,

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",
@@ -258,9 +261,7 @@
       "error": 0.6,
       "restart": 0,
       "index": 0,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -270,9 +271,7 @@
       "error": 1.4,
       "restart": 0,
       "index": 2,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -282,9 +281,7 @@
       "error": 3.0,
       "restart": 0,
       "index": 4,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -294,9 +291,7 @@
       "error": 5.4,
       "restart": 0,
       "index": 6,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -306,9 +301,7 @@
       "error": 8.6,
       "restart": 0,
       "index": 8,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "restart_run": false,

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",
@@ -361,9 +364,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2010-03-31T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -372,9 +373,7 @@
       "error": 0.07,
       "key": "WOPR:OP1",
       "date": "2010-12-26T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -383,9 +382,7 @@
       "error": 0.05,
       "key": "WOPR:OP1",
       "date": "2011-12-21T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -394,9 +391,7 @@
       "error": 0.075,
       "key": "WOPR:OP1",
       "date": "2012-12-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -405,9 +400,7 @@
       "error": 0.035,
       "key": "WOPR:OP1",
       "date": "2013-12-10T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "summary_observation",
@@ -416,9 +409,7 @@
       "error": 0.01,
       "key": "WOPR:OP1",
       "date": "2015-03-15T00:00:00",
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -428,9 +419,7 @@
       "error": 0.1,
       "restart": 199,
       "index": 400,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -440,9 +429,7 @@
       "error": 0.2,
       "restart": 199,
       "index": 800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -452,9 +439,7 @@
       "error": 0.15,
       "restart": 199,
       "index": 1200,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     },
     {
       "type": "general_observation",
@@ -464,9 +449,7 @@
       "error": 0.05,
       "restart": 199,
       "index": 1800,
-      "east": null,
-      "north": null,
-      "radius": null
+      "shape_id": null
     }
   ],
   "restart_run": false,

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
@@ -30,6 +30,52 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {
+      "0": {
+        "shape_id": 0,
+        "type": "circle",
+        "east": 5.5,
+        "north": 3.5,
+        "radius": 15.0
+      },
+      "1": {
+        "shape_id": 1,
+        "type": "circle",
+        "east": 3.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "2": {
+        "shape_id": 2,
+        "type": "circle",
+        "east": 5.5,
+        "north": 7.5,
+        "radius": 15.0
+      },
+      "3": {
+        "shape_id": 3,
+        "type": "circle",
+        "east": 7.5,
+        "north": 5.5,
+        "radius": 15.0
+      },
+      "4": {
+        "shape_id": 4,
+        "type": "circle",
+        "east": 2.5,
+        "north": 2.5,
+        "radius": 15.0
+      },
+      "5": {
+        "shape_id": 5,
+        "type": "circle",
+        "east": 7.5,
+        "north": 2.5,
+        "radius": 15.0
+      }
+    }
+  },
   "forward_model_steps": [
     {
       "name": "heat_equation",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "poly_eval",

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -26,6 +26,9 @@
     "stop_long_running": false,
     "max_runtime": null
   },
+  "shape_registry": {
+    "shapes": {}
+  },
   "forward_model_steps": [
     {
       "name": "SNAKE_OIL_SIMULATOR",

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -11,12 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 from pydantic import ConfigDict
 
-from ert.config import (
-    ErtConfig,
-    ModelConfig,
-    QueueConfig,
-    QueueSystem,
-)
+from ert.config import ErtConfig, ModelConfig, QueueConfig, QueueSystem, ShapeRegistry
 from ert.config.queue_config import LsfQueueOptions
 from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig, StartEvent
 from ert.ensemble_evaluator.evaluator import ParallelismViolation
@@ -53,6 +48,7 @@ def create_run_model(**kwargs):
         "active_realizations": MagicMock(spec=list),
         "random_seed": 123,
         "log_path": Path(""),
+        "shape_registry": ShapeRegistry(),
     }
 
     class RunModelWithMockSupport(RunModel):

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -14,6 +14,7 @@ from hypothesis import strategies as st
 
 from ert.base_model_context import use_runtime_plugins
 from ert.config import (
+    CircleShapeConfig,
     ConfigWarning,
     ErtConfig,
     ErtScriptWorkflow,
@@ -27,6 +28,7 @@ from ert.config import (
     ModelConfig,
     ObservationSettings,
     OutlierSettings,
+    ShapeRegistry,
     SummaryConfig,
     SurfaceConfig,
     UserInstalledForwardModelStep,
@@ -296,6 +298,25 @@ def runmodel_args(draw, tmp_path_factory):
         st.dictionaries(realistic_text(), realistic_text(), max_size=5)
     )
 
+    shape_registry = ShapeRegistry()
+    num_shapes = draw(st.integers(min_value=1, max_value=5))
+    _ = [
+        shape_registry.register(
+            CircleShapeConfig(
+                east=draw(
+                    st.floats(min_value=1, allow_nan=False, allow_infinity=False)
+                ),
+                north=draw(
+                    st.floats(min_value=1, allow_nan=False, allow_infinity=False)
+                ),
+                radius=draw(
+                    st.floats(min_value=1, allow_nan=False, allow_infinity=False)
+                ),
+            )
+        )
+        for _ in range(num_shapes)
+    ]
+
     runtime_plugins = ErtRuntimePlugins(
         installed_forward_model_steps={},
         installed_workflow_jobs=installed_ertscripts,
@@ -322,6 +343,7 @@ def runmodel_args(draw, tmp_path_factory):
         "forward_model_steps": forward_model_step_list,
         "substitutions": substitutions,
         "hooked_workflows": hooked_workflows_dict,
+        "shape_registry": shape_registry,
     }, runtime_plugins
 
 

--- a/tests/ert/unit_tests/storage/migration/test_to27.py
+++ b/tests/ert/unit_tests/storage/migration/test_to27.py
@@ -1,0 +1,291 @@
+import json
+
+import pytest
+
+from ert.storage.migration.to27 import migrate
+
+
+def _make_index(observations):
+    return {
+        "id": "exp-id",
+        "experiment": {"observations": observations},
+    }
+
+
+def _write_experiment(root, observations):
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+    index_file = exp_path / "index.json"
+    index_file.write_text(json.dumps(_make_index(observations)), encoding="utf-8")
+    return index_file
+
+
+def _read_experiment(index_file):
+    return json.loads(index_file.read_text(encoding="utf-8"))["experiment"]
+
+
+def test_that_summary_observation_localization_is_migrated_to_shape_registry(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    index_file = _write_experiment(
+        root,
+        [
+            {
+                "type": "summary_observation",
+                "name": "OBS1",
+                "value": 1.0,
+                "error": 0.1,
+                "key": "FOPR",
+                "date": "2020-01-01",
+                "east": 100.0,
+                "north": 200.0,
+                "radius": 3000.0,
+            },
+        ],
+    )
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    obs = experiment["observations"][0]
+    assert "east" not in obs
+    assert "north" not in obs
+    assert "radius" not in obs
+    assert obs["shape_id"] == 0
+
+    registry = experiment["shape_registry"]["shapes"]
+    assert registry["0"]["east"] == pytest.approx(100.0)
+    assert registry["0"]["north"] == pytest.approx(200.0)
+    assert registry["0"]["radius"] == pytest.approx(3000.0)
+    assert registry["0"]["type"] == "circle"
+
+
+def test_that_summary_observation_without_localization_gets_shape_id_none(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    original_obs = {
+        "type": "summary_observation",
+        "name": "OBS1",
+        "value": 1.0,
+        "error": 0.1,
+        "key": "FOPR",
+        "date": "2020-01-01",
+    }
+    index_file = _write_experiment(root, [original_obs.copy()])
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    obs = experiment["observations"][0]
+    assert obs["shape_id"] is None
+    assert experiment["shape_registry"] == {"shapes": {}}
+
+
+def test_that_summary_observation_defaults_radius_to_2000_when_missing(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    index_file = _write_experiment(
+        root,
+        [
+            {
+                "type": "summary_observation",
+                "name": "OBS1",
+                "value": 1.0,
+                "error": 0.1,
+                "key": "FOPR",
+                "date": "2020-01-01",
+                "east": 100.0,
+                "north": 200.0,
+            },
+        ],
+    )
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    registry = experiment["shape_registry"]["shapes"]
+    assert registry["0"]["radius"] == 2000
+
+
+def test_that_rft_observation_radius_is_migrated_to_shape_registry(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    index_file = _write_experiment(
+        root,
+        [
+            {
+                "type": "rft_observation",
+                "name": "RFT1",
+                "well": "W1",
+                "date": "2020-01-01",
+                "property": "PRESSURE",
+                "value": 300.0,
+                "error": 10.0,
+                "east": 50.0,
+                "north": 60.0,
+                "tvd": 1500.0,
+                "radius": 2400.0,
+            },
+        ],
+    )
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    obs = experiment["observations"][0]
+    assert obs["east"] == pytest.approx(50.0)
+    assert obs["north"] == pytest.approx(60.0)
+    assert "radius" not in obs
+    assert obs["shape_id"] == 0
+
+    registry = experiment["shape_registry"]["shapes"]
+    assert registry["0"]["east"] == pytest.approx(50.0)
+    assert registry["0"]["north"] == pytest.approx(60.0)
+    assert registry["0"]["radius"] == pytest.approx(2400.0)
+
+
+def test_that_identical_shapes_share_shape_id(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    index_file = _write_experiment(
+        root,
+        [
+            {
+                "type": "summary_observation",
+                "name": "OBS1",
+                "value": 1.0,
+                "error": 0.1,
+                "key": "FOPR",
+                "date": "2020-01-01",
+                "east": 100.0,
+                "north": 200.0,
+                "radius": 3000.0,
+            },
+            {
+                "type": "summary_observation",
+                "name": "OBS2",
+                "value": 2.0,
+                "error": 0.2,
+                "key": "FWPR",
+                "date": "2020-06-01",
+                "east": 100.0,
+                "north": 200.0,
+                "radius": 3000.0,
+            },
+            {
+                "type": "summary_observation",
+                "name": "OBS3",
+                "value": 3.0,
+                "error": 0.3,
+                "key": "FGPR",
+                "date": "2020-12-01",
+                "east": 500.0,
+                "north": 600.0,
+                "radius": 1000.0,
+            },
+        ],
+    )
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    obs_list = experiment["observations"]
+    assert obs_list[0]["shape_id"] == obs_list[1]["shape_id"]
+    assert obs_list[0]["shape_id"] != obs_list[2]["shape_id"]
+
+    registry = experiment["shape_registry"]["shapes"]
+    assert len(registry) == 2
+
+
+def test_that_mixed_observation_types_are_migrated(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    index_file = _write_experiment(
+        root,
+        [
+            {
+                "type": "summary_observation",
+                "name": "OBS1",
+                "value": 1.0,
+                "error": 0.1,
+                "key": "FOPR",
+                "date": "2020-01-01",
+                "east": 100.0,
+                "north": 200.0,
+                "radius": 3000.0,
+            },
+            {
+                "type": "rft_observation",
+                "name": "RFT1",
+                "well": "W1",
+                "date": "2020-01-01",
+                "property": "PRESSURE",
+                "value": 300.0,
+                "error": 10.0,
+                "east": 100.0,
+                "north": 200.0,
+                "tvd": 1500.0,
+                "radius": 3000.0,
+            },
+            {
+                "type": "general_observation",
+                "name": "GEN1",
+                "data": "RESPONSE",
+                "value": 5.0,
+                "error": 0.5,
+                "restart": 0,
+                "index": 0,
+            },
+            {
+                "type": "breakthrough",
+                "name": "BT1",
+                "date": "2020-01-01",
+                "value": 300.0,
+                "error": 10.0,
+                "east": 100.0,
+                "north": 200.0,
+                "radius": 3000.0,
+                "threshold": 0.2,
+            },
+        ],
+    )
+
+    migrate(root)
+
+    experiment = _read_experiment(index_file)
+    obs_list = experiment["observations"]
+
+    # Summary: east/north/radius removed, shape_id set
+    assert "east" not in obs_list[0]
+    assert obs_list[0]["shape_id"] == 0
+
+    # RFT: east/north kept, radius removed, shape_id set
+    assert obs_list[1]["east"] == pytest.approx(100.0)
+    assert obs_list[1]["north"] == pytest.approx(200.0)
+    assert "radius" not in obs_list[1]
+    assert obs_list[1]["shape_id"] == 0
+
+    # General: shape_id set to None
+    assert obs_list[2]["shape_id"] is None
+
+    # Breakthrough: east/north/radius removed, shape_id set
+    assert "east" not in obs_list[3]
+    assert obs_list[3]["shape_id"] == 0
+
+    registry = experiment["shape_registry"]["shapes"]
+    assert len(registry) == 1
+
+
+def test_that_experiment_without_observations_has_empty_shape_registry(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+    index_data = {"id": "exp-id", "experiment": {}}
+    index_file = exp_path / "index.json"
+    index_file.write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    experiment = json.loads(index_file.read_text(encoding="utf-8"))["experiment"]
+    assert experiment["shape_registry"] == {"shapes": {}}

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -1190,9 +1190,6 @@ def test_that_breakthrough_observations_and_responses_are_joined_in_endpoint(tmp
                         date=time,
                         error=10,
                         threshold=0.2,
-                        north=None,
-                        east=None,
-                        radius=None,
                     )
                 ],
             }


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/13133


**Approach**
Observations have no longer location attributes (east,north and
radius). Instead, each observation references a shape_id that maps to
a reusable ShapeConfig in a new ShapeRegistry.

This enables to reuse geometry across observations and future support
for variate of shapes (e.g. polygons).

Additionally this adds
- CircleShapeConfig as the basic shape type
- ShapeRegistry that re-use identical geometries on registration
- a new dark_storage API endpoint to expose the registry
- a storage migration (v27) that initialize ShapeRegistry from existing
east,north and radius fields on stored observations.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
