### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_ert_with_site_config.yml
+++ b/.github/workflows/test_ert_with_site_config.yml
@@ -1,5 +1,8 @@
 name: Run ERT tests against dummy site config
 
+permissions:
+  contents: read
+
 on:
  push:
    branches:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/ert/security/code-scanning/34](https://github.com/equinor/ert/security/code-scanning/34)

To fix the problem, add an explicit `permissions` block that grants only the minimal required scopes for this workflow. Since the workflow only checks out repository code and reads it to run tests, it only needs read access to repository contents; no write scopes or additional privileges appear necessary.

The best minimal fix is to add `permissions: contents: read` at the workflow level (top-level, alongside `name` and `on`). This applies to all jobs that do not override `permissions`, including `test-against-lsf`, and it does not change any existing functionality because Actions like `actions/checkout` work with read-only `contents` permissions. No changes to steps, actions, or configuration are needed beyond this one addition.

Concretely, edit `.github/workflows/test_ert_with_site_config.yml` to insert:

```yaml
permissions:
  contents: read
```

after the `name:` line and before the `on:` block. No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
