### PR TITLE
Filter NaN parameter rows in EnIF update

### DIFF
--- a/src/ert/analysis/_enif_update.py
+++ b/src/ert/analysis/_enif_update.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable, Iterable
 
+import networkx as nx
 import numpy as np
 import polars as pl
 import scipy as sp
@@ -34,6 +35,23 @@ from .snapshots import (
     ObservationStatus,
     SmootherSnapshot,
 )
+
+
+def prune_nan_nodes(
+    graph: nx.Graph[int], nan_mask: npt.NDArray[np.bool_]
+) -> nx.Graph[int]:
+    """Remove NaN-flagged nodes from a parameter graph and relabel to 0..n-1.
+
+    After removal, the remaining nodes are relabeled to contiguous integers
+    so that node k corresponds to column k in the NaN-filtered parameter array.
+    Spatial adjacency between surviving nodes is preserved; no new edges are added.
+    """
+    nan_nodes = set(np.where(nan_mask)[0].tolist())
+    graph = graph.copy()
+    graph.remove_nodes_from(nan_nodes)
+    return nx.convert_node_labels_to_integers(  # type: ignore[call-overload]
+        graph, first_label=0, ordering="sorted"
+    )
 
 
 def enif_update(
@@ -154,12 +172,40 @@ def analysis_EnIF(
 
     X_full = np.vstack(list(param_arrays.values()))
 
-    X_full_scaler = StandardScaler()
-    X_full_scaled = X_full_scaler.fit_transform(X_full.T)
+    nan_row_mask = np.any(np.isnan(X_full), axis=1)
+    if nan_row_mask.any():
+        num_nan = int(nan_row_mask.sum())
+        num_all_nan = int(np.all(np.isnan(X_full), axis=1).sum())
+        num_partial_nan = num_nan - num_all_nan
+        log_msg = (
+            f"EnIF: Excluding {num_nan}/{len(nan_row_mask)} parameter rows "
+            f"containing NaN ({num_all_nan} fully inactive"
+        )
+        if num_partial_nan > 0:
+            log_msg += (
+                f", {num_partial_nan} partially active — "
+                f"these will not be updated for any realization"
+            )
+        log_msg += ")"
+        logger.info(log_msg)
+        progress_callback(AnalysisStatusEvent(msg=log_msg))
+
+    X_clean = X_full[~nan_row_mask]
+    if X_clean.shape[0] == 0:
+        msg = "All parameter rows contain NaN — cannot run EnIF update"
+        data = DataSection(
+            header=smoother_snapshot.header,
+            data=smoother_snapshot.csv,
+            extra=smoother_snapshot.extra,
+        )
+        raise ErtAnalysisError(msg, data=data)
+
+    X_clean_scaler = StandardScaler()
+    X_clean_scaled = X_clean_scaler.fit_transform(X_clean.T)
 
     # Call fit: Learn sparse linear map only
     H = linear_boost_ic_regression(
-        U=X_full_scaled,
+        U=X_clean_scaled,
         Y=S.T,
         verbose_level=5,
     )
@@ -168,10 +214,20 @@ def analysis_EnIF(
     Prec_u = sp.sparse.csc_matrix((0, 0), dtype=float)
     for param_group in updated_parameters:
         config_node = source_ensemble.experiment.parameter_configuration[param_group]
+        X_local = param_arrays[param_group]
+
+        local_nan_mask = np.any(np.isnan(X_local), axis=1)
+        X_local_clean = X_local[~local_nan_mask]
+
+        if X_local_clean.shape[0] == 0:
+            continue
+
         X_local_scaler = StandardScaler()
-        X_scaled = X_local_scaler.fit_transform(param_arrays[param_group].T)
+        X_scaled = X_local_scaler.fit_transform(X_local_clean.T)
 
         graph_u_sub = config_node.load_parameter_graph()
+        if local_nan_mask.any():
+            graph_u_sub = prune_nan_nodes(graph_u_sub, local_nan_mask)
 
         # This works for up to ~10^5 parameters
         Prec_u_sub = fit_precision_cholesky_approximate(
@@ -204,8 +260,8 @@ def analysis_EnIF(
         neighbor_propagation_order=15, verbose_level=1
     )
 
-    X_full = gtmap.transport(
-        X_full_scaled,
+    X_updated = gtmap.transport(
+        X_clean_scaled,
         S.T,
         observation_values,
         update_indices=update_indices,
@@ -213,7 +269,9 @@ def analysis_EnIF(
         verbose_level=5,
         seed=random_seed,
     )
-    X_full = X_full_scaler.inverse_transform(X_full).T
+    X_updated = X_clean_scaler.inverse_transform(X_updated).T
+
+    X_full[~nan_row_mask] = X_updated
 
     # Iterate over parameters to store the updated ensemble
     log_msg = f"Storing {len(updated_parameters)} updated parameter groups"

--- a/tests/ert/ui_tests/cli/analysis/test_enif_update.py
+++ b/tests/ert/ui_tests/cli/analysis/test_enif_update.py
@@ -1,0 +1,146 @@
+from typing import Any
+
+import numpy as np
+import polars as pl
+import pytest
+import xarray as xr
+
+from ert.analysis._enif_update import enif_update
+from ert.config import GenDataConfig, GenKwConfig, SurfaceConfig
+from ert.storage import open_storage
+
+ENSEMBLE_SIZE = 20
+NUM_OBS = 5
+SURFACE_CONFIG = SurfaceConfig(
+    name="TOP_SURFACE",
+    forward_init=True,
+    update=True,
+    ncol=20,
+    nrow=25,
+    xori=0.0,
+    yori=0.0,
+    xinc=25.0,
+    yinc=25.0,
+    rotation=0.0,
+    yflip=1,
+    forward_init_file="init_surf",
+    output_file="out_surf",
+    base_surface_path="base_surf",
+)
+OBSERVATIONS = [
+    {
+        "type": "general_observation",
+        "name": f"OBS_{i}",
+        "data": "RESPONSE",
+        "restart": 0,
+        "index": i,
+        "value": 1.0,
+        "error": 0.1,
+    }
+    for i in range(NUM_OBS)
+]
+
+
+def _make_genkw(name: str) -> dict[str, Any]:
+    return GenKwConfig(
+        name=name,
+        group=name,
+        distribution={"name": "uniform", "min": 0.8, "max": 1.2},
+    ).model_dump(mode="json")
+
+
+def _populate_prior(prior, rng, genkw_names):
+    ncol, nrow = SURFACE_CONFIG.ncol, SURFACE_CONFIG.nrow
+    inactive = rng.random((ncol, nrow)) < 0.55
+
+    for real in range(ENSEMBLE_SIZE):
+        vals = rng.normal(1.0, 0.1, (ncol, nrow)).astype(np.float32)
+        vals[inactive] = np.nan
+        prior.save_parameters(
+            xr.Dataset({"values": (["x", "y"], vals)}), "TOP_SURFACE", real
+        )
+
+    for name in genkw_names:
+        prior.save_parameters(
+            dataset=pl.DataFrame(
+                {
+                    name: rng.uniform(0.8, 1.2, ENSEMBLE_SIZE).tolist(),
+                    "realization": range(ENSEMBLE_SIZE),
+                }
+            )
+        )
+
+    for iens in range(ENSEMBLE_SIZE):
+        prior.save_response(
+            "gen_data",
+            pl.DataFrame(
+                {
+                    "response_key": "RESPONSE",
+                    "report_step": pl.Series(
+                        np.zeros(NUM_OBS, dtype=int), dtype=pl.UInt16
+                    ),
+                    "index": pl.Series(np.arange(NUM_OBS), dtype=pl.UInt16),
+                    "values": pl.Series(rng.normal(1, 0.1, NUM_OBS), dtype=pl.Float32),
+                }
+            ),
+            iens,
+        )
+
+
+@pytest.mark.filterwarnings("ignore::scipy.linalg.LinAlgWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.parametrize("param_order", ["genkw_first", "surface_first"])
+def test_that_enif_nan_filtering_does_not_contaminate_genkw(tmp_path, param_order):
+    rng = np.random.default_rng(42)
+    surf_cfg = SURFACE_CONFIG.model_dump(mode="json")
+
+    if param_order == "genkw_first":
+        params = [_make_genkw("MULT_1"), _make_genkw("MULT_2"), surf_cfg]
+        genkw_names = ["MULT_1", "MULT_2"]
+    else:
+        params = [surf_cfg, _make_genkw("MULT_2"), _make_genkw("MULT_1")]
+        genkw_names = ["MULT_2", "MULT_1"]
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment(
+            name="enif_nan_test",
+            experiment_config={
+                "parameter_configuration": params,
+                "response_configuration": [
+                    GenDataConfig(keys=["RESPONSE"]).model_dump(mode="json")
+                ],
+                "observations": OBSERVATIONS,
+            },
+        )
+        prior = storage.create_ensemble(
+            experiment, ensemble_size=ENSEMBLE_SIZE, iteration=0, name="prior"
+        )
+        _populate_prior(prior, rng, genkw_names)
+
+        posterior = storage.create_ensemble(
+            experiment,
+            ensemble_size=ENSEMBLE_SIZE,
+            iteration=1,
+            name="posterior",
+            prior_ensemble=prior,
+        )
+        enif_update(
+            prior,
+            posterior,
+            observations=experiment.observation_keys,
+            parameters=list(experiment.parameter_configuration.keys()),
+            random_seed=42,
+        )
+
+        iens = np.arange(ENSEMBLE_SIZE)
+        for name in genkw_names:
+            post = posterior.load_parameters_numpy(name, iens)
+            assert np.all(np.isfinite(post)), f"{name} contains NaN"
+
+        prior_surf = prior.load_parameters_numpy("TOP_SURFACE", iens)
+        post_surf = posterior.load_parameters_numpy("TOP_SURFACE", iens)
+        nan_mask = np.isnan(prior_surf)
+
+        assert np.array_equal(np.isnan(post_surf), nan_mask)
+        assert np.all(np.isfinite(post_surf[~nan_mask]))
+        assert not np.array_equal(post_surf[~nan_mask], prior_surf[~nan_mask])

--- a/tests/ert/unit_tests/analysis/test_enif_update.py
+++ b/tests/ert/unit_tests/analysis/test_enif_update.py
@@ -1,0 +1,127 @@
+import networkx as nx
+import numpy as np
+
+from ert.analysis._enif_update import prune_nan_nodes
+from ert.config import SurfaceConfig
+
+
+def test_that_prune_nan_nodes_preserves_adjacency_and_relabels():
+    """
+    Remove NaN boundary nodes from a 4x3 surface graph and verify:
+    - Surviving nodes get contiguous 0..n-1 labels
+    - Spatial adjacency is preserved
+    - No false edges appear across the NaN gap
+    """
+
+    # 4x3 grid → 12 nodes
+    config = SurfaceConfig(
+        name="s",
+        forward_init=False,
+        update=True,
+        ncol=4,
+        nrow=3,
+        xori=0,
+        yori=0,
+        xinc=1,
+        yinc=1,
+        rotation=0,
+        yflip=1,
+        forward_init_file="f",
+        output_file="o",
+        base_surface_path="b",
+    )
+    graph = config.load_parameter_graph()
+    assert graph.number_of_nodes() == 12
+
+    # NaN out the last row (nodes 2, 5, 8, 11 all have y=2)
+    nan_mask = np.array(
+        [
+            False,
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+            True,
+        ]
+    )
+    pruned = prune_nan_nodes(graph, nan_mask)
+
+    assert pruned.number_of_nodes() == 8
+    assert set(pruned.nodes()) == set(range(8))
+
+    # Relabeled: 0→0, 1→1, 3→2, 4→3, 6→4, 7→5, 9→6, 10→7
+    expected_edges = {
+        frozenset({0, 1}),
+        frozenset({2, 3}),
+        frozenset({4, 5}),
+        frozenset({6, 7}),
+        frozenset({0, 2}),
+        frozenset({1, 3}),
+        frozenset({2, 4}),
+        frozenset({3, 5}),
+        frozenset({4, 6}),
+        frozenset({5, 7}),
+    }
+    assert set(map(frozenset, pruned.edges())) == expected_edges
+
+
+def test_that_prune_nan_wall_creates_disconnected_components():
+    """
+    A NaN wall splitting a 3x3 surface creates two disconnected components
+    with no false edges across the wall.
+    """
+
+    config = SurfaceConfig(
+        name="s",
+        forward_init=False,
+        update=True,
+        ncol=3,
+        nrow=3,
+        xori=0,
+        yori=0,
+        xinc=1,
+        yinc=1,
+        rotation=0,
+        yflip=1,
+        forward_init_file="f",
+        output_file="o",
+        base_surface_path="b",
+    )
+    graph = config.load_parameter_graph()
+
+    # NaN out the middle row (nodes 1, 4, 7 all have y=1)
+    nan_mask = np.array(
+        [
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+            True,
+            False,
+        ]
+    )
+    pruned = prune_nan_nodes(graph, nan_mask)
+
+    assert pruned.number_of_nodes() == 6
+
+    components = list(nx.connected_components(pruned))
+    assert len(components) == 2
+    # After relabeling, original nodes 0,3,6 (first row) → 0,2,4
+    # and original nodes 2,5,8 (last row) → 1,3,5
+    assert {frozenset(c) for c in components} == {
+        frozenset({0, 2, 4}),
+        frozenset({1, 3, 5}),
+    }
+
+    for left in (0, 2, 4):
+        for right in (1, 3, 5):
+            assert not pruned.has_edge(left, right)


### PR DESCRIPTION
 Surface and field parameters commonly have NaN for inactive grid cells. When EnIF stacks all parameters into a joint matrix, these NaN values corrupt linear_boost_ic_regression — np.argmax treats NaN as
 greater than any real value, so the LASSO preferentially selects NaN columns, corrupting the residual and cascading NaN into the learned H matrix for other parameter groups.

**Issue**
Resolves #13174

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
