### PR TITLE
Fix bug in std dev plotter

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -416,7 +416,7 @@ class PlotWindow(QMainWindow):
 
                 for ensemble in selected_ensembles:
                     try:
-                        std_dev_images[ensemble.name] = self._api.std_dev_for_parameter(
+                        std_dev_images[ensemble.id] = self._api.std_dev_for_parameter(
                             key, ensemble.id, layer
                         )
                     except BaseException as e:

--- a/src/ert/gui/tools/plot/plottery/plots/std_dev.py
+++ b/src/ert/gui/tools/plot/plottery/plots/std_dev.py
@@ -46,7 +46,7 @@ class StdDevPlot:
             for i, ensemble in enumerate(reversed(ensembles), start=1):
                 ax_heat = figure.add_subplot(gridspec[0, i - 1])
                 ax_box = figure.add_subplot(gridspec[1, i - 1])
-                data = std_dev_data[ensemble.name]
+                data = std_dev_data[ensemble.id]
                 if data.size == 0:
                     ax_heat.set_axis_off()
                     ax_box.set_axis_off()

--- a/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
+++ b/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
@@ -34,7 +34,7 @@ def test_stddev_plot_shows_boxplot(plot_context: PlotContext):
         plot_context,
         {},
         {},
-        {"ensemble_1": std_dev_data},
+        {"id": std_dev_data},
         obs_loc,
     )
     ax = figure.axes


### PR DESCRIPTION
Changed to use ensemble.id instead of ensemble.name as key in image map

**Issue**
Resolves #13183 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
