### PR TITLE
Have GUI hide log_scale button for const genkw

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -25,6 +25,8 @@ from PyQt6.QtWidgets import (
 )
 from typing_extensions import override
 
+from ert.config.distribution import ConstSettings
+from ert.config.gen_kw_config import GenKwConfig
 from ert.gui.icon_utils import load_icon
 from ert.gui.tools.plot.plottery.plots import EverestGradientsPlot
 
@@ -184,7 +186,7 @@ class PlotWidget(QWidget):
     def resetPlot(self) -> None:
         self._figure.clear()
 
-    def _sync_log_checkbox(self) -> None:
+    def _sync_log_checkbox(self, key_def: PlotApiKeyDefinition | None = None) -> None:
         if (
             type(self._plotter).__name__
             in {
@@ -194,6 +196,13 @@ class PlotWidget(QWidget):
             }
             and self._negative_values_in_data is False
         ):
+            if key_def is not None:
+                a = key_def.parameter
+                if isinstance(a, GenKwConfig) and isinstance(
+                    a.distribution, ConstSettings
+                ):
+                    self._log_checkbox.setVisible(False)
+                    return
             self._log_checkbox.setVisible(True)
         else:
             self._log_checkbox.setVisible(False)
@@ -217,12 +226,13 @@ class PlotWidget(QWidget):
     ) -> None:
         self.resetPlot()
         try:
-            self._sync_log_checkbox()
+            self._sync_log_checkbox(key_def)
             plot_context.log_scale = (
                 self._log_checkbox.isVisible()
                 and self._log_checkbox.isChecked()
                 and self._negative_values_in_data is False
             )
+
             self._plotter.plot(
                 self._figure,
                 plot_context,

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -15,6 +15,7 @@ from ert.gui.tools.plot.plot_widget import PlotWidget
 from ert.gui.tools.plot.plot_window import PlotWindow, create_error_dialog
 from ert.gui.tools.plot.plottery import PlotConfig, PlotContext
 from ert.gui.tools.plot.plottery.plots.gaussian_kde import plotGaussianKDE
+from ert.gui.tools.plot.plottery.plots.histogram import HistogramPlot
 from ert.services import ErtServerController
 
 
@@ -245,3 +246,73 @@ def test_that_gaussian_kde_plot_skips_categorical_data_without_raising():
 
     # Should not raise (categorical data is simply skipped).
     plotGaussianKDE(fig, ctx, {ensemble: categorical_df}, _observation_data=None)
+
+
+def test_that_plot_widget_hides_log_scale_checkbox_for_const_distribution(qtbot: QtBot):
+    ensemble = EnsembleObject(
+        "ensemble",
+        "ensemble",
+        False,
+        "experiment",
+        "2026-01-01T00:00:00",
+    )
+
+    ctx = PlotContext(
+        PlotConfig(),
+        ensembles=[ensemble],
+        ensembles_color_indexes=[0],
+        key="gen_kw",
+        layer=None,
+    )
+
+    plotter = HistogramPlot()
+    plotter.plot = MagicMock(return_value=None)
+    plot_widget = PlotWidget("Histogram", plotter)
+    qtbot.addWidget(plot_widget)
+    plot_widget.show()
+    qtbot.waitUntil(plot_widget.isVisible)
+
+    log_checkbox = plot_widget.findChild(QCheckBox, name="log_scale_checkbox")
+    assert log_checkbox is not None
+
+    non_const_key_def = PlotApiKeyDefinition(
+        "gen_kw_nonconst",
+        index_type=None,
+        metadata={"data_origin": "GEN_KW"},
+        observations=False,
+        dimensionality=1,
+        parameter=GenKwConfig(
+            name="gen_kw_nonconst",
+            distribution={"name": "uniform", "min": 0.0, "max": 1.0},
+        ),
+    )
+    plot_widget.updatePlot(
+        ctx,
+        {ensemble: pd.DataFrame({0: [0.1, 0.2, 0.3]})},
+        pd.DataFrame(),
+        {},
+        None,
+        non_const_key_def,
+    )
+    assert log_checkbox.isVisible()
+
+    const_key_def = PlotApiKeyDefinition(
+        "gen_kw_const",
+        index_type=None,
+        metadata={"data_origin": "GEN_KW"},
+        observations=False,
+        dimensionality=1,
+        parameter=GenKwConfig(
+            name="gen_kw_const",
+            distribution={"name": "const", "value": 0.1},
+        ),
+    )
+    plot_widget.updatePlot(
+        ctx,
+        {ensemble: pd.DataFrame({0: [0.1, 0.1, 0.1]})},
+        pd.DataFrame(),
+        {},
+        None,
+        const_key_def,
+    )
+    assert not log_checkbox.isVisible()


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
