### PR TITLE
Add iteration number to EnsembleWidget

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -131,9 +131,11 @@ class _EnsembleWidget(QWidget):
         info_frame = QFrame()
         self._name_label = QLabel()
         self._uuid_label = QLabel()
+        self._iteration_label = QLabel()
 
         info_layout = QVBoxLayout()
         info_layout.addWidget(self._name_label)
+        info_layout.addWidget(self._iteration_label)
         info_layout.addWidget(self._uuid_label)
         info_layout.addStretch()
 
@@ -461,6 +463,7 @@ class _EnsembleWidget(QWidget):
 
         self._name_label.setText(f"Name: {ensemble.name!s}")
         self._uuid_label.setText(f"UUID: {ensemble.id!s}")
+        self._iteration_label.setText(f"Iteration: {ensemble.iteration:d}")
 
         current_index = self._tab_widget.currentIndex()
         if current_index > 0:


### PR DESCRIPTION
**Issue**
Resolves #8550

Adding iteration number to the tree view is tricky as it would require a iteration column in for the whole tree view or we would need to create a new treeview just for ensembles

<img width="853" height="324" alt="image" src="https://github.com/user-attachments/assets/bb0ae0f3-9c23-4571-be61-b7888b96f3fd" />

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
