### PR TITLE
Remove ErtPluginManager arg from main fns

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -118,7 +118,7 @@ def run_convert_observations(
     logger.info(msg)
 
 
-def run_ert_storage(args: Namespace, _: ErtRuntimePlugins | None = None) -> None:
+def run_ert_storage(args: Namespace) -> None:
     with ErtServerController.start_server(
         verbose=True,
         project=Path(ErtConfig.from_file(args.config).ens_path),
@@ -214,11 +214,11 @@ def valid_port_range(user_input: str) -> range:
     return range(port_a, port_b + 1)
 
 
-def run_gui_wrapper(args: Namespace, runtime_plugins: ErtRuntimePlugins) -> None:
+def run_gui_wrapper(args: Namespace) -> None:
     # Importing ert.gui on-demand saves ~0.5 seconds off `from ert import __main__`
     from ert.gui import run_gui  # noqa: PLC0415
 
-    run_gui(args, runtime_plugins)
+    run_gui(args)
 
 
 def run_lint_wrapper(args: Namespace, _: ErtRuntimePlugins) -> None:
@@ -737,7 +737,7 @@ def main() -> None:
         setup_site_logging(logging.getLogger())
         with use_runtime_plugins(site_plugins):
             logger.info(f"Running ert with {args} in {Path.cwd()}")
-            args.func(args, site_plugins)
+            args.func(args)
     except ErtStoragePermissionError as err:
         logger.error(str(err))
         sys.exit(str(err))

--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -24,7 +24,7 @@ from ert.mode_definitions import (
     WORKFLOW_MODE,
 )
 from ert.namespace import Namespace
-from ert.plugins import ErtRuntimePlugins, get_site_plugins
+from ert.plugins import get_site_plugins
 from ert.run_models.event import StatusEvents
 from ert.run_models.model_factory import create_model
 from ert.storage import LocalStorage, open_storage
@@ -37,17 +37,14 @@ class ErtCliError(Exception):
     """
 
 
-def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -> None:
+def run_cli(args: Namespace) -> None:
     ert_dir = os.path.abspath(os.path.dirname(args.config))
     os.chdir(ert_dir)
     # Changing current working directory means we need to update
     # the config file to be the base name of the original config
     args.config = os.path.basename(args.config)
 
-    active_plugins = (
-        runtime_plugins if runtime_plugins is not None else get_site_plugins()
-    )
-    ert_config = ErtConfig.with_plugins(active_plugins).from_file(args.config)
+    ert_config = ErtConfig.with_plugins(get_site_plugins()).from_file(args.config)
 
     local_storage_set_ert_config(ert_config)
     counter_fm_steps = Counter(fms.name for fms in ert_config.forward_model_steps)
@@ -118,7 +115,7 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
     status_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
     using_local_queuesystem: bool = True
     try:
-        with use_runtime_plugins(active_plugins):
+        with use_runtime_plugins(get_site_plugins()):
             model = create_model(
                 ert_config,
                 args,

--- a/src/ert/gui/main.py
+++ b/src/ert/gui/main.py
@@ -27,7 +27,7 @@ from ert.gui.tools.event_viewer import (
     add_gui_log_handler,
 )
 from ert.namespace import Namespace
-from ert.plugins import ErtRuntimePlugins, get_site_plugins
+from ert.plugins import get_site_plugins
 from ert.services import ErtServerController
 from ert.storage import (
     ErtStorageException,
@@ -56,7 +56,7 @@ def _perform_migration_with_spinner(path: Path) -> None:
 
 
 @tracer.start_as_current_span("ert.application.gui")
-def run_gui(args: Namespace, plugins: ErtRuntimePlugins | None = None) -> int:
+def run_gui(args: Namespace) -> int:
     span = trace.get_current_span()
     # Replace Python's exception handler for SIGINT with the system default.
     #
@@ -118,7 +118,7 @@ def run_gui(args: Namespace, plugins: ErtRuntimePlugins | None = None) -> int:
     app.setWindowIcon(QIcon("img:ert_icon.svg"))
 
     with add_gui_log_handler() as log_handler:
-        window, ens_path = _start_initial_gui_window(args, log_handler, plugins)
+        window, ens_path = _start_initial_gui_window(args, log_handler)
 
         def show_window() -> int:
             window.show()
@@ -152,7 +152,6 @@ def run_gui(args: Namespace, plugins: ErtRuntimePlugins | None = None) -> int:
 def _start_initial_gui_window(
     args: Namespace,
     log_handler: GUILogHandler,
-    runtime_plugins: ErtRuntimePlugins | None = None,
 ) -> tuple[QWidget, str | None]:
     # Create logger inside function to make sure all handlers have been added to
     # the root-logger.
@@ -166,12 +165,9 @@ def _start_initial_gui_window(
         # the config file to be the base name of the original config
         args.config = os.path.basename(args.config)
 
-        if runtime_plugins is not None:
-            ert_config = ErtConfig.with_plugins(runtime_plugins).from_file(args.config)
-        else:
-            ert_config = ErtConfig.with_plugins(get_site_plugins()).from_file(
-                args.config
-            )
+        runtime_plugins = get_site_plugins()
+        ert_config = ErtConfig.with_plugins(runtime_plugins).from_file(args.config)
+
         local_storage_set_ert_config(ert_config)
 
     storage_path = None
@@ -240,9 +236,7 @@ def _start_initial_gui_window(
         logger.info(f"Warning shown in gui '{msg}'")
 
     assert storage_path is not None
-    main_window = _setup_main_window(
-        ert_config, args, log_handler, storage_path, runtime_plugins
-    )
+    main_window = _setup_main_window(ert_config, args, log_handler, storage_path)
 
     if validation_messages.warnings or validation_messages.deprecations:
 
@@ -279,10 +273,9 @@ def _setup_main_window(
     args: Namespace,
     log_handler: GUILogHandler,
     storage_path: str,
-    runtime_plugins: ErtRuntimePlugins | None = None,
 ) -> ErtMainWindow:
     # window reference must be kept until app.exec returns:
-    window = ErtMainWindow(args.config, ert_config, runtime_plugins, log_handler)
+    window = ErtMainWindow(args.config, ert_config, log_handler)
     window.notifier.set_storage(storage_path)
     window.post_init()
     window.adjustSize()

--- a/src/ert/gui/main_window.py
+++ b/src/ert/gui/main_window.py
@@ -31,7 +31,7 @@ from ert.gui.tools.load_results import LoadResultsTool
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.plugins import PluginHandler, PluginsTool
 from ert.gui.tools.workflows import WorkflowsTool
-from ert.plugins import ErtRuntimePlugins
+from ert.plugins import get_site_plugins
 from ert.trace import get_trace_id
 
 from .detect_mode import is_dark_mode
@@ -90,7 +90,6 @@ class ErtMainWindow(QMainWindow):
         self,
         config_file: str,
         ert_config: ErtConfig,
-        runtime_plugins: ErtRuntimePlugins | None = None,
         log_handler: GUILogHandler | None = None,
     ) -> None:
         QMainWindow.__init__(self)
@@ -103,7 +102,7 @@ class ErtMainWindow(QMainWindow):
         self.setWindowTitle(
             f"ERT - {config_file} - {find_ert_info()} - {get_trace_id()[:8]}"
         )
-        self.runtime_plugins = runtime_plugins
+        self.runtime_plugins = get_site_plugins()
         self.central_widget = QFrame(self)
         self.central_layout = QHBoxLayout(self.central_widget)
         self.central_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/ert/namespace.py
+++ b/src/ert/namespace.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 
-from ert.plugins import ErtRuntimePlugins
-
 
 class Namespace(argparse.Namespace):
     """ERT argument parser namespace"""
@@ -15,4 +13,4 @@ class Namespace(argparse.Namespace):
     experimental_mode: bool
     logdir: str
     experiment_name: str | None = None
-    func: Callable[[Namespace, ErtRuntimePlugins | None], None]
+    func: Callable[[Namespace], None]

--- a/tests/ert/ui_tests/cli/run_cli.py
+++ b/tests/ert/ui_tests/cli/run_cli.py
@@ -1,22 +1,10 @@
 from argparse import ArgumentParser
-from typing import Any
 
 from ert.__main__ import ert_parser
 from ert.cli.main import run_cli as cli_runner
-from ert.plugins.plugin_manager import ErtRuntimePlugins, get_site_plugins
 
 
 def run_cli(*args):
     parser = ArgumentParser(prog="test_main")
     parsed = ert_parser(parser, args)
     return cli_runner(parsed)
-
-
-def run_cli_with_pm(args: list[Any], runtime_plugins: ErtRuntimePlugins | None = None):
-    parser = ArgumentParser(prog="test_main")
-    parsed = ert_parser(parser, args)
-    if runtime_plugins:
-        res = cli_runner(parsed, runtime_plugins)
-    else:
-        res = cli_runner(parsed, get_site_plugins())
-    return res

--- a/tests/ert/ui_tests/cli/test_missing_runpath.py
+++ b/tests/ert/ui_tests/cli/test_missing_runpath.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from ert.cli.main import ErtCliError
-from ert.plugins import get_site_plugins
 
-from .run_cli import run_cli_with_pm
+from .run_cli import run_cli
 
 config_contents = """\
 QUEUE_SYSTEM {queue_system}
@@ -57,9 +56,7 @@ def test_missing_runpath_has_isolated_failures(tmp_path, monkeypatch):
             match=r"successful realizations \(9\) is less "
             r"than .* MIN_REALIZATIONS\(10\)",
         ):
-            run_cli_with_pm(
-                ["ensemble_experiment", "config.ert", "--disable-monitoring"]
-            )
+            run_cli("ensemble_experiment", "config.ert", "--disable-monitoring")
     finally:
         with suppress(FileNotFoundError):
             (tmp_path / "simulations/realization-0/iter-0").chmod(0x777)
@@ -104,7 +101,4 @@ def test_failing_writes_lead_to_isolated_failures(tmp_path, monkeypatch, pytestc
         ),
         patch_raising_named_temporary_file(queue_system.lower()),
     ):
-        run_cli_with_pm(
-            ["ensemble_experiment", "config.ert", "--disable-monitoring"],
-            runtime_plugins=get_site_plugins(),
-        )
+        run_cli("ensemble_experiment", "config.ert", "--disable-monitoring")

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -31,7 +31,7 @@ from ert.field_utils.field_file_format import ROFF_FORMATS
 from ert.mode_definitions import ENSEMBLE_EXPERIMENT_MODE
 from tests.ert.grid_generator import xtgeo_box_grids
 
-from .run_cli import run_cli_with_pm
+from .run_cli import run_cli
 
 names = st.text(
     min_size=1,
@@ -456,9 +456,7 @@ def test_that_parameters_are_placed_in_the_runpath_as_expected(
         smspec.to_file("ECLBASE.SMSPEC")
         unsmry.to_file("ECLBASE.UNSMRY")
 
-        run_cli_with_pm(
-            [ENSEMBLE_EXPERIMENT_MODE, "--disable-monitoring", "config.ert"]
-        )
+        run_cli(ENSEMBLE_EXPERIMENT_MODE, "--disable-monitoring", "config.ert")
 
         mask = np.logical_not(
             np.array(io_source.actnum).reshape(io_source.dims, order="F")

--- a/tests/ert/ui_tests/cli/test_shell.py
+++ b/tests/ert/ui_tests/cli/test_shell.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .run_cli import run_cli_with_pm
+from .run_cli import run_cli
 
 
 def test_shell_scripts_integration(tmpdir):
@@ -33,7 +33,7 @@ FORWARD_MODEL MOVE_DIRECTORY(<FROM>=mydir3, <TO>=mydir4/mydir3)
 
         Path("file.txt").write_text("something", encoding="utf-8")
 
-        run_cli_with_pm(["test_run", "--disable-monitoring", ert_config_fname])
+        run_cli("test_run", "--disable-monitoring", ert_config_fname)
 
         assert (
             Path("realization-0/iter-0/moved.txt").read_text(encoding="utf-8")

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -49,7 +49,6 @@ from ert.gui.plotting.widgets import DataTypeKeysWidget, EnsembleSelectListWidge
 from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import AddWidget, StorageWidget
-from ert.plugins import get_site_plugins
 from ert.run_models import (
     EnsembleExperiment,
     EnsembleInformationFilter,
@@ -185,9 +184,7 @@ def test_that_there_is_a_link_to_github_in_the_suggester(tmp_path, qtbot):
     args = Mock()
     args.config = str(config_file)
     with add_gui_log_handler() as log_handler:
-        gui, *_ = ert.gui.main._start_initial_gui_window(
-            args, log_handler, get_site_plugins()
-        )
+        gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)
         assert isinstance(gui, Suggestor)
 
         with patch("webbrowser.open", MagicMock(return_value=True)) as browser_open:

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -5,12 +5,13 @@ import stat
 from argparse import ArgumentParser
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from hypothesis import given, settings
 from pydantic import TypeAdapter
 
+import ert.plugins
 from ert.__main__ import ert_parser
 from ert.base_model_context import use_runtime_plugins
 from ert.cli.main import ErtCliError, run_cli
@@ -781,11 +782,16 @@ def test_that_validate_pre_realization_run_is_called_when_runmodel_is_evaluated(
         parser,
         [TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert")],
     )
-    runtime_plugins = ErtRuntimePlugins(
-        installed_forward_model_steps={"WILL_FAIL_VALIDATION": FM()}
+
+    plugins_mock = MagicMock(
+        return_value=ErtRuntimePlugins(
+            installed_forward_model_steps={"WILL_FAIL_VALIDATION": FM()}
+        )
     )
+    monkeypatch.setattr(ert.cli.main, "get_site_plugins", plugins_mock)
+
     with pytest.raises(ErtCliError) as exc_info:
-        run_cli(args, runtime_plugins)
+        run_cli(args)
     assert (
         "Validation failed for forward model step WILL_FAIL_VALIDATION: No go"
         in str(exc_info.value)
@@ -829,10 +835,15 @@ def test_that_validate_pre_realization_run_is_not_called_when_user_defined_step_
         parser,
         [TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert")],
     )
-    runtime_plugins = ErtRuntimePlugins(
-        installed_forward_model_steps={"A_POPULAR_STEP_NAME": FM()}
+    plugins_mock = MagicMock(
+        return_value=ErtRuntimePlugins(
+            installed_forward_model_steps={"A_POPULAR_STEP_NAME": FM()}
+        )
     )
-    run_cli(args, runtime_plugins)
+    monkeypatch.setattr(ert.cli.main, "get_site_plugins", plugins_mock)
+
+    run_cli(args)
+    plugins_mock.assert_called()
 
 
 def test_that_plugin_forward_model_validation_accepts_valid_args(tmp_path):


### PR DESCRIPTION
added manual call to pass the global
logger to consumer plugins

Copy of: https://github.com/equinor/ert/pull/11803/changes


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
