### PR TITLE
Avoid flakyness by making problem numerically simpler

### DIFF
--- a/tests/ert/ui_tests/cli/test_restarting_esmda.py
+++ b/tests/ert/ui_tests/cli/test_restarting_esmda.py
@@ -64,7 +64,7 @@ def observations() -> Callable[[bool], str]:
                 """
                 GENERAL_OBSERVATION POLY_OBS {
                     DATA       = POLY_RES;
-                    INDEX_LIST = 0,2;
+                    INDEX_LIST = 0,2,4,6,8,10;
                     OBS_FILE   = obs_data.txt;
                 };
                 """
@@ -73,7 +73,7 @@ def observations() -> Callable[[bool], str]:
             """
             GENERAL_OBSERVATION POLY_OBS {
                 DATA       = POLY_RES;
-                INDEX_LIST = 0;
+                INDEX_LIST = 0,2,4,6,8;
                 OBS_FILE   = obs_data.txt;
             };
             """
@@ -87,6 +87,10 @@ def observations_data() -> str:
     return dedent(
         """
         2.0 0.5
+        9.0 1.5
+        15.0 3.0
+        30.0 6.0
+        50.0 12.0
         """
     )
 
@@ -166,10 +170,10 @@ def test_that_running_esmda_from_restart_uses_previous_observations_and_paramete
 
     assert_series_equal(
         experiment.observations["gen_data"]["observations"],
-        Series("observations", [2.0], dtype=Float32),
+        Series("observations", [2.0, 9.0, 15.0, 30.0, 50.0], dtype=Float32),
     )
 
     assert_series_equal(
         experiment.observations["gen_data"]["std"],
-        Series("std", [0.5], dtype=Float32),
+        Series("std", [0.5, 1.5, 3.0, 6.0, 12.0], dtype=Float32),
     )


### PR DESCRIPTION
Let Ert have an easier time computing a solution so that observations are not deactivated.

**Issue**
Resolves #13219

**Approach**
Avoid simplifications for the sake of reduced line count

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
