### PR TITLE
Add missing slow marker to run dialog test

### DIFF
--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -984,6 +984,7 @@ def test_that_file_dialog_close_when_run_dialog_hidden(qtbot: QtBot, run_dialog)
             assert not file_dialog.isVisible()
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ("events"),
     [


### PR DESCRIPTION
The integration_test to slow marker migration in 9ab0358 dropped the marker from test_that_run_dialog_clears_warnings_when_rerun without adding a replacement. This caused the test to run in rapid-tests where it leaks _ERT_EXPERIMENT_ID and _ERT_ENSEMBLE_ID into os.environ during parallel execution, failing unrelated tests via the env_save fixture.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
