### PR TITLE
Refactor site configuration interaction to happen on server

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -7,7 +7,6 @@ import queue
 import time
 import traceback
 import uuid
-import warnings
 from base64 import b64decode
 from queue import SimpleQueue
 from typing import Annotated
@@ -28,7 +27,7 @@ from starlette.responses import PlainTextResponse, Response
 from starlette.websockets import WebSocket
 
 from ert.base_model_context import use_runtime_plugins
-from ert.config import ConfigWarning, QueueSystem
+from ert.config import QueueSystem
 from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig
 from ert.ensemble_evaluator.event import FullSnapshotEvent, SnapshotUpdateEvent
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
@@ -186,18 +185,19 @@ def stop(
 @router.post("/" + EverEndpoints.start_experiment)
 async def start_experiment(
     request: Request,
+    config: EverestConfig,
     background_tasks: BackgroundTasks,
     credentials: Annotated[HTTPBasicCredentials, Depends(security)],
 ) -> Response:
     _log(request)
     _check_user(credentials)
     if shared_data.status.status == ExperimentState.pending:
-        request_data = await request.json()
-        # The output of warnings is the task of the user interface, not
-        # of everserver. Therefore we suppress them here:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=ConfigWarning)
-            config = EverestConfig.with_plugins(request_data)
+        missing_jobs = config.validate_forward_model_job_name_installed()
+        if missing_jobs:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"missing_jobs": missing_jobs},
+            )
         runner = ExperimentRunner(config)
         try:
             background_tasks.add_task(runner.run)

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -246,10 +246,15 @@ async def run_everest(options: argparse.Namespace) -> None:
         "Starting experiment"
     )
 
-    start_experiment(
-        server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),
-        config=options.config,
-    )
+    try:
+        start_experiment(
+            server_context=ServerConfig.get_server_context_from_conn_info(
+                client.conn_info
+            ),
+            config=options.config,
+        )
+    except Exception as e:
+        raise SystemExit(f"Failed to start the experiment: {e}") from e
 
     # blocks until the run is finished
     if options.gui:

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -26,7 +26,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
-from pydantic_core import ErrorDetails
+from pydantic_core import ErrorDetails, InitErrorDetails, PydanticCustomError
 from pydantic_core.core_schema import ValidationInfo
 from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.nodes import ScalarNode
@@ -94,6 +94,30 @@ class EverestValidationError(ValueError):
 
     def __str__(self) -> str:
         return f"{self._errors!s}"
+
+    @classmethod
+    def from_missing_forward_model_jobs(
+        cls,
+        missing_jobs: list[str],
+        config_path: Path,
+    ) -> "EverestValidationError":
+        errors: list[InitErrorDetails] = [
+            InitErrorDetails(
+                type=PydanticCustomError(
+                    "missing_forward_model_job",
+                    "Job '{job}' is not installed on the server",
+                    {"job": job},
+                ),
+                loc=("forward_model",),
+                input=job,
+            )
+            for job in missing_jobs
+        ]
+        validation_error = ValidationError.from_exception_data(
+            title=EverestConfig.__name__,
+            line_errors=errors,
+        )
+        return _convert_to_everest_validation_error(validation_error, str(config_path))
 
 
 def _error_loc(error: ErrorDetails) -> str:
@@ -568,25 +592,18 @@ class EverestConfig(BaseModelWithContextSupport):
 
         return [format_fm(fm) for fm in forward_model_steps]
 
-    @model_validator(mode="after")
-    def validate_forward_model_job_name_installed(self, info: ValidationInfo) -> Self:
-        install_jobs = self.install_jobs
+    def validate_forward_model_job_name_installed(self) -> list[str]:
         forward_model_jobs = self.forward_model
         if not forward_model_jobs:
-            return self
-        installed_jobs_name = [job.name for job in install_jobs]
-        if info.context:  # Add plugin jobs
-            installed_jobs_name += info.context.installed_forward_model_steps.keys()
-
-        errors = []
-        for fm_job in forward_model_jobs:
-            job_name = fm_job.job.split()[0]
-            if job_name not in installed_jobs_name:
-                errors.append(f"unknown job {job_name}")
-
-        if len(errors) > 0:  # Revisit when pydantic supports ExceptionGroup.
-            raise ValueError(errors)
-        return self
+            return []
+        site_plugins = get_site_plugins()
+        installed_jobs_name = [job.name for job in self.install_jobs]
+        installed_jobs_name += site_plugins.installed_forward_model_steps.keys()
+        return [
+            job_name
+            for fm_job in forward_model_jobs
+            if (job_name := fm_job.job.split()[0]) not in installed_jobs_name
+        ]
 
     @model_validator(mode="after")
     def validate_at_most_one_summary_forward_model(self, _: ValidationInfo) -> Self:

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -20,7 +20,8 @@ from ert.scheduler import create_driver
 from ert.scheduler.driver import Driver, FailedSubmit
 from ert.scheduler.event import StartedEvent
 from ert.trace import get_traceparent
-from everest.config import EverestConfig, ServerConfig
+from everest.config import EverestConfig, EverestValidationError, ServerConfig
+from everest.config.everest_config import _format_errors
 from everest.strings import (
     OPT_PROGRESS_ID,
     SIM_PROGRESS_ID,
@@ -113,7 +114,21 @@ def start_experiment(
                 proxies=PROXY,  # type: ignore
                 json=config.to_dict(),
             )
+            if response.status_code == 422:
+                detail = response.json().get("detail", {})
+                missing_jobs = (
+                    detail.get("missing_jobs", []) if isinstance(detail, dict) else []
+                )
+                if missing_jobs:
+                    raise EverestValidationError.from_missing_forward_model_jobs(
+                        missing_jobs, config.config_path
+                    )
+                raise RuntimeError(f"Server rejected config: {detail}")
             response.raise_for_status()
+        except EverestValidationError as e:
+            raise RuntimeError(
+                f"Config file <{config.config_file}> had errors:\n{_format_errors(e)}"
+            ) from e
         except Exception:
             logger.debug(traceback.format_exc())
             time.sleep(retry)

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -34,12 +34,59 @@ from everest.config.simulator_config import SimulatorConfig
 from everest.detached import (
     PROXY,
     server_is_running,
+    start_experiment,
     start_server,
     stop_server,
     wait_for_server,
     wait_for_server_to_stop,
 )
 from tests.everest.utils import everest_config_with_defaults
+
+
+@pytest.mark.slow
+@pytest.mark.skip_mac_ci
+@pytest.mark.xdist_group(name="starts_everest")
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
+async def test_that_start_experiment_validates_forward_models(change_to_tmpdir):
+    """
+    Tests that the existance of the forward model is not validated on the client,
+    but in the start_experiment on the server, and that given the validation
+    we are able to look up the line in the user file to provide a good error message
+    """
+    Path("./config.yml").touch()
+    config_dict = everest_config_with_defaults(config_path="./config.yml").to_dict()
+    config_dict["forward_model"] = ["this_does_not_exist"]
+    everest_config = EverestConfig.model_validate(config_dict)
+    # start_server() loads config based on config_path, so we need to actually
+    # overwrite it
+    everest_config.write_to_file("config.yml")
+    file_content = Path("config.yml").read_text(encoding="utf-8").splitlines()
+    line_number = next(
+        i + 1 for i, line in enumerate(file_content) if "this_does_not_exist" in line
+    )
+    makedirs_if_needed(Path(everest_config.output_dir), roll_if_exists=True)
+    await start_server(everest_config, logging_level=logging.INFO)
+
+    session = create_ertserver_client(
+        Path(ServerConfig.get_session_dir(everest_config.output_dir)), 240
+    )
+    wait_for_server(session, 240)
+    server_context = ServerConfig.get_server_context_from_conn_info(session.conn_info)
+    url, cert, auth = ServerConfig.get_server_context_from_conn_info(session.conn_info)
+    assert requests.get(url, verify=cert, auth=auth, proxies=PROXY).status_code == 200  # noqa: ASYNC210
+    with pytest.raises(
+        RuntimeError,
+        match=f"line: {line_number}, column: 11. forward_model"
+        f"\n.*'this_does_not_exist' is not installed",
+    ):
+        start_experiment(
+            ServerConfig.get_server_context_from_conn_info(session.conn_info),
+            everest_config,
+        )
+
+    if stop_server(server_context):
+        wait_for_server_to_stop(server_context, 240)
+        assert not server_is_running(*server_context)
 
 
 @pytest.mark.slow

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -132,10 +132,6 @@ def test_extra_key(min_config):
             "executable\n.* should be a valid string",
         ),
         (
-            {"forward_model": ["not_a_job"]},
-            "unknown job not_a_job",
-        ),
-        (
             {"environment": {"simulation_folder": "/usr/bin/unwriteable"}},
             "User does not have write access to",
         ),
@@ -166,6 +162,12 @@ def test_invalid_subconfig(extra_config, min_config, expected):
         min_config[k] = v
     with pytest.raises(ValidationError, match=expected):
         EverestConfig(**min_config)
+
+
+def test_context_validation_of_config(min_config):
+    min_config["forward_model"] = ["not_a_job"]
+    config = EverestConfig(**min_config)
+    assert config.validate_forward_model_job_name_installed() == ["not_a_job"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Conceptually we want to validate the installed jobs on the server, and not on the client. It just so happens that they are currently on the same machine, but in case they are not, it makes sense to split up the validation, schema validation on the client, and context validation on the server.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
