### PR TITLE
Tidy observations labels tree in storage info widget

### DIFF
--- a/src/ert/config/breakthrough_config.py
+++ b/src/ert/config/breakthrough_config.py
@@ -67,7 +67,7 @@ class BreakthroughConfig(DerivedResponseConfig):
         )
 
     @property
-    def primary_key(self) -> list[str]:
+    def match_key(self) -> list[str]:
         return ["threshold"]
 
     def display_column(self, value: Any, column_name: str) -> str:

--- a/src/ert/config/derived_response_config.py
+++ b/src/ert/config/derived_response_config.py
@@ -16,9 +16,10 @@ class DerivedResponseConfig(BaseModel):
 
     @property
     @abstractmethod
-    def primary_key(self) -> list[str]:
-        """Primary key of this response data.
-        For example 'time' for summary and ['index','report_step'] for gen data"""
+    def match_key(self) -> list[str]:
+        """Identification columns for observations and responses. Along with
+        'response_key' they create the key on which response data should match
+        observation data."""
 
     def display_column(self, value: Any, column_name: str) -> str:
         return str(value)

--- a/src/ert/config/everest_response.py
+++ b/src/ert/config/everest_response.py
@@ -18,7 +18,7 @@ class EverestResponse(ResponseConfig):
     scales: list[float]
 
     @property
-    def primary_key(self) -> list[str]:
+    def match_key(self) -> list[str]:
         return []
 
     @property

--- a/src/ert/config/gen_data_config.py
+++ b/src/ert/config/gen_data_config.py
@@ -215,7 +215,7 @@ class GenDataConfig(ResponseConfig):
         return None, None
 
     @property
-    def primary_key(self) -> list[str]:
+    def match_key(self) -> list[str]:
         return ["report_step", "index"]
 
 

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -38,9 +38,11 @@ class ResponseConfig(BaseModel):
 
     @property
     @abstractmethod
-    def primary_key(self) -> list[str]:
-        """Primary key of this response data.
-        For example 'time' for summary and ['index','report_step'] for gen data"""
+    def match_key(self) -> list[str]:
+        """Identification columns for observations and responses. Along with
+        'response_key' they create the key on which response data should match
+        observation data. For example 'time' for summary and ['report_step','index'] for
+        gen data."""
 
     @classmethod
     @abstractmethod

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -449,7 +449,7 @@ class RFTConfig(ResponseConfig):
         return "rft"
 
     @property
-    def primary_key(self) -> list[str]:
+    def match_key(self) -> list[str]:
         return ["east", "north", "tvd", "zone"]
 
     @classmethod

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -60,7 +60,7 @@ class SummaryConfig(ResponseConfig):
         return df
 
     @property
-    def primary_key(self) -> list[str]:
+    def match_key(self) -> list[str]:
         return ["time"]
 
     @classmethod

--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -130,8 +130,8 @@ def data_for_gradient(ensemble: Ensemble, key: str) -> pd.DataFrame:
 
 
 # indexing below is based on observation ds columns:
-# [ "observation_key", "response_key", *primary_key ]
-# for gen_data primary_key is ["report_step", "index"]
+# [ "observation_key", "response_key", *match_key ]
+# for gen_data match_key is ["report_step", "index"]
 # for summary it is ["time"]
 response_to_pandas_x_axis_fns: dict[str, Callable[[tuple[Any, ...]], Any]] = {
     "summary": lambda t: pd.Timestamp(t[2]).isoformat(),

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -29,6 +29,8 @@ from PyQt6.QtWidgets import (
 )
 
 from ert import LibresFacade
+from ert.config.derived_response_config import DerivedResponseConfig
+from ert.config.response_config import ResponseConfig
 from ert.storage import Ensemble, Experiment, RealizationStorageState
 from ert.warnings import capture_specific_warning
 
@@ -121,6 +123,56 @@ class _ExperimentWidget(QWidget):
             html += f"<tr><td>{obs_name}</td></tr>"
         html += "</table>"
         self._observations_text_edit.setHtml(html)
+
+
+class _ObservationTreeWidgetItem(QTreeWidgetItem):
+    def __init__(
+        self,
+        parent: QTreeWidgetItem,
+        observation_key: str,
+        observation_data: dict[str, object],
+        response_config: ResponseConfig | DerivedResponseConfig,
+    ) -> None:
+        self.observation_key = observation_key
+        self.observation_data = observation_data
+        self.response_config = response_config
+        super().__init__(parent, [self.display_label, observation_key])
+
+    @property
+    def match_key_data(self) -> dict[str, object]:
+        return {
+            col: self.observation_data[col] for col in self.response_config.match_key
+        }
+
+    @property
+    def display_label(self) -> str:
+        return ", ".join(
+            self.response_config.display_column(val, col)
+            for col, val in self.match_key_data.items()
+        )
+
+    def __lt__(self, other: QTreeWidgetItem) -> bool:
+        assert isinstance(other, _ObservationTreeWidgetItem)
+        assert self.response_config.match_key == other.response_config.match_key, (
+            "Expecting items being compared to be of the same response type"
+        )
+
+        for val, other_val in zip(
+            self.match_key_data.values(),
+            other.match_key_data.values(),
+            strict=True,
+        ):
+            if isinstance(val, (int, float)) and isinstance(other_val, (int, float)):
+                if val != other_val:
+                    return val < other_val
+                continue
+
+            val_str = str(val)
+            other_val_str = str(other_val)
+            if val_str != other_val_str:
+                return val_str < other_val_str
+
+        return False
 
 
 class _EnsembleWidget(QWidget):
@@ -223,76 +275,26 @@ class _EnsembleWidget(QWidget):
     def _currentItemChanged(
         self, selected: QTreeWidgetItem, _: QTreeWidgetItem
     ) -> None:
-        if not selected:
+        if not selected or not isinstance(selected, _ObservationTreeWidgetItem):
             return
 
-        observation_key = selected.data(1, Qt.ItemDataRole.DisplayRole)
-        parent = selected.parent()
-
-        if not observation_key or not parent:
-            return
-
-        response_type = parent.data(0, Qt.ItemDataRole.UserRole)
-        observation_label = selected.data(0, Qt.ItemDataRole.DisplayRole)
         assert self._ensemble is not None
-        observations_dict = self._ensemble.experiment.observations
 
         self._figure.clear()
         ax = self._figure.add_subplot(111)
-        ax.set_title(observation_key)
+        ax.set_title(selected.observation_key)
         ax.grid(True)
 
-        obs_for_type = observations_dict[response_type]
-
-        configs = (
-            self._ensemble.experiment.response_configuration
-            | self._ensemble.experiment.derived_response_configuration
-        )
-        if response_type not in configs:
-            return
-        response_config = configs[response_type]
-        x_axis_col = response_config.match_key[-1]
-
-        def _filter_on_observation_label(df: pl.DataFrame) -> pl.DataFrame:
-            # We add a column with the display name of the x axis column
-            # to correctly compare it to the observation_label
-            # (which is also such a display name)
-            return df.with_columns(
-                df[x_axis_col]
-                .map_elements(
-                    lambda x: response_config.display_column(x, x_axis_col),
-                )
-                .cast(pl.String)
-                .alias("temp")
-            ).filter(pl.col("temp").eq(observation_label))[
-                [x for x in df.columns if x != "temp"]
-            ]
-
-        obs = obs_for_type.filter(pl.col("observation_key").eq(observation_key))
-        obs = _filter_on_observation_label(obs)
-
-        response_key = obs["response_key"].unique().to_list()[0]
-        reals_with_responses = tuple(
-            self._ensemble.get_realization_list_with_responses()
-        )
-
-        response_ds = (
-            self._ensemble.load_responses(
-                response_key,
-                reals_with_responses,
-            )
-            if reals_with_responses
-            and response_key in self._ensemble.experiment.response_key_to_response_type
-            else None
-        )
-
+        obs = pl.DataFrame(selected.observation_data)
         scaling_df = self._ensemble.load_observation_scaling_factors()
 
         def _try_render_scaled_obs() -> None:
             if scaling_df is None:
                 return None
 
-            index_col = pl.concat_str(response_config.match_key, separator=", ")
+            index_col = pl.concat_str(
+                selected.response_config.match_key, separator=", "
+            )
             joined = obs.with_columns(index_col.alias("_tmp_index")).join(
                 scaling_df,
                 how="left",
@@ -318,8 +320,32 @@ class _EnsembleWidget(QWidget):
                 color="black",
             )
 
+        def _filter_by_match_key(df: pl.DataFrame) -> pl.DataFrame:
+            """
+            Filter df to match 'selected' observation on match keys.
+            """
+            mask = pl.lit(True)
+            for col, val in selected.match_key_data.items():
+                mask &= pl.col(col).eq_missing(val)
+            return df.filter(mask)
+
+        response_key = str(selected.observation_data["response_key"])
+        reals_with_responses = tuple(
+            self._ensemble.get_realization_list_with_responses()
+        )
+
+        response_ds = (
+            self._ensemble.load_responses(
+                response_key,
+                reals_with_responses,
+            )
+            if reals_with_responses
+            and response_key in self._ensemble.experiment.response_key_to_response_type
+            else None
+        )
+
         if response_ds is not None and not response_ds.is_empty():
-            response_ds_for_label = _filter_on_observation_label(response_ds).rename(
+            response_ds_for_label = _filter_by_match_key(response_ds).rename(
                 {"values": "Responses"}
             )[["response_key", "Responses"]]
 
@@ -373,6 +399,13 @@ class _EnsembleWidget(QWidget):
             exp = self._ensemble.experiment
 
             for response_type, obs_ds_for_type in exp.observations.items():
+                configs = (
+                    exp.response_configuration | exp.derived_response_configuration
+                )
+                if response_type not in configs:
+                    continue
+                response_config = configs[response_type]
+
                 for obs_key, response_key in (
                     obs_ds_for_type.select(["observation_key", "response_key"])
                     .unique()
@@ -399,21 +432,11 @@ class _EnsembleWidget(QWidget):
 
                     obs_ds = obs_ds_for_type.filter(
                         pl.col("observation_key").eq(obs_key)
-                    )
-                    configs = (
-                        exp.response_configuration | exp.derived_response_configuration
-                    )
-                    if response_type not in configs:
-                        continue
-                    response_config = configs[response_type]
-                    column_to_display = response_config.match_key[-1]
-                    for t in obs_ds[column_to_display].to_list():
-                        QTreeWidgetItem(
-                            root,
-                            [
-                                response_config.display_column(t, column_to_display),
-                                obs_key,
-                            ],
+                    ).unique()
+
+                    for observation_data in obs_ds.to_dicts():
+                        _ObservationTreeWidgetItem(
+                            root, obs_key, observation_data, response_config
                         )
 
             self._observations_tree_widget.sortItems(0, Qt.SortOrder.AscendingOrder)

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -278,6 +278,7 @@ class _EnsembleWidget(QWidget):
                 reals_with_responses,
             )
             if reals_with_responses
+            and response_key in self._ensemble.experiment.response_key_to_response_type
             else None
         )
 

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -244,9 +244,13 @@ class _EnsembleWidget(QWidget):
 
         obs_for_type = observations_dict[response_type]
 
-        response_config = self._ensemble.experiment.response_configuration[
-            response_type
-        ]
+        configs = (
+            self._ensemble.experiment.response_configuration
+            | self._ensemble.experiment.derived_response_configuration
+        )
+        if response_type not in configs:
+            return
+        response_config = configs[response_type]
         x_axis_col = response_config.match_key[-1]
 
         def _filter_on_observation_label(df: pl.DataFrame) -> pl.DataFrame:
@@ -396,7 +400,12 @@ class _EnsembleWidget(QWidget):
                     obs_ds = obs_ds_for_type.filter(
                         pl.col("observation_key").eq(obs_key)
                     )
-                    response_config = exp.response_configuration[response_type]
+                    configs = (
+                        exp.response_configuration | exp.derived_response_configuration
+                    )
+                    if response_type not in configs:
+                        continue
+                    response_config = configs[response_type]
                     column_to_display = response_config.match_key[-1]
                     for t in obs_ds[column_to_display].to_list():
                         QTreeWidgetItem(

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -247,7 +247,7 @@ class _EnsembleWidget(QWidget):
         response_config = self._ensemble.experiment.response_configuration[
             response_type
         ]
-        x_axis_col = response_config.primary_key[-1]
+        x_axis_col = response_config.match_key[-1]
 
         def _filter_on_observation_label(df: pl.DataFrame) -> pl.DataFrame:
             # We add a column with the display name of the x axis column
@@ -287,7 +287,7 @@ class _EnsembleWidget(QWidget):
             if scaling_df is None:
                 return None
 
-            index_col = pl.concat_str(response_config.primary_key, separator=", ")
+            index_col = pl.concat_str(response_config.match_key, separator=", ")
             joined = obs.with_columns(index_col.alias("_tmp_index")).join(
                 scaling_df,
                 how="left",
@@ -396,7 +396,7 @@ class _EnsembleWidget(QWidget):
                         pl.col("observation_key").eq(obs_key)
                     )
                     response_config = exp.response_configuration[response_type]
-                    column_to_display = response_config.primary_key[-1]
+                    column_to_display = response_config.match_key[-1]
                     for t in obs_ds[column_to_display].to_list():
                         QTreeWidgetItem(
                             root,

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -924,7 +924,7 @@ class LocalEnsemble(BaseMode):
         corresponding simulated responses from an ensemble.
 
         The returned DataFrame includes an "index" column containing a
-        comma-separated string of the response type's primary key values:
+        comma-separated string of the response type's match key values:
         - Summary: "2024-01-15 00:00:00" (time)
         - GenData: "0, 42" (report_step, index)
         - RFT: "123.5, 456.7, 2500.0, ZONE_A" (east, north, tvd, zone)
@@ -962,7 +962,7 @@ class LocalEnsemble(BaseMode):
 
                 observed_cols = {
                     k: observations_for_type[k].unique()
-                    for k in ["response_key", *response_cls.primary_key]
+                    for k in ["response_key", *response_cls.match_key]
                 }
 
                 reals = np.sort(iens_active_index).tolist()
@@ -986,7 +986,7 @@ class LocalEnsemble(BaseMode):
 
                     pivoted = responses.collect(engine="streaming").pivot(
                         on="realization",
-                        index=["response_key", *response_cls.primary_key],
+                        index=["response_key", *response_cls.match_key],
                         values="values",
                         aggregate_function="mean",
                     )
@@ -1007,7 +1007,7 @@ class LocalEnsemble(BaseMode):
                     elif "time" in pivoted:
                         by_cols = [
                             "response_key",
-                            *[k for k in response_cls.primary_key if k != "time"],
+                            *[k for k in response_cls.match_key if k != "time"],
                         ]
                         joined = observations_for_type.sort(
                             by=[*by_cols, "time"]
@@ -1023,25 +1023,23 @@ class LocalEnsemble(BaseMode):
                         joined = observations_for_type.join(
                             pivoted,
                             how="left",
-                            on=["response_key", *response_cls.primary_key],
+                            on=["response_key", *response_cls.match_key],
                             nulls_equal=True,
                         )
 
-                    # Do not drop primary keys which
+                    # Do not drop match keys which
                     # overlap with localization attributes
-                    primary_keys_to_drop = set(response_cls.primary_key).difference(
+                    match_keys_to_drop = set(response_cls.match_key).difference(
                         {"north", "east", "radius"}
                     )
                     joined = (
                         joined.with_columns(
-                            pl.concat_str(
-                                response_cls.primary_key, separator=", "
-                            ).alias(
+                            pl.concat_str(response_cls.match_key, separator=", ").alias(
                                 "__tmp_index_key__"
-                                # Avoid potential collisions w/ primary key
+                                # Avoid potential collisions w/ match key
                             )
                         )
-                        .drop(primary_keys_to_drop)
+                        .drop(match_keys_to_drop)
                         .rename({"__tmp_index_key__": "index"})
                     )
 

--- a/src/ert/storage/migration/to8.py
+++ b/src/ert/storage/migration/to8.py
@@ -40,9 +40,7 @@ class ObservationDatasetInfo:
 
         df = df.with_columns(observation_key=pl.lit(observation_key))
 
-        primary_key = (
-            ["time"] if response_type == "summary" else ["report_step", "index"]
-        )
+        match_key = ["time"] if response_type == "summary" else ["report_step", "index"]
         if response_type == "summary":
             df = df.rename({"name": "response_key"})
 
@@ -51,9 +49,7 @@ class ObservationDatasetInfo:
                 response_key=pl.lit(response_key),
             )
 
-        df = df[
-            ["response_key", "observation_key", *primary_key, "observations", "std"]
-        ]
+        df = df[["response_key", "observation_key", *match_key, "observations", "std"]]
 
         return cls(df, response_type, path)
 

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -76,12 +76,12 @@ def mock_resfo_file(mocked_files):
     return inner
 
 
-def test_that_rfts_primary_key_is_east_north_tvd_and_zone():
+def test_that_rfts_match_key_is_east_north_tvd_and_zone():
     assert set(
         RFTConfig(
             input_files=["BASE.RFT"],
             data_to_read={"*": {"*": ["*"]}},
-        ).primary_key
+        ).match_key
     ) == {"east", "north", "tvd", "zone"}
 
 

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+import polars as pl
+
+from ert.config import ErtConfig, ObservationType
+from ert.gui.tools.manage_experiments.storage_info_widget import (
+    _EnsembleWidget,
+    _EnsembleWidgetTabs,
+)
+
+
+def create_experiment_from_config(config: ErtConfig, storage):
+    ens_config = config.ensemble_config
+
+    def dump_all(configurations):
+        return [c.model_dump(mode="json") for c in configurations]
+
+    experiment = storage.create_experiment(
+        experiment_config={
+            "parameter_configuration": dump_all(ens_config.parameter_configuration),
+            "response_configuration": dump_all(ens_config.response_configuration),
+            "derived_response_configuration": dump_all(
+                ens_config.derived_response_configuration
+            ),
+            "observations": dump_all(config.observation_declarations),
+            "ert_templates": config.ert_templates,
+        },
+    )
+    return experiment
+
+
+def test_that_missing_response_for_observation_response_key_does_not_crash(
+    qtbot, storage
+):
+    date = datetime(year=2000, month=1, day=1)
+    observation_key = "FOPR"
+    requested_keys = ["*"]
+    received_keys = ["WRONG"]
+
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "SUMMARY": requested_keys,
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.SUMMARY,
+                        "name": "sumobs",
+                        "KEY": observation_key,
+                        "DATE": date.isoformat(),
+                        "VALUE": 1.0,
+                        "ERROR": 1.0,
+                    }
+                ],
+            ),
+        }
+    )
+
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+    ensemble.save_response(
+        "summary",
+        pl.DataFrame(
+            {
+                "response_key": received_keys,
+                "time": [pl.Series([date]).dt.cast_time_unit("ms")],
+                "values": [pl.Series([1.0], dtype=pl.Float32)],
+            }
+        ).explode("values", "time"),
+        0,
+    )
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    assert len(ensemble_widget._figure.get_axes()) == 1

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import polars as pl
 
@@ -71,6 +71,59 @@ def test_that_missing_response_for_observation_response_key_does_not_crash(
         ).explode("values", "time"),
         0,
     )
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    assert len(ensemble_widget._figure.get_axes()) == 1
+
+
+def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
+    date = datetime(year=2000, month=1, day=1)
+    key = "WWCT:OP1"
+
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.BREAKTHROUGH,
+                        "name": "BRT_OP1",
+                        "KEY": key,
+                        "ERROR": "3",
+                        "DATE": (date + timedelta(days=5)).isoformat(),
+                        "THRESHOLD": 0.4,
+                    }
+                ],
+            ),
+        }
+    )
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    def summary_response() -> pl.DataFrame:
+        num_points = 15
+        values = range(num_points)
+
+        return pl.DataFrame(
+            {
+                "response_key": [key] * num_points,
+                "time": [date + timedelta(days=day) for day in range(num_points)],
+                "values": pl.Series(values, dtype=pl.Float32),
+            }
+        )
+
+    ensemble.save_response("summary", summary_response(), 0)
+    bt_config = experiment.derived_response_configuration["breakthrough"]
+    breakthrough_response = bt_config.derive_from_storage(0, 0, ensemble)
+    ensemble.save_response("breakthrough", breakthrough_response, 0)
 
     ensemble_widget = _EnsembleWidget()
     ensemble_widget.setEnsemble(ensemble)

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timedelta
 
 import polars as pl
+import pytest
+from PyQt6.QtWidgets import (
+    QTreeWidget,
+)
 
 from ert.config import ErtConfig, ObservationType
 from ert.gui.tools.manage_experiments.storage_info_widget import (
@@ -133,3 +137,320 @@ def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
     panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
 
     assert len(ensemble_widget._figure.get_axes()) == 1
+
+
+def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
+    date = datetime(year=2000, month=1, day=1).date()
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "RFT": [{"WELL": "WELL", "DATE": "2000-01-01", "PROPERTIES": "PRESSURE"}],
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": date.isoformat(),
+                        "PROPERTY": "PRESSURE",
+                        "EAST": 10.0,
+                        "NORTH": 11.0,
+                        "TVD": 12.0,
+                    },
+                ],
+            ),
+        }
+    )
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    def partial_rft_response() -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "response_key": ["WELL:2000-01-01:PRESSURE"],
+                "well": ["WELL"],
+                "date": [date.isoformat()],
+                "property": ["PRESSURE"],
+                "time": [date],
+                "depth": [0.0],
+                "values": [0.0],
+                "zone": None,
+                "east": [10.0],
+                "north": [11.0],
+                "tvd": [12.0],
+            }
+        )
+
+    ensemble.save_response("rft", partial_rft_response(), 0)
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    plot = ensemble_widget._figure.get_axes()
+    assert len(plot) == 1
+    assert len(plot[0].collections) == 2
+
+
+def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
+    date = datetime(year=2000, month=1, day=1).date()
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "SUMMARY": ["*"],
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": date.isoformat(),
+                        "PROPERTY": "PRESSURE",
+                        "EAST": 10.0,
+                        "NORTH": 11.0,
+                        "TVD": 12.0,
+                        "ZONE": "zone",
+                    },
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT_match_key_duplicate",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": date.isoformat(),
+                        "PROPERTY": "PRESSURE",
+                        "EAST": 10.0,
+                        "NORTH": 11.0,
+                        "TVD": 12.0,
+                        "ZONE": "zone",
+                    },
+                ],
+            ),
+        }
+    )
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    observation_widget = ensemble_widget.findChild(QTreeWidget)
+    top = observation_widget.topLevelItem(0)
+    assert top
+    assert top.childCount() == 2
+
+
+@pytest.mark.parametrize(
+    ("observations", "expected_name_order"),
+    [
+        pytest.param(
+            [
+                {
+                    "type": ObservationType.BREAKTHROUGH,
+                    "name": "BRT_OP1",
+                    "KEY": "WWCT:OP1",
+                    "ERROR": "3",
+                    "DATE": datetime(year=2000, month=1, day=1).isoformat(),
+                    "THRESHOLD": 0.4,
+                },
+                {
+                    "type": ObservationType.BREAKTHROUGH,
+                    "name": "BRT_OP2",
+                    "KEY": "WWCT:OP1",
+                    "ERROR": "3",
+                    "DATE": datetime(year=2000, month=1, day=9).isoformat(),
+                    "THRESHOLD": 0.7,
+                },
+            ],
+            ["0.4", "0.7"],
+            id="breakthrough",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": ObservationType.RFT,
+                    "name": "RFT2",
+                    "WELL": "WELL",
+                    "VALUE": "700",
+                    "ERROR": "0.1",
+                    "DATE": "2000-01-01",
+                    "PROPERTY": "PRESSURE",
+                    "EAST": 11.0,
+                    "NORTH": 5.0,
+                    "TVD": 4.0,
+                    "ZONE": "zone",
+                },
+                {
+                    "type": ObservationType.RFT,
+                    "name": "RFT1",
+                    "WELL": "WELL",
+                    "VALUE": "700",
+                    "ERROR": "0.1",
+                    "DATE": "2000-01-01",
+                    "PROPERTY": "PRESSURE",
+                    "EAST": 5.0,
+                    "NORTH": 6.0,
+                    "TVD": 7.0,
+                    "ZONE": "zone",
+                },
+            ],
+            ["5.0, 6.0, 7.0, zone", "11.0, 5.0, 4.0, zone"],
+            id="rft",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": ObservationType.RFT,
+                    "name": "RFT2",
+                    "WELL": "WELL",
+                    "VALUE": "700",
+                    "ERROR": "0.1",
+                    "DATE": "2000-01-01",
+                    "PROPERTY": "PRESSURE",
+                    "EAST": 700.0,
+                    "NORTH": 500.0,
+                    "TVD": 400.0,
+                },
+                {
+                    "type": ObservationType.RFT,
+                    "name": "RFT1",
+                    "WELL": "WELL",
+                    "VALUE": "700",
+                    "ERROR": "0.1",
+                    "DATE": "2000-01-01",
+                    "PROPERTY": "PRESSURE",
+                    "EAST": 5.0,
+                    "NORTH": 6.0,
+                    "TVD": 7.0,
+                },
+            ],
+            ["5.0, 6.0, 7.0, None", "700.0, 500.0, 400.0, None"],
+            id="rft without zone",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": ObservationType.SUMMARY,
+                    "name": "FOPR_1",
+                    "KEY": "FOPR",
+                    "VALUE": "1",
+                    "ERROR": "1",
+                    "DATE": "2023-03-15",
+                },
+                {
+                    "type": ObservationType.SUMMARY,
+                    "name": "FOPR_2",
+                    "KEY": "FOPR",
+                    "VALUE": "1",
+                    "ERROR": "1",
+                    "DATE": "2024-11-07",
+                },
+            ],
+            ["2023-03-15", "2024-11-07"],
+            id="summary",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": ObservationType.GENERAL,
+                    "name": "GOBS1",
+                    "DATA": "GEN",
+                    "RESTART": "11",
+                    "INDEX_LIST": "60,400,1200,1600,1800",
+                    "OBS_FILE": "<OBS_FILE_PLACEHOLDER>",
+                },
+                {
+                    "type": ObservationType.GENERAL,
+                    "name": "GOBS2",
+                    "DATA": "GEN",
+                    "RESTART": "100",
+                    "INDEX_LIST": "60,400,1200,1600,1800",
+                    "OBS_FILE": "<OBS_FILE_PLACEHOLDER>",
+                },
+            ],
+            [
+                "11, 60",
+                "11, 400",
+                "11, 1200",
+                "11, 1600",
+                "11, 1800",
+                "100, 60",
+                "100, 400",
+                "100, 1200",
+                "100, 1600",
+                "100, 1800",
+            ],
+            id="general",
+        ),
+    ],
+)
+def test_that_observations_are_identified_and_sorted_by_full_match_key(
+    qtbot, storage, tmp_path, observations, expected_name_order
+):
+    def patch_gen_obs_file(observations_list):
+        obs_file = tmp_path / "obs_data.txt"
+        gen_obs = [float(i + 1) for i in range(5)]
+        obs_file.write_text(
+            "\n".join(f"{obs} {obs}" for obs in gen_obs),
+            encoding="utf-8",
+        )
+
+        return [
+            {
+                k: str(obs_file) if v == "<OBS_FILE_PLACEHOLDER>" else v
+                for k, v in observation_dict.items()
+            }
+            for observation_dict in observations_list
+        ]
+
+    observations = patch_gen_obs_file(observations)
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "GEN_DATA": [
+                ["GEN", {"RESULT_FILE": "gen%d.txt", "REPORT_STEPS": "100,11"}]
+            ],
+            "OBS_CONFIG": (
+                "obs_config",
+                observations,
+            ),
+        }
+    )
+
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    observation_widget = ensemble_widget.findChild(QTreeWidget)
+    top = observation_widget.topLevelItem(0)
+    assert top
+    children = [
+        child.text(0)
+        for i in range(top.childCount())
+        if (child := top.child(i)) is not None
+    ]
+    assert children == expected_name_order, (
+        f"Expected observation names in order {expected_name_order}, but got {children}"
+    )


### PR DESCRIPTION
**Issue**
None.

Stems from my needs to change primary_key in RFT observation. And this was only place other than `get_observations_and_responses` where it was used, so I had to understand what is going on here.
RFT observations were suffering in particular, so decided to figure out what expected behavior should be.


**Approach**
- Renamed "primary key" to "match key" as key is used for matching observations and responses along with response_key.
- Fixes some of the crashes that I saw. (There is no safety net, so all errors crash ert).
- Used full match key as an observation label, not just the last part of the key.
- Added custom label sorting to make it look more natural.
- Changed internal logic based on assumption I am pretty sure holds: `observation key` together with `match_key` uniquely identify observation. (I believe for majority of observations already `observation_key` is enough, but I think general observation is different in this regard.) This allows us to drop searching for observations twice.

Note that "breakthrough" is not fully integrated into ert. For example, `derived configurations` are not saved to Manual Update experiment. Here I guarded against it the best I can, but probably there are more cases.

Behavior of the plots is verified just visually, seems unchanged to me.

---

Tree before:

<img width="524" height="524" alt="image" src="https://github.com/user-attachments/assets/b29eb368-7f0c-47b8-86ef-cee223d8d931" />

Tree after:

<img width="525" height="526" alt="image" src="https://github.com/user-attachments/assets/df566841-4c01-4251-9d64-cda5cefafefd" />

RFT observations look like this, scaling is there at least (not touched and not tested)
<img width="1142" height="731" alt="image" src="https://github.com/user-attachments/assets/536b5277-ef0c-4bb6-85ad-bde1eb5a894c" />

---

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
