### PR TITLE
Reuse hypothesis example database for fuzzing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
    contents: read
+   actions: read
 
 env:
   ERT_SHOW_BACKTRACE: 1   # resdata print on failure https://github.com/equinor/resdata/blob/5fdf0280726a2670161ed536705dc9156aea39be/lib/util/util_abort.cpp#L96

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
    contents: read
+   actions: read
 
 env:
   ERT_SHOW_BACKTRACE: 1
@@ -61,6 +62,14 @@ jobs:
         chmod 700 storage
         rm storage
 
+    - name: Download example database
+      if: inputs.test-type == 'fuzz'
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh run download --name hypothesis-example-db --dir .hypothesis/examples
+
     - name: Fuzzing
       if: inputs.test-type == 'fuzz'
       run: |
@@ -69,6 +78,13 @@ jobs:
         uv run just fuzz
         chmod 700 storage
         rm storage
+
+    - name: Upload example database
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      if: always()
+      with:
+        name: hypothesis-example-db
+        path: .hypothesis/examples
 
 
     - name: Upload artifact images


### PR DESCRIPTION
Follows the setup in https://hypothesis.readthedocs.io/en/latest/reference/api.html for reusing the hypothesis example database for fuzzing.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
