### PR TITLE
Clean up cached heat-equation test setup

### DIFF
--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -427,11 +427,11 @@ def _shared_snake_oil_case(request, monkeypatch, source_root):
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
     """
-    snake_path = request.config.cache.mkdir(
+    cache_path = request.config.cache.mkdir(
         "snake_oil_data" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
-    monkeypatch.chdir(snake_path)
-    if not (snake_path / "test_data").exists():
+    monkeypatch.chdir(cache_path)
+    if not (cache_path / "test_data").exists():
         _run_snake_oil(source_root)
     else:
         monkeypatch.chdir("test_data")
@@ -445,11 +445,11 @@ def _shared_heat_equation_es(request, monkeypatch, source_root):
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
     """
-    snake_path = request.config.cache.mkdir(
+    cache_path = request.config.cache.mkdir(
         "heat_equation_data_es" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
-    monkeypatch.chdir(snake_path)
-    if not os.listdir(snake_path):
+    monkeypatch.chdir(cache_path)
+    if not os.listdir(cache_path):
         _run_heat_equation(source_root, ENSEMBLE_SMOOTHER_MODE)
     else:
         monkeypatch.chdir("test_data")
@@ -463,11 +463,11 @@ def _shared_heat_equation_esmda(request, monkeypatch, source_root):
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
     """
-    snake_path = request.config.cache.mkdir(
+    cache_path = request.config.cache.mkdir(
         "heat_equation_data_esmda" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
-    monkeypatch.chdir(snake_path)
-    if not os.listdir(snake_path):
+    monkeypatch.chdir(cache_path)
+    if not os.listdir(cache_path):
         _run_heat_equation(source_root, ES_MDA_MODE)
     else:
         monkeypatch.chdir("test_data")
@@ -481,11 +481,11 @@ def _shared_heat_equation_enif(request, monkeypatch, source_root):
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
     """
-    snake_path = request.config.cache.mkdir(
+    cache_path = request.config.cache.mkdir(
         "heat_equation_data_enif" + os.environ.get("PYTEST_XDIST_WORKER", "")
     )
-    monkeypatch.chdir(snake_path)
-    if not os.listdir(snake_path):
+    monkeypatch.chdir(cache_path)
+    if not os.listdir(cache_path):
         _run_heat_equation(source_root, ENIF_MODE)
     else:
         monkeypatch.chdir("test_data")

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
-import numpy.testing
 import polars as pl
 import pytest
 import resfo
@@ -182,7 +181,7 @@ def _compare_ensemble_params(
 def test_field_param_update_using_heat_equation_enif_snapshot(
     symlinked_heat_equation_storage_enif, snapshot, request
 ):
-    config = ErtConfig.from_file("config.ert")
+    config = symlinked_heat_equation_storage_enif
     with open_storage(config.ens_path, mode="r") as storage:
         experiment = storage.get_experiment_by_name("enif")
         prior = experiment.get_ensemble_by_name("iter-0")
@@ -223,7 +222,7 @@ def test_field_param_update_using_heat_equation_enif_snapshot(
 
 @pytest.mark.xdist_group(name="uses_heat_equation_storage")
 def test_field_param_update_using_heat_equation(symlinked_heat_equation_storage_es):
-    config = ErtConfig.from_file("config.ert")
+    config = symlinked_heat_equation_storage_es
     with open_storage(config.ens_path, mode="r") as storage:
         experiment = storage.get_experiment_by_name("es")
         prior = experiment.get_ensemble_by_name("iter-0")


### PR DESCRIPTION
Reuse the config returned by the symlinked heat-equation fixtures instead of reparsing config.ert in CLI tests, and rename cached fixture paths for clarity.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
