### PR TITLE
Split ValuesOverIterations and limit realizations legend

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -347,6 +347,28 @@ class PlotApi:
                 }
             )
 
+    def data_for_controls(
+        self, ensemble_id: str, parameter_keys: list[str]
+    ) -> pd.DataFrame:
+        frames = []
+
+        for parameter_key in parameter_keys:
+            df = self.data_for_parameter(ensemble_id, parameter_key)
+            if not df.empty and {"batch_id", "realization"}.issubset(df.columns):
+                value_cols = [
+                    c for c in df.columns if c not in {"batch_id", "realization"}
+                ]
+                melted = df.melt(
+                    id_vars=["batch_id", "realization"],
+                    value_vars=value_cols,
+                    var_name="control_name",
+                    value_name="control_value",
+                )
+                frames.append(melted)
+        if not frames:
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
+
     def data_for_parameter(self, ensemble_id: str, parameter_key: str) -> pd.DataFrame:
         with create_ertserver_client(self.ens_path) as client:
             http_response = client.get(

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -37,14 +37,19 @@ if TYPE_CHECKING:
     from .plottery.plots.cesp import CrossEnsembleStatisticsPlot
     from .plottery.plots.distribution import DistributionPlot
     from .plottery.plots.ensemble import EnsemblePlot
+    from .plottery.plots.everest_batch_objective_function_plot import (
+        EverestBatchObjectiveFunctionPlot,
+    )
+    from .plottery.plots.everest_constraints_plot import EverestConstraintsPlot
+    from .plottery.plots.everest_controls_plot import EverestControlsPlot
+    from .plottery.plots.everest_objective_function_plot import (
+        EverestObjectiveFunctionPlot,
+    )
     from .plottery.plots.gaussian_kde import GaussianKDEPlot
     from .plottery.plots.histogram import HistogramPlot
     from .plottery.plots.misfits import MisfitsPlot
     from .plottery.plots.statistics import StatisticsPlot
     from .plottery.plots.std_dev import StdDevPlot
-    from .plottery.plots.values_over_iteration_plot import (
-        ValuesOverIterationsPlot,
-    )
 
 logger = logging.getLogger(__name__)
 
@@ -131,9 +136,12 @@ class PlotWidget(QWidget):
             "DistributionPlot",
             "CrossEnsembleStatisticsPlot",
             "StdDevPlot",
-            "ValuesOverIterationsPlot",
             "MisfitsPlot",
+            "EverestBatchObjectiveFunctionPlot",
+            "EverestConstraintsPlot",
+            "EverestControlsPlot",
             "EverestGradientsPlot",
+            "EverestObjectiveFunctionPlot",
         ],
         parent: QWidget | None = None,
     ) -> None:

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -42,13 +42,16 @@ from .plottery.plots import (
     CrossEnsembleStatisticsPlot,
     DistributionPlot,
     EnsemblePlot,
+    EverestBatchObjectiveFunctionPlot,
+    EverestConstraintsPlot,
+    EverestControlsPlot,
     EverestGradientsPlot,
+    EverestObjectiveFunctionPlot,
     GaussianKDEPlot,
     HistogramPlot,
     MisfitsPlot,
     StatisticsPlot,
     StdDevPlot,
-    ValuesOverIterationsPlot,
 )
 from .widgets.everest_control_selection_widget import EverestControlSelectionWidget
 
@@ -60,9 +63,11 @@ HISTOGRAM = "Histogram"
 STATISTICS = "Statistics"
 STD_DEV = "Std Dev"
 MISFITS = "Misfits"
-EVEREST_RESPONSES_PLOT = "Batch responses"
-EVEREST_CONTROLS_PLOT = "Batch controls"
-EVEREST_GRADIENTS_PLOT = "Batch Gradients"
+EVEREST_CONTROLS_PLOT = "Controls"
+EVEREST_GRADIENTS_PLOT = "Gradient"
+EVEREST_OBJECTIVE_FUNCTION_PLOT = "Objective function"
+EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT = "Aggregated objective values"
+EVEREST_CONSTRAINT_PLOT = "Constraints"
 
 RESPONSE_DEFAULT = 0
 GEN_KW_DEFAULT = 3
@@ -214,8 +219,15 @@ class PlotWindow(QMainWindow):
                 self.addPlotWidget(STD_DEV, StdDevPlot())
             else:
                 self.addPlotWidget(ENSEMBLE, EnsemblePlot())
-                self.addPlotWidget(EVEREST_CONTROLS_PLOT, ValuesOverIterationsPlot())
-                self.addPlotWidget(EVEREST_RESPONSES_PLOT, ValuesOverIterationsPlot())
+                self.addPlotWidget(
+                    EVEREST_OBJECTIVE_FUNCTION_PLOT, EverestObjectiveFunctionPlot()
+                )
+                self.addPlotWidget(
+                    EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT,
+                    EverestBatchObjectiveFunctionPlot(),
+                )
+                self.addPlotWidget(EVEREST_CONSTRAINT_PLOT, EverestConstraintsPlot())
+                self.addPlotWidget(EVEREST_CONTROLS_PLOT, EverestControlsPlot())
                 self.addPlotWidget(EVEREST_GRADIENTS_PLOT, EverestGradientsPlot())
 
             self._central_tab.currentChanged.connect(self.currentTabChanged)
@@ -262,13 +274,13 @@ class PlotWindow(QMainWindow):
             )
             self.addDock("Plot ensemble", self._ensemble_selection_widget)
 
-            everest_parameters = [
+            self._everest_parameters = [
                 kd.parameter.name
                 for kd in self._key_definitions
                 if kd.parameter and kd.parameter.type == "everest_parameters"
             ]
             self._everest_control_selection_widget = EverestControlSelectionWidget(
-                everest_parameters
+                self._everest_parameters
             )
             self._everest_control_selection_widget.controlSelectionChanged.connect(
                 self.updatePlot
@@ -314,16 +326,19 @@ class PlotWindow(QMainWindow):
             key = key.replace("BREAKTHROUGH:", "")
 
         is_gradient_plot = plot_widget.name == EVEREST_GRADIENTS_PLOT
-        self._everest_dock.setVisible(is_gradient_plot)
+        is_controls_plot = plot_widget.name == EVEREST_CONTROLS_PLOT
+        self._everest_dock.setVisible(is_gradient_plot or is_controls_plot)
 
         if (
             plot_widget._plotter.dimensionality == key_def.dimensionality
             or (
                 plot_widget.name
                 in {
-                    EVEREST_RESPONSES_PLOT,
+                    EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT,
+                    EVEREST_OBJECTIVE_FUNCTION_PLOT,
                     EVEREST_CONTROLS_PLOT,
                     EVEREST_GRADIENTS_PLOT,
+                    EVEREST_CONSTRAINT_PLOT,
                 }
             )
             or (key_def.metadata.get("data_origin") == "everest_batch_objectives")
@@ -333,7 +348,13 @@ class PlotWindow(QMainWindow):
             )
             ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame] = {}
 
-            if is_gradient_plot:
+            selected_controls: list[str] = []
+            if is_gradient_plot or is_controls_plot:
+                self._everest_control_selection_widget.set_pinned_control(
+                    key_def.parameter.name
+                    if is_controls_plot and key_def.parameter
+                    else None
+                )
                 selected_controls = (
                     self._everest_control_selection_widget.get_selected_controls()
                 )
@@ -355,6 +376,12 @@ class PlotWindow(QMainWindow):
                             ensemble_id=ensemble.id,
                             response_key=key,
                             filter_on=key_def.filter_on,
+                        )
+                    elif is_controls_plot:
+                        data = self._api.data_for_controls(
+                            ensemble_id=ensemble.id,
+                            parameter_keys=selected_controls
+                            or self._everest_parameters,
                         )
                     elif key_def.parameter is not None and (
                         key_def.parameter.type
@@ -508,8 +535,11 @@ class PlotWindow(QMainWindow):
         | CrossEnsembleStatisticsPlot
         | StdDevPlot
         | MisfitsPlot
-        | ValuesOverIterationsPlot
-        | EverestGradientsPlot,
+        | EverestBatchObjectiveFunctionPlot
+        | EverestConstraintsPlot
+        | EverestControlsPlot
+        | EverestGradientsPlot
+        | EverestObjectiveFunctionPlot,
         enabled: bool = True,
     ) -> None:
         plot_widget = PlotWidget(name, plotter)
@@ -544,53 +574,50 @@ class PlotWindow(QMainWindow):
             return
         self._plot_customizer.switchPlotConfigHistory(key_def)
 
+        is_everest_specific_widget = key_def.metadata.get("data_origin") in {
+            "everest_objectives",
+            "everest_constraints",
+            "everest_batch_objectives",
+        }
+
         available_widgets = [
             widget
             for widget in self._plot_widgets
             if widget._plotter.dimensionality == key_def.dimensionality
             and (key_def.observations or not widget._plotter.requires_observations)
+            and not is_everest_specific_widget
         ]
 
-        everest_widget = next(
-            (w for w in self._plot_widgets if w.name == EVEREST_RESPONSES_PLOT), None
-        )
+        def everest_data_origin_check(origin: list[str]) -> bool:
+            return key_def.metadata.get("data_origin") in origin
 
-        if everest_widget:
-            if (
-                self.is_everest
-                or key_def.metadata.get("data_origin") == "everest_batch_objectives"
-            ):
-                available_widgets = [everest_widget]
-            elif everest_widget in available_widgets:
-                available_widgets.remove(everest_widget)
+        def everest_widget_locator(widget_name: str) -> PlotWidget | None:
+            return next(
+                (w for w in self._plot_widgets if w.name == widget_name),
+                None,
+            )
 
-        is_everest_control = (
-            key_def.parameter is not None
-            and key_def.parameter.type == "everest_parameters"
-        )
-        everest_control_widget = next(
-            (w for w in self._plot_widgets if w.name == EVEREST_CONTROLS_PLOT), None
-        )
+        everest_plot_and_origin = [
+            (EVEREST_OBJECTIVE_FUNCTION_PLOT, ["everest_objectives"]),
+            (EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT, ["everest_batch_objectives"]),
+            (EVEREST_CONSTRAINT_PLOT, ["everest_constraints"]),
+            (EVEREST_CONTROLS_PLOT, ["everest_parameters"]),
+            (EVEREST_GRADIENTS_PLOT, ["everest_constraints", "everest_objectives"]),
+        ]
 
-        if everest_control_widget:
-            if is_everest_control:
-                available_widgets = [everest_control_widget]
-            elif everest_control_widget in available_widgets:
-                available_widgets.remove(everest_control_widget)
+        def everest_available_widget_selection(
+            widget_tuple_list: list[tuple[str, list[str]]],
+        ) -> None:
+            for widget_name, origin in widget_tuple_list:
+                widget = everest_widget_locator(widget_name)
+                if widget:
+                    if everest_data_origin_check(origin):
+                        if widget not in available_widgets:
+                            available_widgets.append(widget)
+                    elif widget in available_widgets:
+                        available_widgets.remove(widget)
 
-        everest_gradients_widget = next(
-            (w for w in self._plot_widgets if w.name == EVEREST_GRADIENTS_PLOT), None
-        )
-
-        if everest_gradients_widget:
-            if self.is_everest:
-                if everest_gradients_widget not in available_widgets:
-                    available_widgets.append(everest_gradients_widget)
-            elif (
-                key_def.metadata.get("data_origin") == "everest_batch_objectives"
-                and everest_gradients_widget in available_widgets
-            ) or everest_gradients_widget in available_widgets:
-                available_widgets.remove(everest_gradients_widget)
+        everest_available_widget_selection(everest_plot_and_origin)
 
         # Enabling/disabling tab triggers the
         # currentTabChanged event which also triggers

--- a/src/ert/gui/tools/plot/plottery/plots/__init__.py
+++ b/src/ert/gui/tools/plot/plottery/plots/__init__.py
@@ -1,23 +1,29 @@
 from .cesp import CrossEnsembleStatisticsPlot
 from .distribution import DistributionPlot
 from .ensemble import EnsemblePlot
+from .everest_batch_objective_function_plot import EverestBatchObjectiveFunctionPlot
+from .everest_constraints_plot import EverestConstraintsPlot
+from .everest_controls_plot import EverestControlsPlot
 from .everest_gradients_plot import EverestGradientsPlot
+from .everest_objective_function_plot import EverestObjectiveFunctionPlot
 from .gaussian_kde import GaussianKDEPlot
 from .histogram import HistogramPlot
 from .misfits import MisfitsPlot
 from .statistics import StatisticsPlot
 from .std_dev import StdDevPlot
-from .values_over_iteration_plot import ValuesOverIterationsPlot
 
 __all__ = [
     "CrossEnsembleStatisticsPlot",
     "DistributionPlot",
     "EnsemblePlot",
+    "EverestBatchObjectiveFunctionPlot",
+    "EverestConstraintsPlot",
+    "EverestControlsPlot",
     "EverestGradientsPlot",
+    "EverestObjectiveFunctionPlot",
     "GaussianKDEPlot",
     "HistogramPlot",
     "MisfitsPlot",
     "StatisticsPlot",
     "StdDevPlot",
-    "ValuesOverIterationsPlot",
 ]

--- a/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from matplotlib.lines import Line2D
+from matplotlib.ticker import MaxNLocator
+
+from .plot_tools import PlotTools
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    from matplotlib.figure import Figure
+
+    from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.tools.plot.plottery import PlotContext
+
+
+class EverestBatchObjectiveFunctionPlot:
+    """Plot of each batch's aggregated objective function value.
+
+    Layout:
+        X-axis: iteration
+        Y-axis: aggregated objective value across all realizations in the batch
+        Glyphs: One line chart with a dot at each batch iteration.
+
+    Input data: assumed to be a dictionary of DataFrames, where
+    each DataFrame contains columns for 'batch_id',
+    some variation of the aggregated objective value
+    and 'is_improvement'.
+    """
+
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = False
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: npt.NDArray[np.float32] | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+        config = plot_context.plotConfig()
+        axes = figure.add_subplot(111)
+
+        plot_context.y_axis = plot_context.VALUE_AXIS
+        plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.deactivateDateSupport()
+
+        all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
+
+        if not all_dfs:
+            return
+
+        combined = pd.concat(all_dfs, ignore_index=True)
+
+        if "is_improvement" in combined.columns:
+            value_col = next(
+                c
+                for c in combined.columns
+                if c not in {"batch_id", "realization", "is_improvement"}
+            )
+            data = combined.sort_values("batch_id")
+
+            color = config.nextColor()
+
+            improvement_data = data[data["is_improvement"]]
+
+            lines = axes.plot(
+                improvement_data["batch_id"],
+                improvement_data[value_col],
+                "-o",
+                color=color,
+            )
+
+            rejected_data = data[~data["is_improvement"]]
+            axes.scatter(
+                rejected_data["batch_id"],
+                rejected_data[value_col],
+                c="red",
+                s=20,
+                zorder=5,
+            )
+
+            annotation_color = {True: color, False: "red"}
+            for _, row in data.iterrows():
+                axes.annotate(
+                    f"Batch {int(row['batch_id'])}",
+                    xy=(row["batch_id"], row[value_col]),
+                    xytext=(5, -5),
+                    textcoords="offset points",
+                    color=annotation_color[row["is_improvement"]],
+                    verticalalignment="top",
+                    horizontalalignment="left",
+                )
+
+            config.addLegendItem("Accepted", lines[0])
+            config.addLegendItem(
+                "Rejected",
+                Line2D(
+                    [0], [0], marker="o", color="w", markerfacecolor="red", markersize=8
+                ),
+            )
+
+            axes.spines["right"].set_visible(False)
+            axes.spines["top"].set_visible(False)
+
+            axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+            PlotTools.finalizePlot(
+                plot_context,
+                figure,
+                axes,
+                default_x_label="Batch Iteration",
+                default_y_label="Aggregated Objective Value",
+            )
+            figure.tight_layout()
+            return

--- a/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from matplotlib.lines import Line2D
 from matplotlib.ticker import MaxNLocator
 
 from .plot_tools import PlotTools
@@ -17,23 +16,23 @@ if TYPE_CHECKING:
     from ert.gui.tools.plot.plottery import PlotContext
 
 
-class ValuesOverIterationsPlot:
-    """Plot of a value for each realization over iterations.
+class EverestConstraintsPlot:
+    """Plot of each batch's constraint value over iterations.
 
     Layout:
         X-axis: iteration
-        Y-axis: value
+        Y-axis: constraint value
         Glyphs: One line chart per realization, with a dot at each iteration.
 
     Input data: assumed to be a dictionary of DataFrames, where
     each DataFrame contains columns for 'batch_id', 'realization', and
-    exactly one other column (named according to its source data,
-    i.e., objective or control name) which is treated as the value to plot.
+    constraint value.
     """
 
     def __init__(self) -> None:
         self.dimensionality = 2
         self.requires_observations = False
+        self.LEGEND_THRESHOLD = 5
 
     def plot(
         self,
@@ -59,48 +58,6 @@ class ValuesOverIterationsPlot:
 
         combined = pd.concat(all_dfs, ignore_index=True)
 
-        if "is_improvement" in combined.columns:
-            value_col = next(
-                c
-                for c in combined.columns
-                if c not in {"batch_id", "realization", "is_improvement"}
-            )
-            data = combined.sort_values("batch_id")
-
-            color = config.nextColor()
-            improvement_data = data[data["is_improvement"]]
-
-            lines = axes.plot(
-                improvement_data["batch_id"],
-                improvement_data[value_col],
-                "-",
-                color=color,
-            )
-
-            colors = [
-                "red" if not row.is_improvement else color for _, row in data.iterrows()
-            ]
-            axes.scatter(data["batch_id"], data[value_col], c=colors, s=20, zorder=5)
-
-            config.addLegendItem("Accepted", lines[0])
-            config.addLegendItem(
-                "Rejected",
-                Line2D(
-                    [0], [0], marker="o", color="w", markerfacecolor="red", markersize=8
-                ),
-            )
-            axes.xaxis.set_major_locator(MaxNLocator(integer=True))
-
-            PlotTools.finalizePlot(
-                plot_context,
-                figure,
-                axes,
-                default_x_label="Iteration",
-                default_y_label="Value",
-            )
-            figure.tight_layout()
-            return
-
         # Assume only one value is in the input data to make it same across
         # controls, constraints, and objectives
         value_col = next(
@@ -109,8 +66,6 @@ class ValuesOverIterationsPlot:
 
         realizations = sorted(combined["realization"].unique())
 
-        # This loop is the reason batch controls
-        # plot multiple identical plots for each realization.
         for realization in realizations:
             data = combined[combined["realization"] == realization].sort_values(
                 "batch_id"
@@ -126,14 +81,17 @@ class ValuesOverIterationsPlot:
                 color=color,
                 markersize=4,
             )
-            config.addLegendItem(f"Realization {int(realization)}", lines[0])
+            if len(realizations) <= self.LEGEND_THRESHOLD:
+                config.addLegendItem(f"Realization {int(realization)}", lines[0])
 
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+        axes.spines["right"].set_visible(False)
+        axes.spines["top"].set_visible(False)
         PlotTools.finalizePlot(
             plot_context,
             figure,
             axes,
-            default_x_label="Iteration",
-            default_y_label="Value",
+            default_x_label="Batch Iteration",
+            default_y_label="Constraint Value",
         )
         figure.tight_layout()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from matplotlib.ticker import MaxNLocator
+
+from .plot_tools import PlotTools
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    from matplotlib.figure import Figure
+
+    from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.tools.plot.plottery import PlotContext
+
+
+class EverestControlsPlot:
+    """Plot of each batch's control values over iterations.
+
+    Layout:
+        X-axis: iteration
+        Y-axis: control value
+        Glyphs: One line chart per control, with a dot at each iteration.
+
+    Input data: assumed to be a dictionary of DataFrames, where
+    each DataFrame contains columns for 'batch_id', 'realization', 'control_name', and
+    'control_value'.
+    """
+
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = False
+        self.selected_controls: list[str] = []
+
+    def set_selected_controls(self, controls: list[str]) -> None:
+        self.selected_controls = controls
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: npt.NDArray[np.float32] | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+        config = plot_context.plotConfig()
+        axes = figure.add_subplot(111)
+
+        plot_context.y_axis = plot_context.VALUE_AXIS
+        plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.deactivateDateSupport()
+
+        all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
+
+        if not all_dfs:
+            return
+
+        combined = pd.concat(all_dfs, ignore_index=True)
+
+        for control in self.selected_controls:
+            data = combined[combined["control_name"] == control].sort_values("batch_id")
+            if data.empty:
+                continue
+
+            color = config.nextColor()
+            lines = axes.plot(
+                data["batch_id"],
+                data["control_value"],
+                "-o",
+                color=color,
+                markersize=4,
+            )
+            config.addLegendItem(control, lines[0])
+            if len(control) <= 20:
+                axes.annotate(
+                    control,
+                    xy=(data["batch_id"].iloc[-1], data["control_value"].iloc[-1]),
+                    xytext=(5, 0),
+                    textcoords="offset points",
+                    color=color,
+                    verticalalignment="bottom",
+                    horizontalalignment="left",
+                )
+
+        axes.spines["right"].set_visible(False)
+        axes.spines["left"].set_visible(False)
+        axes.spines["top"].set_visible(False)
+
+        # Conversion to integer ticks for batch_id (number of batches)
+        axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        PlotTools.finalizePlot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Batch Iteration",
+            default_y_label="Control Value",
+        )
+        figure.tight_layout()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -103,11 +103,14 @@ class EverestGradientsPlot:
         axes.set_xticks(pos)
         axes.set_xticklabels([str(b) for b in batch_ids], rotation=0)
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
+        axes.spines["right"].set_visible(False)
+        axes.spines["left"].set_visible(False)
+        axes.spines["top"].set_visible(False)
 
         PlotTools.finalizePlot(
             plot_context,
             figure,
             axes,
-            default_x_label="Batch",
+            default_x_label="Batch Iteration",
             default_y_label="Gradient",
         )

--- a/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from matplotlib.ticker import MaxNLocator
+
+from .plot_tools import PlotTools
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+    from matplotlib.figure import Figure
+
+    from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.tools.plot.plottery import PlotContext
+
+
+class EverestObjectiveFunctionPlot:
+    """Plot of each realization's objective function value over iterations.
+
+    Layout:
+        X-axis: iteration
+        Y-axis: objective value (mean or stddev)
+        Glyphs: One line chart per realization, with a dot at each iteration.
+
+    Input data: assumed to be a dictionary of DataFrames, where
+    each DataFrame contains columns for 'batch_id', 'realization', and
+    the objective value (e.g. 'distance').
+    """
+
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = False
+        self.LEGEND_THRESHOLD = 5
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: npt.NDArray[np.float32] | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+        config = plot_context.plotConfig()
+        axes = figure.add_subplot(111)
+
+        plot_context.y_axis = plot_context.VALUE_AXIS
+        plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.deactivateDateSupport()
+
+        all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
+
+        if not all_dfs:
+            return
+
+        combined = pd.concat(all_dfs, ignore_index=True)
+
+        # Assume only one value is in the input data to make it same across
+        # controls, constraints, and objectives
+        value_col = next(
+            c for c in combined.columns if c not in {"batch_id", "realization"}
+        )
+
+        realizations = sorted(combined["realization"].unique())
+
+        for realization in realizations:
+            data = combined[combined["realization"] == realization].sort_values(
+                "batch_id"
+            )
+            if data.empty:
+                continue
+
+            color = config.nextColor()
+            lines = axes.plot(
+                data["batch_id"],
+                data[value_col],
+                "-o",
+                color=color,
+                markersize=4,
+            )
+            if len(realizations) <= self.LEGEND_THRESHOLD:
+                config.addLegendItem(f"Realization {int(realization)}", lines[0])
+
+        axes.spines["right"].set_visible(False)
+        axes.spines["left"].set_visible(False)
+        axes.spines["top"].set_visible(False)
+
+        axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+        PlotTools.finalizePlot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Batch Iteration",
+            default_y_label="Objective Value",
+        )
+        figure.tight_layout()

--- a/src/ert/gui/tools/plot/widgets/everest_control_selection_widget.py
+++ b/src/ert/gui/tools/plot/widgets/everest_control_selection_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QListWidget,
@@ -15,6 +15,7 @@ class EverestControlSelectionWidget(QWidget):
 
     def __init__(self, controls: list[str]) -> None:
         super().__init__()
+        self._pinned_control: str | None = None
         self._controls_list = QListWidget()
         self._controls_list.setSelectionMode(
             QAbstractItemView.SelectionMode.MultiSelection
@@ -36,6 +37,17 @@ class EverestControlSelectionWidget(QWidget):
             self._controls_list.addItem(item)
         self._controls_list.blockSignals(False)
 
+    def set_pinned_control(self, control: str | None) -> None:
+        if self._pinned_control == control:
+            return
+        self._pinned_control = control
+        self._controls_list.blockSignals(True)
+        self._controls_list.clearSelection()
+        matches = self._controls_list.findItems(control, Qt.MatchFlag.MatchExactly)
+        for item in matches:
+            item.setSelected(True)
+        self._controls_list.blockSignals(False)
+
     def get_selected_controls(self) -> list[str]:
         selected = []
         for i in range(self._controls_list.count()):
@@ -46,4 +58,13 @@ class EverestControlSelectionWidget(QWidget):
         return selected
 
     def _onSelectionChanged(self) -> None:
+        if self._pinned_control is not None:
+            for i in range(self._controls_list.count()):
+                item = self._controls_list.item(i)
+                assert item is not None
+                if item.text() == self._pinned_control and not item.isSelected():
+                    self._controls_list.blockSignals(True)
+                    item.setSelected(True)
+                    self._controls_list.blockSignals(False)
+                    break
         self.controlSelectionChanged.emit()


### PR DESCRIPTION
**Issue**
Resolves #13185 
Resolves #13114 
Resolves #13038
Resolves #13277


**Approach**
Split ValuesOverIterationsPlot into multiple Everest plots, one plot for each type of data type.
Some might have overlap of functionality, but idea is that this approach will allow easier modifications at a later stage. 

Added condition to plots that plot realizations to prevent legends larger than 5 realizations (#13038) 

**Objective Function**
<img width="1308" height="783" alt="image" src="https://github.com/user-attachments/assets/d3a2fb6a-1d71-4f2f-8bd8-316d771aee41" />
Plots all the realizations for each toggled batch in a single plot

**Constraints** 
<img width="1395" height="854" alt="image" src="https://github.com/user-attachments/assets/ad126390-c74d-4215-83f4-cbe163d105c2" />
Plots each realizations' constraint value for each toggled batch 

**Aggregated Objective Values/ Batch Objective**
<img width="1393" height="852" alt="image" src="https://github.com/user-attachments/assets/686f01a8-fda3-4bc5-bd8f-3c3e86bc1f3c" />
Plots each toggled batch's aggregated objective value. Still relies on the `is_improvement` column, but should be dynamically determined at a later stage (#10998)

**Controls**
<img width="1393" height="853" alt="image" src="https://github.com/user-attachments/assets/92919fc2-17f5-46c2-a606-001dcb93e68f" />
*Only the data type entry selected*
<img width="1393" height="850" alt="image" src="https://github.com/user-attachments/assets/e1349785-f954-45c5-b4c3-15f9a76b5cb5" />
*Multiple controls selected*
 
Similar to previous functionality, but now allows to plot multiple controls (Everest parameters) in the same plot. 

The selected control point from the data type list will **ALWAYS** be toggled, so that the plot will never be empty. When selecting a new point from the data types list and not the Everest Controls, the selected controls list is reset to avoid flooding the plot.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
