### PR TITLE
Restore subclasses for ForwardModelStep

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -127,7 +127,7 @@ def _log_unsubstituted_forward_model_args(
 
 def create_forward_model_json(
     context: dict[str, str],
-    forward_model_steps: list[ForwardModelStep],
+    forward_model_steps: list[SiteOrUserForwardModelStep],
     run_id: str | None,
     iens: int = 0,
     itr: int = 0,
@@ -636,14 +636,14 @@ def installed_forward_model_steps_from_dict(
 
 
 def create_list_of_forward_model_steps_to_run(
-    installed_steps: dict[str, ForwardModelStep],
+    installed_steps: dict[str, SiteOrUserForwardModelStep],
     substitutions: dict[str, str],
     config_dict: ConfigDict,
-    preinstalled_forward_model_steps: Mapping[str, ForwardModelStep],
+    preinstalled_forward_model_steps: Mapping[str, SiteInstalledForwardModelStep],
     env_pr_fm_step: dict[str, dict[str, Any]],
-) -> list[ForwardModelStep]:
+) -> list[SiteOrUserForwardModelStep]:
     errors = []
-    fm_steps: list[ForwardModelStep] = []
+    fm_steps: list[SiteOrUserForwardModelStep] = []
 
     user_positional_args_by_step: dict[int, list[str]] = {}
     substituter = Substitutions(substitutions)
@@ -659,7 +659,9 @@ def create_list_of_forward_model_steps_to_run(
             args = []
         fm_step_name = substituter.substitute(unsubstituted_step_name)
         try:
-            fm_step = copy.deepcopy(installed_steps[fm_step_name])
+            fm_step: SiteOrUserForwardModelStep = copy.deepcopy(
+                installed_steps[fm_step_name]
+            )
 
             # Preserve as ContextString
             fm_step.name = fm_step_name
@@ -781,7 +783,9 @@ USER_CONFIG_SCHEMA = init_user_config_schema()
 class ErtConfig(BaseModel):
     DEFAULT_ENSPATH: ClassVar[str] = "storage"
     DEFAULT_RUNPATH_FILE: ClassVar[str] = ".ert_runpath_list"
-    PREINSTALLED_FORWARD_MODEL_STEPS: ClassVar[Mapping[str, ForwardModelStep]] = {}
+    PREINSTALLED_FORWARD_MODEL_STEPS: ClassVar[
+        Mapping[str, SiteInstalledForwardModelStep]
+    ] = {}
     PREINSTALLED_WORKFLOWS: ClassVar[dict[str, WorkflowJob]] = {}
     ENV_PR_FM_STEP: ClassVar[dict[str, dict[str, Any]]] = {}
     ENV_VARIABLES: ClassVar[dict[str, str]] = {}
@@ -1247,10 +1251,10 @@ class ErtConfig(BaseModel):
     @classmethod
     def _create_list_of_forward_model_steps_to_run(
         cls,
-        installed_steps: dict[str, ForwardModelStep],
+        installed_steps: dict[str, SiteOrUserForwardModelStep],
         substitutions: dict[str, str],
         config_dict: ConfigDict,
-    ) -> list[ForwardModelStep]:
+    ) -> list[SiteOrUserForwardModelStep]:
         return create_list_of_forward_model_steps_to_run(
             installed_steps,
             substitutions,

--- a/src/ert/run_models/_create_run_path.py
+++ b/src/ert/run_models/_create_run_path.py
@@ -21,7 +21,6 @@ from _ert.utils import file_safe_timestamp
 from ert.config import (
     EverestControl,
     Field,
-    ForwardModelStep,
     GenKwConfig,
     ParameterCardinality,
     ParameterConfig,
@@ -30,6 +29,7 @@ from ert.config import (
 from ert.config.design_matrix import DESIGN_MATRIX_GROUP
 from ert.config.distribution import LogNormalSettings, LogUnifSettings
 from ert.config.ert_config import create_forward_model_json
+from ert.config.forward_model_step import SiteOrUserForwardModelStep
 from ert.ensemble_evaluator.evaluator import UserCancelled
 from ert.run_models.event import (
     FinishedTotalRunPathCreationEvent,
@@ -287,7 +287,7 @@ def _create_one_run_path(
     user_config_file: str,
     env_vars: dict[str, str],
     env_pr_fm_step: dict[str, dict[str, Any]],
-    forward_model_steps: list[ForwardModelStep],
+    forward_model_steps: list[SiteOrUserForwardModelStep],
     substituter: Substitutions,
     substitutions: dict[str, str],
     parameters_file: str,
@@ -399,7 +399,7 @@ async def create_run_path(
     user_config_file: str,
     env_vars: dict[str, str],
     env_pr_fm_step: dict[str, dict[str, Any]],
-    forward_model_steps: list[ForwardModelStep],
+    forward_model_steps: list[SiteOrUserForwardModelStep],
     substitutions: dict[str, str],
     parameters_file: str,
     runpaths: Runpaths,

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -19,13 +19,14 @@ from collections.abc import Callable, Generator, MutableSequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, Self, cast
 
 import numpy as np
 from pydantic import (
     PrivateAttr,
     computed_field,
     field_validator,
+    model_validator,
 )
 from pydantic_core.core_schema import ValidationInfo
 
@@ -35,7 +36,7 @@ from _ert.events import (
     EESnapshotUpdate,
     EnsembleEvaluationWarning,
 )
-from ert.base_model_context import BaseModelWithContextSupport
+from ert.base_model_context import BaseModelWithContextSupport, init_context_var
 from ert.config import (
     ConfigValidationError,
     DesignMatrix,
@@ -47,6 +48,8 @@ from ert.config import (
     PostSimulationFixtures,
     PreSimulationFixtures,
     QueueConfig,
+    SiteOrUserForwardModelStep,
+    UserInstalledForwardModelStep,
     Workflow,
     create_workflow_fixtures_from_hooked,
 )
@@ -171,7 +174,7 @@ class RunModelConfig(BaseModelWithContextSupport):
     env_pr_fm_step: dict[str, dict[str, Any]]
     runpath_config: ModelConfig
     queue_config: QueueConfig
-    forward_model_steps: list[ForwardModelStep]
+    forward_model_steps: list[SiteOrUserForwardModelStep]
     substitutions: dict[str, str]
     hooked_workflows: defaultdict[HookRuntime, list[Workflow]]
     active_realizations: list[bool]
@@ -180,6 +183,29 @@ class RunModelConfig(BaseModelWithContextSupport):
     start_iteration: int = 0
     minimum_required_realizations: int = 0
     supports_rerunning_failed_realizations: ClassVar[bool] = False
+
+    @model_validator(mode="after")
+    def _restore_plugin_forward_model_step_subclasses(self) -> Self:
+        runtime_plugins = init_context_var.get()
+        if runtime_plugins is None:
+            return self
+        restored = []
+        for step in self.forward_model_steps:
+            installed = runtime_plugins.installed_forward_model_steps.get(step.name)
+            if installed is not None and not isinstance(
+                step, (UserInstalledForwardModelStep, type(installed))
+            ):
+                fm_step = installed.model_copy(
+                    update={
+                        field: getattr(step, field)
+                        for field in ForwardModelStep.model_fields
+                    }
+                )
+                restored.append(fm_step)
+            else:
+                restored.append(step)
+        self.forward_model_steps = restored
+        return self
 
 
 class RunModel(RunModelConfig, ABC):

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import shutil
 import stat
+from argparse import ArgumentParser
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
@@ -11,7 +12,9 @@ import pytest
 from hypothesis import given, settings
 from pydantic import TypeAdapter
 
+from ert.__main__ import ert_parser
 from ert.base_model_context import use_runtime_plugins
+from ert.cli.main import ErtCliError, run_cli
 from ert.config import ConfigValidationError, ConfigWarning, ErtConfig
 from ert.config.ert_config import (
     create_forward_model_json,
@@ -25,6 +28,7 @@ from ert.config.forward_model_step import (
     SiteOrUserForwardModelStep,
 )
 from ert.config.parsing import SchemaItemType
+from ert.mode_definitions import TEST_RUN_MODE
 from ert.plugins import ErtRuntimePlugins, get_site_plugins
 
 from .config_dict_generator import config_generators
@@ -741,6 +745,96 @@ def test_that_plugin_forward_model_validation_failure_propagates(tmp_path):
             iens=0,
             itr=0,
         )
+
+
+@pytest.mark.slow
+def test_that_validate_pre_realization_run_is_called_when_runmodel_is_evaluated(
+    tmp_path,
+):
+    (tmp_path / "test.ert").write_text(
+        dedent(
+            """
+            NUM_REALIZATIONS  1
+            FORWARD_MODEL WILL_FAIL_VALIDATION()
+            """
+        )
+    )
+
+    class FM(ForwardModelStepPlugin):
+        def __init__(self) -> None:
+            super().__init__(
+                name="WILL_FAIL_VALIDATION",
+                command=["echo"],
+            )
+
+        def validate_pre_realization_run(
+            self, fm_step_json: ForwardModelStepJSON
+        ) -> ForwardModelStepJSON:
+            raise ForwardModelStepValidationError("No go")
+
+    parser = ArgumentParser(prog="test_main")
+    args = ert_parser(
+        parser,
+        [TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert")],
+    )
+    runtime_plugins = ErtRuntimePlugins(
+        installed_forward_model_steps={"WILL_FAIL_VALIDATION": FM()}
+    )
+    original_cwd = Path.cwd()
+    try:
+        with pytest.raises(ErtCliError) as exc_info:
+            run_cli(args, runtime_plugins)
+    finally:
+        os.chdir(original_cwd)
+    assert (
+        "Validation failed for forward model step WILL_FAIL_VALIDATION: No go"
+        in str(exc_info.value)
+    )
+
+
+@pytest.mark.slow
+def test_that_validate_pre_realization_run_is_not_called_when_user_defined_step_overwrites(  # noqa: E501
+    tmp_path,
+):
+    """If a site plugin defines a forward model step that will fail validation, but
+    the user has defined her own step that does not have any validation,
+    the site-installed step validation should not run"""
+    (tmp_path / "A_POPULAR_STEP_NAME").write_text("EXECUTABLE echo", encoding="utf-8")
+    (tmp_path / "test.ert").write_text(
+        dedent(
+            """
+            NUM_REALIZATIONS  1
+            INSTALL_JOB A_POPULAR_STEP_NAME A_POPULAR_STEP_NAME
+            FORWARD_MODEL A_POPULAR_STEP_NAME()
+            """
+        )
+    )
+
+    class FM(ForwardModelStepPlugin):
+        def __init__(self) -> None:
+            super().__init__(
+                name="A_POPULAR_STEP_NAME",
+                command=["echo"],
+            )
+
+        def validate_pre_realization_run(
+            self, fm_step_json: ForwardModelStepJSON
+        ) -> ForwardModelStepJSON:
+            raise ForwardModelStepValidationError("No go from site-installed step")
+
+    parser = ArgumentParser(prog="test_main")
+    args = ert_parser(
+        parser,
+        [TEST_RUN_MODE, "--disable-monitoring", str(tmp_path / "test.ert")],
+    )
+    runtime_plugins = ErtRuntimePlugins(
+        installed_forward_model_steps={"A_POPULAR_STEP_NAME": FM()}
+    )
+    original_cwd = Path.cwd()
+    try:
+        run_cli(args, runtime_plugins)
+    finally:
+        os.chdir(original_cwd)
 
 
 def test_that_plugin_forward_model_validation_accepts_valid_args(tmp_path):

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_evaluate_ensemble_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
@@ -58,7 +58,8 @@
       "private_args": {
         "<ARG0>": "<IENS>",
         "<ARG1>": "<ITER>"
-      }
+      },
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -48,7 +48,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_NPV",
@@ -71,7 +72,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     },
     {
       "name": "SNAKE_OIL_DIFF",
@@ -94,7 +96,8 @@
         "_ERT_RUNPATH": "<RUNPATH>"
       },
       "default_mapping": {},
-      "private_args": {}
+      "private_args": {},
+      "type": "user_installed"
     }
   ],
   "substitutions": {

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -21,7 +21,6 @@ from ert.config import (
     ExecutableWorkflow,
     ExternalErtScript,
     Field,
-    ForwardModelStep,
     GenDataConfig,
     GenKwConfig,
     HookRuntime,
@@ -30,6 +29,7 @@ from ert.config import (
     OutlierSettings,
     SummaryConfig,
     SurfaceConfig,
+    UserInstalledForwardModelStep,
     Workflow,
 )
 from ert.config.parsing import SchemaItemType
@@ -145,7 +145,7 @@ def optional_file(draw):
 
 def forward_model_steps(substitutions):
     return st.builds(
-        ForwardModelStep,
+        UserInstalledForwardModelStep,
         stdin_file=optional_file(),
         stdout_file=optional_file(),
         stderr_file=optional_file(),


### PR DESCRIPTION
This must be done in order to ensure we call the correct implementation of validate_pre_realization_run after pydantic has deserialized a RunModel.

This is a regression that has popped up when making the runmodels serializable. Now covered by a regression test.

**Issue**
Resolves #13250 


**Approach**
Restore subclass objects after deserialization.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
