### PR TITLE
Redesign some elements of the experiment view

### DIFF
--- a/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
+++ b/src/ert/gui/tools/manage_experiments/manage_experiments_panel.py
@@ -73,7 +73,7 @@ class ManageExperimentsPanel(QTabWidget):
             self._storage_info_widget.setRealization
         )
 
-        self.addTab(panel, "Create new experiment")
+        self.addTab(panel, "Experiments Overview")
 
     def _add_initialize_from_scratch_tab(self) -> None:
         panel = QWidget()

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -76,10 +76,12 @@ class _ExperimentWidget(QWidget):
         info_frame = QFrame()
         self._name_label = QLabel()
         self._uuid_label = QLabel()
+        self._created_at_label = QLabel()
 
         layout = QVBoxLayout()
         layout.addWidget(self._name_label)
         layout.addWidget(self._uuid_label)
+        layout.addWidget(self._created_at_label)
         layout.addStretch()
 
         info_frame.setLayout(layout)
@@ -113,6 +115,14 @@ class _ExperimentWidget(QWidget):
 
         self._name_label.setText(f"Name: {experiment.name!s}")
         self._uuid_label.setText(f"UUID: {experiment.id!s}")
+
+        # Determine creation time from the earliest ensemble start time
+        created_text = "Unknown"
+        ensemble_start_times = [ens.started_at for ens in experiment.ensembles]
+        if ensemble_start_times:
+            created_text = min(ensemble_start_times).strftime("%Y-%m-%d %H:%M:%S")
+
+        self._created_at_label.setText(f"Created at: {created_text}")
 
         self._responses_text_edit.setText(yaml.dump(experiment.response_info, indent=4))
         self._parameters_text_edit.setText(

--- a/src/ert/gui/tools/manage_experiments/storage_model.py
+++ b/src/ert/gui/tools/manage_experiments/storage_model.py
@@ -18,7 +18,7 @@ class _Column(IntEnum):
 _NUM_COLUMNS = max(_Column).value + 1
 _COLUMN_TEXT = {
     0: "Name",
-    1: "Created at",
+    1: "Created",
 }
 
 
@@ -83,6 +83,11 @@ class EnsembleModel:
         elif role == Qt.ItemDataRole.ToolTipRole:
             if col == _Column.TIME:
                 return str(self._start_time)
+        elif role == Qt.ItemDataRole.UserRole:
+            if col == _Column.TIME:
+                return self._start_time
+            if col == _Column.NAME:
+                return self._name
 
         return None
 
@@ -118,6 +123,11 @@ class ExperimentModel:
                     if self._children
                     else "None"
                 )
+        elif role == Qt.ItemDataRole.UserRole:
+            if col == _Column.NAME:
+                return self._name
+            if col == _Column.TIME:
+                return self._children[0]._start_time if self._children else None
 
         return None
 

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -6,7 +6,6 @@ from PyQt6.QtCore import (
     QAbstractItemModel,
     QItemSelectionModel,
     QModelIndex,
-    QSize,
     QSortFilterProxyModel,
     Qt,
 )
@@ -15,7 +14,7 @@ from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLineEdit,
-    QToolButton,
+    QPushButton,
     QTreeView,
     QVBoxLayout,
     QWidget,
@@ -24,7 +23,6 @@ from PyQt6.QtWidgets import (
 from ert.config import ErrorInfo, ErtConfig
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.ertwidgets import CreateExperimentDialog, Suggestor
-from ert.gui.icon_utils import load_icon
 from ert.storage import Ensemble, Experiment
 from ert.storage.local_experiment import ExperimentType
 
@@ -49,9 +47,7 @@ class AddWidget(QWidget):
     def __init__(self, addFunction: Callable[[], None]) -> None:
         super().__init__()
 
-        self.addButton = QToolButton(self)
-        self.addButton.setIcon(load_icon("add_circle_outlined.svg"))
-        self.addButton.setIconSize(QSize(16, 16))
+        self.addButton = QPushButton("Add new experiment", self)
         self.addButton.clicked.connect(addFunction)
 
         self.removeButton = None

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Callable
 from typing import cast
 
@@ -67,21 +68,46 @@ class _SortingProxyModel(QSortFilterProxyModel):
         self.setSourceModel(model)
 
     def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:
-        left_data = left.data()
-        right_data = right.data()
-
+        left_display = left.data(Qt.ItemDataRole.DisplayRole)
+        right_display = right.data(Qt.ItemDataRole.DisplayRole)
         if (
-            isinstance(left_data, str)
-            and "Realization" in left_data
-            and isinstance(right_data, str)
-            and "Realization" in right_data
+            isinstance(left_display, str)
+            and left_display.startswith("Realization ")
+            and isinstance(right_display, str)
+            and right_display.startswith("Realization ")
         ):
-            left_realization_number = int(left_data.split(" ")[1])
-            right_realization_number = int(right_data.split(" ")[1])
+            try:
+                left_num = int(left_display.split(" ")[1])
+                right_num = int(right_display.split(" ")[1])
+            except (IndexError, ValueError):
+                return left_display.lower() < right_display.lower()
+            return left_num < right_num
 
-            return left_realization_number < right_realization_number
+        role = int(self.sortRole())
+        left_data = left.data(role)
+        right_data = right.data(role)
 
-        return super().lessThan(left, right)
+        if left_data is None and right_data is None:
+            return False
+        if left_data is None:
+            return False
+        if right_data is None:
+            return True
+
+        if isinstance(left_data, str) and isinstance(right_data, str):
+
+            def natural_key(s: str) -> list[int | str]:
+                return [
+                    int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", s)
+                ]
+
+            lk = natural_key(left_data)
+            rk = natural_key(right_data)
+            if lk == rk:
+                return left_data.lower() < right_data.lower()
+            return lk < rk
+
+        return left_data < right_data
 
 
 class StorageWidget(QWidget):
@@ -110,9 +136,16 @@ class StorageWidget(QWidget):
         proxy_model = _SortingProxyModel(storage_model)
         proxy_model.setFilterKeyColumn(-1)  # Search all columns.
         proxy_model.setSourceModel(storage_model)
-        proxy_model.sort(0, Qt.SortOrder.AscendingOrder)
+        proxy_model.setSortRole(Qt.ItemDataRole.UserRole)
+        proxy_model.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        proxy_model.setDynamicSortFilter(True)
+        proxy_model.sort(1, Qt.SortOrder.DescendingOrder)
 
         self._tree_view.setModel(proxy_model)
+        self._tree_view.setSortingEnabled(True)
+        header = self._tree_view.header()
+        if header is not None:
+            header.setSortIndicatorShown(True)
         search_bar.textChanged.connect(proxy_model.setFilterFixedString)
 
         self._sel_model = QItemSelectionModel(proxy_model)

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -1,4 +1,5 @@
 import shutil
+import time
 from pathlib import Path
 
 import numpy as np
@@ -441,10 +442,18 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
         # select the ensemble
         storage_widget = tool.findChild(StorageWidget)
         storage_widget._tree_view.expandAll()
-        model_index = storage_widget._tree_view.model().index(
-            0, 0, storage_widget._tree_view.model().index(0, 0)
-        )
-        storage_widget._tree_view.setCurrentIndex(model_index)
+
+        model = storage_widget._tree_view.model()
+        experiment_index = model.index(0, 0)
+
+        target_index = None
+        for r in range(model.rowCount(experiment_index)):
+            idx = model.index(r, 0, experiment_index)
+            if model.data(idx, Qt.ItemDataRole.DisplayRole) == "iter-0":
+                target_index = idx
+                break
+        assert target_index is not None
+        storage_widget._tree_view.setCurrentIndex(target_index)
         assert (
             tool._storage_info_widget._content_layout.currentIndex()
             == _WidgetType.ENSEMBLE_WIDGET
@@ -716,3 +725,76 @@ def test_that_export_parameters_button_opens_the_export_dialog(
     parameters_frame = ensemble_widget._tab_widget.currentWidget()
     parameters_frame.findChild(QPushButton).click()
     assert isinstance(QApplication.activeModalWidget(), ExportDialog)
+
+
+def _child_names_under(model, parent_index):
+    return [
+        model.data(model.index(r, 0, parent_index), Qt.ItemDataRole.DisplayRole)
+        for r in range(model.rowCount(parent_index))
+    ]
+
+
+def _find_root_row_by_name(model, name: str):
+    for r in range(model.rowCount()):
+        idx = model.index(r, 0)
+        if model.data(idx, Qt.ItemDataRole.DisplayRole) == name:
+            return idx
+    return None
+
+
+@pytest.mark.usefixtures("copy_poly_case")
+def test_that_storage_widget_sorts_by_name_and_created(qtbot):
+    config = ErtConfig.from_file("poly.ert")
+    notifier = ErtNotifier()
+    notifier.set_storage(config.ens_path)
+
+    with notifier.write_storage() as storage:
+        exp = storage.create_experiment(
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json")
+                    for pc in config.ensemble_config.parameter_configuration
+                ],
+                "response_configuration": [
+                    rc.model_dump(mode="json")
+                    for rc in config.ensemble_config.response_configuration
+                ],
+            },
+            name="exp-sort",
+        )
+
+        # Create two ensembles with a small delay to ensure distinct started_at
+        exp.create_ensemble(
+            name="a-ens", ensemble_size=config.runpath_config.num_realizations
+        )
+        time.sleep(1)
+        exp.create_ensemble(
+            name="b-ens", ensemble_size=config.runpath_config.num_realizations
+        )
+
+    tool = ManageExperimentsPanel(
+        config, notifier, config.runpath_config.num_realizations
+    )
+    storage_widget = tool.findChild(StorageWidget)
+    assert storage_widget is not None
+
+    tree_view = storage_widget._tree_view
+    tree_view.expandAll()
+    model = tree_view.model()
+    exp_index = _find_root_row_by_name(model, "exp-sort")
+    assert exp_index is not None
+
+    def current_child_names():
+        return _child_names_under(model, exp_index)
+
+    tree_view.sortByColumn(0, Qt.SortOrder.AscendingOrder)
+    qtbot.waitUntil(lambda: current_child_names() == ["a-ens", "b-ens"], timeout=500)
+
+    tree_view.sortByColumn(0, Qt.SortOrder.DescendingOrder)
+    qtbot.waitUntil(lambda: current_child_names() == ["b-ens", "a-ens"], timeout=500)
+
+    tree_view.sortByColumn(1, Qt.SortOrder.AscendingOrder)
+    qtbot.waitUntil(lambda: current_child_names() == ["a-ens", "b-ens"], timeout=500)
+
+    tree_view.sortByColumn(1, Qt.SortOrder.DescendingOrder)
+    qtbot.waitUntil(lambda: current_child_names() == ["b-ens", "a-ens"], timeout=500)


### PR DESCRIPTION
**Issue**
Resolves #12660 


**Approach**
Changes to the GUI:
1. Renamed the tab
2. Changed the look of the "add experiment" button
3. Added the ability to sort by columns when you click on them
4. Added a creation timestamp in the view of an experiment

AFTER: 
<img width="1495" height="815" alt="bilde" src="https://github.com/user-attachments/assets/f7775cb6-7684-4284-a4ae-0a3e335004fd" />

BEFORE:
<img width="1491" height="825" alt="bilde" src="https://github.com/user-attachments/assets/8c18bc15-d3a6-44b0-bc8b-dbc4f7ddccbb" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
