### PR TITLE
Disallow --np as an explicit option to FLOW forward model

### DIFF
--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -350,6 +350,17 @@ class Flow(ForwardModelStepPlugin):
 
     def validate_pre_experiment(self, fm_json: ForwardModelStepJSON) -> None:
         allowed_args = {"<VERSION>", "<NUM_CPU>", "<OPTS>", "<ECLBASE>"}
+        if "--np" in self.private_args.get("<OPTS>", ""):
+            raise ForwardModelStepValidationError(
+                "Do not supply --np as an option to FLOW, "
+                "set NUM_CPU in the Ert config instead."
+            )
+        if "--threads" in self.private_args.get("<OPTS>", ""):
+            raise ForwardModelStepValidationError(
+                "Do not supply --threads as an option to FLOW, "
+                "set NUM_CPU in the Ert config instead."
+            )
+
         if unknowns := set(self.private_args) - allowed_args:
             raise ForwardModelStepWarning(
                 f"Unknown option(s) supplied to Flow: {sorted(unknowns)}"

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -584,6 +584,24 @@ def test_that_flow_fm_step_check_version_availability(plugins_ert_config):
         )
 
 
+def test_that_flow_fm_gives_error_on_np_in_opts(plugins_ert_config):
+    with pytest.raises(
+        ConfigValidationError, match=r".*Do not supply --np as an option to FLOW*"
+    ):
+        plugins_ert_config.from_file_contents(
+            'NUM_REALIZATIONS 1\nFORWARD_MODEL FLOW(<OPTS>="--np=4")\n'
+        )
+
+
+def test_that_flow_fm_gives_error_on_threads_in_opts(plugins_ert_config):
+    with pytest.raises(
+        ConfigValidationError, match=r".*Do not supply --threads as an option to FLOW*"
+    ):
+        plugins_ert_config.from_file_contents(
+            'NUM_REALIZATIONS 1\nFORWARD_MODEL FLOW(<OPTS>="--threads=2")\n'
+        )
+
+
 def test_that_flow_fm_gives_config_warning_on_unknown_options(plugins_ert_config):
     with pytest.warns(ConfigWarning, match=r".*Unknown option.*Flow: .*DUMMY.*"):
         plugins_ert_config.from_file_contents(


### PR DESCRIPTION
Users should use NUM_CPU instead to ensure Ert can book CPU resources properly.

**Issue**
Resolves #13274 


**Approach**
Detect and raise

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
