### PR TITLE
EverestObjectiveFunctionPlot and EverestControlsPlot improvements

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
@@ -33,6 +33,7 @@ class EverestControlsPlot:
         self.dimensionality = 2
         self.requires_observations = False
         self.selected_controls: list[str] = []
+        self.LEGEND_THRESHOLD = 5
 
     def set_selected_controls(self, controls: list[str]) -> None:
         self.selected_controls = controls
@@ -61,20 +62,32 @@ class EverestControlsPlot:
 
         combined = pd.concat(all_dfs, ignore_index=True)
 
-        for control in self.selected_controls:
+        n_colors = config.getNumberOfColors()
+        for i, control in (
+            enumerate(self.selected_controls) if self.selected_controls else []
+        ):
             data = combined[combined["control_name"] == control].sort_values("batch_id")
             if data.empty:
                 continue
 
             color = config.nextColor()
+            if i < n_colors:
+                style = "-o"
+            elif i < n_colors * 2:
+                style = "--o"
+            elif i < n_colors * 3:
+                style = ":o"
+            else:
+                style = "-.o"
             lines = axes.plot(
                 data["batch_id"],
                 data["control_value"],
-                "-o",
+                style,
                 color=color,
                 markersize=4,
             )
-            config.addLegendItem(control, lines[0])
+            if len(self.selected_controls) <= self.LEGEND_THRESHOLD:
+                config.addLegendItem(control, lines[0])
             if len(control) <= 20:
                 axes.annotate(
                     control,

--- a/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
@@ -66,6 +66,7 @@ class EverestObjectiveFunctionPlot:
 
         realizations = sorted(combined["realization"].unique())
 
+        color = config.nextColor()
         for realization in realizations:
             data = combined[combined["realization"] == realization].sort_values(
                 "batch_id"
@@ -73,7 +74,6 @@ class EverestObjectiveFunctionPlot:
             if data.empty:
                 continue
 
-            color = config.nextColor()
             lines = axes.plot(
                 data["batch_id"],
                 data[value_col],
@@ -82,6 +82,7 @@ class EverestObjectiveFunctionPlot:
                 markersize=4,
             )
             if len(realizations) <= self.LEGEND_THRESHOLD:
+                color = config.nextColor()
                 config.addLegendItem(f"Realization {int(realization)}", lines[0])
 
         axes.spines["right"].set_visible(False)


### PR DESCRIPTION
**Issue**
Resolves #13266 
Resolves #13265 


**Approach**

Added 4 different line-styles to the `EverestControlsPlot`, using `PlotConfig.getNumberOfColors()` to determine when to change line style. Set the `LEGEND_THRESHOLD` to 5 controls as pr the other plots. 
<img width="2299" height="1367" alt="Screenshot 2026-04-09 at 16 23 06" src="https://github.com/user-attachments/assets/1f09cc62-7f14-4799-ba54-6ae0328b4f53" />
*16 controls toggled, 4 different line styles. No legend* 
<img width="2301" height="1362" alt="Screenshot 2026-04-09 at 16 23 44" src="https://github.com/user-attachments/assets/2497d2fb-5fc3-4c1f-b670-0b5cc78d1869" />
*5 controls toggled, so legend is showing*

Moved `nextColor()` outside of `for-loop` for single color(unless number of realizations < 5), but keeps potential future color-palette changes, in `ObjectiveFunctionPlot` 
<img width="1719" height="1086" alt="Screenshot 2026-04-09 at 16 26 29" src="https://github.com/user-attachments/assets/6546d652-5169-4859-946b-26c51d2399c9" />
*More than 5 realizations*
<img width="957" height="680" alt="image" src="https://github.com/user-attachments/assets/2207c6f0-5aab-45df-adb3-a1de4650ffcf" />
*Less than 5 realizations, includes different colors and legend* 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
