### PR TITLE
Make observation localization radius defaulted on config creation

### DIFF
--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -8,6 +8,7 @@ from typing import assert_never
 import polars as pl
 
 from ._observations import (
+    DEFAULT_LOCALIZATION_RADIUS,
     BreakthroughObservation,
     GeneralObservation,
     Observation,
@@ -19,8 +20,6 @@ from .parsing import (
     ObservationConfigError,
 )
 from .rft_config import Point, RFTConfig, ZoneName
-
-DEFAULT_LOCALIZATION_RADIUS = 2000
 
 
 def create_observation_dataframes(

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -24,6 +24,8 @@ from .parsing import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_LOCALIZATION_RADIUS = 2000
+
 
 class ErrorModes(StrEnum):
     REL = "REL"
@@ -427,7 +429,7 @@ class RFTObservation(BaseModel):
                 error=validate_float(str(row.ERROR), "ERROR"),
                 north=validate_float(str(row.NORTH), "NORTH"),
                 east=validate_float(str(row.EAST), "EAST"),
-                radius=radius,
+                radius=radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS,
                 tvd=validate_float(str(row.TVD), "TVD"),
                 md=validate_float(str(row.MD), "MD") if "MD" in csv_file else None,
                 zone=row.ZONE if "ZONE" in csv_file else None,
@@ -558,7 +560,7 @@ class RFTObservation(BaseModel):
             tvd=tvd,
             md=md,
             zone=zone,
-            radius=radius,
+            radius=radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS,
         )
 
         # Bypass pydantic discarding context

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -11,6 +11,7 @@ from resdata.summary import Summary
 
 from ert.__main__ import run_convert_observations
 from ert.config._observations import (
+    DEFAULT_LOCALIZATION_RADIUS,
     BreakthroughObservation,
     GeneralObservation,
     RFTObservation,
@@ -210,7 +211,7 @@ def test_rft_observation_declaration():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=None,
+            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
         )
     ]
@@ -247,7 +248,7 @@ def test_rft_observation_csv_declaration():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=None,
+            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
             md=2500.0,
             zone="zone1",
@@ -261,7 +262,7 @@ def test_rft_observation_csv_declaration():
             property="PRESSURE",
             north=72.0,
             east=31.0,
-            radius=None,
+            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2100.0,
             md=2600.0,
             zone="zone2",
@@ -270,7 +271,7 @@ def test_rft_observation_csv_declaration():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_rft_csv_without_radius_column_gets_radius_defaulted_to_none():
+def test_that_rft_csv_without_radius_column_gets_defaulted():
     Path("rft_observations.csv").write_text(
         dedent(
             """
@@ -299,7 +300,7 @@ def test_that_rft_csv_without_radius_column_gets_radius_defaulted_to_none():
             property="PRESSURE",
             north=71.0,
             east=30.0,
-            radius=None,
+            radius=DEFAULT_LOCALIZATION_RADIUS,
             tvd=2000.0,
             md=2500.0,
             zone="zone1",
@@ -448,7 +449,7 @@ def test_that_property_can_be_specified_for_rft_observation_csv_declaration():
             east=30.0,
             tvd=2000.0,
             md=2500.0,
-            radius=None,
+            radius=DEFAULT_LOCALIZATION_RADIUS,
             zone="zone1",
         )
     ]


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/13273


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
