### PR TITLE
Fix test_surface_config::test_that_ert_writes_surface_in_same_the_for…

### DIFF
--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 import warnings
 from pathlib import Path
 
@@ -437,7 +438,7 @@ def test_that_ert_warns_if_ascii_surface_is_used(tmp_path, is_ascii_surface, cap
 
 
 @pytest.mark.parametrize("is_ascii_surface", [True, False])
-def test_that_ert_writes_surface_in_same_the_format_that_was_read(
+async def test_that_ert_writes_surface_in_same_the_format_that_was_read(
     is_ascii_surface, tmp_path, caplog
 ):
     os.chdir(tmp_path)
@@ -494,7 +495,7 @@ def test_that_ert_writes_surface_in_same_the_format_that_was_read(
                 num_realizations=1,
                 design_matrix_df=None,
             )
-            create_run_path(
+            await create_run_path(
                 run_args=run_args,
                 ensemble=ensemble,
                 user_config_file="config.ert",
@@ -504,6 +505,7 @@ def test_that_ert_writes_surface_in_same_the_format_that_was_read(
                 substitutions={},
                 parameters_file="parameters",
                 runpaths=runpaths,
+                end_event=threading.Event(),
             )
             surface_path_in_runpath = Path(
                 "runpaths/realization-0/iteration-0/surf.irap"


### PR DESCRIPTION
…mat_that_was_read

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
