### PR TITLE
Limit design matrix sheet name length

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -229,6 +229,25 @@ class DesignMatrix:
         # preserved exactly as they appear in the Excel sheet. By doing this, we
         # can properly validate variable names, including detecting duplicates or
         # missing names.
+        sheet_name_errors: list[str] = []
+        MAX_EXCEL_SHEET_NAME_LENGTH = 31
+        if len(self.design_sheet) > MAX_EXCEL_SHEET_NAME_LENGTH:
+            sheet_name_errors.append(
+                f"Design sheet name '{self.design_sheet}' exceeds maximum length of "
+                f"{MAX_EXCEL_SHEET_NAME_LENGTH} characters."
+            )
+        if (
+            self.default_sheet is not None
+            and len(self.default_sheet) > MAX_EXCEL_SHEET_NAME_LENGTH
+        ):
+            sheet_name_errors.append(
+                f"Default sheet name '{self.default_sheet}' exceeds maximum length of "
+                f"{MAX_EXCEL_SHEET_NAME_LENGTH} characters."
+            )
+        if sheet_name_errors:
+            error_msg = "\n".join(sheet_name_errors)
+            raise ValueError(f"Excel sheet name error(s):\n{error_msg}")
+
         try:
             param_names = (
                 pl.read_excel(

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -15,6 +15,7 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from lark import Token
 from pydantic import RootModel, TypeAdapter
+from xlsxwriter import Workbook
 
 from ert import ErtScript, ErtScriptWorkflow
 from ert.config import (
@@ -3025,3 +3026,39 @@ def test_that_reusing_workflow_name_warns(ert_config_with_job, workflow1, workfl
         Path("my_wf").write_text("MY_JOB\n", encoding="utf-8")
     with pytest.warns(ConfigWarning, match=r"Workflow 'my_wf' was added twice"):
         ert_config_with_job.from_file_contents(config)
+
+
+def test_that_using_too_long_sheetname_in_design_matrix_raises_validation_error(
+    tmp_path,
+):
+    design_matrix_file = tmp_path / "my_design_matrix.xlsx"
+    long_sheet_name = (
+        "A" * 35
+    )  # Excel sheet names have a max length of 31, so this is definitely too long
+    long_default_sheet_name = "B" * 35
+    design_matrix_df = pl.DataFrame()
+    with Workbook(design_matrix_file) as xl_write:
+        design_matrix_df.write_excel(xl_write)
+
+    expected_error = (
+        r"Excel sheet name error\(s\):\n"
+        f"Design sheet name '{long_sheet_name}' exceeds maximum length "
+        r"of 31 characters\.\n"
+        f"Default sheet name '{long_default_sheet_name}' exceeds maximum "
+        r"length of 31 characters\."
+    )
+
+    with pytest.raises(
+        ConfigValidationError,
+        match=expected_error,
+    ):
+        ErtConfig.from_file_contents(
+            dedent(
+                f"""
+                NUM_REALIZATIONS 1
+                DESIGN_MATRIX {design_matrix_file} \
+                DESIGN_SHEET:{long_sheet_name} \
+                DEFAULT_SHEET:{long_default_sheet_name}
+                """
+            )
+        )


### PR DESCRIPTION
**Issue**
Resolves #13270 


**Approach**
[Have DESIGN_MATRIX validate that sheet name < 32 characters](https://github.com/equinor/ert/pull/13300/changes/bc7507675e16071e736b19575e0b7afac3537a06)

(Screenshot of new behavior in GUI if applicable)
<img width="980" height="698" alt="image" src="https://github.com/user-attachments/assets/38c44c77-9308-4e34-9ba6-3bbe404b3b22" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
