### PR TITLE
Fix handling of custom runtime_plugins in run_cli

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -43,10 +43,10 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
     # the config file to be the base name of the original config
     args.config = os.path.basename(args.config)
 
-    if runtime_plugins is not None:
-        ert_config = ErtConfig.with_plugins(runtime_plugins).from_file(args.config)
-    else:
-        ert_config = ErtConfig.with_plugins(get_site_plugins()).from_file(args.config)
+    active_plugins = (
+        runtime_plugins if runtime_plugins is not None else get_site_plugins()
+    )
+    ert_config = ErtConfig.with_plugins(active_plugins).from_file(args.config)
 
     local_storage_set_ert_config(ert_config)
     counter_fm_steps = Counter(fms.name for fms in ert_config.forward_model_steps)
@@ -98,7 +98,7 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
     status_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
     using_local_queuesystem: bool = True
     try:
-        with use_runtime_plugins(get_site_plugins()):
+        with use_runtime_plugins(active_plugins):
             model = create_model(
                 ert_config,
                 args,


### PR DESCRIPTION
If a custom runtime_plugins object was supplied, it would be used to create the ErtConfig object, but when later creating and running the model, site installed plugins would be used no matter what.

This is a bug in that run_cli does not do what is expected from the function, but it does not affect any users as it only relevant for Python code that calls this function (as in testing). It is not possible to see this bug from regulars user runs of Ert.

**Issue**
Aids resolving #13250 

When #13250 is resolved, it will contain tests that depends on this change.

**Approach**
🧠 + 🤖 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
