### PR TITLE
Narrow try/except blocks in observation_locations

### DIFF
--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -395,22 +395,33 @@ class PlotApi:
             return df
 
     def observation_locations(self) -> pd.DataFrame:
-
-        all_observations = pd.DataFrame()
         with create_ertserver_client(self.ens_path) as client:
+            http_response = client.get("/experiments", timeout=self._timeout)
+            self._check_http_response(http_response)
             try:
-                http_response = client.get("/experiments", timeout=self._timeout)
-                self._check_http_response(http_response)
                 experiments = http_response.json()
-                for experiment in experiments:
-                    experiment_id = str(experiment["id"])
-                    http_response = client.get(
-                        f"/experiments/{experiment_id}/observations",
-                        timeout=self._timeout,
-                    )
-                    self._check_http_response(http_response)
+            except JSONDecodeError as e:
+                raise httpx.RequestError(
+                    f"Failed to parse experiments response: {e}"
+                ) from e
 
+            all_observations_list = []
+            for experiment in experiments:
+                experiment_id = str(experiment["id"])
+                http_response = client.get(
+                    f"/experiments/{experiment_id}/observations",
+                    timeout=self._timeout,
+                )
+                self._check_http_response(http_response)
+                try:
                     observations = http_response.json()
+                except JSONDecodeError as e:
+                    raise httpx.RequestError(
+                        f"Failed to parse observations for"
+                        f" experiment {experiment_id}: {e}"
+                    ) from e
+
+                try:
                     if not observations:
                         continue
                     new_obs = pd.concat(
@@ -426,15 +437,17 @@ class PlotApi:
                         ),
                         ignore_index=True,
                     ).dropna()
+                    if not new_obs.empty:
+                        all_observations_list.append(new_obs)
+                except KeyError as e:
+                    raise httpx.RequestError(
+                        f"Observation payload missing coordinate key {e} for"
+                        f" experiment {experiment_id}"
+                    ) from e
 
-                    all_observations = pd.concat(
-                        [all_observations, new_obs], ignore_index=True
-                    )
-            except (KeyError, IndexError, JSONDecodeError) as e:
-                raise httpx.RequestError(
-                    f"Experiment/Observation schema might have changed e={e}"
-                ) from e
-            return all_observations
+            if not all_observations_list:
+                return pd.DataFrame()
+            return pd.concat(all_observations_list, ignore_index=True)
 
     def observations_for_key(self, ensemble_ids: list[str], key: str) -> pd.DataFrame:
         """Returns a pandas DataFrame with the datapoints for a given observation key

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import combinations as combi
-from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import quote
 
@@ -398,12 +397,7 @@ class PlotApi:
         with create_ertserver_client(self.ens_path) as client:
             http_response = client.get("/experiments", timeout=self._timeout)
             self._check_http_response(http_response)
-            try:
-                experiments = http_response.json()
-            except JSONDecodeError as e:
-                raise httpx.RequestError(
-                    f"Failed to parse experiments response: {e}"
-                ) from e
+            experiments = http_response.json()
 
             all_observations_list = []
             for experiment in experiments:
@@ -413,13 +407,7 @@ class PlotApi:
                     timeout=self._timeout,
                 )
                 self._check_http_response(http_response)
-                try:
-                    observations = http_response.json()
-                except JSONDecodeError as e:
-                    raise httpx.RequestError(
-                        f"Failed to parse observations for"
-                        f" experiment {experiment_id}: {e}"
-                    ) from e
+                observations = http_response.json()
 
                 try:
                     if not observations:
@@ -481,15 +469,15 @@ class PlotApi:
                 )
                 self._check_http_response(http_response)
 
+                observations = http_response.json()
                 try:
-                    observations = http_response.json()
                     observations_dfs = []
                     if not observations:
                         continue
 
                     observations[0]  # Just preserving the old logic/behavior
                     # but this should really be revised
-                except (KeyError, IndexError, JSONDecodeError) as e:
+                except (KeyError, IndexError) as e:
                     raise httpx.RequestError(
                         f"Observation schema might have changed key={key}, "
                         f"ensemble_name={ensemble.name}, e={e}"


### PR DESCRIPTION
Scope each try/except to the specific call that can raise the caught exception, replacing a single broad block that caught KeyError, IndexError, and JSONDecodeError from unrelated operations. Also collect DataFrames in a list and concat once.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
