### PR TITLE
Fix bug in output constraint violation handling

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -797,7 +797,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                 else (
                     ensemble.batch_bound_constraint_violations.drop("batch_id")
                     .to_numpy()
-                    .min()
+                    .max()
                     .item()
                 )
             )
@@ -807,7 +807,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                 else (
                     ensemble.batch_input_constraint_violations.drop("batch_id")
                     .to_numpy()
-                    .min()
+                    .max()
                     .item()
                 )
             )
@@ -817,7 +817,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                 else (
                     ensemble.batch_output_constraint_violations.drop("batch_id")
                     .to_numpy()
-                    .min()
+                    .max()
                     .item()
                 )
             )

--- a/tests/everest/test_is_improvement.py
+++ b/tests/everest/test_is_improvement.py
@@ -1,0 +1,40 @@
+import pytest
+
+from ert.base_model_context import use_runtime_plugins
+from ert.config import ConfigWarning
+from ert.ensemble_evaluator.config import EvaluatorServerConfig
+from ert.plugins import get_site_plugins
+from ert.run_models.everest_run_model import EverestRunModel
+from everest.config import EverestConfig
+from tests.everest.utils import get_optimal_result
+
+CONFIG_FILE_ADVANCED = "config_advanced.yml"
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
+def test_that_is_improvement_flag_handles_multiple_constraints(
+    copy_math_func_test_data_to_tmp,
+):
+    config = EverestConfig.load_file(CONFIG_FILE_ADVANCED)
+    config_dict = {
+        **config.model_dump(exclude_none=True),
+        "output_constraints": [
+            {"name": "x-0_coord", "lower_bound": 0.255, "upper_bound": 0.3},
+            {"name": "x-1_coord", "lower_bound": 0.1, "upper_bound": 0.4},
+        ],
+    }
+    config_dict["optimization"]["max_batch_num"] = 1
+    with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
+        config = EverestConfig.model_validate(config_dict)
+
+    site_plugins = get_site_plugins()
+    with use_runtime_plugins(site_plugins):
+        run_model = EverestRunModel.create(config, runtime_plugins=site_plugins)
+
+    evaluator_server_config = EvaluatorServerConfig()
+    run_model.run_experiment(evaluator_server_config)
+
+    # Check that the first variable remains fixed:
+    optimal_result = get_optimal_result(config.storage_dir)
+    assert optimal_result is None


### PR DESCRIPTION
**Issue**
If there are multiple constraints, they are not properly tested, as a result, batches may be marked as `is_improvement` while they are in fact violating a constraint.

**Approach**
The minimum of all constraint violations was tested against a threshold, this should be the maximum.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
