### PR TITLE
Default RFT observation name to primary keys

### DIFF
--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -166,8 +166,14 @@ class SummaryObservation(_SummaryValues):
                 )
             )
 
+        name = (
+            observation_dict["name"]
+            if observation_dict["name"] is not None
+            else f"{summary_key}:{date}"
+        )
+
         obs_instance = cls(
-            name=observation_dict["name"],
+            name=name,
             error=error,
             key=summary_key,
             value=value,
@@ -177,7 +183,7 @@ class SummaryObservation(_SummaryValues):
         # Bypass pydantic discarding context
         # only relevant for ERT config surfacing validation errors
         # irrelevant for runmodels etc.
-        obs_instance.name = observation_dict["name"]
+        obs_instance.name = name
 
         return [obs_instance]
 
@@ -282,21 +288,28 @@ class GeneralObservation(_GeneralObservation):
                     context=observation_dict.context,
                 )
 
+            index = 0
+            name = (
+                observation_dict["name"]
+                if observation_dict["name"] is not None
+                else f"{data}:{restart}:{index}"
+            )
+
             obs_instance = cls(
-                name=observation_dict["name"],
+                name=name,
                 data=data,
                 value=validate_float(observation_dict["VALUE"], "VALUE"),
                 error=validate_positive_float(
                     observation_dict["ERROR"], "ERROR", strictly_positive=True
                 ),
                 restart=restart,
-                index=0,
+                index=index,
                 shape_id=None,
             )
             # Bypass pydantic discarding context
             # only relevant for ERT config surfacing validation errors
             # irrelevant for runmodels etc.
-            obs_instance.name = observation_dict["name"]
+            obs_instance.name = name
             return [obs_instance]
 
         obs_filename = _resolve_path(directory, observation_dict["OBS_FILE"])
@@ -332,20 +345,25 @@ class GeneralObservation(_GeneralObservation):
                     f"{values}), error ({stds}) and index list ({indices}) "
                     "must be of equal length"
                 ),
-                observation_dict["name"],
+                observation_dict.context,
             )
 
         if np.any(stds <= 0):
             raise ObservationConfigError.with_context(
                 "Observation uncertainty must be strictly > 0",
-                observation_dict["name"],
+                observation_dict.context,
             )
 
         obs_instances: list[Self] = []
         for _pos, (val, std, idx) in enumerate(zip(values, stds, indices, strict=True)):
             # index should reflect the index provided by INDEX_FILE / INDEX_LIST
+            name = (
+                observation_dict["name"]
+                if observation_dict["name"] is not None
+                else f"{data}:{restart}:{int(idx)}"
+            )
             inst = cls(
-                name=observation_dict["name"],
+                name=name,
                 data=data,
                 value=float(val),
                 error=float(std),
@@ -356,7 +374,7 @@ class GeneralObservation(_GeneralObservation):
             # Bypass pydantic discarding context
             # only relevant for ERT config surfacing validation errors
             # irrelevant for runmodels etc.
-            inst.name = observation_dict["name"]
+            inst.name = name
             obs_instances.append(inst)
         return obs_instances
 
@@ -606,6 +624,15 @@ class RFTObservation(BaseObservation):
         if tvd is None:
             raise _missing_value_error(observation_dict.context, "TVD")
 
+        name = (
+            observation_dict["name"]
+            if observation_dict["name"] is not None
+            else (
+                f"{well}:{date}:{observed_property}:{east}:{north}:{tvd}"
+                + (f":{zone}" if zone is not None else "")
+            )
+        )
+
         radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
         shape_id = shape_registry.register(
             CircleShapeConfig(
@@ -616,7 +643,7 @@ class RFTObservation(BaseObservation):
         )
 
         obs_instance = cls(
-            name=observation_dict["name"],
+            name=name,
             well=well,
             property=observed_property,
             value=observed_value,
@@ -633,7 +660,7 @@ class RFTObservation(BaseObservation):
         # Bypass pydantic discarding context
         # only relevant for ERT config surfacing validation errors
         # irrelevant for runmodels etc.
-        obs_instance.name = observation_dict["name"]
+        obs_instance.name = name
 
         return [obs_instance]
 
@@ -705,9 +732,14 @@ class BreakthroughObservation(BaseObservation):
                 )
             )
 
+        name = (
+            obs_dict["name"]
+            if obs_dict["name"] is not None
+            else f"BREAKTHROUGH:{summary_key}:{threshold}"
+        )
         return [
             cls(
-                name=obs_dict["name"],
+                name=name,
                 key=summary_key,
                 date=date,
                 error=error,
@@ -921,8 +953,7 @@ def _invalid_rft_localization_key_error(
     key: str, context: FileContextToken
 ) -> ObservationConfigError:
     return ObservationConfigError.with_context(
-        f"Invalid key: '{key}' in 'LOCALIZATION' for "
-        f"RFT observation: '{context!s}'. "
+        f"Invalid key: '{key}' in LOCALIZATION for RFT_OBSERVATION. "
         f"The '{key}' keyword must be defined outside the LOCALIZATION section for "
         f"RFT observations - or in the CSV RFT configuration file.",
         context,

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -22,6 +22,7 @@ from .parsing import (
     ObservationDict,
     ObservationType,
 )
+from .parsing.file_context_token import FileContextToken
 
 logger = logging.getLogger(__name__)
 
@@ -115,16 +116,16 @@ class SummaryObservation(_SummaryValues):
                 case "DATE":
                     date = value
                 case "LOCALIZATION":
-                    validate_localization(value, observation_dict["name"])
+                    validate_localization(value, observation_dict.context)
                     east, north, radius = extract_localization_values(value)
                 case _:
-                    raise _unknown_key_error(str(key), observation_dict["name"])
+                    raise _unknown_key_error(str(key), observation_dict.context)
         if "VALUE" not in float_values:
-            raise _missing_value_error(observation_dict["name"], "VALUE")
+            raise _missing_value_error(observation_dict.context, "VALUE")
         if summary_key is None:
-            raise _missing_value_error(observation_dict["name"], "KEY")
+            raise _missing_value_error(observation_dict.context, "KEY")
         if "ERROR" not in float_values:
-            raise _missing_value_error(observation_dict["name"], "ERROR")
+            raise _missing_value_error(observation_dict.context, "ERROR")
 
         assert date is not None
         # Raise errors if the date is off
@@ -208,7 +209,7 @@ class GeneralObservation(_GeneralObservation):
         try:
             data = observation_dict["DATA"]
         except KeyError as err:
-            raise _missing_value_error(observation_dict["name"], "DATA") from err
+            raise _missing_value_error(observation_dict.context, "DATA") from err
 
         allowed = {
             "type",
@@ -227,7 +228,7 @@ class GeneralObservation(_GeneralObservation):
 
         extra = set(observation_dict.keys()) - allowed
         if extra:
-            raise _unknown_key_error(str(next(iter(extra))), observation_dict["name"])
+            raise _unknown_key_error(str(next(iter(extra))), observation_dict.context)
 
         if any(k in observation_dict for k in ("DATE", "DAYS", "HOURS")):
             bad_key = next(
@@ -248,7 +249,7 @@ class GeneralObservation(_GeneralObservation):
         ):
             raise ObservationConfigError.with_context(
                 "GENERAL_OBSERVATION cannot contain both VALUE/ERROR and OBS_FILE",
-                observation_dict["name"],
+                observation_dict.context,
             )
 
         if "INDEX_FILE" in observation_dict and "INDEX_LIST" in observation_dict:
@@ -257,7 +258,7 @@ class GeneralObservation(_GeneralObservation):
                     "GENERAL_OBSERVATION "
                     f"{observation_dict['name']} has both INDEX_FILE and INDEX_LIST."
                 ),
-                observation_dict["name"],
+                observation_dict.context,
             )
 
         restart = (
@@ -271,14 +272,14 @@ class GeneralObservation(_GeneralObservation):
                 raise ObservationConfigError.with_context(
                     f"For GENERAL_OBSERVATION {observation_dict['name']}, with"
                     f" VALUE = {observation_dict['VALUE']}, ERROR must also be given.",
-                    observation_dict["name"],
+                    observation_dict.context,
                 )
 
             if "VALUE" not in observation_dict and "ERROR" not in observation_dict:
                 raise ObservationConfigError.with_context(
                     "GENERAL_OBSERVATION must contain either VALUE "
                     "and ERROR or OBS_FILE",
-                    context=observation_dict["name"],
+                    context=observation_dict.context,
                 )
 
             obs_instance = cls(
@@ -572,13 +573,13 @@ class RFTObservation(BaseObservation):
                 case "MD":
                     md = validate_float(value, key)
                 case "LOCALIZATION":
-                    validate_rft_localization(value, observation_dict["name"])
+                    validate_rft_localization(value, observation_dict.context)
                     east, north, radius = extract_localization_values(value)
                     radius = (
                         radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
                     )
                 case _:
-                    raise _unknown_key_error(str(key), observation_dict["name"])
+                    raise _unknown_key_error(str(key), observation_dict.context)
         if csv_filename is not None:
             return cls.from_csv(
                 directory,
@@ -589,21 +590,21 @@ class RFTObservation(BaseObservation):
                 radius=radius,
             )
         if well is None:
-            raise _missing_value_error(observation_dict["name"], "WELL")
+            raise _missing_value_error(observation_dict.context, "WELL")
         if observed_value is None:
-            raise _missing_value_error(observation_dict["name"], "VALUE")
+            raise _missing_value_error(observation_dict.context, "VALUE")
         if observed_property is None:
-            raise _missing_value_error(observation_dict["name"], "PROPERTY")
+            raise _missing_value_error(observation_dict.context, "PROPERTY")
         if error is None:
-            raise _missing_value_error(observation_dict["name"], "ERROR")
+            raise _missing_value_error(observation_dict.context, "ERROR")
         if date is None:
-            raise _missing_value_error(observation_dict["name"], "DATE")
+            raise _missing_value_error(observation_dict.context, "DATE")
         if north is None:
-            raise _missing_value_error(observation_dict["name"], "NORTH")
+            raise _missing_value_error(observation_dict.context, "NORTH")
         if east is None:
-            raise _missing_value_error(observation_dict["name"], "EAST")
+            raise _missing_value_error(observation_dict.context, "EAST")
         if tvd is None:
-            raise _missing_value_error(observation_dict["name"], "TVD")
+            raise _missing_value_error(observation_dict.context, "TVD")
 
         radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
         shape_id = shape_registry.register(
@@ -678,19 +679,19 @@ class BreakthroughObservation(BaseObservation):
                 case "THRESHOLD":
                     threshold = validate_float(value, key)
                 case "LOCALIZATION":
-                    validate_localization(value, obs_dict["name"])
+                    validate_localization(value, obs_dict.context)
                     east, north, radius = extract_localization_values(value)
                 case _:
-                    raise _unknown_key_error(str(key), value)
+                    raise _unknown_key_error(str(key), obs_dict.context)
 
         if summary_key is None:
-            raise _missing_value_error(obs_dict["name"], "KEY")
+            raise _missing_value_error(obs_dict.context, "KEY")
         if date is None:
-            raise _missing_value_error(obs_dict["name"], "DATE")
+            raise _missing_value_error(obs_dict.context, "DATE")
         if error is None:
-            raise _missing_value_error(obs_dict["name"], "ERROR")
+            raise _missing_value_error(obs_dict.context, "ERROR")
         if threshold is None:
-            raise _missing_value_error(obs_dict["name"], "THRESHOLD")
+            raise _missing_value_error(obs_dict.context, "THRESHOLD")
 
         # Register shape if localization is present
         shape_id = None
@@ -825,14 +826,14 @@ def validate_positive_float(
     return v
 
 
-def validate_rft_localization(val: dict[str, Any], obs_name: str) -> None:
+def validate_rft_localization(val: dict[str, Any], context: FileContextToken) -> None:
     errors = []
     if "EAST" in val:
-        errors.append(_invalid_rft_localization_key_error("EAST", f"{obs_name}"))
+        errors.append(_invalid_rft_localization_key_error("EAST", context))
     if "NORTH" in val:
-        errors.append(_invalid_rft_localization_key_error("NORTH", f"{obs_name}"))
+        errors.append(_invalid_rft_localization_key_error("NORTH", context))
     errors.extend(
-        _unknown_key_error(key, f"LOCALIZATION for {obs_name}")
+        _unknown_key_error(key, context)
         for key in val
         if key not in {"EAST", "NORTH", "RADIUS"}
     )
@@ -840,14 +841,15 @@ def validate_rft_localization(val: dict[str, Any], obs_name: str) -> None:
         raise ObservationConfigError.from_collected(errors)
 
 
-def validate_localization(val: dict[str, Any], obs_name: str) -> None:
+def validate_localization(val: dict[str, Any], context: FileContextToken) -> None:
     errors = []
+    localization_context = context.update(value=f"LOCALIZATION for {context!s}")
     if "EAST" not in val:
-        errors.append(_missing_value_error(f"LOCALIZATION for {obs_name}", "EAST"))
+        errors.append(_missing_value_error(localization_context, "EAST"))
     if "NORTH" not in val:
-        errors.append(_missing_value_error(f"LOCALIZATION for {obs_name}", "NORTH"))
+        errors.append(_missing_value_error(localization_context, "NORTH"))
     errors.extend(
-        _unknown_key_error(key, f"LOCALIZATION for {obs_name}")
+        _unknown_key_error(key, localization_context)
         for key in val
         if key not in {"EAST", "NORTH", "RADIUS"}
     )
@@ -879,9 +881,11 @@ def validate_positive_int(val: str, key: str) -> int:
     return v
 
 
-def _missing_value_error(name_token: str, value_key: str) -> ObservationConfigError:
+def _missing_value_error(
+    context: FileContextToken, value_key: str
+) -> ObservationConfigError:
     return ObservationConfigError.with_context(
-        f'Missing item "{value_key}" in {name_token}', name_token
+        f'Missing item "{value_key}" in {context!s}', context
     )
 
 
@@ -903,20 +907,23 @@ def _conversion_error(token: str, value: Any, type_name: str) -> ObservationConf
     )
 
 
-def _unknown_key_error(key: str, name: str) -> ObservationConfigError:
-    raise ObservationConfigError.with_context(f"Unknown {key} in {name}", key)
+def _unknown_key_error(key: str, context: FileContextToken) -> ObservationConfigError:
+    raise ObservationConfigError.with_context(f"Unknown {key} in {context!s}", context)
 
 
 def _unknown_observation_type_error(obs: ObservationDict) -> ObservationConfigError:
     return ObservationConfigError.with_context(
-        f"Unexpected type in observations {obs}", obs["name"]
+        f"Unexpected type in observations {obs}", obs.context
     )
 
 
-def _invalid_rft_localization_key_error(key: str, name: str) -> ObservationConfigError:
+def _invalid_rft_localization_key_error(
+    key: str, context: FileContextToken
+) -> ObservationConfigError:
     return ObservationConfigError.with_context(
-        f"Invalid key: '{key}' in 'LOCALIZATION' for RFT observation: '{name}'. "
+        f"Invalid key: '{key}' in 'LOCALIZATION' for "
+        f"RFT observation: '{context!s}'. "
         f"The '{key}' keyword must be defined outside the LOCALIZATION section for "
         f"RFT observations - or in the CSV RFT configuration file.",
-        key,
+        context,
     )

--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from itertools import starmap
 from pathlib import Path
 from typing import Any, Self, assert_never, cast
 
@@ -31,6 +30,7 @@ from .parsing import (
     read_file,
 )
 from .parsing.config_errors import ConfigValidationError, ConfigWarning
+from .parsing.file_context_token import FileContextToken
 from .refcase import Refcase
 
 DEFAULT_TIME_DELTA = timedelta(seconds=30)
@@ -50,7 +50,9 @@ class Segment(ObservationError):
     stop: int
 
 
-def _validate_segment_dict(name_token: str, inp: dict[str, Any]) -> Segment:
+def _validate_segment_dict(
+    name_token: str, inp: dict[str, Any], context: FileContextToken
+) -> Segment:
     start = None
     stop = None
     error_mode = ErrorModes.RELMIN
@@ -69,12 +71,12 @@ def _validate_segment_dict(name_token: str, inp: dict[str, Any]) -> Segment:
             case "ERROR_MODE":
                 error_mode = validate_error_mode(value)
             case _:
-                raise _unknown_key_error(key, name_token)
+                raise _unknown_key_error(key, context)
 
     if start is None:
-        raise _missing_value_error(name_token, "START")
+        raise _missing_value_error(context, "START")
     if stop is None:
-        raise _missing_value_error(name_token, "STOP")
+        raise _missing_value_error(context, "STOP")
     return Segment(
         name=name_token,
         start=start,
@@ -119,9 +121,12 @@ class HistoryObservation(ObservationError):
                 case "ERROR_MODE":
                     error_mode = validate_error_mode(value)
                 case "segments":
-                    segments = list(starmap(_validate_segment_dict, value))
+                    segments = [
+                        _validate_segment_dict(name, seg, observation_dict.context)
+                        for name, seg in value
+                    ]
                 case _:
-                    raise _unknown_key_error(str(key), observation_dict["name"])
+                    raise _unknown_key_error(str(key), observation_dict.context)
 
         instance = cls(
             name=observation_dict["name"],
@@ -350,11 +355,11 @@ class LegacySummaryObservation(
                 case _:
                     raise _unknown_key_error(str(key), observation_dict["name"])
         if "VALUE" not in float_values:
-            raise _missing_value_error(observation_dict["name"], "VALUE")
+            raise _missing_value_error(observation_dict.context, "VALUE")
         if summary_key is None:
-            raise _missing_value_error(observation_dict["name"], "KEY")
+            raise _missing_value_error(observation_dict.context, "KEY")
         if "ERROR" not in float_values:
-            raise _missing_value_error(observation_dict["name"], "ERROR")
+            raise _missing_value_error(observation_dict.context, "ERROR")
 
         return [
             cls(
@@ -396,7 +401,7 @@ class LegacyGeneralObservation(_LegacyGeneralObservation):
         try:
             data = observation_dict["DATA"]
         except KeyError as err:
-            raise _missing_value_error(observation_dict["name"], "DATA") from err
+            raise _missing_value_error(observation_dict.context, "DATA") from err
 
         output = cls(name=observation_dict["name"], data=data)
         for key, value in observation_dict.items():

--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -353,7 +353,7 @@ class LegacySummaryObservation(
                 case "LOCATION_RANGE":
                     localization_values["range"] = validate_float(value, key)
                 case _:
-                    raise _unknown_key_error(str(key), observation_dict["name"])
+                    raise _unknown_key_error(str(key), observation_dict.context)
         if "VALUE" not in float_values:
             raise _missing_value_error(observation_dict.context, "VALUE")
         if summary_key is None:
@@ -433,12 +433,12 @@ class LegacyGeneralObservation(_LegacyGeneralObservation):
                 case "DATA":
                     output.data = value
                 case _:
-                    raise _unknown_key_error(str(key), observation_dict["name"])
+                    raise _unknown_key_error(str(key), observation_dict.context)
         if output.value is not None and output.error is None:
             raise ObservationConfigError.with_context(
-                f"For GENERAL_OBSERVATION {observation_dict['name']}, with"
+                f"For GENERAL_OBSERVATION, with"
                 f" VALUE = {output.value}, ERROR must also be given.",
-                observation_dict["name"],
+                observation_dict.context,
             )
         return [output]
 

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 from enum import StrEnum
 from typing import Any, assert_never, no_type_check
 
@@ -22,7 +23,15 @@ class ObservationType(StrEnum):
     BREAKTHROUGH = "BREAKTHROUGH_OBSERVATION"
 
 
-ObservationDict = dict[str, Any]
+class ObservationDict(UserDict[str, Any]):
+    def __init__(
+        self,
+        *args: Any,
+        context: FileContextToken,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.context = context
 
 
 def parse_observations(content: str, filename: str) -> list[ObservationDict]:
@@ -161,32 +170,40 @@ class TreeToObservations(Transformer[FileContextToken, list[ObservationDict]]):
     @staticmethod
     @no_type_check
     def observation(tree):
-        if len(tree) == 2:
-            return {
-                "type": ObservationType(tree[0].children[0]),
-                "name": tree[1],
-            }
-        else:
-            non_segments = {
-                k: v for k, v in tree[2].items() if not isinstance(k, tuple)
-            }
-            segments = [(k[1], v) for k, v in tree[2].items() if isinstance(k, tuple)]
-            error_list = [
-                ErrorInfo(f"Unknown {unknown_key} in {tree[1]}").set_context(tree[1])
-                for unknown_key in ["type", "segments", "name"]
-                if unknown_key in non_segments
-            ]
-            if error_list:
-                raise ObservationConfigError.from_collected(error_list)
+        context_token = tree[0].children[0]
+        observation_type = ObservationType(context_token)
 
-            res = {
-                "type": ObservationType(tree[0].children[0]),
-                "name": tree[1],
-                **non_segments,
-            }
-            if segments:
-                res["segments"] = segments
-            return res
+        name = tree[1] if len(tree) > 1 and isinstance(tree[1], str) else None
+        object_ = tree[-1] if isinstance(tree[-1], dict) else None
+
+        res = {
+            "type": observation_type,
+            "name": name,
+        }
+
+        if object_ is None or len(tree) == 1:
+            return ObservationDict(res, context=context_token)
+
+        non_segments = {k: v for k, v in object_.items() if not isinstance(k, tuple)}
+        segments = [(k[1], v) for k, v in object_.items() if isinstance(k, tuple)]
+        error_list = [
+            ErrorInfo(f"Unknown {unknown_key} in {observation_type!s}").set_context(
+                context_token
+            )
+            for unknown_key in ["type", "segments", "name"]
+            if unknown_key in non_segments
+        ]
+        if error_list:
+            raise ObservationConfigError.from_collected(error_list)
+
+        res = {
+            **res,
+            **non_segments,
+        }
+
+        if segments:
+            res["segments"] = segments
+        return ObservationDict(res, context=context_token)
 
     @staticmethod
     @no_type_check

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -123,7 +123,7 @@ def parse_observations(content: str, filename: str) -> list[ObservationDict]:
 observations_parser = Lark(
     r"""
     start: observation*
-    ?observation: type OBSERVATION_NAME object? ";"
+    observation: type OBSERVATION_NAME object? ";"
     TYPE: "HISTORY_OBSERVATION"
       | "SUMMARY_OBSERVATION"
       | "GENERAL_OBSERVATION"

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -132,7 +132,7 @@ def parse_observations(content: str, filename: str) -> list[ObservationDict]:
 observations_parser = Lark(
     r"""
     start: observation*
-    observation: type OBSERVATION_NAME object? ";"
+    observation: type OBSERVATION_NAME? object? ";"
     TYPE: "HISTORY_OBSERVATION"
       | "SUMMARY_OBSERVATION"
       | "GENERAL_OBSERVATION"

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -16,6 +16,7 @@ import polars as pl
 import pytest
 from hypothesis import HealthCheck, settings
 from hypothesis import strategies as st
+from lark import Token
 from PyQt6.QtCore import QDir
 from PyQt6.QtWidgets import QApplication
 from xlsxwriter import Workbook
@@ -25,6 +26,7 @@ from _ert.threading import set_signal_handler
 from ert.__main__ import ert_parser
 from ert.cli.main import run_cli
 from ert.config import ConfigWarning, ErtConfig
+from ert.config.parsing.file_context_token import FileContextToken
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.mode_definitions import (
     ENIF_MODE,
@@ -566,3 +568,14 @@ def set_multiprocessing_method():
         and multiprocessing.get_start_method(allow_none=True) != "forkserver"
     ):
         multiprocessing.set_start_method("forkserver")
+
+
+@pytest.fixture
+def file_context_token():
+    def _file_context_token(obs_type="SUMMARY_OBSERVATION"):
+        return FileContextToken(
+            Token(type="foo", line=2, column=5, end_column=13, value=obs_type),
+            "observations.txt",
+        )
+
+    return _file_context_token

--- a/tests/ert/unit_tests/config/parsing/test_observations_parser.py
+++ b/tests/ert/unit_tests/config/parsing/test_observations_parser.py
@@ -247,3 +247,45 @@ def test_that_breakthrough_observations_can_be_parsed_with_localization():
     assert breakthrough_obs["LOCALIZATION"]["EAST"] == "10"
     assert breakthrough_obs["LOCALIZATION"]["NORTH"] == "20"
     assert breakthrough_obs["LOCALIZATION"]["RADIUS"] == "2500"
+
+
+def test_that_parser_sets_undefined_observation_names_to_none():
+    all_observations = """
+        GENERAL_OBSERVATION
+        {
+           DATA       = POLY_RES;
+           INDEX_LIST = 0,2,4,6,8;
+           OBS_FILE   = poly_obs_data.txt;
+        };
+        SUMMARY_OBSERVATION
+        {
+            VALUE   = 0.2;
+            ERROR   = 0.035;
+            DATE    = 2013-12-10;
+            KEY     = WOPR:OP1;
+        };
+        RFT_OBSERVATION
+        {
+            WELL=PROD;
+            DATE=2015-02-01;
+            PROPERTY=PRESSURE;
+            VALUE=3800;
+            ERROR=10;
+            TVD=8400;
+            EAST=9500;
+            NORTH=9500;
+        };
+        BREAKTHROUGH_OBSERVATION
+        {
+            KEY=WWCT:OP_1;
+            DATE=2012-10-01;
+            ERROR=3;
+            THRESHOLD=0.1;
+        };
+    """
+    parsed_obs = parse_observations(
+        content=all_observations,
+        filename="",
+    )
+    for obs in parsed_obs:
+        assert obs["name"] is None

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -45,7 +45,7 @@ from ert.config.parsing.context_values import (
     ContextList,
     ContextString,
 )
-from ert.config.parsing.observations_parser import ObservationType
+from ert.config.parsing.observations_parser import ObservationDict, ObservationType
 from ert.config.queue_config import LocalQueueOptions
 from ert.config.refcase import Refcase
 from ert.plugins import ErtPluginManager, ErtRuntimePlugins, get_site_plugins
@@ -1680,7 +1680,9 @@ def test_that_context_types_are_json_serializable():
     assert isinstance(r["context_list"], list)
 
 
-def test_that_multiple_errors_are_shown_when_validating_observation_config():
+def test_that_multiple_errors_are_shown_when_validating_observation_config(
+    file_context_token,
+):
     with pytest.raises(ConfigValidationError) as err:
         ErtConfig.from_dict(
             {
@@ -1688,27 +1690,33 @@ def test_that_multiple_errors_are_shown_when_validating_observation_config():
                 "OBS_CONFIG": (
                     "obs_config",
                     [
-                        {
-                            "type": ObservationType.SUMMARY,
-                            "name": "SUM1",
-                            "VALUE": "0.7",
-                            "ERROR": "0.07",
-                            "DATE": "2010-12-26",
-                        },
-                        {
-                            "type": ObservationType.SUMMARY,
-                            "name": "SUM2",
-                            "ERROR": "0.05",
-                            "DATE": "2011-12-21",
-                            "KEY": "WOPR:OP1",
-                        },
+                        ObservationDict(
+                            {
+                                "type": ObservationType.SUMMARY,
+                                "name": "SUM1",
+                                "VALUE": "0.7",
+                                "ERROR": "0.07",
+                                "DATE": "2010-12-26",
+                            },
+                            context=file_context_token(),
+                        ),
+                        ObservationDict(
+                            {
+                                "type": ObservationType.SUMMARY,
+                                "name": "SUM2",
+                                "ERROR": "0.05",
+                                "DATE": "2011-12-21",
+                                "KEY": "WOPR:OP1",
+                            },
+                            context=file_context_token(),
+                        ),
                     ],
                 ),
             }
         )
     expected_errors = [
-        'Missing item "KEY" in SUM1',
-        'Missing item "VALUE" in SUM2',
+        'Missing item "KEY" in SUMMARY_OBSERVATION',
+        'Missing item "VALUE" in SUMMARY_OBSERVATION',
     ]
 
     for error in expected_errors:

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -24,6 +24,7 @@ from ert.config.observation_config_migrations import HistoryObservation
 from ert.config.parsing import parse_observations
 from ert.config.parsing.observations_parser import (
     ObservationConfigError,
+    ObservationDict,
     ObservationType,
     observations_parser,
 )
@@ -639,8 +640,14 @@ def test_that_breakthrough_observation_raises_error_when_missing_required_keywor
     Path("obs_config.txt").write_text(obs_config_str, encoding="utf8")
     parsed_obs_dict = parse_observations(obs_config_str, "obs_config.txt")
     shape_registry = ShapeRegistry()
+
+    match = (
+        r"obs_config.txt: Line \d+ \(Column \d+-\d+\): "
+        f'Missing item "{missing_keyword}" in BREAKTHROUGH_OBSERVATION'
+    )
     with pytest.raises(
-        ObservationConfigError, match=f'Missing item "{missing_keyword}" in BRT_OBS'
+        ObservationConfigError,
+        match=match,
     ):
         BreakthroughObservation.from_obs_dict(
             "", parsed_obs_dict[0], shape_registry=shape_registry
@@ -679,7 +686,9 @@ def test_that_breakthrough_observation_can_be_instantiated_with_localization():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_rft_observation_raises_error_given_north_or_east_keys_in_config():
+def test_that_rft_observation_raises_error_given_north_or_east_keys_in_config(
+    file_context_token,
+):
     Path("rft_observations.csv").write_text(
         dedent(
             """
@@ -692,32 +701,41 @@ def test_that_rft_observation_raises_error_given_north_or_east_keys_in_config():
     )
     with pytest.raises(
         ObservationConfigError,
-        match=r"Invalid key: 'EAST' in 'LOCALIZATION' for RFT observation: 'RFT_OBS'. "
-        r"The 'EAST' keyword must be defined outside the LOCALIZATION section "
-        r"for RFT observations - or in the CSV RFT configuration file.;"
-        r"Invalid key: 'NORTH' in 'LOCALIZATION' for RFT observation: 'RFT_OBS'. "
-        r"The 'NORTH' keyword must be defined outside the LOCALIZATION section for "
-        r"RFT observations - or in the CSV RFT configuration file.",
+        match=(
+            r"observations.txt: Line 2 \(Column 5-13\): Invalid key: 'EAST' in "
+            r"'LOCALIZATION' for RFT observation: 'RFT_OBSERVATION'. The 'EAST' "
+            r"keyword must be defined outside the LOCALIZATION section for RFT "
+            r"observations - or in the CSV RFT configuration file.;"
+            r"observations.txt: Line 2 \(Column 5-13\): Invalid key: 'NORTH' in "
+            r"'LOCALIZATION' for RFT observation: 'RFT_OBSERVATION'. The 'NORTH' "
+            r"keyword must be defined outside the LOCALIZATION section for RFT "
+            r"observations - or in the CSV RFT configuration file."
+        ),
     ):
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.RFT,
-                    "name": "RFT_OBS",
-                    "CSV": "rft_observations.csv",
-                    "LOCALIZATION": {
-                        "NORTH": 30,
-                        "EAST": 10,
+                ObservationDict(
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT_OBS",
+                        "CSV": "rft_observations.csv",
+                        "LOCALIZATION": {
+                            "NORTH": 30,
+                            "EAST": 10,
+                        },
                     },
-                }
+                    context=file_context_token(obs_type="RFT_OBSERVATION"),
+                )
             ],
             shape_registry=ShapeRegistry(),
         )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_rft_observation_can_be_provided_radius_localization_keyword():
+def test_that_rft_observation_can_be_provided_radius_localization_keyword(
+    file_context_token,
+):
     Path("rft_observations.csv").write_text(
         dedent(
             """
@@ -733,14 +751,17 @@ def test_that_rft_observation_can_be_provided_radius_localization_keyword():
     obss = make_observations(
         "",
         [
-            {
-                "type": ObservationType.RFT,
-                "name": "RFT_OBS",
-                "CSV": "rft_observations.csv",
-                "LOCALIZATION": {
-                    "RADIUS": 2500,
+            ObservationDict(
+                {
+                    "type": ObservationType.RFT,
+                    "name": "RFT_OBS",
+                    "CSV": "rft_observations.csv",
+                    "LOCALIZATION": {
+                        "RADIUS": 2500,
+                    },
                 },
-            }
+                context=file_context_token(obs_type="RFT_OBSERVATION"),
+            )
         ],
         shape_registry=shape_registry,
     )

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -233,6 +233,40 @@ def test_rft_observation_declaration():
     assert shape.radius == DEFAULT_LOCALIZATION_RADIUS
 
 
+def test_that_rft_observations_defaults_name_to_key_combination():
+    assert make_observations(
+        "",
+        [
+            {
+                "type": ObservationType.RFT,
+                "name": None,
+                "WELL": "well_name",
+                "VALUE": "700",
+                "ERROR": "0.1",
+                "DATE": "2020-01-01",
+                "PROPERTY": "PRESSURE",
+                "NORTH": 71.0,
+                "EAST": 30.0,
+                "TVD": 8600.0,
+            },
+        ],
+        shape_registry=ShapeRegistry(),
+    ) == [
+        RFTObservation(
+            name="well_name:2020-01-01:PRESSURE:30.0:71.0:8600.0",
+            well="well_name",
+            date="2020-01-01",
+            value=700.0,
+            error=0.1,
+            property="PRESSURE",
+            north=71.0,
+            east=30.0,
+            shape_id=0,
+            tvd=8600.0,
+        )
+    ]
+
+
 @pytest.mark.usefixtures("use_tmpdir")
 def test_rft_observation_csv_declaration():
     Path("rft_observations.csv").write_text(
@@ -703,11 +737,11 @@ def test_that_rft_observation_raises_error_given_north_or_east_keys_in_config(
         ObservationConfigError,
         match=(
             r"observations.txt: Line 2 \(Column 5-13\): Invalid key: 'EAST' in "
-            r"'LOCALIZATION' for RFT observation: 'RFT_OBSERVATION'. The 'EAST' "
+            r"LOCALIZATION for RFT_OBSERVATION. The 'EAST' "
             r"keyword must be defined outside the LOCALIZATION section for RFT "
             r"observations - or in the CSV RFT configuration file.;"
             r"observations.txt: Line 2 \(Column 5-13\): Invalid key: 'NORTH' in "
-            r"'LOCALIZATION' for RFT observation: 'RFT_OBSERVATION'. The 'NORTH' "
+            r"LOCALIZATION for RFT_OBSERVATION. The 'NORTH' "
             r"keyword must be defined outside the LOCALIZATION section for RFT "
             r"observations - or in the CSV RFT configuration file."
         ),

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -2234,3 +2234,114 @@ def test_that_base_observation_fails_validation_with_unknown_kwarg():
 
     with pytest.raises(ValidationError):
         BaseObservation(random_kwarg=42)
+
+
+def test_that_missing_rft_observations_name_is_defaulted_to_primary_keys():
+    well = "PROD"
+    date = "2015-02-01"
+    property_ = "PRESSURE"
+    east = "9500.0"
+    north = "10000.0"
+    tvd = "8400.0"
+    obs_config_contents = (
+        """
+        RFT_OBSERVATION {
+        VALUE=3800;
+        ERROR=10;"""
+        f"EAST={east};\n"
+        f"NORTH={north};\n"
+        f"WELL={well};\n"
+        f"DATE={date};\n"
+        f"PROPERTY={property_};\n"
+        f"TVD={tvd};\n"
+        "};"
+    )
+    ert_config = ert_config_from_parser(obs_config_contents)
+    obs_name = ert_config.observation_declarations[0].name
+    assert obs_name == f"{well}:{date}:{property_}:{east}:{north}:{tvd}"
+
+
+def test_that_missing_summary_observations_name_is_defaulted_to_primary_key():
+    key = "WOPR:OP1"
+    date = "2011-12-21"
+    obs_config_contents = (
+        """
+        SUMMARY_OBSERVATION
+        {
+            VALUE   = 0.5;
+            ERROR   = 0.05;
+            """
+        f"KEY={key};\n"
+        f"DATE={date};\n"
+        """
+        };"""
+    )
+    ert_config = ert_config_from_parser(obs_config_contents)
+    obs_name = ert_config.observation_declarations[0].name
+    assert obs_name == f"{key}:{date}"
+
+
+def test_that_missing_gen_obs_name_is_defaulted_to_primary_key_without_obs_file(
+    use_tmpdir,
+):
+    obs_config_contents = """
+        GENERAL_OBSERVATION {
+           DATA    = GEN;
+           VALUE   = 5;
+           ERROR   = 0.2;
+           RESTART = 1;
+        };
+        """
+    ert_config = ert_config_from_parser(obs_config_contents)
+    obs_name = ert_config.observation_declarations[0].name
+    assert obs_name == "GEN:1:0"
+
+
+def test_that_missing_gen_obs_name_is_defaulted_to_primary_key_with_obs_file(
+    use_tmpdir,
+):
+    obs_content = "1 0.1"
+    Path("foo.txt").write_text(obs_content, encoding="utf-8")
+    obs_config_contents = """
+        GENERAL_OBSERVATION {
+           DATA       = GEN;
+           INDEX_LIST = 0;
+           OBS_FILE   = foo.txt;
+           RESTART = 1;
+        };
+        """
+    ert_config = ert_config_from_parser(obs_config_contents)
+    obs_name = ert_config.observation_declarations[0].name
+    assert obs_name == "GEN:1:0"
+
+
+def test_that_missing_breakthrough_name_is_defaulted_to_primary_keys():
+    key = "WWCT:OP1"
+    threshold = 0.5
+    obs_config_contents = (
+        """
+        BREAKTHROUGH_OBSERVATION {
+            DATE=2012-10-01;
+            ERROR=3;
+            """
+        f"KEY={key};"
+        f"THRESHOLD={threshold};"
+        "};"
+    )
+    ert_config = ert_config_from_parser(obs_config_contents)
+    obs_name = ert_config.observation_declarations[0].name
+    assert obs_name == "BREAKTHROUGH:WWCT:OP1:0.5"
+
+
+@pytest.mark.parametrize(
+    "obs_content",
+    [
+        "SUMMARY_OBSERVATION;",
+        "BREAKTHROUGH_OBSERVATION;",
+        "RFT_OBSERVATION;",
+    ],
+)
+def test_that_providing_no_name_or_object_to_obs_raises_config_error(obs_content):
+    expected_error = r'Missing item "(.+)" in ' + obs_content.replace(";", "")
+    with pytest.raises(ConfigValidationError, match=expected_error):
+        ert_config_from_parser(obs_content)

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -25,7 +25,7 @@ from ert.config._observations import (
     extract_localization_values,
     make_observations,
 )
-from ert.config.parsing import parse_observations
+from ert.config.parsing import ObservationDict, parse_observations
 from ert.config.parsing.observations_parser import (
     ObservationConfigError,
     ObservationType,
@@ -654,7 +654,9 @@ def test_that_error_must_be_greater_than_zero_in_general_observations(std):
         )
 
 
-def test_that_all_errors_in_general_observations_must_be_greater_than_zero(tmpdir):
+def test_that_all_errors_in_general_observations_must_be_greater_than_zero(
+    tmpdir, file_context_token
+):
     with tmpdir.as_cwd():
         # First error value will be 0
         Path("obs_data.txt").write_text(
@@ -666,13 +668,16 @@ def test_that_all_errors_in_general_observations_must_be_greater_than_zero(tmpdi
             make_observations(
                 "",
                 [
-                    {
-                        "type": ObservationType.GENERAL,
-                        "name": "OBS",
-                        "DATA": "GEN",
-                        "RESTART": 1,
-                        "OBS_FILE": "obs_data.txt",
-                    }
+                    ObservationDict(
+                        {
+                            "type": ObservationType.GENERAL,
+                            "name": "OBS",
+                            "DATA": "GEN",
+                            "RESTART": 1,
+                            "OBS_FILE": "obs_data.txt",
+                        },
+                        context=file_context_token(),
+                    )
                 ],
                 ShapeRegistry(),
             )
@@ -747,7 +752,9 @@ def test_that_having_no_refcase_but_history_observations_causes_exception():
         ("INDEX_FILE", "obs_idx.txt"),
     ],
 )
-def test_that_indices_from_file_and_list_are_read(tmpdir, indices_type, indices_value):
+def test_that_indices_from_file_and_list_are_read(
+    tmpdir, indices_type, indices_value, file_context_token
+):
     with tmpdir.as_cwd():
         if indices_type == "INDEX_FILE":
             Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
@@ -757,14 +764,17 @@ def test_that_indices_from_file_and_list_are_read(tmpdir, indices_type, indices_
         obs = make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "GEN",
-                    f"{indices_type}": f"{indices_value}",
-                    "RESTART": "1",
-                    "OBS_FILE": "obs_data.txt",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "GEN",
+                        f"{indices_type}": f"{indices_value}",
+                        "RESTART": "1",
+                        "OBS_FILE": "obs_data.txt",
+                    },
+                    context=file_context_token(),
+                ),
             ],
             ShapeRegistry(),
         )
@@ -808,7 +818,7 @@ def test_that_invalid_time_map_file_raises_config_validation_error():
         run_convert_observations(Namespace(config="config.ert"))
 
 
-def test_that_non_existent_obs_file_is_invalid():
+def test_that_non_existent_obs_file_is_invalid(file_context_token):
     with pytest.raises(
         expected_exception=ConfigValidationError,
         match="did not resolve to a valid path",
@@ -816,14 +826,17 @@ def test_that_non_existent_obs_file_is_invalid():
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "RES",
-                    "INDEX_LIST": "0,2,4,6,8",
-                    "RESTART": "0",
-                    "OBS_FILE": "does_not_exist/at_all",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "RES",
+                        "INDEX_LIST": "0,2,4,6,8",
+                        "RESTART": "0",
+                        "OBS_FILE": "does_not_exist/at_all",
+                    },
+                    context=file_context_token(),
+                )
             ],
             ShapeRegistry(),
         )
@@ -858,7 +871,9 @@ def test_that_non_existent_time_map_file_is_invalid():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_general_observation_cannot_contain_both_value_and_obs_file():
+def test_that_general_observation_cannot_contain_both_value_and_obs_file(
+    file_context_token,
+):
     Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
     Path("obs_data.txt").write_text(
         "\n".join(f"{float(i)} 0.1" for i in range(5)), encoding="utf-8"
@@ -869,40 +884,50 @@ def test_that_general_observation_cannot_contain_both_value_and_obs_file():
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "GEN",
-                    "RESTART": "1",
-                    "INDEX_FILE": "obs_idx.txt",
-                    "OBS_FILE": "obs_data.txt",
-                    "VALUE": "1.0",
-                    "ERROR": "0.1",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "GEN",
+                        "RESTART": "1",
+                        "INDEX_FILE": "obs_idx.txt",
+                        "OBS_FILE": "obs_data.txt",
+                        "VALUE": "1.0",
+                        "ERROR": "0.1",
+                    },
+                    context=file_context_token(),
+                )
             ],
             ShapeRegistry(),
         )
 
 
-def test_that_general_observation_must_contain_either_value_or_obs_file():
+def test_that_general_observation_must_contain_either_value_or_obs_file(
+    file_context_token,
+):
     with pytest.raises(
         ConfigValidationError, match=r"must contain either VALUE.*OBS_FILE"
     ):
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "GEN",
-                    "RESTART": "1",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "GEN",
+                        "RESTART": "1",
+                    },
+                    context=file_context_token(),
+                ),
             ],
             ShapeRegistry(),
         )
 
 
-def test_that_non_numbers_in_obs_file_shows_informative_error_message(tmpdir):
+def test_that_non_numbers_in_obs_file_shows_informative_error_message(
+    tmpdir, file_context_token
+):
     with tmpdir.as_cwd():
         Path("obs_data.txt").write_text("not_an_int 0.1\n", encoding="utf-8")
         with pytest.raises(
@@ -913,21 +938,24 @@ def test_that_non_numbers_in_obs_file_shows_informative_error_message(tmpdir):
             make_observations(
                 "",
                 [
-                    {
-                        "type": ObservationType.GENERAL,
-                        "name": "OBS",
-                        "DATA": "GEN",
-                        "INDEX_LIST": "0,2,4,6,8",
-                        "RESTART": 1,
-                        "OBS_FILE": "obs_data.txt",
-                    }
+                    ObservationDict(
+                        {
+                            "type": ObservationType.GENERAL,
+                            "name": "OBS",
+                            "DATA": "GEN",
+                            "INDEX_LIST": "0,2,4,6,8",
+                            "RESTART": 1,
+                            "OBS_FILE": "obs_data.txt",
+                        },
+                        context=file_context_token(),
+                    )
                 ],
                 ShapeRegistry(),
             )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_the_number_of_columns_in_obs_file_cannot_change():
+def test_that_the_number_of_columns_in_obs_file_cannot_change(file_context_token):
     with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
         fh.writelines(f"{float(i)} 0.1\n" for i in range(5))
         fh.writelines("0.1\n")
@@ -937,41 +965,49 @@ def test_that_the_number_of_columns_in_obs_file_cannot_change():
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "GEN",
-                    "INDEX_LIST": "0,2,4,6,8",
-                    "RESTART": 1,
-                    "OBS_FILE": "obs_data.txt",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "GEN",
+                        "INDEX_LIST": "0,2,4,6,8",
+                        "RESTART": 1,
+                        "OBS_FILE": "obs_data.txt",
+                    },
+                    context=file_context_token(),
+                )
             ],
             ShapeRegistry(),
         )
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_the_number_of_values_in_obs_file_must_be_even():
+def test_that_the_number_of_values_in_obs_file_must_be_even(file_context_token):
     with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
         fh.writelines(f"{float(i)} 0.1 0.1\n" for i in range(5))
     with pytest.raises(ConfigValidationError, match="Expected even number of values"):
         make_observations(
             "",
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "OBS",
-                    "DATA": "GEN",
-                    "INDEX_LIST": "0,2,4,6,8",
-                    "RESTART": "1",
-                    "OBS_FILE": "obs_data.txt",
-                }
+                ObservationDict(
+                    {
+                        "type": ObservationType.GENERAL,
+                        "name": "OBS",
+                        "DATA": "GEN",
+                        "INDEX_LIST": "0,2,4,6,8",
+                        "RESTART": "1",
+                        "OBS_FILE": "obs_data.txt",
+                    },
+                    context=file_context_token(),
+                )
             ],
             ShapeRegistry(),
         )
 
 
-def test_that_giving_both_index_file_and_index_list_raises_an_exception(tmpdir):
+def test_that_giving_both_index_file_and_index_list_raises_an_exception(
+    tmpdir, file_context_token
+):
     with tmpdir.as_cwd():
         Path("obs_idx.txt").write_text("0\n2\n4\n6\n8", encoding="utf-8")
         with pytest.raises(
@@ -981,16 +1017,19 @@ def test_that_giving_both_index_file_and_index_list_raises_an_exception(tmpdir):
             make_observations(
                 "",
                 [
-                    {
-                        "type": ObservationType.GENERAL,
-                        "name": "OBS",
-                        "DATA": "GEN",
-                        "INDEX_LIST": "0,2,4,6,8",
-                        "INDEX_FILE": "obs_idx.txt",
-                        "RESTART": "1",
-                        "VALUE": "0.0",
-                        "ERROR": "0.1",
-                    }
+                    ObservationDict(
+                        {
+                            "type": ObservationType.GENERAL,
+                            "name": "OBS",
+                            "DATA": "GEN",
+                            "INDEX_LIST": "0,2,4,6,8",
+                            "INDEX_FILE": "obs_idx.txt",
+                            "RESTART": "1",
+                            "VALUE": "0.0",
+                            "ERROR": "0.1",
+                        },
+                        context=file_context_token(),
+                    )
                 ],
                 ShapeRegistry(),
             )
@@ -1237,7 +1276,9 @@ def test_that_history_observations_values_are_fetched_from_refcase(
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_obs_file_must_have_the_same_number_of_lines_as_the_index_file():
+def test_that_obs_file_must_have_the_same_number_of_lines_as_the_index_file(
+    file_context_token,
+):
     Path("obs_idx.txt").write_text("0\n2\n4\n6", encoding="utf-8")
     Path("obs_data.txt").write_text(
         "\n".join(f"{float(i)} 0.1" for i in range(5)), encoding="utf-8"
@@ -1251,13 +1292,16 @@ def test_that_obs_file_must_have_the_same_number_of_lines_as_the_index_file():
                 "OBS_CONFIG": (
                     "obsconf",
                     [
-                        {
-                            "type": ObservationType.GENERAL,
-                            "name": "OBS",
-                            "DATA": "RES",
-                            "INDEX_FILE": "obs_idx.txt",  # shorter than obs_file
-                            "OBS_FILE": "obs_data.txt",
-                        }
+                        ObservationDict(
+                            {
+                                "type": ObservationType.GENERAL,
+                                "name": "OBS",
+                                "DATA": "RES",
+                                "INDEX_FILE": "obs_idx.txt",  # shorter than obs_file
+                                "OBS_FILE": "obs_data.txt",
+                            },
+                            context=file_context_token(),
+                        )
                     ],
                 ),
             }
@@ -1265,7 +1309,7 @@ def test_that_obs_file_must_have_the_same_number_of_lines_as_the_index_file():
 
 
 def test_that_obs_file_must_have_the_same_number_of_lines_as_the_length_of_index_list(
-    tmpdir,
+    tmpdir, file_context_token
 ):
     with tmpdir.as_cwd():
         with Path("obs_data.txt").open("w", encoding="utf-8") as fh:
@@ -1283,13 +1327,16 @@ def test_that_obs_file_must_have_the_same_number_of_lines_as_the_length_of_index
                     "OBS_CONFIG": (
                         "obsconf",
                         [
-                            {
-                                "type": ObservationType.GENERAL,
-                                "name": "OBS",
-                                "DATA": "RES",
-                                "INDEX_LIST": "200",  # shorter than obs_file
-                                "OBS_FILE": "obs_data.txt",
-                            }
+                            ObservationDict(
+                                {
+                                    "type": ObservationType.GENERAL,
+                                    "name": "OBS",
+                                    "DATA": "RES",
+                                    "INDEX_LIST": "200",  # shorter than obs_file
+                                    "OBS_FILE": "obs_data.txt",
+                                },
+                                context=file_context_token(),
+                            )
                         ],
                     ),
                 }
@@ -1297,7 +1344,7 @@ def test_that_obs_file_must_have_the_same_number_of_lines_as_the_length_of_index
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_general_observations_data_must_match_a_gen_datas_name():
+def test_that_general_observations_data_must_match_a_gen_datas_name(file_context_token):
     with pytest.raises(
         ConfigValidationError,
         match="No GEN_DATA with name 'RES' found",
@@ -1309,15 +1356,18 @@ def test_that_general_observations_data_must_match_a_gen_datas_name():
                 "OBS_CONFIG": (
                     "obsconf",
                     [
-                        {
-                            "type": ObservationType.GENERAL,
-                            "name": "OBS",
-                            "DATA": "RES",
-                            "INDEX_LIST": "0,2,4,6,8",
-                            "RESTART": "0",
-                            "VALUE": "1",
-                            "ERROR": "1",
-                        }
+                        ObservationDict(
+                            {
+                                "type": ObservationType.GENERAL,
+                                "name": "OBS",
+                                "DATA": "RES",
+                                "INDEX_LIST": "0,2,4,6,8",
+                                "RESTART": "0",
+                                "VALUE": "1",
+                                "ERROR": "1",
+                            },
+                            context=file_context_token(),
+                        )
                     ],
                 ),
             }
@@ -1325,7 +1375,9 @@ def test_that_general_observations_data_must_match_a_gen_datas_name():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_general_observation_restart_must_match_gen_data_report_step():
+def test_that_general_observation_restart_must_match_gen_data_report_step(
+    file_context_token,
+):
     with pytest.raises(
         ConfigValidationError,
         match="is not configured to load from report step",
@@ -1345,15 +1397,18 @@ def test_that_general_observation_restart_must_match_gen_data_report_step():
                 "OBS_CONFIG": (
                     "obsconf",
                     [
-                        {
-                            "type": ObservationType.GENERAL,
-                            "name": "OBS",
-                            "DATA": "RES",
-                            "INDEX_LIST": "0,2,4,6,8",
-                            "RESTART": "0",
-                            "VALUE": "1",
-                            "ERROR": "1",
-                        }
+                        ObservationDict(
+                            {
+                                "type": ObservationType.GENERAL,
+                                "name": "OBS",
+                                "DATA": "RES",
+                                "INDEX_LIST": "0,2,4,6,8",
+                                "RESTART": "0",
+                                "VALUE": "1",
+                                "ERROR": "1",
+                            },
+                            context=file_context_token(),
+                        )
                     ],
                 ),
             }

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -168,7 +168,9 @@ def test_that_summary_observations_raises_error_when_east_or_north_are_undefined
     with pytest.raises(ConfigValidationError) as e, tmpdir.as_cwd():
         create_summary_observation("LOCALIZATION {" + loc_config_lines + "};")
     for kw in missing_keywords:
-        assert f'Missing item "{kw}" in LOCALIZATION for FOPR_1' in str(e.value)
+        assert f'Missing item "{kw}" in LOCALIZATION for SUMMARY_OBSERVATION' in str(
+            e.value
+        )
 
 
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
@@ -177,7 +179,8 @@ def test_that_summary_observations_raises_error_given_unknown_localization_key(
 ):
     with (
         pytest.raises(
-            ConfigValidationError, match="Unknown FOO in LOCALIZATION for FOPR_1"
+            ConfigValidationError,
+            match=r"Unknown FOO in LOCALIZATION for SUMMARY_OBSERVATION",
         ),
         tmpdir.as_cwd(),
     ):


### PR DESCRIPTION
**Issue**
Resolves #13269 

Removing all observation names from snake oil:
```
WOPR:OP1:2010-03-31
WOPR:OP1:2010-12-26
WOPR:OP1:2011-12-21
WOPR:OP1:2012-12-15
WOPR:OP1:2013-12-10
WOPR:OP1:2015-03-15
SNAKE_OIL_WPR_DIFF:199:400
SNAKE_OIL_WPR_DIFF:199:800
SNAKE_OIL_WPR_DIFF:199:1200
SNAKE_OIL_WPR_DIFF:199:1800
```

... from poly example:
```
POLY_RES:0:0
POLY_RES:0:2
POLY_RES:0:4
POLY_RES:0:6
POLY_RES:0:8
```

... from rft example:
```
PROD:2015-02-01:PRESSURE:8400.0
```

As name is now optional, it is not straight forward how to reference a given observation given some error in the configuration. I solved it with `observation_referece`, but this will just be `RFT_OBSERVATION` for a nameless rft observation. There is probably some improvement to be made here.

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
