### PR TITLE
Add UTC timestamps to all datetime objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ select = [
     "B",     # flake-8-bugbear
     "C4",    # flake8-comprehensions
     "DJ",
+    "DTZ",
     "E",     # pycodestyle
     "EXE",
     "F",     # pyflakes

--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
@@ -62,7 +62,7 @@ class Id:
 
 class BaseEvent(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
-    time: datetime = Field(default_factory=datetime.now)
+    time: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
 
 
 class ForwardModelStepBaseEvent(BaseEvent):

--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -83,7 +83,9 @@ def _setup_logging(directory: str = "logs") -> None:
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    timestamp = file_safe_timestamp(datetime.now().isoformat(timespec="minutes"))
+    timestamp = file_safe_timestamp(
+        datetime.now().astimezone().isoformat(timespec="minutes")
+    )
 
     filename = f"forward-model-runner-log-{timestamp}.txt"
     csv_filename = f"memory-profile-{timestamp}.csv"

--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import io
 import logging
 import os
@@ -11,7 +12,6 @@ import time
 import uuid
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime as dt
 from os import path
 from pathlib import Path
 from subprocess import Popen, run
@@ -165,7 +165,7 @@ class ForwardModelStep:
         existing_target_file_mtime: int | None = _get_existing_target_file_mtime(
             target_file
         )
-        run_start_time = dt.now()
+        run_start_time = datetime.datetime.now(tz=datetime.UTC)
         try:
             proc = Popen(
                 arg_list,
@@ -291,11 +291,11 @@ class ForwardModelStep:
         self,
         exit_code: int | None,
         proc: Popen[Process],  # type: ignore
-        run_start_time: dt,
+        run_start_time: datetime.datetime,
     ) -> Exited | None:
         max_running_minutes = self.step_data.get("max_running_minutes")
 
-        run_time = dt.now() - run_start_time
+        run_time = datetime.datetime.now(tz=datetime.UTC) - run_start_time
         if max_running_minutes is None or run_time.seconds < max_running_minutes * 60:
             return None
 

--- a/src/_ert/forward_model_runner/reporting/message.py
+++ b/src/_ert/forward_model_runner/reporting/message.py
@@ -1,5 +1,5 @@
 import dataclasses
-from datetime import datetime as dt
+import datetime
 from typing import TYPE_CHECKING, Literal, NotRequired, Self
 
 import psutil
@@ -41,7 +41,7 @@ class ProcessTreeStatus:
     oom_score: int | None = None
 
     def __post_init__(self) -> None:
-        self.timestamp = dt.now().isoformat()
+        self.timestamp = datetime.datetime.now(tz=datetime.UTC).isoformat()
         self.free = psutil.virtual_memory().available
 
     def __repr__(self) -> str:
@@ -60,7 +60,7 @@ class _MetaMessage(type):
 
 class Message(metaclass=_MetaMessage):
     def __init__(self, step: "ForwardModelStep | None" = None) -> None:
-        self.timestamp = dt.now()
+        self.timestamp = datetime.datetime.now(tz=datetime.UTC)
         self.step = step
         self.error_message: str | None = None
 

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -106,7 +106,7 @@ def run_convert_observations(
 
     os.rename(
         changes.obs_config_path,
-        f"{changes.obs_config_path}-{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.old",
+        f"{changes.obs_config_path}-{datetime.now().astimezone().strftime('%Y-%m-%d-%H-%M-%S')}.old",
     )
     os.rename(obs_config_to_edit_path, changes.obs_config_path)
     msg = (

--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from queue import SimpleQueue
 from typing import TextIO
@@ -60,7 +60,7 @@ class Monitor:
     def __init__(self, out: TextIO = sys.stdout, color_always: bool = False) -> None:
         self._out = out
         self._snapshots: dict[int, EnsembleSnapshot] = {}
-        self._start_time: datetime | None = None
+        self._start_time: datetime.datetime | None = None
         self._colorize = ansi_color
         # If out is not (like) a tty, disable colors.
         if not out.isatty() and not color_always:
@@ -75,7 +75,7 @@ class Monitor:
         event_queue: SimpleQueue[StatusEvents],
         output_path: Path | None = None,
     ) -> EndEvent:
-        self._start_time = datetime.now()
+        self._start_time = datetime.datetime.now(tz=datetime.UTC)
         while True:
             match event_queue.get():
                 case FullSnapshotEvent(
@@ -144,9 +144,9 @@ class Monitor:
     def _print_progress(self, event: SnapshotUpdateEvent) -> None:
         current_iteration = min(event.total_iterations, event.iteration + 1)
         if self._start_time is not None:
-            elapsed = datetime.now() - self._start_time
+            elapsed = datetime.datetime.now(tz=datetime.UTC) - self._start_time
         else:
-            elapsed = timedelta()
+            elapsed = datetime.timedelta()
 
         nphase = f" {current_iteration}/{event.total_iterations}"
 

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -50,7 +50,7 @@ def _parse_date(date_str: str) -> datetime:
         return datetime.fromisoformat(date_str)
     except ValueError:
         try:
-            date = datetime.strptime(date_str, "%d/%m/%Y")
+            date = datetime.strptime(date_str, "%d/%m/%Y")  # noqa: DTZ007
         except ValueError as err:
             raise ObservationConfigError.with_context(
                 f"Unsupported date format {date_str}. Please use ISO date format",

--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -813,7 +813,7 @@ def _read_time_map(file_contents: str) -> list[datetime]:
                 "DD/MM/YYYY date format is deprecated"
                 ", please use ISO date format YYYY-MM-DD."
             )
-            return datetime.strptime(date_str, "%d/%m/%Y")
+            return datetime.strptime(date_str, "%d/%m/%Y")  # noqa: DTZ007
 
     dates = [str_to_datetime(line.strip()) for line in file_contents.splitlines()]
     return dates

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -499,7 +499,7 @@ def _transform_tree(
         pre_defines = [
             ["<CONFIG_PATH>", config_dir],
             ["<CONFIG_FILE_BASE>", config_file_base],
-            ["<DATE>", datetime.date.today().isoformat()],
+            ["<DATE>", datetime.datetime.now().astimezone().date().isoformat()],
             ["<CWD>", config_dir],
             ["<CONFIG_FILE>", os.path.basename(file)],
         ]

--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -310,7 +310,7 @@ class ExperimentRunner:
             with use_runtime_plugins(site_plugins):
                 run_model = EverestRunModel.create(
                     everest_config=self._everest_config,
-                    experiment_name=f"EnOpt@{datetime.datetime.now().isoformat(timespec='seconds')}",
+                    experiment_name=f"EnOpt@{datetime.datetime.now().astimezone().isoformat(timespec='seconds')}",
                     target_ensemble="batch",
                     status_queue=status_queue,
                     runtime_plugins=site_plugins,

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -327,7 +327,7 @@ class EnsembleEvaluator:
             memory_usage = fm_step.get(ids.MAX_MEMORY_USAGE) or "-1"
             max_memory_usage = max(int(memory_usage), max_memory_usage)
 
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(tz=datetime.UTC)
             walltime_seconds += (
                 (fm_step.get(ids.END_TIME) or now)
                 - (fm_step.get(ids.START_TIME) or now)

--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -253,7 +253,7 @@ class RunDialog(QFrame):
             self,
         )
 
-        date_time: str = datetime.now(UTC).isoformat(timespec="seconds")
+        date_time: str = datetime.now(tz=UTC).isoformat(timespec="seconds")
         experiment_type = self._run_model_api.experiment_name
         experiment_id = experiment_type + " : " + date_time
 
@@ -549,7 +549,9 @@ class RunDialog(QFrame):
     def _on_ticker(self) -> None:
         if self._start_time:
             humanized_runtime = humanize.precisedelta(
-                datetime.now() - self._start_time, minimum_unit="seconds", format="%d"
+                datetime.now(tz=UTC) - self._start_time,
+                minimum_unit="seconds",
+                format="%d",
             )
             self.running_time.setText(f"Running time:\n{humanized_runtime}")
 

--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -36,7 +36,9 @@ _FORMATS = _FORMATS_ANSI if os.isatty(sys.stderr.fileno()) else _FORMATS_NO_COLO
 
 class TimestampedFileHandler(logging.FileHandler):
     def __init__(self, filename: str, *args: Any, **kwargs: Any) -> None:
-        timestamp = file_safe_timestamp(datetime.now().isoformat(timespec="minutes"))
+        timestamp = file_safe_timestamp(
+            datetime.now().astimezone().isoformat(timespec="minutes")
+        )
 
         filename, extension = os.path.splitext(filename)
 

--- a/src/ert/resources/forward_models/run_reservoirsimulator.py
+++ b/src/ert/resources/forward_models/run_reservoirsimulator.py
@@ -104,9 +104,11 @@ def await_completed_unsmry_file(
     interval is specified in seconds.
 
     The return value is the waited time (in seconds)"""
-    start_time = datetime.datetime.now()
+    start_time = datetime.datetime.now(tz=datetime.UTC)
     prev_len = 0
-    while (datetime.datetime.now() - start_time).total_seconds() < max_wait:
+    while (
+        datetime.datetime.now(tz=datetime.UTC) - start_time
+    ).total_seconds() < max_wait:
         try:
             resfo_sum = [r.read_keyword() for r in resfo.lazy_read(smry_path)]
         except Exception:
@@ -122,7 +124,7 @@ def await_completed_unsmry_file(
 
         time.sleep(poll_interval)
 
-    return (datetime.datetime.now() - start_time).total_seconds()
+    return (datetime.datetime.now(tz=datetime.UTC) - start_time).total_seconds()
 
 
 class RunReservoirSimulator:

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -262,7 +262,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
         cls,
         everest_config: EverestConfig,
         experiment_name: str = (
-            f"EnOpt@{datetime.datetime.now().isoformat(timespec='seconds')}"
+            f"EnOpt@{datetime.datetime.now().astimezone().isoformat(timespec='seconds')}"
         ),
         target_ensemble: str = "batch",
         optimization_callback: OptimizerCallback | None = None,

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import copy
+import datetime
 import functools
 import logging
 import os
@@ -17,7 +18,6 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, MutableSequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
@@ -402,7 +402,7 @@ class RunModel(RunModelConfig, ABC):
         def handle_captured_event(message: Warning | str) -> None:
             self.send_event(WarningEvent(msg=str(message)))
 
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.datetime.now(tz=datetime.UTC)
         try:
             self.send_event(StartEvent(timestamp=start_timestamp))
             with (
@@ -473,10 +473,10 @@ class RunModel(RunModelConfig, ABC):
                     ),
                 )
             )
-            logger.info(
-                "Experiment run finished in: "
-                f"{(datetime.now() - start_timestamp).total_seconds():g}s"
-            )
+            seconds_used = (
+                datetime.datetime.now(tz=datetime.UTC) - start_timestamp
+            ).total_seconds()
+            logger.info(f"Experiment run finished in: {seconds_used:g}s")
 
     @abstractmethod
     def run_experiment(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -7,7 +7,7 @@ import os
 import time
 from collections import Counter
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cache, cached_property, lru_cache
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -172,7 +172,7 @@ class LocalEnsemble(BaseMode):
             iteration=iteration,
             name=name,
             prior_ensemble_id=prior_ensemble_id,
-            started_at=datetime.now(),
+            started_at=datetime.now(tz=UTC),
         )
 
         storage._write_transaction(
@@ -203,6 +203,12 @@ class LocalEnsemble(BaseMode):
 
     @property
     def started_at(self) -> datetime:
+        if self._index.started_at.tzinfo is None:
+            logger.warning(
+                "Assuming local timezone for 'started_at' "
+                f"property of ensemble named {self.name}"
+            )
+            return self._index.started_at.astimezone()
         return self._index.started_at
 
     @property
@@ -307,7 +313,9 @@ class LocalEnsemble(BaseMode):
         message: str | None = None,
     ) -> None:
         filename: Path = self._realization_dir(realization) / self._error_log_name
-        error = _Failure(type=failure_type, message=message or "", time=datetime.now())
+        error = _Failure(
+            type=failure_type, message=message or "", time=datetime.now(tz=UTC)
+        )
         if not filename.parent.parent.exists():
             logger.warning(
                 f"Storage {filename.parent.parent} does not exist, "

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -5,7 +5,7 @@ import json
 import logging
 import shutil
 from collections.abc import Generator
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum, auto
 from functools import cached_property
 from pathlib import Path
@@ -143,7 +143,7 @@ class LocalExperiment(BaseMode):
         name: str | None = None,
     ) -> LocalExperiment:
         if name is None:
-            name = datetime.today().isoformat()
+            name = datetime.now(tz=UTC).date().isoformat()
 
         storage._write_transaction(
             path / cls._index_file,

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import types
 from collections.abc import Generator, MutableSequence
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cached_property
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -36,7 +36,7 @@ _LOCAL_STORAGE_VERSION = 26
 
 class _Migrations(BaseModel):
     ert_version: str = __version__
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
     name: str
     version_range: tuple[int, int]
 

--- a/test-data/ert/heat_equation/heat_equation.py
+++ b/test-data/ert/heat_equation/heat_equation.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
     smspec, unsmry = create_summary_smspec_unsmry(
         summary_vectors=summary_values,
-        start_date=datetime.datetime(2010, 1, 1),
+        start_date=datetime.datetime(2010, 1, 1),  # noqa: DTZ001
         time_step_in_days=1,
     )
 

--- a/tests/ert/performance_tests/performance_utils.py
+++ b/tests/ert/performance_tests/performance_utils.py
@@ -117,7 +117,11 @@ def make_poly_example(folder, source, **kwargs):
         )
     else:
         summary = Summary.writer(
-            str(folder) + "/refcase/REFCASE", datetime.datetime(2010, 1, 1), 10, 10, 10
+            str(folder) + "/refcase/REFCASE",
+            datetime.datetime(2010, 1, 1),  # noqa: DTZ001
+            10,
+            10,
+            10,
         )
         for s in range(summary_count):
             summary.add_variable(f"PSUM{s}")

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -268,7 +268,7 @@ def test_plot_api_big_summary_memory_usage(
     dates = []
 
     for i in range(num_keys):
-        dates += [datetime(2000, 1, 1) + timedelta(days=i)] * num_dates
+        dates += [datetime(2000, 1, 1) + timedelta(days=i)] * num_dates  # noqa: DTZ001
 
     dates_df = pl.Series(dates, dtype=pl.Datetime).dt.cast_time_unit("ms")
 

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -150,8 +150,8 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
             source.save_response("gen_data", pl.concat(gendatas), real)
 
             # Corresponds to refcase previously used in this test
-            refcase_start = datetime.datetime(2010, 1, 1)
-            refcase_end = datetime.datetime(2010, 4, 11)
+            refcase_start = datetime.datetime(2010, 1, 1)  # noqa: DTZ001
+            refcase_end = datetime.datetime(2010, 4, 11)  # noqa: DTZ001
 
             obs_time_list = [
                 refcase_start + datetime.timedelta(days=i)

--- a/tests/ert/performance_tests/test_obs_and_responses_performance.py
+++ b/tests/ert/performance_tests/test_obs_and_responses_performance.py
@@ -146,7 +146,7 @@ def create_experiment_args(
 
     _summary_time_delta = datetime.timedelta(30)
     summary_timesteps = [
-        datetime.datetime(2000, 1, 1) + datetime.timedelta(30) * i
+        datetime.datetime(2000, 1, 1) + datetime.timedelta(30) * i  # noqa: DTZ001
         for i in range(num_summary_timesteps)
     ]
     summary_response_keys = [

--- a/tests/ert/ui_tests/cli/test_observation_times.py
+++ b/tests/ert/ui_tests/cli/test_observation_times.py
@@ -22,7 +22,7 @@ from tests.ert.unit_tests.config.observations_generator import (
 
 from .run_cli import run_cli
 
-start = datetime(1969, 1, 1)
+start = datetime(1969, 1, 1)  # noqa: DTZ001
 observation_times = st.dates(
     min_value=date.fromordinal((start + timedelta(hours=1)).toordinal()),
     max_value=date(2024, 1, 1),

--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -411,7 +411,7 @@ class SurfaceParameter(Parameter):
     io_source=st.builds(IoProvider, data=st.data()),
     grid_format=st.sampled_from(["grid", "egrid"]),
     summary=summaries(
-        start_date=st.just(datetime(1996, 1, 1)),
+        start_date=st.just(datetime(1996, 1, 1)),  # noqa: DTZ001
         time_deltas=st.just([1.0, 2.0]),
         summary_keys=st.just(["FOPR"]),
     ),

--- a/tests/ert/ui_tests/gui/test_breakthrough_visualization.py
+++ b/tests/ert/ui_tests/gui/test_breakthrough_visualization.py
@@ -91,7 +91,10 @@ def summary_response(realization: int) -> pl.DataFrame:
     return pl.DataFrame(
         {
             "response_key": ["WWCT:OP1"] * num_points,
-            "time": [datetime(2000, 1, day) for day in range(1, num_points + 1)],
+            "time": [
+                datetime(2000, 1, day)  # noqa: DTZ001
+                for day in range(1, num_points + 1)
+            ],
             "values": pl.Series(values, dtype=pl.Float32),
         }
     )

--- a/tests/ert/unit_tests/cli/test_cli_monitor.py
+++ b/tests/ert/unit_tests/cli/test_cli_monitor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 
 from ert.cli.monitor import Monitor
@@ -74,7 +74,7 @@ def test_print_progress():
             str(i), RealizationSnapshot(status=status, active=True)
         )
     monitor._snapshots[0] = snapshot
-    monitor._start_time = datetime.now()
+    monitor._start_time = datetime.now(tz=UTC)
     general_event = SnapshotUpdateEvent(
         iteration_label="Test Phase",
         total_iterations=2,

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -369,7 +369,7 @@ class ErtConfigValues:
         result = [
             ("<CONFIG_PATH>", cwd),
             ("<CONFIG_FILE_BASE>", config_file_name.split(".")[0]),
-            ("<DATE>", datetime.date.today().isoformat()),
+            ("<DATE>", datetime.datetime.now().astimezone().date().isoformat()),
             ("<CWD>", cwd),
             ("<CONFIG_FILE>", config_file_name),
         ]
@@ -424,7 +424,7 @@ def ert_config_values(draw, use_eclbase=booleans):
         )
     )
     sum_keys = draw(small_list(summary_variables(), min_size=1))
-    first_date = datetime.datetime.strptime("1999-1-1", "%Y-%m-%d")
+    first_date = datetime.datetime.strptime("1999-1-1", "%Y-%m-%d")  # noqa: DTZ007
     smspec = draw(
         smspecs(
             sum_keys=st.just(sum_keys),
@@ -539,7 +539,7 @@ def sim_job(installed_jobs):
 
 def get_date(observation, start):
     if observation.date is not None:
-        return datetime.datetime.strptime(observation.date, "%Y-%m-%d")
+        return datetime.datetime.strptime(observation.date, "%Y-%m-%d")  # noqa: DTZ007
     delta = datetime.timedelta(days=0)
     if observation.days is not None:
         delta += datetime.timedelta(days=observation.days)

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1,10 +1,10 @@
+import datetime
 import json
 import logging
 import os
 import os.path
 import stat
 import warnings
-from datetime import date
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock
@@ -396,7 +396,7 @@ def test_that_the_date_magic_string_is_substituted_with_todays_date():
     Path(test_config_file_name).write_text(test_config_contents, encoding="utf-8")
     ert_config = ErtConfig.from_file(test_config_file_name)
 
-    date_string = date.today().isoformat()
+    date_string = datetime.datetime.now().astimezone().date().isoformat()
     expected_storage = os.path.abspath(f"storage/{test_config_file_base}-{date_string}")
     expected_run_path = f"{expected_storage}/runpath/realization-<IENS>/iter-<ITER>"
     expected_ens_path = f"{expected_storage}/ensemble"

--- a/tests/ert/unit_tests/config/test_observation_config_migrations.py
+++ b/tests/ert/unit_tests/config/test_observation_config_migrations.py
@@ -77,7 +77,7 @@ def test_that_history_observations_are_converted_to_summary_observations(tmp_pat
             "FOPTH": [2] * 10,
             "FWPTH": [3] * 10,
         },
-        start_date=datetime(2020, 1, 1),
+        start_date=datetime(2020, 1, 1),  # noqa: DTZ001
         time_step_in_days=30,
     )
 
@@ -226,7 +226,8 @@ def test_that_summary_observations_with_restart_use_date_from_refcase():
     """
     # Create a refcase
     smspec, unsmry = create_summary_smspec_unsmry(
-        summary_vectors={"FOPR": [100, 110, 120]}, start_date=datetime(2020, 1, 1)
+        summary_vectors={"FOPR": [100, 110, 120]},
+        start_date=datetime(2020, 1, 1),  # noqa: DTZ001
     )
     smspec.to_file(Path("REFCASE.SMSPEC"))
     unsmry.to_file(Path("REFCASE.UNSMRY"))
@@ -306,7 +307,7 @@ SUMMARY_OBSERVATION FOPR_OBS2 {
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_history_summary_and_general_obs_are_all_migrated_together(tmp_path):
-    start_date = datetime(2024, 1, 1)
+    start_date = datetime(2024, 1, 1)  # noqa: DTZ001
     smspec, unsmry = create_summary_smspec_unsmry(
         summary_vectors={
             "FOPRH": [1.0] * 5,
@@ -437,8 +438,8 @@ SUMMARY_OBSERVATION SUM_OBS_2 {
         (c.source_observation.name, c.source_observation.restart, c.date)
         for c in result.summary_obs_changes
     ] == [
-        ("SUM_OBS_1", 2, datetime(2024, 1, 11, 0, 0)),
-        ("SUM_OBS_2", 4, datetime(2024, 1, 31, 0, 0)),
+        ("SUM_OBS_1", 2, datetime(2024, 1, 11, 0, 0)),  # noqa: DTZ001
+        ("SUM_OBS_2", 4, datetime(2024, 1, 31, 0, 0)),  # noqa: DTZ001
     ]
 
     shutil.copy("observations.txt", "observations_edited.txt")

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -97,14 +97,14 @@ def test_that_make_observations_migrates_observations():
     Path("obs_config").write_text(obs_config_contents, encoding="utf8")
 
     # Create a simple refcase so the migration can read history values
-    summary = Summary.writer("MY_REFCASE", datetime(2000, 1, 1), 10, 10, 10)
+    summary = Summary.writer("MY_REFCASE", datetime(2000, 1, 1), 10, 10, 10)  # noqa: DTZ001
     summary.add_variable("FOPR", unit="SM3/DAY")
     summary.add_variable("FOPRH", unit="SM3/DAY")
     summary.add_variable("FWPR", unit="SM3/DAY")
     summary.add_variable("FWPRH", unit="SM3/DAY")
 
     # Create two timesteps: the explicit dates used in the test
-    start_date = datetime(2010, 3, 31)
+    start_date = datetime(2010, 3, 31)  # noqa: DTZ001
     # overwrite writer start date by recreating with desired start
     summary = Summary.writer("MY_REFCASE", start_date, 10, 10, 10)
     summary.add_variable("FOPR", unit="SM3/DAY")
@@ -120,7 +120,7 @@ def test_that_make_observations_migrates_observations():
     t0["FWPRH"] = 4
 
     # second step: 2015-06-13
-    second_date = datetime(2015, 6, 13)
+    second_date = datetime(2015, 6, 13)  # noqa: DTZ001
     days_between = (second_date - start_date).days
     t1 = summary.addTStep(1, sim_days=days_between)
     t1["FOPR"] = 1

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -69,7 +69,13 @@ def run_simulator(summary_values=SUMMARY_VALUES):
     Create :term:`summary files` with one value for FOPR (1) and a different
     for FOPRH (2) so we can assert on the difference.
     """
-    summary = Summary.writer("MY_REFCASE", datetime(2000, 1, 1), 10, 10, 10)
+    summary = Summary.writer(
+        "MY_REFCASE",
+        datetime(2000, 1, 1),  # noqa: DTZ001
+        10,
+        10,
+        10,
+    )
 
     for key in summary_values:
         summary.add_variable(key, unit="SM3/DAY")
@@ -991,7 +997,12 @@ def run_sim(start_date, keys=None, values=None, days=None):
 @pytest.mark.parametrize(
     ("time_map_statement", "time_map_creator"),
     [
-        ({"REFCASE": "ECLIPSE_CASE"}, lambda: run_sim(datetime(2014, 9, 10))),
+        (
+            {"REFCASE": "ECLIPSE_CASE"},
+            lambda: run_sim(
+                datetime(2014, 9, 10)  # noqa: DTZ001
+            ),
+        ),
         (
             {"TIME_MAP": ("time_map.txt", "2014-09-10\n2014-09-11\n")},
             lambda: None,
@@ -1119,7 +1130,7 @@ def test_that_loading_summary_obs_with_days_is_within_tolerance(
 def test_that_out_of_bounds_segments_are_truncated(tmpdir, start, stop, message):
     with tmpdir.as_cwd():
         run_sim(
-            datetime(2014, 9, 10),
+            datetime(2014, 9, 10),  # noqa: DTZ001
             [("FOPR", "SM3/DAY", None), ("FOPRH", "SM3/DAY", None)],
         )
 
@@ -1331,7 +1342,7 @@ def test_that_general_observation_restart_must_match_gen_data_report_step():
 def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
     with tmpdir.as_cwd():
         run_sim(
-            datetime(2014, 9, 10),
+            datetime(2014, 9, 10),  # noqa: DTZ001
             [
                 (k, "SM3/DAY", None)
                 for k in ["FOPR", "FWPR", "FOPRH", "FWPRH", "FGPR", "FGPRH"]
@@ -1382,7 +1393,7 @@ def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
 def test_that_segment_defaults_are_applied(tmpdir):
     with tmpdir.as_cwd():
         run_sim(
-            datetime(2014, 9, 10),
+            datetime(2014, 9, 10),  # noqa: DTZ001
             [("FOPR", "SM3/DAY", None), ("FOPRH", "SM3/DAY", None)],
             days=range(10),
         )

--- a/tests/ert/unit_tests/dark_storage/test_common.py
+++ b/tests/ert/unit_tests/dark_storage/test_common.py
@@ -92,7 +92,10 @@ def test_data_for_response_doesnt_mistake_history_for_response(tmp_path):
                 {
                     "response_key": ["FGPR", "FGPR"],
                     "time": pl.Series(
-                        [datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2)],
+                        [
+                            datetime.datetime(2000, 1, 1),  # noqa: DTZ001
+                            datetime.datetime(2000, 1, 2),  # noqa: DTZ001
+                        ],
                         dtype=pl.Datetime("ms"),
                     ),
                     "values": pl.Series([0.0, 1.0], dtype=pl.Float32),

--- a/tests/ert/unit_tests/ensemble_evaluator/test_snapshot.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_snapshot.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from _ert.events import (
     ForwardModelStepFailure,
@@ -19,8 +19,8 @@ def test_snapshot_merge(snapshot: EnsembleSnapshot):
         fm_step=FMStepSnapshot(
             status="Finished",
             index="0",
-            start_time=datetime(year=2020, month=10, day=27),
-            end_time=datetime(year=2020, month=10, day=28),
+            start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
+            end_time=datetime(year=2020, month=10, day=28, tzinfo=UTC),
         ),
     )
     update_event.update_fm_step(
@@ -29,7 +29,7 @@ def test_snapshot_merge(snapshot: EnsembleSnapshot):
         fm_step=FMStepSnapshot(
             status="Running",
             index="1",
-            start_time=datetime(year=2020, month=10, day=27),
+            start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
         ),
     )
     update_event.update_fm_step(
@@ -38,7 +38,7 @@ def test_snapshot_merge(snapshot: EnsembleSnapshot):
         fm_step=FMStepSnapshot(
             status="Running",
             index="0",
-            start_time=datetime(year=2020, month=10, day=27),
+            start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
         ),
     )
 
@@ -49,15 +49,15 @@ def test_snapshot_merge(snapshot: EnsembleSnapshot):
     assert snapshot.get_fm_step(real_id="1", fm_step_id="0") == FMStepSnapshot(
         status="Finished",
         index="0",
-        start_time=datetime(year=2020, month=10, day=27),
-        end_time=datetime(year=2020, month=10, day=28),
+        start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
+        end_time=datetime(year=2020, month=10, day=28, tzinfo=UTC),
         name="forward_model0",
     )
 
     assert snapshot.get_fm_step(real_id="1", fm_step_id="1") == FMStepSnapshot(
         status="Running",
         index="1",
-        start_time=datetime(year=2020, month=10, day=27),
+        start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
         name="forward_model1",
     )
 
@@ -65,7 +65,7 @@ def test_snapshot_merge(snapshot: EnsembleSnapshot):
     assert snapshot.get_fm_step(real_id="9", fm_step_id="0") == FMStepSnapshot(
         status="Running",
         index="0",
-        start_time=datetime(year=2020, month=10, day=27),
+        start_time=datetime(year=2020, month=10, day=27, tzinfo=UTC),
         name="forward_model0",
     )
 

--- a/tests/ert/unit_tests/gui/conftest.py
+++ b/tests/ert/unit_tests/gui/conftest.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import UTC
 from datetime import datetime as dt
 
 import pytest
@@ -27,8 +28,8 @@ def full_snapshot() -> EnsembleSnapshot:
         exec_hosts="COMP-01",
         fm_steps={
             "0": FMStepSnapshot(
-                start_time=dt.now(),
-                end_time=dt.now(),
+                start_time=dt.now(tz=UTC),
+                end_time=dt.now(tz=UTC),
                 name="poly_eval",
                 index="0",
                 status=FORWARD_MODEL_STATE_START,
@@ -39,8 +40,8 @@ def full_snapshot() -> EnsembleSnapshot:
                 max_memory_usage=312,
             ),
             "1": FMStepSnapshot(
-                start_time=dt.now(),
-                end_time=dt.now(),
+                start_time=dt.now(tz=UTC),
+                end_time=dt.now(tz=UTC),
                 name="poly_postval",
                 index="1",
                 status=FORWARD_MODEL_STATE_START,
@@ -51,7 +52,7 @@ def full_snapshot() -> EnsembleSnapshot:
                 max_memory_usage=312,
             ),
             "2": FMStepSnapshot(
-                start_time=dt.now(),
+                start_time=dt.now(tz=UTC),
                 end_time=None,
                 name="poly_post_mortem",
                 index="2",
@@ -63,7 +64,7 @@ def full_snapshot() -> EnsembleSnapshot:
                 max_memory_usage=312,
             ),
             "3": FMStepSnapshot(
-                start_time=dt.now(),
+                start_time=dt.now(tz=UTC),
                 end_time=None,
                 name="poly_not_started",
                 index="3",
@@ -90,8 +91,8 @@ def fail_snapshot() -> EnsembleSnapshot:
         active=True,
         fm_steps={
             "0": FMStepSnapshot(
-                start_time=dt.now(),
-                end_time=dt.now(),
+                start_time=dt.now(tz=UTC),
+                end_time=dt.now(tz=UTC),
                 name="poly_eval",
                 index="0",
                 status=FORWARD_MODEL_STATE_FINISHED,
@@ -125,8 +126,8 @@ def large_snapshot() -> EnsembleSnapshot:
             status=FORWARD_MODEL_STATE_START,
             stdout=f"job_{i}.stdout",
             stderr=f"job_{i}.stderr",
-            start_time=dt(1999, 1, 1),
-            end_time=dt(2019, 1, 1),
+            start_time=dt(1999, 1, 1, tzinfo=UTC),
+            end_time=dt(2019, 1, 1, tzinfo=UTC),
         )
     real_ids = [str(i) for i in range(150)]
     return builder.build(real_ids, REALIZATION_STATE_UNKNOWN)

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -36,7 +36,7 @@ def create_experiment_from_config(config: ErtConfig, storage):
 def test_that_missing_response_for_observation_response_key_does_not_crash(
     qtbot, storage
 ):
-    date = datetime(year=2000, month=1, day=1)
+    date = datetime(year=2000, month=1, day=1)  # noqa: DTZ001
     observation_key = "FOPR"
     requested_keys = ["*"]
     received_keys = ["WRONG"]
@@ -87,7 +87,7 @@ def test_that_missing_response_for_observation_response_key_does_not_crash(
 
 
 def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
-    date = datetime(year=2000, month=1, day=1)
+    date = datetime(year=2000, month=1, day=1)  # noqa: DTZ001
     key = "WWCT:OP1"
 
     config = ErtConfig.from_dict(
@@ -140,7 +140,7 @@ def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
 
 
 def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
-    date = datetime(year=2000, month=1, day=1).date()
+    date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
     config = ErtConfig.from_dict(
         {
             "NUM_REALIZATIONS": 1,
@@ -200,7 +200,7 @@ def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
 
 
 def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
-    date = datetime(year=2000, month=1, day=1).date()
+    date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
     config = ErtConfig.from_dict(
         {
             "NUM_REALIZATIONS": 1,
@@ -265,7 +265,7 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
                     "name": "BRT_OP1",
                     "KEY": "WWCT:OP1",
                     "ERROR": "3",
-                    "DATE": datetime(year=2000, month=1, day=1).isoformat(),
+                    "DATE": datetime(year=2000, month=1, day=1).isoformat(),  # noqa: DTZ001
                     "THRESHOLD": 0.4,
                 },
                 {
@@ -273,7 +273,7 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
                     "name": "BRT_OP2",
                     "KEY": "WWCT:OP1",
                     "ERROR": "3",
-                    "DATE": datetime(year=2000, month=1, day=9).isoformat(),
+                    "DATE": datetime(year=2000, month=1, day=9).isoformat(),  # noqa: DTZ001
                     "THRESHOLD": 0.7,
                 },
             ],

--- a/tests/ert/unit_tests/gui/experiments/conftest.py
+++ b/tests/ert/unit_tests/gui/experiments/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import uuid4
 
 from ert.storage.local_ensemble import LocalEnsemble
@@ -32,7 +32,7 @@ class MockEnsemble(LocalEnsemble):
             iteration=iteration,
             name=ensemble_name,
             prior_ensemble_id=None,
-            started_at=datetime.now(),
+            started_at=datetime.now(tz=UTC),
         )
         self._storage_state = storage_states
         self._storage = storage

--- a/tests/ert/unit_tests/gui/experiments/view/test_realization.py
+++ b/tests/ert/unit_tests/gui/experiments/view/test_realization.py
@@ -1,3 +1,4 @@
+from datetime import UTC
 from datetime import datetime as dt
 
 import pytest
@@ -31,8 +32,8 @@ def small_snapshot() -> EnsembleSnapshot:
             status=FORWARD_MODEL_STATE_START,
             stdout=f"job_{i}.stdout",
             stderr=f"job_{i}.stderr",
-            start_time=dt(1999, 1, 1),
-            end_time=dt(2019, 1, 1),
+            start_time=dt(1999, 1, 1, tzinfo=UTC),
+            end_time=dt(2019, 1, 1, tzinfo=UTC),
         )
     real_ids = [str(i) for i in range(5)]
     return builder.build(real_ids, REALIZATION_STATE_UNKNOWN)

--- a/tests/ert/unit_tests/gui/model/test_snapshot.py
+++ b/tests/ert/unit_tests/gui/model/test_snapshot.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import UTC
 from datetime import datetime as dt
 
 import pytest
@@ -29,8 +30,8 @@ def small_snapshot() -> EnsembleSnapshot:
         exec_hosts="COMP-01",
         fm_steps={
             "0": FMStepSnapshot(
-                start_time=dt.now(),
-                end_time=dt.now(),
+                start_time=dt.now(tz=UTC),
+                end_time=dt.now(tz=UTC),
                 name="poly_eval",
                 index="0",
                 status=FORWARD_MODEL_STATE_START,
@@ -41,8 +42,8 @@ def small_snapshot() -> EnsembleSnapshot:
                 max_memory_usage=312,
             ),
             "1": FMStepSnapshot(
-                start_time=dt.now(),
-                end_time=dt.now(),
+                start_time=dt.now(tz=UTC),
+                end_time=dt.now(tz=UTC),
                 name="poly_postval",
                 index="1",
                 status=FORWARD_MODEL_STATE_START,

--- a/tests/ert/unit_tests/gui/model/test_step_list.py
+++ b/tests/ert/unit_tests/gui/model/test_step_list.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -58,8 +58,8 @@ def test_changes(full_snapshot):
     assert model.index(0, _id_to_col(ids.STATUS)).data() == FORWARD_MODEL_STATE_START
 
     snapshot = full_snapshot
-    start_time = datetime(year=2020, month=10, day=27, hour=12)
-    end_time = datetime(year=2020, month=10, day=28, hour=13)
+    start_time = datetime(year=2020, month=10, day=27, hour=12, tzinfo=UTC)
+    end_time = datetime(year=2020, month=10, day=28, hour=13, tzinfo=UTC)
     snapshot.update_fm_step(
         "0",
         "0",

--- a/tests/ert/unit_tests/gui/plottery/test_misfits_plot.py
+++ b/tests/ert/unit_tests/gui/plottery/test_misfits_plot.py
@@ -104,7 +104,7 @@ def test_that_misfit_conversion_for_summary_converts_to_equivalent_long_polars_d
     expected_df = pl.DataFrame(
         {
             "Realization": [0, 0],
-            "key_index": [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+            "key_index": [datetime(2023, 1, 1), datetime(2023, 1, 2)],  # noqa: DTZ001
             "response": [12.0, 18.0],
             "error": [2.0, 2.0],
             "observation": [10.0, 20.0],

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -218,7 +218,7 @@ def api_and_storage(monkeypatch, tmp_path):
 def test_plot_api_handles_urlescape(api_and_storage):
     api, storage = api_and_storage
     key = "WBHP:46/3-7S"
-    date = datetime(year=2024, month=10, day=4)
+    date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
 
     experiment = storage.create_experiment(
         experiment_config={
@@ -472,7 +472,7 @@ def test_that_response_key_has_observation_when_only_one_experiment_has_observat
 ):
     api, storage = api_and_storage
 
-    date = datetime(year=2024, month=10, day=4)
+    date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
     experiment_with_observation = storage.create_experiment(
         experiment_config={
             "parameter_configuration": [],
@@ -562,7 +562,7 @@ def test_that_response_keys_do_not_match_keys_that_are_substrings(
 ):
     api, storage = api_and_storage
     key = f"WBHP:{well_name}"
-    date = datetime(year=2024, month=10, day=4)
+    date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
 
     experiment = storage.create_experiment(
         experiment_config={

--- a/tests/ert/unit_tests/run_models/test_status_events_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_status_events_serialization.py
@@ -1,5 +1,6 @@
 import uuid
 from collections import defaultdict
+from datetime import UTC
 from datetime import datetime as dt
 
 import pytest
@@ -47,7 +48,7 @@ METADATA = EnsembleSnapshotMetadata(
                         max_memory_usage="1000",
                         stdout="job_fm_step_0.stdout",
                         stderr="job_fm_step_0.stderr",
-                        start_time=dt(1999, 1, 1),
+                        start_time=dt(1999, 1, 1, tzinfo=UTC),
                     )
                     .add_fm_step(
                         fm_step_id="1",
@@ -58,13 +59,13 @@ METADATA = EnsembleSnapshotMetadata(
                         max_memory_usage="1000",
                         stdout="job_fm_step_1.stdout",
                         stderr="job_fm_step_1.stderr",
-                        start_time=dt(1999, 1, 1),
+                        start_time=dt(1999, 1, 1, tzinfo=UTC),
                         end_time=None,
                     )
                     .build(
                         real_ids=["0", "1"],
                         status=state.REALIZATION_STATE_UNKNOWN,
-                        start_time=dt(1999, 1, 1),
+                        start_time=dt(1999, 1, 1, tzinfo=UTC),
                         exec_hosts="12121.121",
                         message="Some message",
                     )
@@ -86,7 +87,7 @@ METADATA = EnsembleSnapshotMetadata(
                     index="0",
                     status=state.FORWARD_MODEL_STATE_FINISHED,
                     name="fm_step_0",
-                    end_time=dt(2019, 1, 1),
+                    end_time=dt(2019, 1, 1, tzinfo=UTC),
                 )
                 .build(
                     real_ids=["1"],
@@ -113,7 +114,7 @@ METADATA = EnsembleSnapshotMetadata(
                 .build(
                     real_ids=["0"],
                     status=state.REALIZATION_STATE_FAILED,
-                    end_time=dt(2019, 1, 1),
+                    end_time=dt(2019, 1, 1, tzinfo=UTC),
                 ),
                 iteration_label="Foo",
                 total_iterations=1,

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -110,7 +110,12 @@ def test_that_reading_matching_time_is_ok(ert_config, storage, prior_ensemble):
 
     create_responses(
         prior_ensemble,
-        ert_config.runpath_config.num_realizations * [[datetime(2014, 9, 9, 1, 11)]],
+        ert_config.runpath_config.num_realizations
+        * [
+            [
+                datetime(2014, 9, 9, 1, 11)  # noqa: DTZ001
+            ]
+        ],
     )
 
     target_ensemble = storage.create_ensemble(
@@ -139,9 +144,9 @@ def test_that_mismatched_responses_give_error(ert_config, storage, prior_ensembl
     )
 
     response_times = [
-        [datetime(2014, 9, 9)],
-        [datetime(2014, 9, 9)],
-        [datetime(2017, 9, 9)],
+        [datetime(2014, 9, 9)],  # noqa: DTZ001
+        [datetime(2014, 9, 9)],  # noqa: DTZ001
+        [datetime(2017, 9, 9)],  # noqa: DTZ001
     ]
     create_responses(prior_ensemble, response_times)
 
@@ -175,11 +180,11 @@ def test_that_different_length_is_ok_as_long_as_observation_time_exists(
         prior_ensemble.ensemble_size,
     )
     response_times = [
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11), datetime(2017, 9, 9)],
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11), datetime(1988, 9, 9)],
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11), datetime(2017, 9, 9)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11), datetime(1988, 9, 9)],  # noqa: DTZ001
     ]
     create_responses(prior_ensemble, response_times)
 
@@ -227,11 +232,11 @@ def test_that_duplicate_summary_time_steps_does_not_fail(
         prior_ensemble.ensemble_size,
     )
     response_times = [
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11), datetime(2014, 9, 9)],
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11), datetime(1988, 9, 9)],
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11), datetime(2014, 9, 9)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11), datetime(1988, 9, 9)],  # noqa: DTZ001
     ]
     create_responses(prior_ensemble, response_times)
 
@@ -262,9 +267,9 @@ def test_that_mismatched_responses_gives_nan_measured_data(prior_ensemble):
     )
 
     response_times = [
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2014, 9, 9, 1, 11)],
-        [datetime(2017, 9, 9)],
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2014, 9, 9, 1, 11)],  # noqa: DTZ001
+        [datetime(2017, 9, 9)],  # noqa: DTZ001
     ]
     create_responses(prior_ensemble, response_times)
 
@@ -297,7 +302,7 @@ def test_reading_past_2263_is_ok(ert_config, prior_ensemble):
 
     create_responses(
         prior_ensemble,
-        ert_config.runpath_config.num_realizations * [[datetime(2500, 9, 9)]],
+        ert_config.runpath_config.num_realizations * [[datetime(2500, 9, 9)]],  # noqa: DTZ001
     )
 
     responses = prior_ensemble.load_responses("summary", (0, 1, 2))
@@ -309,16 +314,16 @@ def test_reading_past_2263_is_ok(ert_config, prior_ensemble):
         {
             "realization": 0,
             "response_key": "FOPR",
-            "time": datetime(2500, 9, 10, 0, 0),
+            "time": datetime(2500, 9, 10, 0, 0),  # noqa: DTZ001
         },
         {
             "realization": 1,
             "response_key": "FOPR",
-            "time": datetime(2500, 9, 10, 0, 0),
+            "time": datetime(2500, 9, 10, 0, 0),  # noqa: DTZ001
         },
         {
             "realization": 2,
             "response_key": "FOPR",
-            "time": datetime(2500, 9, 10, 0, 0),
+            "time": datetime(2500, 9, 10, 0, 0),  # noqa: DTZ001
         },
     ]

--- a/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
+++ b/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
@@ -596,7 +596,7 @@ def test_that_excel_datetime_columns_are_converted_to_strings_with_warning(tmp_p
         ws.write(1, 2, 1.5)
 
         ws.write(2, 0, 1)
-        ws.write_datetime(2, 1, datetime(2026, 3, 2, 10, 30), date_format)
+        ws.write_datetime(2, 1, datetime(2026, 3, 2, 10, 30), date_format)  # noqa: DTZ001
         ws.write(2, 2, 2.5)
 
     with pytest.warns(

--- a/tests/ert/unit_tests/storage/migration/test_to17.py
+++ b/tests/ert/unit_tests/storage/migration/test_to17.py
@@ -1,4 +1,4 @@
-# test_migrate.py
+# ruff: noqa: DTZ005  # Timezones were not present in old storages
 import json
 from datetime import datetime
 from pathlib import Path
@@ -13,6 +13,7 @@ def test_add_experiment_status_to_index_json():
     input_json = {
         "type": 8,
         "message": "An error occurred.",
+        # timezone is not included as it was not present until Ert version 21.1
         "time": datetime.now().isoformat(),
     }
 

--- a/tests/ert/unit_tests/storage/migration/test_to25.py
+++ b/tests/ert/unit_tests/storage/migration/test_to25.py
@@ -74,7 +74,7 @@ def test_that_migration_creates_experiment_index_with_params_responses_and_obs_c
             {
                 "response_key": "FOPR",
                 "observation_key": "FOPR",
-                "time": datetime(2020, 1, 1),
+                "time": datetime(2020, 1, 1),  # noqa: DTZ001
                 "observations": 3.21,
                 "std": 0.05,
             }

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -526,7 +526,7 @@ def test_that_get_rft_observations_and_responses_maps_report_step_from_summary_t
         {
             "response_key": ["FOPR"] * 3,
             "time": pl.Series(
-                [datetime(2020, 1, 1), datetime(2020, 1, 15), datetime(2020, 2, 15)]
+                [datetime(2020, 1, 1), datetime(2020, 1, 15), datetime(2020, 2, 15)]  # noqa: DTZ001
             ).dt.cast_time_unit("ms"),
             "values": pl.Series([100.0, 200.0, 300.0], dtype=pl.Float32),
         }

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -160,7 +160,7 @@ def test_that_saving_response_updates_configs(tmp_path):
             {
                 "response_key": ["FOPR", "FOPT:OP1", "FOPR:OP3", "FLAP", "F*"],
                 "time": pl.Series(
-                    [datetime(2000, 1, i) for i in range(1, 6)]
+                    [datetime(2000, 1, i) for i in range(1, 6)]  # noqa: DTZ001
                 ).dt.cast_time_unit("ms"),
                 "values": pl.Series([0.0, 1.0, 2.0, 3.0, 4.0], dtype=pl.Float32),
             }
@@ -414,7 +414,7 @@ def test_that_reader_storage_reads_most_recent_response_configs(tmp_path):
         {
             "response_key": ["FOPR", "FOPR", "WOPR", "WOPR", "FOPT", "FOPT"],
             "time": pl.Series(
-                [datetime.now() + timedelta(days=i) for i in range(6)]
+                [datetime.now() + timedelta(days=i) for i in range(6)]  # noqa: DTZ005
             ).dt.cast_time_unit("ms"),
             "values": pl.Series([0.2, 0.2, 1.0, 1.1, 3.3, 3.3], dtype=pl.Float32),
         }
@@ -679,7 +679,7 @@ def test_asof_joining_summary(tmp_path, perturb_observations, perturb_responses)
     with open_storage(tmp_path, mode="w") as storage:
         response_keys = ["FOPR", "FOPT_OP1", "FOPR:OP3", "FLAP", "F*"]
         obs_keys = [f"o_{k}" for k in response_keys]
-        times = [datetime(2000, 1, 1, 1, 0)] * len(response_keys)
+        times = [datetime(2000, 1, 1, 1, 0)] * len(response_keys)  # noqa: DTZ001
         summary_observations = [
             {
                 "type": "summary_observation",
@@ -1056,7 +1056,7 @@ def test_save_response_will_create_realization_directory(storage):
         pl.DataFrame(
             {
                 "response_key": ["DUMMY"],
-                "time": pl.Series([datetime(2000, 1, 1)]).dt.cast_time_unit("ms"),
+                "time": pl.Series([datetime(2000, 1, 1)]).dt.cast_time_unit("ms"),  # noqa: DTZ001
                 "values": pl.Series([0.0], dtype=pl.Float32),
             }
         ),
@@ -1082,7 +1082,7 @@ def test_save_response_will_not_recreate_ensemble_directory(storage):
             pl.DataFrame(
                 {
                     "response_key": ["DUMMY"],
-                    "time": pl.Series([datetime(2000, 1, 1)]).dt.cast_time_unit("ms"),
+                    "time": pl.Series([datetime(2000, 1, 1)]).dt.cast_time_unit("ms"),  # noqa: DTZ001
                     "values": pl.Series([0.0], dtype=pl.Float32),
                 }
             ),
@@ -1164,7 +1164,7 @@ def test_that_breakthrough_observations_and_responses_are_joined_in_endpoint(tmp
     with open_storage(tmp_path, mode="w") as storage:
         response_key = "WWCT:OP1"
         # This observed time will be 1 day and 12 hours after derived breakthrough time
-        time = datetime(2000, 3, 2, 13, 0)
+        time = datetime(2000, 3, 2, 13, 0)  # noqa: DTZ001
 
         breakthrough_config = BreakthroughConfig(
             keys=[f"BREAKTHROUGH:{response_key}"],
@@ -1206,7 +1206,7 @@ def test_that_breakthrough_observations_and_responses_are_joined_in_endpoint(tmp
             {
                 "realization": [0] * 10,
                 "response_key": ["WWCT:OP1"] * 10,
-                "time": [datetime(2000, month, 1, 1, 0) for month in range(1, 11)],
+                "time": [datetime(2000, month, 1, 1, 0) for month in range(1, 11)],  # noqa: DTZ001
                 "values": [n / 10 for n in range(10)],
             }
         )
@@ -1677,8 +1677,8 @@ class StatefulStorageTest(RuleBasedStateMachine):
         summaries_strategy = summaries(
             summary_keys=expected_summary_keys,
             start_date=st.datetimes(
-                min_value=datetime.strptime("1969-1-1", "%Y-%m-%d"),
-                max_value=datetime.strptime("2010-1-1", "%Y-%m-%d"),
+                min_value=datetime.strptime("1969-1-1", "%Y-%m-%d"),  # noqa: DTZ007
+                max_value=datetime.strptime("2010-1-1", "%Y-%m-%d"),  # noqa: DTZ007
             ),
             time_deltas=st.lists(
                 st.floats(

--- a/tests/ert/unit_tests/storage/test_storage_migration.py
+++ b/tests/ert/unit_tests/storage/test_storage_migration.py
@@ -525,7 +525,9 @@ def test_that_storages_with_failed_realizations_are_migrated_without_errors(
                 {
                     "type": 1,
                     "message": "this is undefined",
-                    "time": datetime.datetime(2000, 1, 5).isoformat(),
+                    "time": datetime.datetime(
+                        2000, 1, 5, tzinfo=datetime.UTC
+                    ).isoformat(),
                 },
                 RealizationStorageState.UNDEFINED,
             ),
@@ -534,7 +536,9 @@ def test_that_storages_with_failed_realizations_are_migrated_without_errors(
                 {
                     "type": 8,
                     "message": "this is failure",
-                    "time": datetime.datetime(2000, 1, 5).isoformat(),
+                    "time": datetime.datetime(
+                        2000, 1, 5, tzinfo=datetime.UTC
+                    ).isoformat(),
                 },
                 RealizationStorageState.FAILURE_IN_CURRENT,
             ),
@@ -543,7 +547,9 @@ def test_that_storages_with_failed_realizations_are_migrated_without_errors(
                 {
                     "type": 16,
                     "message": "this is parent failure",
-                    "time": datetime.datetime(2000, 1, 5).isoformat(),
+                    "time": datetime.datetime(
+                        2000, 1, 5, tzinfo=datetime.UTC
+                    ).isoformat(),
                 },
                 RealizationStorageState.FAILURE_IN_PARENT,
             ),

--- a/tests/ert/unit_tests/test_load_forward_model.py
+++ b/tests/ert/unit_tests/test_load_forward_model.py
@@ -126,7 +126,7 @@ async def test_load_forward_model_summary(
     summary_configuration, storage, expected, caplog, run_args
 ):
     # Create refcase
-    ecl_sum = run_simulator(1, datetime(2014, 9, 10))
+    ecl_sum = run_simulator(1, datetime(2014, 9, 10))  # noqa: DTZ001
     ecl_sum.fwrite()
 
     ert_config = ErtConfig.from_file_contents(

--- a/tests/ert/unit_tests/test_run_path_creation.py
+++ b/tests/ert/unit_tests/test_run_path_creation.py
@@ -337,13 +337,13 @@ async def test_that_substitutions_created_with_the_define_keyword_is_substituted
     ],
 )
 async def test_that_pre_defines_are_substituted_templates(
-    key, expected, make_run_path, monkeypatch
+    key, expected: str, make_run_path, monkeypatch
 ):
-    fixed_date = datetime.fromisoformat(EXPECTED_DATE).date()
+    fixed_datetime = datetime.fromisoformat(EXPECTED_DATE)
     monkeypatch.setattr(
         lark_parser.datetime,
-        "date",
-        MagicMock(today=MagicMock(return_value=fixed_date)),
+        "datetime",
+        MagicMock(now=MagicMock(return_value=fixed_datetime)),
     )
 
     Path("template.tmpl").write_text(f"I WANT TO REPLACE:{key}", encoding="utf-8")
@@ -421,11 +421,11 @@ async def test_that_the_data_file_keyword_also_has_similar_behavior_to_run_templ
     to ECLBASE
     """
 
-    fixed_date = datetime.fromisoformat(EXPECTED_DATE).date()
+    fixed_datetime = datetime.fromisoformat(EXPECTED_DATE)
     monkeypatch.setattr(
         lark_parser.datetime,
-        "date",
-        MagicMock(today=MagicMock(return_value=fixed_date)),
+        "datetime",
+        MagicMock(now=MagicMock(return_value=fixed_datetime)),
     )
 
     Path("MY_DATA_FILE.DATA").write_text(f"I WANT TO REPLACE:{key}", encoding="utf-8")

--- a/tests/everest/test_api_snapshots.py
+++ b/tests/everest/test_api_snapshots.py
@@ -131,7 +131,7 @@ def test_api_summary_snapshot(config_file, snapshot, cached_example):
             {
                 "response_key": ["FOPR", "FOPR", "WOPR", "WOPR", "FOPT", "FOPT"],
                 "time": pl.Series(
-                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3
+                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3  # noqa: DTZ001
                 ).dt.cast_time_unit("ms"),
                 "values": pl.Series([0.2, 0.2, 1.0, 1.1, 3.3, 3.3], dtype=pl.Float32),
             }
@@ -174,7 +174,7 @@ def test_api_summary_snapshot_missing_batch(snapshot, cached_example):
             {
                 "response_key": ["FOPR", "FOPR", "WOPR", "WOPR", "FOPT", "FOPT"],
                 "time": pl.Series(
-                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3
+                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3  # noqa: DTZ001
                 ).dt.cast_time_unit("ms"),
                 "values": pl.Series([0.2, 0.2, 1.0, 1.1, 3.3, 3.3], dtype=pl.Float32),
             }
@@ -223,7 +223,7 @@ def test_api_summary_snapshot_with_differing_columns_per_batch(
             {
                 "response_key": ["FOPR", "FOPR", "WOPR", "WOPR", "FOPT", "FOPT"],
                 "time": pl.Series(
-                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3
+                    [datetime(2000, 1, 1), datetime(2000, 1, 2)] * 3  # noqa: DTZ001
                 ).dt.cast_time_unit("ms"),
                 "values": pl.Series([0.2, 0.2, 1.0, 1.1, 3.3, 3.3], dtype=pl.Float32),
             }

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -1,7 +1,7 @@
 import json
 import string
 from collections import defaultdict
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import partial
 from unittest.mock import MagicMock, patch
 
@@ -41,7 +41,7 @@ def full_snapshot_event():
         max_memory_usage="1000",
         stdout="job_fm_step_0.stdout",
         stderr="job_fm_step_0.stderr",
-        start_time=datetime(1999, 1, 1),
+        start_time=datetime(1999, 1, 1, tzinfo=UTC),
     )
     for i, command in enumerate(all_shell_script_fm_steps):
         snapshot.add_fm_step(
@@ -53,13 +53,13 @@ def full_snapshot_event():
             max_memory_usage="1000",
             stdout=None,
             stderr=None,
-            start_time=datetime(1999, 1, 1),
+            start_time=datetime(1999, 1, 1, tzinfo=UTC),
         )
     event = FullSnapshotEvent(
         snapshot=snapshot.build(
             real_ids=["0", "1"],
             status=state.REALIZATION_STATE_PENDING,
-            start_time=datetime(1999, 1, 1),
+            start_time=datetime(1999, 1, 1, tzinfo=UTC),
             exec_hosts="12121.121",
             message="",
         ),
@@ -86,7 +86,7 @@ def snapshot_update_event():
             name=None,
             index="0",
             status=state.FORWARD_MODEL_STATE_FINISHED,
-            end_time=datetime(2019, 1, 1),
+            end_time=datetime(2019, 1, 1, tzinfo=UTC),
         )
         .build(
             real_ids=["1"],
@@ -111,7 +111,7 @@ def snapshot_update_failure_event():
             name=None,
             index="0",
             status=state.FORWARD_MODEL_STATE_FAILURE,
-            end_time=datetime(2019, 1, 1),
+            end_time=datetime(2019, 1, 1, tzinfo=UTC),
             error="The run is cancelled due to reaching MAX_RUNTIME",
         )
         .build(
@@ -137,7 +137,7 @@ def snapshot_update_event_with_fm_message():
             name=None,
             index="0",
             status=state.FORWARD_MODEL_STATE_FINISHED,
-            end_time=datetime(2019, 1, 1),
+            end_time=datetime(2019, 1, 1, tzinfo=UTC),
         )
         .build(
             real_ids=["1"],


### PR DESCRIPTION
**Issue**
Resolves #13260 


**Approach**
    Add UTC timestamps to all datetime objects
    
    Except those that relates to data inside a reservoir simulation
    (summary, observations, etc), which should be kept as timezone-unaware
    objects.
    
    This solves a bug in the GUI run-dialog which would show wrong elapsed
    times when the compute nodes are in a different timezone than the
    computer on which Ert is running.
    
    Instead of a regression test for this bug, the ruff rule DTZ is enforced
    from now on.



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
