### PR TITLE
Solve ruff float-equality-comparison (RUF069) in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,6 @@ ignore = [
     "PLR0904", # too-many-public-methods
     "PLR1702", # too-many-nested-blocks
     "RUF067",  # code in __init__ files
-    "RUF069",  # unreliable floating point comparison
 ]
 
 # Allow EN DASH (U+2013)

--- a/tests/ert/ui_tests/cli/test_field_parameter.py
+++ b/tests/ert/ui_tests/cli/test_field_parameter.py
@@ -102,7 +102,7 @@ def _compare_ensemble_params(
         [
             pl.concat_list(columns)
             .map_elements(
-                lambda row: sum(1 for x in row if x != 0.0) / len(row),
+                lambda row: sum(1 for x in row if not math.isclose(x, 0.0)) / len(row),
             )
             .cast(pl.Float32)
             .alias("outlier_percentage")

--- a/tests/ert/unit_tests/config/test_field.py
+++ b/tests/ert/unit_tests/config/test_field.py
@@ -1,3 +1,4 @@
+import math
 import os
 from pathlib import Path
 
@@ -472,7 +473,7 @@ def test_that_calculate_ertbox_parameters_detects_axis_orientation_from_egrid(
     assert params.nx == nx
     assert params.ny == ny
     assert params.nz == nz
-    assert params.rotation_angle == 0.0
+    assert math.isclose(params.rotation_angle, 0.0)
     if flip == 1:
         assert params.origin == (0, 0)
     if flip == -1:

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -1,3 +1,4 @@
+import math
 import os
 from contextlib import suppress
 from datetime import datetime
@@ -160,14 +161,14 @@ def test_that_make_observations_migrates_observations():
     # Check specific properties
     wopr = next(o for o in observations if getattr(o, "name", None) == "WOPR_OP1_9")
     assert isinstance(wopr, SummaryObservation)
-    assert wopr.value == 0.1
+    assert math.isclose(wopr.value, 0.1)
     assert wopr.key == "WOPR:OP1"
     # Migration converts RESTART 0 -> start date
     assert wopr.date == "2010-03-31T00:00:00"
 
     wopr = next(o for o in observations if getattr(o, "name", None) == "WOPR_OP2_7")
     assert isinstance(wopr, SummaryObservation)
-    assert wopr.value == 0.2
+    assert math.isclose(wopr.value, 0.2)
     assert wopr.key == "WOPR:OP2"
     # Migration converts RESTART 1 -> second date
     assert wopr.date == "2015-06-13T00:00:00"
@@ -567,7 +568,7 @@ def test_that_breakthrough_observation_can_be_instantiated_from_config():
     assert brt_obs.key == "WWCT:OP_1"
     assert brt_obs.date == datetime.fromisoformat("2012-10-01")
     assert brt_obs.error == 3
-    assert brt_obs.threshold == 0.1
+    assert math.isclose(brt_obs.threshold, 0.1)
     assert brt_obs.east is None
     assert brt_obs.north is None
     assert brt_obs.radius is None

--- a/tests/ert/unit_tests/field_utils/test_field_utils_for_distance_based_localization.py
+++ b/tests/ert/unit_tests/field_utils/test_field_utils_for_distance_based_localization.py
@@ -189,7 +189,7 @@ def test_that_calc_rho_for_2d_grid_layer_ignores_obs_outside_the_grid():
     assert np.any(rho_inside > 0), "Observation inside the grid should have nonzero rho"
 
     rho_outside = rho[:, :, 1]
-    assert np.all(rho_outside == 0.0), (
+    assert np.allclose(rho_outside, 0.0), (
         "Observation outside the grid should have all zero rho values"
     )
 

--- a/tests/ert/unit_tests/field_utils/test_grdecl_io.py
+++ b/tests/ert/unit_tests/field_utils/test_grdecl_io.py
@@ -1,3 +1,4 @@
+import math
 from string import ascii_letters
 
 import hypothesis.strategies as st
@@ -53,8 +54,8 @@ def test_that_importing_missing_keyword_in_bgrdecl_fails(tmp_path):
 
 def test_that_import_picks_just_the_field_with_given_name(tmp_path):
     (tmp_path / "test.grdecl").write_text("KEYWORD1\n 1.0 /\nKEYWORD2\n 2.0 /")
-    assert (
-        import_grdecl(tmp_path / "test.grdecl", "KEYWORD2", (1, 1, 1))[0, 0, 0] == 2.0
+    assert math.isclose(
+        import_grdecl(tmp_path / "test.grdecl", "KEYWORD2", (1, 1, 1))[0, 0, 0], 2.0
     )
 
 

--- a/tests/ert/unit_tests/field_utils/test_roff_io.py
+++ b/tests/ert/unit_tests/field_utils/test_roff_io.py
@@ -1,3 +1,4 @@
+import math
 import re
 from dataclasses import dataclass
 from io import BytesIO, StringIO
@@ -333,7 +334,7 @@ def test_that_once_parameter_and_dimensions_are_read_rest_of_file_is_not_conside
     """
     )
 
-    assert import_roff(StringIO(content), "parameter")[0] == 1.0
+    assert math.isclose(import_roff(StringIO(content), "parameter")[0], 1.0)
 
 
 def test_that_values_are_correctly_shaped():

--- a/tests/ert/unit_tests/gui/plottery/test_plot_style.py
+++ b/tests/ert/unit_tests/gui/plottery/test_plot_style.py
@@ -47,10 +47,10 @@ def test_plot_style_test_defaults():
     assert style.name == "Test"
     assert style.color == "#000000"
     assert style.line_style == "-"
-    assert style.alpha == 1.0
+    assert math.isclose(style.alpha, 1.0)
     assert style.marker == ""  # noqa: PLC1901
-    assert style.width == 1.0
-    assert style.size == 7.5
+    assert math.isclose(style.width, 1.0)
+    assert math.isclose(style.size, 7.5)
     assert style.isEnabled()
 
     style.line_style = None
@@ -76,16 +76,16 @@ def test_plot_style_builtin_checks():
     assert style.marker == ""  # noqa: PLC1901
 
     style.width = -1
-    assert style.width == 0.0
+    assert math.isclose(style.width, 0.0)
 
     style.size = -1
-    assert style.size == 0.0
+    assert math.isclose(style.size, 0.0)
 
     style.alpha = 1.1
-    assert style.alpha == 1.0
+    assert math.isclose(style.alpha, 1.0)
 
     style.alpha = -0.1
-    assert style.alpha == 0.0
+    assert math.isclose(style.alpha, 0.0)
 
     style.setEnabled(False)
     assert not style.isEnabled()

--- a/tests/ert/unit_tests/run_models/test_multiple_data_assimilation.py
+++ b/tests/ert/unit_tests/run_models/test_multiple_data_assimilation.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 
@@ -16,7 +18,7 @@ from ert.run_models import MultipleDataAssimilation as mda
 def test_weights(weights, expected):
     weights = mda.parse_weights(weights)
     assert weights == expected
-    assert np.reciprocal(weights).sum() == 1.0
+    assert math.isclose(np.reciprocal(weights).sum(), 1.0)
 
 
 def test_invalid_weights():

--- a/tests/everest/test_ropt_initialization.py
+++ b/tests/everest/test_ropt_initialization.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 from orjson import orjson
 from pydantic import ValidationError
@@ -78,7 +80,7 @@ def test_tutorial_everest2ropt(ever_config):
     )
     realizations = ropt_config["realizations"]
     assert len(realizations["weights"]) == 2
-    assert realizations["weights"][0] == 0.2
+    assert math.isclose(realizations["weights"][0], 0.2)
 
 
 def test_everest2ropt_controls(ever_config):
@@ -315,7 +317,9 @@ def test_everest2ropt_cvar(ever_config):
     assert len(ropt_config["realization_filters"]) == 1
     assert ropt_config["realization_filters"][0]["method"] == "cvar-objective"
     assert ropt_config["realization_filters"][0]["options"]["sort"] == [0]
-    assert ropt_config["realization_filters"][0]["options"]["percentile"] == 0.3
+    assert math.isclose(
+        ropt_config["realization_filters"][0]["options"]["percentile"], 0.3
+    )
 
 
 def test_everest2ropt_arbitrary_backend_options(ever_config):


### PR DESCRIPTION
**Issue**
Resolves #12940 


**Approach**
Solve ruff float-equality-comparison (RUF069) in tests

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
