### PR TITLE
Fix test warnings

### DIFF
--- a/tests/everest/test_is_improvement.py
+++ b/tests/everest/test_is_improvement.py
@@ -35,6 +35,6 @@ def test_that_is_improvement_flag_handles_multiple_constraints(
     evaluator_server_config = EvaluatorServerConfig()
     run_model.run_experiment(evaluator_server_config)
 
-    # Check that the first variable remains fixed:
+    # The `is_improvement` flag should be False, no valid result:
     optimal_result = get_optimal_result(config.storage_dir)
     assert optimal_result is None

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -50,7 +50,7 @@ def test_get_values(change_to_tmpdir):
 def test_show_scaled_controls_warning_user_info_file_present(
     change_to_tmpdir, monkeypatch, user_reply, existing_value, result
 ):
-    monkeypatch.setenv("HOME", Path.cwd())
+    monkeypatch.setenv("HOME", str(Path.cwd()))
     if existing_value:
         monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
@@ -82,7 +82,7 @@ def test_show_scaled_controls_warning_user_info_file_present(
 def test_show_scaled_controls_warning_no_user_info_file_present(
     change_to_tmpdir, monkeypatch, user_reply, result
 ):
-    monkeypatch.setenv("HOME", Path.cwd())
+    monkeypatch.setenv("HOME", str(Path.cwd()))
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     assert not Path(".ert").exists()
@@ -116,7 +116,7 @@ def test_show_scaled_controls_warning_no_user_info_file_present(
 def test_show_scaled_controls_warning_error_reading_from_user_info(
     change_to_tmpdir, monkeypatch, user_reply, result
 ):
-    monkeypatch.setenv("HOME", Path.cwd())
+    monkeypatch.setenv("HOME", str(Path.cwd()))
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     Path(".ert").write_text("{ not valid json ", encoding="utf-8")
@@ -154,7 +154,7 @@ def test_show_scaled_controls_warning_error_reading_from_user_info(
 def test_show_scaled_controls_warning_error_writing_user_info(
     change_to_tmpdir, monkeypatch, user_reply
 ):
-    monkeypatch.setenv("HOME", Path.cwd())
+    monkeypatch.setenv("HOME", str(Path.cwd()))
     monkeypatch.setattr("builtins.input", lambda _: user_reply)
 
     Path(".ert").touch()
@@ -179,7 +179,7 @@ def test_show_scaled_controls_warning_error_writing_user_info(
 def test_show_scaled_controls_warning_preserves_extra_keys(
     change_to_tmpdir, monkeypatch, user_reply, existing_value, result
 ):
-    monkeypatch.setenv("HOME", Path.cwd())
+    monkeypatch.setenv("HOME", str(Path.cwd()))
     if existing_value:
         monkeypatch.setattr("builtins.input", lambda _: user_reply)
 


### PR DESCRIPTION
- Fix comment in test
- Fix the following warning: PytestWarning: Value of environment variable HOME type should be str


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
