### PR TITLE
Fix erroneous duration shown in run_dialogue due to timezones

### DIFF
--- a/src/_ert/events.py
+++ b/src/_ert/events.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
@@ -62,7 +62,7 @@ class Id:
 
 class BaseEvent(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
-    time: datetime = Field(default_factory=datetime.now)
+    time: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
 
 
 class ForwardModelStepBaseEvent(BaseEvent):

--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import io
 import logging
 import os
@@ -11,7 +12,6 @@ import time
 import uuid
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime as dt
 from os import path
 from pathlib import Path
 from subprocess import Popen, run
@@ -165,7 +165,7 @@ class ForwardModelStep:
         existing_target_file_mtime: int | None = _get_existing_target_file_mtime(
             target_file
         )
-        run_start_time = dt.now()
+        run_start_time = datetime.datetime.now(tz=datetime.UTC)
         try:
             proc = Popen(
                 arg_list,
@@ -289,11 +289,11 @@ class ForwardModelStep:
         self,
         exit_code: int | None,
         proc: Popen[Process],  # type: ignore
-        run_start_time: dt,
+        run_start_time: datetime.datetime,
     ) -> Exited | None:
         max_running_minutes = self.step_data.get("max_running_minutes")
 
-        run_time = dt.now() - run_start_time
+        run_time = datetime.datetime.now(tz=datetime.UTC) - run_start_time
         if max_running_minutes is None or run_time.seconds < max_running_minutes * 60:
             return None
 

--- a/src/_ert/forward_model_runner/reporting/message.py
+++ b/src/_ert/forward_model_runner/reporting/message.py
@@ -1,5 +1,5 @@
 import dataclasses
-from datetime import datetime as dt
+import datetime
 from typing import TYPE_CHECKING, Literal, NotRequired, Self
 
 import psutil
@@ -41,7 +41,7 @@ class ProcessTreeStatus:
     oom_score: int | None = None
 
     def __post_init__(self) -> None:
-        self.timestamp = dt.now().isoformat()
+        self.timestamp = datetime.datetime.now(tz=datetime.UTC).isoformat()
         self.free = psutil.virtual_memory().available
 
     def __repr__(self) -> str:
@@ -60,7 +60,7 @@ class _MetaMessage(type):
 
 class Message(metaclass=_MetaMessage):
     def __init__(self, step: "ForwardModelStep | None" = None) -> None:
-        self.timestamp = dt.now()
+        self.timestamp = datetime.datetime.now(tz=datetime.UTC)
         self.step = step
         self.error_message: str | None = None
 

--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import datetime
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 from queue import SimpleQueue
 from typing import TextIO
@@ -60,7 +60,7 @@ class Monitor:
     def __init__(self, out: TextIO = sys.stdout, color_always: bool = False) -> None:
         self._out = out
         self._snapshots: dict[int, EnsembleSnapshot] = {}
-        self._start_time: datetime | None = None
+        self._start_time: datetime.datetime | None = None
         self._colorize = ansi_color
         # If out is not (like) a tty, disable colors.
         if not out.isatty() and not color_always:
@@ -75,7 +75,7 @@ class Monitor:
         event_queue: SimpleQueue[StatusEvents],
         output_path: Path | None = None,
     ) -> EndEvent:
-        self._start_time = datetime.now()
+        self._start_time = datetime.datetime.now(tz=datetime.UTC)
         while True:
             match event_queue.get():
                 case FullSnapshotEvent(
@@ -144,9 +144,9 @@ class Monitor:
     def _print_progress(self, event: SnapshotUpdateEvent) -> None:
         current_iteration = min(event.total_iterations, event.iteration + 1)
         if self._start_time is not None:
-            elapsed = datetime.now() - self._start_time
+            elapsed = datetime.datetime.now(tz=datetime.UTC) - self._start_time
         else:
-            elapsed = timedelta()
+            elapsed = datetime.timedelta()
 
         nphase = f" {current_iteration}/{event.total_iterations}"
 

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -327,7 +327,7 @@ class EnsembleEvaluator:
             memory_usage = fm_step.get(ids.MAX_MEMORY_USAGE) or "-1"
             max_memory_usage = max(int(memory_usage), max_memory_usage)
 
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(tz=datetime.UTC)
             walltime_seconds += (
                 (fm_step.get(ids.END_TIME) or now)
                 - (fm_step.get(ids.START_TIME) or now)

--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -244,7 +244,7 @@ class RunDialog(QFrame):
             self,
         )
 
-        date_time: str = datetime.now(UTC).isoformat(timespec="seconds")
+        date_time: str = datetime.now(tz=UTC).isoformat(timespec="seconds")
         experiment_type = self._run_model_api.experiment_name
         experiment_id = experiment_type + " : " + date_time
 
@@ -540,7 +540,9 @@ class RunDialog(QFrame):
     def _on_ticker(self) -> None:
         if self._start_time:
             humanized_runtime = humanize.precisedelta(
-                datetime.now() - self._start_time, minimum_unit="seconds", format="%d"
+                datetime.now(tz=UTC) - self._start_time,
+                minimum_unit="seconds",
+                format="%d",
             )
             self.running_time.setText(f"Running time:\n{humanized_runtime}")
 

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import copy
+import datetime
 import functools
 import logging
 import os
@@ -17,7 +18,6 @@ from collections import defaultdict
 from collections.abc import Callable, Generator, MutableSequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
@@ -402,7 +402,7 @@ class RunModel(RunModelConfig, ABC):
         def handle_captured_event(message: Warning | str) -> None:
             self.send_event(WarningEvent(msg=str(message)))
 
-        start_timestamp = datetime.now()
+        start_timestamp = datetime.datetime.now(tz=datetime.UTC)
         try:
             self.send_event(StartEvent(timestamp=start_timestamp))
             with (
@@ -473,10 +473,10 @@ class RunModel(RunModelConfig, ABC):
                     ),
                 )
             )
-            logger.info(
-                "Experiment run finished in: "
-                f"{(datetime.now() - start_timestamp).total_seconds():g}s"
-            )
+            seconds_used = (
+                datetime.datetime.now(tz=datetime.UTC) - start_timestamp
+            ).total_seconds()
+            logger.info(f"Experiment run finished in: {seconds_used:g}s")
 
     @abstractmethod
     def run_experiment(

--- a/tests/ert/unit_tests/cli/test_cli_monitor.py
+++ b/tests/ert/unit_tests/cli/test_cli_monitor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 
 from ert.cli.monitor import Monitor
@@ -74,7 +74,7 @@ def test_print_progress():
             str(i), RealizationSnapshot(status=status, active=True)
         )
     monitor._snapshots[0] = snapshot
-    monitor._start_time = datetime.now()
+    monitor._start_time = datetime.now(tz=UTC)
     general_event = SnapshotUpdateEvent(
         iteration_label="Test Phase",
         total_iterations=2,


### PR DESCRIPTION
**Issue**
Resolves #13260 in version-21.0


**Approach**
Partial backport of #13311


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
