### PR TITLE
Security: Hardcoded default API token enables predictable authentication

### DIFF
--- a/src/ert/dark_storage/security.py
+++ b/src/ert/dark_storage/security.py
@@ -3,8 +3,10 @@ import os
 from fastapi import HTTPException, Security, status
 from fastapi.security import APIKeyHeader
 
-DEFAULT_TOKEN = "hunter2"
 _security_header = APIKeyHeader(name="Token", auto_error=False)
+
+if not os.getenv("ERT_STORAGE_NO_TOKEN") and not os.getenv("ERT_STORAGE_TOKEN"):
+    raise RuntimeError("ERT_STORAGE_TOKEN must be set")
 
 
 async def security(*, token: str | None = Security(_security_header)) -> None:
@@ -14,7 +16,7 @@ async def security(*, token: str | None = Security(_security_header)) -> None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Not authenticated"
         )
-    real_token = os.getenv("ERT_STORAGE_TOKEN", DEFAULT_TOKEN)
+    real_token = os.getenv("ERT_STORAGE_TOKEN")
     if token == real_token:
         # Success
         return


### PR DESCRIPTION
## Summary

Security: Hardcoded default API token enables predictable authentication

## Problem

**Severity**: `High` | **File**: `src/ert/dark_storage/security.py:L6`

Authentication falls back to a hardcoded token (`DEFAULT_TOKEN = "hunter2"`) when `ERT_STORAGE_TOKEN` is not set. If operators forget to configure the environment variable, attackers can authenticate using a publicly known default credential.

## Solution

Remove hardcoded fallback tokens. Require `ERT_STORAGE_TOKEN` to be explicitly set at startup and fail fast if missing. Consider loading secrets from a secret manager and rotating tokens regularly.

## Changes

- `src/ert/dark_storage/security.py` (modified)