### PR TITLE
Fix flaky test test_that_exception_in_run_model_is_displayed_in_a_sug…

### DIFF
--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -619,42 +619,32 @@ def test_that_exception_in_run_model_is_displayed_in_a_suggestor_window_after_si
         qtbot.addWidget(gui)
         run_experiment = gui.findChild(QToolButton, name="run_experiment")
 
-        handler_done = False
-
-        def assert_failure_in_error_dialog(run_dialog):
-            nonlocal handler_done
-            wait_until(lambda: run_dialog.fail_msg_box is not None, timeout=10000)
-            suggestor_termination_window = run_dialog.fail_msg_box
-            assert suggestor_termination_window
-            text = (
-                suggestor_termination_window.findChild(
-                    QWidget, name="suggestor_messages"
-                )
-                .findChild(QLabel)
-                .text()
-            )
-            assert "I failed :(" in text
-            button = suggestor_termination_window.findChild(
-                QPushButton, name="close_button"
-            )
-            assert button
-            button.click()
-            handler_done = True
-
         simulation_mode_combo = gui.findChild(QComboBox)
         simulation_mode_combo.setCurrentText("Single realization test-run")
         qtbot.mouseClick(run_experiment, Qt.MouseButton.LeftButton)
         run_dialog = wait_for_child(gui, qtbot, RunDialog)
 
-        QTimer.singleShot(100, lambda: assert_failure_in_error_dialog(run_dialog))
-        # Capturing exceptions in order to catch an assertion error
-        # from assert_failure_in_error_dialog and stop waiting
+        qtbot.waitUntil(lambda: run_dialog.fail_msg_box is not None, timeout=10000)
+        suggestor_termination_window = run_dialog.fail_msg_box
+        assert suggestor_termination_window
+
+        text = (
+            suggestor_termination_window.findChild(QWidget, name="suggestor_messages")
+            .findChild(QLabel)
+            .text()
+        )
+        assert "I failed :(" in text
+
+        button = suggestor_termination_window.findChild(
+            QPushButton, name="close_button"
+        )
+        assert button
+        qtbot.mouseClick(button, Qt.MouseButton.LeftButton)
         with qtbot.captureExceptions() as exceptions:
             qtbot.waitUntil(
                 lambda: run_dialog.is_experiment_done() is True or bool(exceptions),
                 timeout=100000,
             )
-            qtbot.waitUntil(lambda: handler_done or bool(exceptions), timeout=100000)
         if exceptions:
             raise AssertionError(
                 f"Exception(s) happened in Qt event loop: {exceptions}"


### PR DESCRIPTION
…gestor_window_after_simulation_fails

**Issue**
Resolves #13258


**Approach**
The flakiness was called by a deadlock in the Qt gui thread. The timer callback ran on the Qt GUI thread. So when it entered wait_until(...), it could block the same thread that needed to create run_dialog.fail_msg_box. It was flaky sometimes because waiting for the dialog could prevent Qt from creating that dialog.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
