### PR TITLE
Remove usage of typing.Union

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import traceback
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -128,21 +128,19 @@ class PlotWidget(QWidget):
     def __init__(
         self,
         name: str,
-        plotter: Union[
-            "EnsemblePlot",
-            "StatisticsPlot",
-            "HistogramPlot",
-            "GaussianKDEPlot",
-            "DistributionPlot",
-            "CrossEnsembleStatisticsPlot",
-            "StdDevPlot",
-            "MisfitsPlot",
-            "EverestBatchObjectiveFunctionPlot",
-            "EverestConstraintsPlot",
-            "EverestControlsPlot",
-            "EverestGradientsPlot",
-            "EverestObjectiveFunctionPlot",
-        ],
+        plotter: EnsemblePlot
+        | StatisticsPlot
+        | HistogramPlot
+        | GaussianKDEPlot
+        | DistributionPlot
+        | CrossEnsembleStatisticsPlot
+        | StdDevPlot
+        | MisfitsPlot
+        | EverestBatchObjectiveFunctionPlot
+        | EverestConstraintsPlot
+        | EverestControlsPlot
+        | EverestGradientsPlot
+        | EverestObjectiveFunctionPlot,
         parent: QWidget | None = None,
     ) -> None:
         QWidget.__init__(self, parent)

--- a/src/ert/validation/ensemble_realizations_argument.py
+++ b/src/ert/validation/ensemble_realizations_argument.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from .range_string_argument import RangeStringArgument
 from .rangestring import rangestring_to_list
@@ -16,7 +16,7 @@ class EnsembleRealizationsArgument(RangeStringArgument):
 
     def __init__(
         self,
-        ensemble: Callable[[], Union["Ensemble", None]],
+        ensemble: Callable[[], Ensemble | None],
         required_realization_storage_states: Iterable["RealizationStorageState"],
         **kwargs: bool,
     ) -> None:


### PR DESCRIPTION
This has not been needed since Python 3.10

**Issue**
Resolves gruff

**Approach**
`|`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
