### PR TITLE
Refactor parameter sampling to avoid list copy

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -708,7 +708,7 @@ class LocalEnsemble(BaseMode):
             {parameter.name: parameter_values},
             schema={parameter.name: pl.Float64},
         )
-        realizations_series = pl.Series("realization", list(active_realizations))
+        realizations_series = pl.Series("realization", active_realizations)
 
         return parameters.with_columns(realizations_series)
 


### PR DESCRIPTION
The `active_realizations` argument is already a list, so calling `list()` when creating the polars Series creates an unnecessary copy. Passing it directly simplifies the code.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
