### PR TITLE
Add and plot constraint bounds

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -279,6 +279,19 @@ def data_for_response(
                 return pd.DataFrame()
 
             columns = ["batch_id", "realization", response_key]
+
+            if response_type == "everest_constraints":
+                constraints = ensemble.experiment.output_constraints
+                if constraints is not None and response_key in constraints.keys:
+                    idx = constraints.keys.index(response_key)
+                    return (
+                        df_pl.select(columns)
+                        .with_columns(
+                            pl.lit(constraints.lower_bounds[idx]).alias("lower_bound"),
+                            pl.lit(constraints.upper_bounds[idx]).alias("upper_bound"),
+                        )
+                        .to_pandas()
+                    )
             return df_pl.select(columns).to_pandas()
         case _:
             return pd.DataFrame()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from matplotlib.patches import Patch
 from matplotlib.ticker import MaxNLocator
 
 from .plot_tools import PlotTools
@@ -25,8 +26,8 @@ class EverestConstraintsPlot:
         Glyphs: One line chart per realization, with a dot at each iteration.
 
     Input data: assumed to be a dictionary of DataFrames, where
-    each DataFrame contains columns for 'batch_id', 'realization', and
-    constraint value.
+    each DataFrame contains columns for 'batch_id', 'realization',
+    constraint value and upper/lower bounds.
     """
 
     def __init__(self) -> None:
@@ -84,6 +85,36 @@ class EverestConstraintsPlot:
             if len(realizations) <= self.LEGEND_THRESHOLD:
                 config.addLegendItem(f"Realization {int(realization)}", lines[0])
 
+        if "lower_bound" in combined.columns or "upper_bound" in combined.columns:
+            ylim = axes.get_ylim()
+            config.addLegendItem(
+                "Outside of bounds",
+                Patch(facecolor="red", alpha=0.15, edgecolor="none"),
+            )
+            for bound in ["lower_bound", "upper_bound"]:
+                if bound in combined.columns:
+                    bound_min = bound_max = combined[bound].iloc[0]
+
+                    if bound == "lower_bound":
+                        bound_min = -abs(bound_min * 1e10)
+                    else:
+                        bound_max = abs(bound_max * 1e10)
+
+                    axes.axhspan(
+                        bound_min,
+                        bound_max,
+                        alpha=0.15,
+                        color="red",
+                        zorder=0,
+                    )
+                    axes.axhline(
+                        bound_max if bound == "lower_bound" else bound_min,
+                        color="grey",
+                        linestyle="--",
+                        alpha=0.7,
+                    )
+            axes.set_ylim(ylim)
+
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
         axes.spines["right"].set_visible(False)
         axes.spines["top"].set_visible(False)
@@ -91,7 +122,7 @@ class EverestConstraintsPlot:
             plot_context,
             figure,
             axes,
-            default_x_label="Batch Iteration",
-            default_y_label="Constraint Value",
+            default_x_label="Batch iteration",
+            default_y_label="Constraint value",
         )
         figure.tight_layout()


### PR DESCRIPTION
**Issue**
Resolves #13321
Resolves #13322 

**Approach**

Loads the experiment from the ensemble which contains all the bounds. Uses `response_key` to locate the correct index for the constraint value, e.g we want to plot the constraint `x-0_coord`, uses name to find index in list of constraint keys `[x-0_coord, x-1_coord]` then uses index to find the correct bound `lower_bounds: [0.2 , 0.3]`. Adds as additional columns to the DF before returning, fills upper/lower with the same value to match dim.

Plots the bounds as transparent red area with dotted line to highlight whenever plot is within and without bounds. 
<img width="1503" height="872" alt="image" src="https://github.com/user-attachments/assets/d66bec2d-ffd2-452f-b01b-76fbcd930838" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
