### PR TITLE
Add default value for perturbation_type

### DIFF
--- a/src/ert/config/everest_control.py
+++ b/src/ert/config/everest_control.py
@@ -159,7 +159,7 @@ class EverestControl(ParameterConfig):
     enabled: bool
     min: float
     max: float
-    perturbation_type: Literal["absolute", "relative"]
+    perturbation_type: Literal["absolute", "relative"] = "absolute"
     perturbation_magnitude: float
     scaled_range: tuple[float, float]
     sampler: SamplerConfig | None


### PR DESCRIPTION
This makes it possible to load storages from the future when `perturbation_type` has been removed.

In `control_config`.py, `perturbation_type` is already defined with `absolute` as the default

**Issue**
Relates to #13319 


**Approach**
➕ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
