### PR TITLE
Fix timedelta.seconds bug in forward model timeout check

### DIFF
--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -296,7 +296,10 @@ class ForwardModelStep:
         max_running_minutes = self.step_data.get("max_running_minutes")
 
         run_time = datetime.datetime.now(tz=datetime.UTC) - run_start_time
-        if max_running_minutes is None or run_time.seconds < max_running_minutes * 60:
+        if (
+            max_running_minutes is None
+            or run_time.total_seconds() < max_running_minutes * 60
+        ):
             return None
 
         # If the spawned process is not in the same process group as

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import os
 import stat
 import sys
@@ -373,3 +374,39 @@ def test_target_file_only_sets_error_if_specified_and_fm_step_succeeded(
         assert expected_error_message in statuses[1].error_message
     else:
         assert statuses[1].error_message is None
+
+
+def test_that_max_running_minutes_timeout_triggers_for_jobs_running_over_24_hours():
+    fmstep = ForwardModelStep({"name": "timeout_step", "max_running_minutes": 1440}, 0)
+    mock_proc = MagicMock()
+    mock_proc.pid = os.getpid()
+
+    # Simulate a job that has been running for 25 hours (exceeds 1440-min limit)
+    run_start_time = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+        hours=25
+    )
+    result = fmstep.handle_process_timeout_and_create_exited_msg(
+        0, mock_proc, run_start_time
+    )
+
+    assert result is not None, (
+        "Timeout should have triggered for a job running 25h with a 1440-minute limit"
+    )
+    assert "explicitly killed" in result.error_message
+
+
+def test_that_max_running_minutes_timeout_does_not_trigger_before_limit():
+    fmstep = ForwardModelStep({"name": "timeout_step", "max_running_minutes": 1440}, 0)
+    mock_proc = MagicMock()
+
+    # Simulate a job that has been running for 23 hours (within the 24-hour limit)
+    run_start_time = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+        hours=23
+    )
+    result = fmstep.handle_process_timeout_and_create_exited_msg(
+        0, mock_proc, run_start_time
+    )
+
+    assert result is None, (
+        "Timeout should not trigger for a job running 23h with a 1440-minute limit"
+    )


### PR DESCRIPTION
timedelta.seconds only returns the sub-day seconds component (0-86399), so jobs running longer than 24 hours would never be killed even when max_running_minutes was exceeded.

Replace with total_seconds() which returns the full elapsed duration.

**Issue**
Resolves #13358 

**Approach**
🤖 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
