### PR TITLE
Have test_main_logging not use site config logger

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,12 @@ def env_save():
 
 
 @pytest.fixture
+def use_site_configurations_with_no_site_logging():
+    with patch("ert.__main__.setup_site_logging", lambda *args, **kwargs: None):
+        yield
+
+
+@pytest.fixture
 def use_site_configurations_with_no_queue_options():
     def ErtRuntimePluginsWithNoQueueOptions(**kwargs):
         return ErtRuntimePlugins(**(kwargs | {"queue_options": None}))

--- a/tests/ert/unit_tests/shared/test_main_entry.py
+++ b/tests/ert/unit_tests/shared/test_main_entry.py
@@ -12,7 +12,9 @@ import ert.__main__ as main
 
 
 @pytest.mark.usefixtures("use_tmpdir")
-def test_main_logging(monkeypatch, caplog):
+def test_main_logging(
+    monkeypatch, caplog, use_site_configurations_with_no_site_logging
+):
     parser_mock = MagicMock()
     parser_mock.func.side_effect = ValueError("This is a test")
     monkeypatch.setattr(logging.config, "dictConfig", MagicMock())


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
