### PR TITLE
Fix timedelta.seconds bug in CLI monitor running time display

### DIFF
--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -155,7 +155,9 @@ class Monitor:
         tqdm.write("\n", end="", file=self._out)
         with tqdm(total=100, ncols=100, bar_format=bar_format, file=self._out) as pbar:
             pbar.set_description_str(nphase, refresh=False)
-            pbar.unit = f"Running time: {humanize.precisedelta(elapsed.seconds)}"
+            pbar.unit = (
+                f"Running time: {humanize.precisedelta(elapsed.total_seconds())}"
+            )
             pbar.update(event.progress * 100)
         tqdm.write("\n", end="", file=self._out)
         tqdm.write(self._get_legends(), file=self._out)

--- a/tests/ert/unit_tests/cli/test_cli_monitor.py
+++ b/tests/ert/unit_tests/cli/test_cli_monitor.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from io import StringIO
 
 from ert.cli.monitor import Monitor
@@ -107,3 +107,35 @@ def test_print_progress():
 """  # noqa: E501
 
     assert out.getvalue().replace("\r", "\n") == expected
+
+
+def test_that_print_progress_shows_correct_elapsed_time_beyond_24_hours():
+    """timedelta.seconds wraps at 86400; total_seconds() gives the true elapsed."""
+    out = StringIO()
+    monitor = Monitor(out=out)
+    snapshot = EnsembleSnapshot()
+    snapshot._ensemble_state = ""
+    for i in range(10):
+        snapshot.add_realization(
+            str(i), RealizationSnapshot(status=REALIZATION_STATE_RUNNING, active=True)
+        )
+    monitor._snapshots[0] = snapshot
+    # Simulate a run that has been going for 25 hours
+    monitor._start_time = datetime.now(tz=UTC) - timedelta(hours=25)
+    event = SnapshotUpdateEvent(
+        iteration_label="Long Phase",
+        total_iterations=1,
+        progress=0.5,
+        realization_count=10,
+        status_count={"Running": 10},
+        iteration=0,
+    )
+
+    monitor._print_progress(event)
+
+    output = out.getvalue()
+    # The running time line must contain "1 day" (not "1 hour", which is
+    # what the buggy timedelta.seconds expression would produce: 25*3600 % 86400
+    # = 3600 seconds = 1 hour).
+    assert "1 day" in output
+    assert "1 hour" in output


### PR DESCRIPTION
timedelta.seconds only returns the sub-day seconds component (0-86399), so runs longer than 24 hours would display incorrect elapsed time (e.g. a 25-hour run shows "1 hour" instead of "1 day and 1 hour").

Replace with total_seconds() which returns the full elapsed duration.

**Issue**
Resolves wrong text output in cli version of ert for jobs running > 24 hours.

**Approach**
🤖 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
