### PR TITLE
Fix discrete uniform transform theoretically exceeding max

### DIFF
--- a/src/ert/config/distribution.py
+++ b/src/ert/config/distribution.py
@@ -101,7 +101,8 @@ class DUnifSettings(TransSettingsValidation):
         y = ndtr(x)
         span = self.max - self.min
         steps_denom = float(self.steps - 1)
-        return (np.floor(y * self.steps) / steps_denom) * span + self.min
+        bin_index = np.minimum(np.floor(y * self.steps), self.steps - 1)
+        return (bin_index / steps_denom) * span + self.min
 
 
 class NormalSettings(TransSettingsValidation):

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -466,6 +466,27 @@ def test_gen_kw_trans_func(tmpdir, params, xinput, expected):
         assert abs(out - expected) < 10**-15
 
 
+def test_that_dunif_transform_does_not_exceed_max_for_extreme_input_values(tmpdir):
+    """ndtr(x) returns exactly 1.0 for x >= ~8.3 due to floating-point limits."""
+    with tmpdir.as_cwd():
+        cfg = GenKwConfig(
+            name="MYNAME",
+            forward_init=False,
+            update=False,
+            distribution=GenKwConfig._parse_distribution(
+                "MYNAME", "DUNIF", ["5", "1", "5"]
+            ),
+        )
+        for x in [8.3, 100]:
+            result = float(
+                cfg.distribution.transform_numpy(np.asarray([x], dtype=np.float64))[0]
+            )
+            assert result <= 5.0, f"DUNIF result {result} exceeds max=5.0 for x={x}"
+            assert result >= 5.0, (
+                f"DUNIF result {result} != 5.0 (max) for extreme x={x}"
+            )
+
+
 def test_gen_kw_objects_equal(tmpdir):
     with tmpdir.as_cwd():
         with Path("template.txt").open("w", encoding="utf-8") as fh:


### PR DESCRIPTION
It is mathematically possible for x (standard normally distributed) to become >= 8.3, and if that happened, previous code would give a discrete value larger than the configured maximum.

Fix by clamping the bin index to [0, steps-1] before dividing.

**Issue**
Resolves a theoretical problem that would probably never surface in production.

**Approach**
Simple clamp. 🤖 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
