### PR TITLE
Validate that LOGUNIF min is strictly positive

### DIFF
--- a/src/ert/config/distribution.py
+++ b/src/ert/config/distribution.py
@@ -51,16 +51,28 @@ class UnifSettings(TransSettingsValidation):
 
 class LogUnifSettings(TransSettingsValidation):
     name: Literal["logunif"] = "logunif"
-    min: float = 0.0
+    min: float = 0.1
     max: float = 1.0
 
     @model_validator(mode="after")
     def valid_logunif_params(self) -> Self:
-        if not (self.min < self.max):
-            raise ConfigValidationError(
-                f"Minimum {self.min} must be strictly less than the maximum {self.max}"
-                " for log uniform distribution"
+        errors = []
+        if not (self.min > 0):
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly greater than 0"
+                    " for log uniform distribution"
+                )
             )
+        if not (self.min < self.max):
+            errors.append(
+                ErrorInfo(
+                    message=f"Minimum {self.min} must be strictly less than"
+                    f" the maximum {self.max} for log uniform distribution"
+                )
+            )
+        if errors:
+            raise ConfigValidationError.from_collected(errors)
         return self
 
     def transform_numpy(self, x: np.ndarray) -> np.ndarray:

--- a/tests/ert/unit_tests/config/test_gen_kw_config.py
+++ b/tests/ert/unit_tests/config/test_gen_kw_config.py
@@ -354,7 +354,10 @@ def test_that_very_high_mean_stddev_lognormal_gives_error():
             "The width -1.0 must be greater than 0 for errf distribution",
         ),
         ("MYNAME DERRF 3 1 2 3 4", None),
-        ("MYNAME LOGUNIF 0 1", None),
+        (
+            "MYNAME LOGUNIF 0 1",
+            "Minimum 0.0 must be strictly greater than 0 for log uniform distribution",
+        ),
         ("MYNAME CONST 0", None),
         ("MYNAME RAW", None),
         (
@@ -621,6 +624,14 @@ def test_validation_unif_distribution(tmpdir, distribution, minimum, maximum, er
                 GenKwConfig.from_config_list(config_list)
         else:
             GenKwConfig.from_config_list(config_list)
+
+
+def test_that_logunif_rejects_non_positive_min():
+    with pytest.raises(ConfigValidationError, match="strictly greater than 0"):
+        GenKwConfig._parse_distribution("MYNAME", "LOGUNIF", ["0", "1"])
+
+    with pytest.raises(ConfigValidationError, match="strictly greater than 0"):
+        GenKwConfig._parse_distribution("MYNAME", "LOGUNIF", ["-1", "1"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
LogUnifSettings only validated min < max, but log-uniform distributions require min > 0. With min=0, np.log(0) = -inf, causing all transform outputs to be NaN. With min<0, np.log(negative) = nan for the same reason.

Add validation that min > 0 and update the existing test that incorrectly expected LOGUNIF 0 1 to parse without error.

**Issue**
Resolves lack of validation

**Approach**
`copilot -i "find a bug"`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
