### PR TITLE
Remove non-working commented out configuration

### DIFF
--- a/test-data/everest/math_func/config_advanced.yml
+++ b/test-data/everest/math_func/config_advanced.yml
@@ -49,8 +49,6 @@ forward_model:
       type: gen_data
   # Write the value of each control to a separate file
   - job: adv_dump_controls --controls-file point.json --out-suffix _coord
-# Left this  here for testing/debugging purposes
-# - job: sleep --min 0.1 --max 5 --fail-chance 0.5
 
 model:
   realizations: 0, 2


### PR DESCRIPTION
There is no sleep job that accepts these options. This must have been a custom script that is now lost.

**Issue**
Resolves leftover demo code


**Approach**
✂️ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
