### PR TITLE
Make doc more precise

### DIFF
--- a/src/everest/config/input_constraint_config.py
+++ b/src/everest/config/input_constraint_config.py
@@ -71,7 +71,7 @@ class InputConstraintConfig(BaseModel, extra="forbid"):
             Scaling of input constraints.
 
             `scale` is a normalization factor which can be used to scale the
-            input constraint. The bounds or target, and the weights will be
+            input constraint. The bounds, target and the weights will be
             scaled with this number.
 
             This option will be disabled if `auto_scale` is set in the


### PR DESCRIPTION
The previous sentence was hard to read, although it probably intended to impliclity say that you should either provide bounds or target, not both. But that should not be documented in when documenting scales.

**Issue**
Resolves hard-to-read doc sentence

**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
