### PR TITLE
Check bounds

### DIFF
--- a/src/everest/config/control_config.py
+++ b/src/everest/config/control_config.py
@@ -267,7 +267,7 @@ class ControlConfig(BaseModel):
         if error := list(
             chain.from_iterable(
                 control_variables_validation(
-                    variable.name,
+                    f"{self.name}.{variable.name}",
                     self.min if variable.min is None else variable.min,
                     self.max if variable.max is None else variable.max,
                     (

--- a/src/everest/config/input_constraint_config.py
+++ b/src/everest/config/input_constraint_config.py
@@ -102,6 +102,9 @@ class InputConstraintConfig(BaseModel, extra="forbid"):
 
     @model_validator(mode="after")
     def validate_bounds(self) -> Self:
-        if self.target is None and (self.lower_bound > self.upper_bound):
-            raise ValueError("The upper_bound must be greater than the lower_bound")
+        if self.target is None and (self.lower_bound >= self.upper_bound):
+            raise ValueError(
+                "Error in input constraint: lower_bound must be less "
+                f"than the upper_bound : {self.lower_bound} >= {self.upper_bound}"
+            )
         return self

--- a/src/everest/config/input_constraint_config.py
+++ b/src/everest/config/input_constraint_config.py
@@ -1,7 +1,8 @@
 from textwrap import dedent
+from typing import Self
 
 import numpy as np
-from pydantic import BaseModel, Field, PositiveFloat, field_validator
+from pydantic import BaseModel, Field, PositiveFloat, field_validator, model_validator
 
 
 class InputConstraintConfig(BaseModel, extra="forbid"):
@@ -86,3 +87,21 @@ class InputConstraintConfig(BaseModel, extra="forbid"):
         if weights is None or weights == {}:
             raise ValueError("Input weight data required for input constraints")
         return weights
+
+    @model_validator(mode="after")
+    def validate_target_and_bounds(self) -> Self:
+        if self.target is not None and (
+            np.isfinite(self.lower_bound) or np.isfinite(self.upper_bound)
+        ):
+            raise ValueError("Cannot combine target and bounds")
+        if self.target is None and not (
+            np.isfinite(self.lower_bound) or np.isfinite(self.upper_bound)
+        ):
+            raise ValueError("Must provide target or lower_bound/upper_bound")
+        return self
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> Self:
+        if self.target is None and (self.lower_bound > self.upper_bound):
+            raise ValueError("The upper_bound must be greater than the lower_bound")
+        return self

--- a/src/everest/config/output_constraint_config.py
+++ b/src/everest/config/output_constraint_config.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 from pydantic import BaseModel, Field, PositiveFloat, model_validator
@@ -71,22 +71,23 @@ class OutputConstraintConfig(BaseModel, extra="forbid"):
         ),
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_target_or_bounds(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if (values.get("target") is not None) and (
-            "lower_bound" in values or "upper_bound" in values
+    @model_validator(mode="after")
+    def validate_target_and_bounds(self) -> Self:
+        if self.target is not None and (
+            np.isfinite(self.lower_bound) or np.isfinite(self.upper_bound)
         ):
-            raise ValueError("Can not combine target and bounds")
-        elif not any(
-            (
-                (values.get("target") is not None),
-                "lower_bound" in values,
-                "upper_bound" in values,
-            )
+            raise ValueError("Cannot combine target and bounds")
+        if self.target is None and not (
+            np.isfinite(self.lower_bound) or np.isfinite(self.upper_bound)
         ):
             raise ValueError("Must provide target or lower_bound/upper_bound")
-        return values
+        return self
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> Self:
+        if self.target is None and (self.lower_bound >= self.upper_bound):
+            raise ValueError("The upper_bound must be greater than the lower_bound")
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/src/everest/config/output_constraint_config.py
+++ b/src/everest/config/output_constraint_config.py
@@ -86,7 +86,10 @@ class OutputConstraintConfig(BaseModel, extra="forbid"):
     @model_validator(mode="after")
     def validate_bounds(self) -> Self:
         if self.target is None and (self.lower_bound >= self.upper_bound):
-            raise ValueError("The upper_bound must be greater than the lower_bound")
+            raise ValueError(
+                f"Error in output constraint {self.name}: lower_bound must be less "
+                f"than the upper_bound : {self.lower_bound} >= {self.upper_bound}"
+            )
         return self
 
     @model_validator(mode="before")

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -131,6 +131,14 @@ def control_variables_validation(
         error.append(
             _VARIABLE_ERROR_MESSAGE.format(name=name, variable_type="initial_guess")
         )
+    if error:
+        return error
+
+    assert min_ is not None
+    assert max_ is not None
+    if min_ >= max_:
+        return ["The control minimum value must be less than the maximum value"]
+
     if isinstance(initial_guess, float):
         initial_guess = [initial_guess]
     if (

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -137,7 +137,7 @@ def control_variables_validation(
     assert min_ is not None
     assert max_ is not None
     if min_ >= max_:
-        return ["The control minimum value must be less than the maximum value"]
+        return [f"Control {name} must respect min < max: {min_} >= {max_}"]
 
     if isinstance(initial_guess, float):
         initial_guess = [initial_guess]

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -19,7 +19,7 @@ from everest.util.forward_models import (
 from .install_job_config import InstallForwardModelStepConfig
 
 _VARIABLE_ERROR_MESSAGE = (
-    "Variable {name} must define {variable_type} value either"
+    "Variable {name} must define {variable_type} either"
     " at control level or variable level"
 )
 
@@ -122,38 +122,50 @@ def control_variables_validation(
     max_: float | None,
     initial_guess: float | list[float] | None,
 ) -> list[str]:
-    error = []
-    if min_ is None:
-        error.append(_VARIABLE_ERROR_MESSAGE.format(name=name, variable_type="min"))
-    if max_ is None:
-        error.append(_VARIABLE_ERROR_MESSAGE.format(name=name, variable_type="max"))
-    if initial_guess is None:
-        error.append(
-            _VARIABLE_ERROR_MESSAGE.format(name=name, variable_type="initial_guess")
+    errors = []
+
+    msg: str | None
+    match (min_, max_):
+        case (None, None):
+            msg = "min and max values"
+        case (None, _):
+            msg = "min value"
+        case (_, None):
+            msg = "max value"
+        case _:
+            msg = None
+    if msg is not None:
+        errors.append(
+            f"Variable {name} must define {msg} either at "
+            "control level or at variable level"
         )
-    if error:
-        return error
+
+    if initial_guess is None or (isinstance(initial_guess, list) and not initial_guess):
+        errors.append(
+            f"Variable {name} must define an initial_guess either at "
+            "control level or at variable level"
+        )
+
+    if errors:
+        return errors
 
     assert min_ is not None
     assert max_ is not None
+
     if min_ >= max_:
         return [f"Control {name} must respect min < max: {min_} >= {max_}"]
 
+    assert initial_guess is not None
+
     if isinstance(initial_guess, float):
         initial_guess = [initial_guess]
-    if (
-        min_ is not None
-        and max_ is not None
-        and (
-            msg := ", ".join(
-                str(guess) for guess in initial_guess or [] if not min_ <= guess <= max_
-            )
-        )
+    if msg := ", ".join(
+        str(guess) for guess in initial_guess if not min_ <= guess <= max_
     ):
-        error.append(
+        return [
             f"Variable {name} must respect {min_} <= initial_guess <= {max_}: {msg}"
-        )
-    return error
+        ]
+    return []
 
 
 def no_dots_in_string(value: str) -> str:

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -182,6 +182,45 @@ def test_that_scaled_range_is_valid_range():
 
 
 @pytest.mark.parametrize(
+    ("control_min", "control_max", "var_min", "var_max"),
+    [
+        (1.0, 0.0, None, None),
+        (None, 0.0, 1.0, None),
+        (1.0, None, None, 0.0),
+        (None, None, 1.0, 0.0),
+    ],
+)
+def test_that_control_minimum_is_less_than_maximum(
+    control_min: float | None,
+    control_max: float | None,
+    var_min: float | None,
+    var_max: float | None,
+):
+    with pytest.raises(
+        ValueError,
+        match=r"(?s).*The control minimum value must be less than the maximum value.*",
+    ):
+        everest_config_with_defaults(
+            controls=[
+                {
+                    "name": "group_0",
+                    "min": control_min,
+                    "max": control_max,
+                    "perturbation_magnitude": 0.01,
+                    "variables": [
+                        {
+                            "name": "w00",
+                            "initial_guess": 0.5,
+                            "min": var_min,
+                            "max": var_max,
+                        },
+                    ],
+                }
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("variables", "count"),
     [
         pytest.param(
@@ -395,50 +434,6 @@ def test_that_control_variables_index_is_defined_for_all_variables():
                 }
             ]
         )
-
-
-def test_that_duplicate_output_constraint_names_raise_error():
-    with pytest.raises(ValueError, match="Output constraint names must be unique"):
-        everest_config_with_defaults(
-            output_constraints=[
-                {"target": 0.3, "name": "a"},
-                {"target": 0.3, "name": "a"},
-            ],
-        )
-
-
-@pytest.mark.parametrize(
-    ("constraint", "expectation"),
-    [
-        (
-            {
-                "name": "w110",
-            },
-            pytest.raises(
-                ValueError, match="Must provide target or lower_bound/upper_bound"
-            ),
-        ),
-        (
-            {"name": "w110", "target": 1.0},
-            does_not_raise(),
-        ),
-        (
-            {"name": "w110", "lower_bound": 0.0, "upper_bound": 1.0},
-            does_not_raise(),
-        ),
-        (
-            {"name": "w110", "target": 1.0, "lower_bound": 0.0},
-            pytest.raises(ValueError, match="Can not combine target and bounds"),
-        ),
-        (
-            {"name": "w110", "target": 1.0, "upper_bound": 2.0},
-            pytest.raises(ValueError, match="Can not combine target and bounds"),
-        ),
-    ],
-)
-def test_that_output_constraints_bounds_are_mutex(constraint, expectation):
-    with expectation:
-        everest_config_with_defaults(output_constraints=[constraint])
 
 
 def test_that_variable_name_does_not_contain_dots():

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -198,7 +198,7 @@ def test_that_control_minimum_is_less_than_maximum(
 ):
     with pytest.raises(
         ValueError,
-        match=r"(?s).*The control minimum value must be less than the maximum value.*",
+        match=r"(?s).*Control group_0.w00 must respect min < max: 1.0 >= 0.0.*",
     ):
         everest_config_with_defaults(
             controls=[

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -221,6 +221,48 @@ def test_that_control_minimum_is_less_than_maximum(
 
 
 @pytest.mark.parametrize(
+    ("control_min", "control_max", "var_min", "var_max", "msg"),
+    [
+        (None, 1.0, None, 1.0, "min value"),
+        (0.0, None, 0.0, None, "max value"),
+        (None, None, None, None, "min and max values"),
+    ],
+)
+def test_that_control_minimum_or_maximum_is_defined(
+    control_min: float | None,
+    control_max: float | None,
+    var_min: float | None,
+    var_max: float | None,
+    msg: str,
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"(?s).*Variable group_0.w00 must define {msg} "
+            r"either at control level or at variable level.*"
+        ),
+    ):
+        everest_config_with_defaults(
+            controls=[
+                {
+                    "name": "group_0",
+                    "min": control_min,
+                    "max": control_max,
+                    "perturbation_magnitude": 0.01,
+                    "variables": [
+                        {
+                            "name": "w00",
+                            "initial_guess": 0.5,
+                            "min": var_min,
+                            "max": var_max,
+                        },
+                    ],
+                }
+            ]
+        )
+
+
+@pytest.mark.parametrize(
     ("variables", "count"),
     [
         pytest.param(
@@ -398,18 +440,24 @@ def test_that_perturbation_magnitude_can_be_set_for_all_variables():
     )
 
 
-def test_that_invalid_control_undefined_fields():
+@pytest.mark.parametrize("var_guess", [None, []])
+def test_that_an_initial_guess_is_defined(var_guess: list | None):
     with pytest.raises(
         ValueError,
-        match=r"define min.* value.*define max*. value.*define initial_guess.* value",
+        match=(
+            r"(?s).*Variable group_0.w00 must define an initial_guess "
+            r"either at control level or at variable level.*"
+        ),
     ):
         everest_config_with_defaults(
             controls=[
                 {
                     "name": "group_0",
+                    "min": 0,
+                    "max": 1,
                     "perturbation_magnitude": 0.01,
                     "variables": [
-                        {"name": "w00"},
+                        {"name": "w00", "initial_guess": var_guess},
                     ],
                 }
             ]

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -156,7 +156,7 @@ def test_extra_key(min_config):
             "output_folder\n.* str type expected",
         ),
         (
-            {"input_constraints": [{"weights": {"not_exists": 1.0}}]},
+            {"input_constraints": [{"weights": {"not_exists": 1.0}, "target": 1.0}]},
             "not_exists.*not match any instance of control_name.variable_name",
         ),
     ],
@@ -252,7 +252,9 @@ def test_well_ref_validation(min_config):
 
 
 def test_control_ref_validation(min_config):
-    min_config["input_constraints"] = [{"weights": {"my_control.test": 1.0}}]
+    min_config["input_constraints"] = [
+        {"weights": {"my_control.test": 1.0}, "target": 1.0}
+    ]
     EverestConfig(**min_config)
 
 

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -136,7 +136,10 @@ def test_that_target_and_bounds_are_mutually_exclusive():
 def test_that_lower_bound_cannot_be_greater_than_upper_bound():
     with pytest.raises(
         ValueError,
-        match=(r"(?s).*The upper_bound must be greater than the lower_bound.*"),
+        match=(
+            r"(?s).*Error in input constraint: lower_bound must "
+            r"be less than the upper_bound : 2.0 >= 1.0.*"
+        ),
     ):
         everest_config_with_defaults(
             input_constraints=[

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -33,7 +33,8 @@ def test_input_constraint_control_references(tmp_path, capsys, monkeypatch):
                 "dummy.x.1": 1.0,
                 "dummy.x.2": 1.0,
                 "dummy.y.0": 1.0,
-            }
+            },
+            "target": 1.0,
         }
     ]
 
@@ -44,7 +45,8 @@ def test_input_constraint_control_references(tmp_path, capsys, monkeypatch):
                 "dummy.x-1": 1.0,
                 "dummy.x-2": 1.0,
                 "dummy.y-0": 1.0,
-            }
+            },
+            "target": 1.0,
         }
     ]
 
@@ -101,5 +103,49 @@ def test_that_auto_scale_and_input_constraints_scale_are_mutually_exclusive():
                     {"upper_bound": 1.0, "weights": {"a": 1.0, "b": 1.0}, "scale": 2.0}
                 )
                 for i in range(2)
+            ],
+        )
+
+
+def test_that_target_or_bounds_are_provided():
+    with pytest.raises(
+        ValueError,
+        match=(r"(?s).*Must provide target or lower_bound/upper_bound.*"),
+    ):
+        everest_config_with_defaults(
+            input_constraints=[
+                InputConstraintConfig.model_validate({"weights": {"a": 1.0, "b": 1.0}})
+            ],
+        )
+
+
+def test_that_target_and_bounds_are_mutually_exclusive():
+    with pytest.raises(
+        ValueError,
+        match=(r"(?s).*Cannot combine target and bounds.*"),
+    ):
+        everest_config_with_defaults(
+            input_constraints=[
+                InputConstraintConfig.model_validate(
+                    {"target": 1.0, "weights": {"a": 1.0, "b": 1.0}, "lower_bound": 0.0}
+                )
+            ],
+        )
+
+
+def test_that_lower_bound_cannot_be_greater_than_upper_bound():
+    with pytest.raises(
+        ValueError,
+        match=(r"(?s).*The upper_bound must be greater than the lower_bound.*"),
+    ):
+        everest_config_with_defaults(
+            input_constraints=[
+                InputConstraintConfig.model_validate(
+                    {
+                        "weights": {"a": 1.0, "b": 1.0},
+                        "lower_bound": 2.0,
+                        "upper_bound": 1.0,
+                    }
+                )
             ],
         )

--- a/tests/everest/test_output_constraints.py
+++ b/tests/everest/test_output_constraints.py
@@ -41,49 +41,6 @@ def test_constraints_init(tmp_path):
     ]
 
 
-@pytest.mark.parametrize(
-    ("config", "error"),
-    [
-        (
-            [
-                {"name": "some_name"},
-            ],
-            "Must provide target or lower_bound/upper_bound",
-        ),
-        (
-            [
-                {"name": "same_name", "upper_bound": 5000},
-                {"name": "same_name", "upper_bound": 5000},
-            ],
-            "Output constraint names must be unique",
-        ),
-        (
-            [
-                {"name": "some_name", "upper_bound": 5000, "target": 5000},
-            ],
-            r"Can not combine target and bounds",
-        ),
-        (
-            [
-                {"name": "some_name", "lower_bound": 10, "upper_bund": 2},
-            ],
-            "Extra inputs are not permitted",
-        ),
-        (
-            [
-                {"name": "some_name", "upper_bound": "2ooo"},
-            ],
-            "unable to parse string as a number",
-        ),
-    ],
-)
-def test_output_constraint_config(config, error):
-    with pytest.raises(ValueError, match=error):
-        EverestConfig(
-            output_constraints=config,
-        )
-
-
 def test_that_auto_scale_and_constraints_scale_are_mutually_exclusive():
     with pytest.raises(
         ValueError,
@@ -151,3 +108,60 @@ def test_upper_bound_output_constraint_def(tmp_path):
     site_plugins = get_site_plugins()
     with use_runtime_plugins(site_plugins):
         EverestRunModel.create(config, runtime_plugins=site_plugins)
+
+
+def test_that_duplicate_output_constraint_names_raise_error():
+    with pytest.raises(ValueError, match="Output constraint names must be unique"):
+        everest_config_with_defaults(
+            output_constraints=[
+                {"target": 0.3, "name": "a"},
+                {"target": 0.3, "name": "a"},
+            ],
+        )
+
+
+def test_that_target_or_bounds_are_provided():
+    with pytest.raises(
+        ValueError,
+        match=(r"(?s).*Must provide target or lower_bound/upper_bound.*"),
+    ):
+        everest_config_with_defaults(
+            input_constraints=[
+                OutputConstraintConfig.model_validate(
+                    {
+                        "name": "some_name",
+                    }
+                )
+            ],
+        )
+
+
+def test_that_target_and_bounds_are_mutually_exclusive():
+    with pytest.raises(
+        ValueError,
+        match=(r"(?s).*Cannot combine target and bounds.*"),
+    ):
+        everest_config_with_defaults(
+            input_constraints=[
+                OutputConstraintConfig.model_validate(
+                    {"name": "some_name", "target": 1.0, "lower_bound": 0.0}
+                )
+            ],
+        )
+
+
+def test_that_lower_bound_cannot_be_greater_than_upper_bound():
+    with pytest.raises(
+        match=(r"(?s).*The upper_bound must be greater than the lower_bound.*"),
+    ):
+        everest_config_with_defaults(
+            output_constraints=[
+                OutputConstraintConfig.model_validate(
+                    {
+                        "name": "some_name",
+                        "lower_bound": 2.0,
+                        "upper_bound": 1.0,
+                    }
+                )
+            ],
+        )

--- a/tests/everest/test_output_constraints.py
+++ b/tests/everest/test_output_constraints.py
@@ -126,7 +126,7 @@ def test_that_target_or_bounds_are_provided():
         match=(r"(?s).*Must provide target or lower_bound/upper_bound.*"),
     ):
         everest_config_with_defaults(
-            input_constraints=[
+            output_constraints=[
                 OutputConstraintConfig.model_validate(
                     {
                         "name": "some_name",
@@ -142,7 +142,7 @@ def test_that_target_and_bounds_are_mutually_exclusive():
         match=(r"(?s).*Cannot combine target and bounds.*"),
     ):
         everest_config_with_defaults(
-            input_constraints=[
+            output_constraints=[
                 OutputConstraintConfig.model_validate(
                     {"name": "some_name", "target": 1.0, "lower_bound": 0.0}
                 )
@@ -152,7 +152,10 @@ def test_that_target_and_bounds_are_mutually_exclusive():
 
 def test_that_lower_bound_cannot_be_greater_than_upper_bound():
     with pytest.raises(
-        match=(r"(?s).*The upper_bound must be greater than the lower_bound.*"),
+        match=(
+            r"(?s).*Error in output constraint some_name: lower_bound must "
+            r"be less than the upper_bound : 2.0 >= 1.0.*"
+        ),
     ):
         everest_config_with_defaults(
             output_constraints=[


### PR DESCRIPTION
**Issue**
Resolves #13342
Resolves #13374 


**Approach**
Following checks are implemented in the configuration code and covered by tests:
1. After combining the min/max field from the `control` and `variables` sections, the minimum value of each control may not be larger than or equal to its maximum value.
2. The target and lower/upper bound options are mutually exclusive, both in the input and output constraint configurations.
3. The lower bounds may not be larger than or equal to the upper bounds in both the input and output constraint configurations.
4. Remove some redundant tests from test_config_validation.py.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
