### PR TITLE
Remove duplicated data from ObservationLocations

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -188,9 +188,7 @@ def perform_ensemble_update(
             xpos=filtered_data["east"].to_numpy()[has_location],
             ypos=filtered_data["north"].to_numpy()[has_location],
             main_range=filtered_data["radius"].to_numpy()[has_location],
-            responses_with_loc=responses[has_location, :],
-            observation_values=observation_values[has_location],
-            observation_errors=observation_errors[has_location],
+            location_mask=has_location,
         )
 
     obs_context = ObservationContext(

--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -55,14 +55,20 @@ class DistanceLocalizationUpdate:
             )
         self._obs_loc = obs_context.observation_locations
         self._ensemble_size = obs_context.ensemble_size
+
+        mask = self._obs_loc.location_mask
+        responses = obs_context.responses[mask, :]
+        obs_values = obs_context.observation_values[mask]
+        obs_errors = obs_context.observation_errors[mask]
+
         self._smoother = LocalizedESMDA(
-            covariance=self._obs_loc.observation_errors**2,
-            observations=self._obs_loc.observation_values,
+            covariance=obs_errors**2,
+            observations=obs_values,
             alpha=1,
             seed=self._rng,
         )
         self._smoother.prepare_assimilation(
-            Y=self._obs_loc.responses_with_loc,
+            Y=responses,
             truncation=self._enkf_truncation,
             overwrite=True,
         )

--- a/src/ert/analysis/_update_strategies/_protocol.py
+++ b/src/ert/analysis/_update_strategies/_protocol.py
@@ -89,8 +89,7 @@ class ObservationLocations:
     """Observation location data for distance-based localization methods.
 
     Contains coordinates and correlation ranges for observations that have
-    spatial location information. All arrays are filtered to only include
-    observations that have valid location data.
+    spatial location information.
     """
 
     xpos: npt.NDArray[np.floating]
@@ -102,14 +101,8 @@ class ObservationLocations:
     main_range: npt.NDArray[np.floating]
     """Correlation range (radius) for each observation."""
 
-    responses_with_loc: npt.NDArray[np.floating]
-    """Response matrix filtered to observations with locations."""
-
-    observation_values: npt.NDArray[np.floating]
-    """Observation values filtered to observations with locations."""
-
-    observation_errors: npt.NDArray[np.floating]
-    """Scaled observation errors filtered to observations with locations."""
+    location_mask: npt.NDArray[np.bool_]
+    """Boolean mask indicating which observations have valid location data."""
 
 
 @dataclass(frozen=True)

--- a/tests/ert/unit_tests/analysis/test_distance_localization.py
+++ b/tests/ert/unit_tests/analysis/test_distance_localization.py
@@ -85,9 +85,7 @@ def test_that_distance_localization_updates_all_z_layers_at_observation_xy(
         xpos=obs_x,
         ypos=obs_y,
         main_range=main_range,
-        responses_with_loc=responses,
-        observation_values=obs_values,
-        observation_errors=obs_errors,
+        location_mask=np.ones(responses.shape[0], dtype=bool),
     )
 
     obs_context = ObservationContext(


### PR DESCRIPTION
ObservationLocations carried filtered copies of responses, observation_values, and observation_errors that duplicated data already in ObservationContext. Replace these with a location_mask and let DistanceLocalizationUpdate do the filtering in prepare(), making ObservationContext the single owner of observation data.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
