### PR TITLE
Calculate is_improvement rather than use storage flag

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from urllib.parse import unquote
 from uuid import UUID
 
+import numpy as np
 import pandas as pd
 import polars as pl
 from fastapi import APIRouter, Body, Depends, Header, Query, status
@@ -163,24 +164,61 @@ def data_for_response(
         if ensemble.batch_objectives is None:
             return pd.DataFrame()
 
-        df = ensemble.batch_objectives.clone()
-        improvements = {}
-        for ens in ensemble.experiment.ensembles:
-            improvements[ens.iteration] = ens.is_improvement
+        def constraint_violation_check(violation: pl.DataFrame | None) -> float:
+            if violation is None:
+                return 0.0
+            return violation.drop("batch_id").to_numpy().max().item()
 
-        imp_df = pl.DataFrame(
-            {
-                "batch_id": list(improvements.keys()),
-                "is_improvement": list(improvements.values()),
-            },
-            schema={"batch_id": pl.Int64, "is_improvement": pl.Boolean},
+        CONSTRAINT_TOL = 1e-6
+        accepted_batches = []
+        max_total_objective = np.inf
+        for current_ensemble in ensemble.experiment.ensembles_with_function_results:
+            if current_ensemble.batch_objectives is None:
+                raise ValueError(
+                    f"Ensemble {current_ensemble.id} does not have batch objectives"
+                )
+            total_objective = current_ensemble.batch_objectives[
+                "total_objective_value"
+            ].item()
+
+            bound_constraint_violation = constraint_violation_check(
+                current_ensemble.batch_bound_constraint_violations
+            )
+            input_constraint_violation = constraint_violation_check(
+                current_ensemble.batch_input_constraint_violations
+            )
+            output_constraint_violation = constraint_violation_check(
+                current_ensemble.batch_output_constraint_violations
+            )
+
+            if (
+                max(
+                    bound_constraint_violation,
+                    input_constraint_violation,
+                    output_constraint_violation,
+                )
+                < CONSTRAINT_TOL
+                and total_objective < max_total_objective
+            ):
+                accepted_batches.append(current_ensemble)
+                max_total_objective = total_objective
+
+        objective_value_df = ensemble.batch_objectives.clone().select(
+            ["batch_id", "total_objective_value"]
         )
 
-        df = df.join(imp_df, on="batch_id", how="left")
-        df = df.with_columns(pl.col("is_improvement").fill_null(False))
-
         return (
-            df.select(["batch_id", "total_objective_value", "is_improvement"])
+            objective_value_df.join(
+                pl.DataFrame(
+                    {
+                        "batch_id": [batch.iteration for batch in accepted_batches],
+                        "is_improvement": [True] * len(accepted_batches),
+                    }
+                ),
+                on="batch_id",
+                how="left",
+            )
+            .with_columns(pl.col("is_improvement").fill_null(False))
             .to_pandas()
             .astype(
                 {


### PR DESCRIPTION
**Issue**
Resolves #13291


**Approach**

Moved the logic in `_update_ensemble_improvement_flags` from `everest_run_model` to `responses.py`(PR [12788](https://github.com/equinor/ert/pull/12788)), so that the `is_improvement`-condition is not fetched from storage, but calculated before return. Creates `is_improvement`-column so that the plotting remains the same.  Can be expanded upon in future with including the constraint violation value and reason (bound, input or output-violation). 

Naming-convention kept as Ert (e.g ensemble over batch), but I think could be more readable if made Everest-specific

Have not removed the methods from the `everest_run_model` since `everviz`still relies on the `is_improvement`-flag (ref #10998).




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
