### PR TITLE
Deprecate everviz in favour of --ert_plotter

### DIFF
--- a/src/everest/bin/visualization_script.py
+++ b/src/everest/bin/visualization_script.py
@@ -25,20 +25,7 @@ from .utils import ArgParseFormatter
 
 def _build_args_parser() -> argparse.ArgumentParser:
     arg_parser = argparse.ArgumentParser(
-        description=dedent(
-            """
-            Start an everest visualization plugin.
-
-            If no visualization plugin is installed the message: ``No
-            visualization plugin installed!`` will be displayed in the console.
-
-            The recommended open-source everest visualization plugin is Everviz:
-
-            https://github.com/equinor/everviz
-
-            It can be installed using ``pip install everviz``.
-            """
-        ),
+        description=dedent("""Start a visualization tool for Everest data."""),
         formatter_class=ArgParseFormatter,
         usage="""everest results <config_file>""",
     )
@@ -84,6 +71,19 @@ def visualization_entry(args: list[str] | None = None) -> None:
             return
 
         if not options.ert_plotter:
+            print()
+            print(
+                "==============================================================================="
+            )
+            print()
+            print("Everviz is deprecated and will be replaced in the next release.")
+            print("Use the command `everest result --ert_plotter <config_file>` to use")
+            print("the upcoming visualization tool.")
+            print()
+            print(
+                "==============================================================================="
+            )
+            print()
             pm = EverestPluginManager()
             pm.hook.visualize_data(api=EverestDataAPI(options.config))
         else:


### PR DESCRIPTION
Display a banner to the user instructing to use a command line option to start the ert based plotter for Everest results instead.

**Issue**
Resolves #13383


**Approach**
`print` (instead of `warnings.warn`) - in order to ensure it might be visible.

The printout when launching looks like:

```
(venv) berland@eqbob:~/projects/ert/test-data/everest/math_func$ (main) everest results config_minimal.yml 

===============================================================================

Everviz is deprecated and will be replaced in the next release.
Use the command `everest result --ert_plotter <config_file>` to use the
upcoming visualization tool.

===============================================================================

2026-04-22 16:39:11,385 — everviz — INFO — Generating objective values plot
2026-04-22 16:39:11,416 — everviz — INFO — File created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/objective_values.csv
2026-04-22 16:39:11,417 — everviz — INFO — Generating total objective values plot
2026-04-22 16:39:11,434 — everviz — INFO — File created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/total_objective_values.csv
2026-04-22 16:39:11,590 — everviz — INFO — Generating controls per batch source data file
2026-04-22 16:39:11,641 — everviz — INFO — File created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/controls_per_batch.csv
2026-04-22 16:39:11,641 — everviz — INFO — Generating initial vs best controls source data file
2026-04-22 16:39:11,711 — everviz — INFO — Generating controls per batch source data file
2026-04-22 16:39:11,722 — everviz — INFO — File created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/gradient_values.csv
2026-04-22 16:39:11,735 — everviz — INFO — Generating objective delta plot source data file
2026-04-22 16:39:11,771 — everviz — INFO — File created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/objective_delta_values.csv
2026-04-22 16:39:11,771 — everviz — INFO — Generating summary delta plot source data file
2026-04-22 16:39:11,796 — everviz — INFO — No summary data, not creating summary_delta_values.csv
2026-04-22 16:39:11,803 — everviz — INFO — Webviz config file created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/everviz_webviz_config.yml
2026-04-22 16:39:11,803 — everviz — INFO — Default everviz config created: /home/berland/projects/ert/test-data/everest/math_func/everest_output/everviz/everviz_webviz_config.yml
 Starting up your webviz application. Please wait...
 Opening the application (http://localhost:5000) in your browser.
 Note that your browser might display security issues.
 See: https://equinor.github.io/webviz-config/#/?id=localhost-hsts
 Press CTRL + C in this terminal window to stop the application.
```


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
