### PR TITLE
Remove redundant title labels from experiment panels

### DIFF
--- a/src/ert/gui/experiments/ensemble_experiment_panel.py
+++ b/src/ert/gui/experiments/ensemble_experiment_panel.py
@@ -52,10 +52,7 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
         self.setObjectName("Ensemble_experiment_panel")
 
         layout = QFormLayout()
-        lab = QLabel(" ".join(EnsembleExperiment.__doc__.split()))  # type: ignore
-        lab.setWordWrap(True)
-        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addRow(lab)
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
         self._experiment_name_field = StringBox(
             TextModel(""),

--- a/src/ert/gui/experiments/ensemble_information_filter_panel.py
+++ b/src/ert/gui/experiments/ensemble_information_filter_panel.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtWidgets import QFormLayout, QLabel, QWidget
+from PyQt6.QtWidgets import QFormLayout, QHBoxLayout, QLabel, QWidget
 from typing_extensions import override
 
 from ert.gui.ertnotifier import ErtNotifier
@@ -54,6 +55,7 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         self.notifier = notifier
 
         layout = QFormLayout()
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setObjectName("enif_panel")
 
         self._experiment_name_field = StringBox(
@@ -72,8 +74,16 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
+        number_of_realizations_container = QWidget()
+        number_of_realizations_layout = QHBoxLayout(number_of_realizations_container)
+        number_of_realizations_layout.setContentsMargins(0, 0, 0, 0)
         number_of_realizations_label = QLabel(f"<b>{len(active_realizations)}</b>")
-        layout.addRow(QLabel("Number of realizations:"), number_of_realizations_label)
+        number_of_realizations_label.setObjectName("num_reals_label")
+        number_of_realizations_layout.addWidget(number_of_realizations_label)
+
+        layout.addRow(
+            QLabel("Number of realizations:"), number_of_realizations_container
+        )
 
         self._ensemble_format_model = TargetEnsembleModel(analysis_config, notifier)
         self._ensemble_format_field = StringBox(

--- a/src/ert/gui/experiments/ensemble_smoother_panel.py
+++ b/src/ert/gui/experiments/ensemble_smoother_panel.py
@@ -57,9 +57,7 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
         self.setObjectName("ensemble_smoother_panel")
 
         layout = QFormLayout()
-        lab = QLabel(EnsembleSmoother.name())
-        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addRow(lab)
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
         self._experiment_name_field = StringBox(
             TextModel(""),

--- a/src/ert/gui/experiments/evaluate_ensemble_panel.py
+++ b/src/ert/gui/experiments/evaluate_ensemble_panel.py
@@ -40,10 +40,7 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         self.setObjectName("Evaluate_parameters_panel")
 
         layout = QFormLayout()
-        lab = QLabel(" ".join(EvaluateEnsemble.__doc__.split()))  # type: ignore
-        lab.setWordWrap(True)
-        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addRow(lab)
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
         def show_only_no_children_filter(
             ensembles: Iterable[Ensemble],

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import cast
 
 import numpy as np
-from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import QComboBox, QFormLayout, QLabel, QWidget
 from typing_extensions import override
@@ -52,6 +52,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         self.setObjectName("Manual_update_panel")
 
         layout = QFormLayout()
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self._update_method_dropdown = QComboBox()
         self._update_method_dropdown.addItems(
             ["ES Update", "EnIF Update (Experimental)"]

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -75,10 +75,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self.notifier = notifier
 
         layout = QFormLayout()
-        lab = QLabel(" ".join(MultipleDataAssimilation.__doc__.split()))  # type: ignore
-        lab.setWordWrap(True)
-        lab.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addRow(lab)
+        layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setObjectName("ES_MDA_panel")
 
         self._experiment_name_field = StringBox(


### PR DESCRIPTION
Each panel's experiment type is already communicated by the dropdown used to select it. The title labels were therefore redundant and inconsistently present across panels.

Replace the implicit left-alignment side-effect of the full-width title row with an explicit
`layout.setFormAlignment(AlignLeft | AlignTop)` on all panels.

## EnIF before

<img width="1612" height="1059" alt="image" src="https://github.com/user-attachments/assets/f109847b-4776-4b54-8c4d-3058a5eb2ef4" />

## EnIF after

<img width="1612" height="1035" alt="image" src="https://github.com/user-attachments/assets/76765929-3019-4a80-ab77-0aa1d1ce471c" />

## ES-MDA before

<img width="1612" height="1059" alt="image" src="https://github.com/user-attachments/assets/14bdc38d-bd8e-4b39-9115-75239ca1d164" />

## ES-MDA after

<img width="1612" height="1035" alt="image" src="https://github.com/user-attachments/assets/d1f8b31f-0f95-4f07-9f6e-c3ebba5c7812" />

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
