### PR TITLE
Add data type separator to data list in plot window for Everest

### DIFF
--- a/src/ert/gui/tools/plot/data_type_keys_list_model.py
+++ b/src/ert/gui/tools/plot/data_type_keys_list_model.py
@@ -1,7 +1,8 @@
+from dataclasses import dataclass
 from typing import Any, overload
 
 from PyQt6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
-from PyQt6.QtGui import QColor
+from PyQt6.QtGui import QColor, QFont
 from typing_extensions import override
 
 from ert.gui.detect_mode import is_dark_mode
@@ -10,12 +11,17 @@ from ert.gui.icon_utils import load_icon
 from .plot_api import PlotApiKeyDefinition
 
 
+@dataclass(frozen=True)
+class DataTypeSeparator:
+    label: str
+
+
 class DataTypeKeysListModel(QAbstractItemModel):
     DEFAULT_DATA_TYPE = QColor(255, 255, 255)
     HAS_OBSERVATIONS = QColor(237, 218, 116)
     GROUP_ITEM = QColor(64, 64, 64)
 
-    def __init__(self, keys: list[PlotApiKeyDefinition]) -> None:
+    def __init__(self, keys: list[PlotApiKeyDefinition | DataTypeSeparator]) -> None:
         QAbstractItemModel.__init__(self)
         self._keys = keys
         self.__icon = load_icon("star_filled.svg")
@@ -43,13 +49,37 @@ class DataTypeKeysListModel(QAbstractItemModel):
         return 1
 
     @override
+    def flags(self, index: QModelIndex) -> Qt.ItemFlag:
+        if index.isValid() and index.row() < len(self._keys):
+            item = self._keys[index.row()]
+            if isinstance(item, DataTypeSeparator):
+                return Qt.ItemFlag.ItemIsEnabled
+        else:
+            return Qt.ItemFlag.NoItemFlags
+        return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+
+    @override
     def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
         assert isinstance(index, QModelIndex)
 
         if index.isValid():
-            items = self._keys
             row = index.row()
-            item = items[row]
+            item = self._keys[row]
+
+            if isinstance(item, DataTypeSeparator):
+                if role == Qt.ItemDataRole.DisplayRole:
+                    return item.label
+                if role == Qt.ItemDataRole.FontRole:
+                    font = QFont()
+                    font.setBold(True)
+                    return font
+                if role == Qt.ItemDataRole.ForegroundRole:
+                    return (
+                        QColor(Qt.GlobalColor.white)
+                        if is_dark_mode()
+                        else QColor(Qt.GlobalColor.black)
+                    )
+                return None
 
             if role == Qt.ItemDataRole.DisplayRole:
                 return item.key
@@ -69,6 +99,9 @@ class DataTypeKeysListModel(QAbstractItemModel):
 
         if index.isValid():
             row = index.row()
-            return self._keys[row]
+            item = self._keys[row]
+            if isinstance(item, DataTypeSeparator):
+                return None
+            return item
 
         return None

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -21,10 +21,11 @@ from .plot_api import PlotApiKeyDefinition
 from .widgets import FilterPopup
 
 _EVEREST_GROUP_ORDER = [
-    "everest_objectives",
     "everest_batch_objectives",
-    "everest_constraints",
+    "everest_objectives",
     "everest_parameters",
+    "everest_constraints",
+    "summary",
 ]
 
 _EVEREST_GROUP_LABELS: dict[str, str] = {

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -25,6 +25,7 @@ _EVEREST_GROUP_ORDER = [
     "everest_objectives",
     "everest_parameters",
     "everest_constraints",
+    "gen_data",
     "summary",
 ]
 
@@ -33,7 +34,8 @@ _EVEREST_GROUP_LABELS: dict[str, str] = {
     "everest_constraints": "Constraints",
     "everest_objectives": "Objectives",
     "everest_parameters": "Controls",
-    "summary": "Summary vectors",
+    "gen_data": "Generic results",
+    "summary": "Summary results",
 }
 
 

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -28,10 +28,11 @@ _EVEREST_GROUP_ORDER = [
 ]
 
 _EVEREST_GROUP_LABELS: dict[str, str] = {
-    "everest_objectives": "Objectives",
     "everest_batch_objectives": "Aggregated objective values",
     "everest_constraints": "Constraints",
+    "everest_objectives": "Objectives",
     "everest_parameters": "Controls",
+    "summary": "Summary vectors",
 }
 
 

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -15,10 +15,46 @@ from ert.gui.ertwidgets import SearchBox
 from ert.gui.icon_utils import load_icon
 from ert.gui.utils import is_everest_application
 
-from .data_type_keys_list_model import DataTypeKeysListModel
+from .data_type_keys_list_model import DataTypeKeysListModel, DataTypeSeparator
 from .data_type_proxy_model import DataTypeProxyModel
 from .plot_api import PlotApiKeyDefinition
 from .widgets import FilterPopup
+
+_EVEREST_GROUP_ORDER = [
+    "everest_objectives",
+    "everest_batch_objectives",
+    "everest_constraints",
+    "everest_parameters",
+]
+
+_EVEREST_GROUP_LABELS: dict[str, str] = {
+    "everest_objectives": "Objectives",
+    "everest_batch_objectives": "Aggregated objective values",
+    "everest_constraints": "Constraints",
+    "everest_parameters": "Controls",
+}
+
+
+def _group_everest_keys(
+    key_defs: list[PlotApiKeyDefinition],
+) -> list[PlotApiKeyDefinition | DataTypeSeparator]:
+    groups: dict[str, list[PlotApiKeyDefinition]] = {}
+    for key_def in key_defs:
+        origin = key_def.metadata.get("data_origin", "")
+        groups.setdefault(origin, []).append(key_def)
+
+    ordered_origins = _EVEREST_GROUP_ORDER + [
+        origin for origin in groups if origin not in _EVEREST_GROUP_ORDER
+    ]
+
+    result: list[PlotApiKeyDefinition | DataTypeSeparator] = []
+    for origin in ordered_origins:
+        if origin not in groups:
+            continue
+        label = _EVEREST_GROUP_LABELS.get(origin, origin)
+        result.append(DataTypeSeparator(label=f"— {label} —"))
+        result.extend(groups[origin])
+    return result
 
 
 class _LegendMarker(QWidget):
@@ -82,7 +118,11 @@ class DataTypeKeysWidget(QWidget):
 
         layout = QVBoxLayout()
 
-        self.model = DataTypeKeysListModel(key_defs)
+        is_everest = is_everest_application()
+        model_items: list[PlotApiKeyDefinition | DataTypeSeparator] = (
+            _group_everest_keys(key_defs) if is_everest else list(key_defs)
+        )
+        self.model = DataTypeKeysListModel(model_items)
         self.filter_model = DataTypeProxyModel(self, self.model)
 
         filter_layout = QHBoxLayout()
@@ -106,8 +146,6 @@ class DataTypeKeysWidget(QWidget):
         layout.addSpacing(15)
         layout.addWidget(self.data_type_keys_widget, 2)
         layout.addStretch()
-
-        is_everest = is_everest_application()
 
         if not is_everest:
             layout.addWidget(
@@ -134,7 +172,13 @@ class DataTypeKeysWidget(QWidget):
         return item
 
     def selectDefault(self) -> None:
-        self.data_type_keys_widget.setCurrentIndex(self.filter_model.index(0, 0))
+        for i in range(self.filter_model.rowCount()):
+            # Need to skip the DataTypeSeparators
+            index = self.filter_model.index(i, 0)
+            source_index = self.filter_model.mapToSource(index)
+            if self.model.itemAt(source_index) is not None:
+                self.data_type_keys_widget.setCurrentIndex(index)
+                return
 
     def setSearchString(self, filter_: str | None) -> None:
         self.filter_model.setFilterFixedString(filter_ or "")

--- a/src/ert/gui/tools/plot/data_type_proxy_model.py
+++ b/src/ert/gui/tools/plot/data_type_proxy_model.py
@@ -24,14 +24,17 @@ class DataTypeProxyModel(QSortFilterProxyModel):
 
     @override
     def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:
+        source_model = self.sourceModel()
+        source_index = source_model.index(source_row, 0, source_parent)
+        key = source_model.itemAt(source_index)
+
+        if key is None:
+            # Separator items are always shown
+            return True
+
         show = QSortFilterProxyModel.filterAcceptsRow(self, source_row, source_parent)
 
         if show:
-            source_model = self.sourceModel()
-            source_index = source_model.index(source_row, 0, source_parent)
-            key = source_model.itemAt(source_index)
-            assert key is not None
-
             for meta_key, values in self._metadata_filters.items():
                 for value, visible in values.items():
                     if (

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -10,6 +10,8 @@ from pytestqt.qtbot import QtBot
 
 from ert.config.distribution import RawSettings
 from ert.config.gen_kw_config import DataSource, GenKwConfig
+from ert.gui.tools.plot.data_type_keys_list_model import DataTypeSeparator
+from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
 from ert.gui.tools.plot.plot_widget import PlotWidget
 from ert.gui.tools.plot.plot_window import PlotWindow, create_error_dialog
@@ -17,6 +19,30 @@ from ert.gui.tools.plot.plottery import PlotConfig, PlotContext
 from ert.gui.tools.plot.plottery.plots.gaussian_kde import plotGaussianKDE
 from ert.gui.tools.plot.plottery.plots.histogram import HistogramPlot
 from ert.services import ErtServerController
+
+EVEREST_KEY_DEFS = [
+    PlotApiKeyDefinition(
+        "obj1",
+        index_type="VALUE",
+        metadata={"data_origin": "everest_objectives"},
+        observations=False,
+        dimensionality=2,
+    ),
+    PlotApiKeyDefinition(
+        "ctrl1",
+        index_type=None,
+        metadata={"data_origin": "everest_parameters"},
+        observations=False,
+        dimensionality=1,
+    ),
+    PlotApiKeyDefinition(
+        "con1",
+        index_type="VALUE",
+        metadata={"data_origin": "everest_constraints"},
+        observations=False,
+        dimensionality=2,
+    ),
+]
 
 
 def test_pressing_copy_button_in_error_dialog(qtbot: QtBot):
@@ -225,7 +251,6 @@ def test_that_plot_window_ignores_negative_check_for_non_numeric_columns(
 
 
 def test_that_gaussian_kde_plot_skips_categorical_data_without_raising():
-
     ensemble = EnsembleObject(
         "ensemble",
         "ensemble",
@@ -316,3 +341,52 @@ def test_that_plot_widget_hides_log_scale_checkbox_for_const_distribution(qtbot:
         const_key_def,
     )
     assert not log_checkbox.isVisible()
+
+
+def test_that_separators_are_included_in_everest(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ert.gui.tools.plot.data_type_keys_widget.is_everest_application",
+        lambda: True,
+    )
+
+    widget = DataTypeKeysWidget(EVEREST_KEY_DEFS)
+    qtbot.addWidget(widget)
+    model = widget.model
+    assert any(isinstance(item, DataTypeSeparator) for item in model._keys)
+
+
+def test_that_datatype_separators_are_not_selectable(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ert.gui.tools.plot.data_type_keys_widget.is_everest_application",
+        lambda: True,
+    )
+    widget = DataTypeKeysWidget(EVEREST_KEY_DEFS)
+    qtbot.addWidget(widget)
+    model = widget.model
+    for i, item in enumerate(model._keys):
+        if isinstance(item, DataTypeSeparator):
+            idx = model.index(i, 0)
+            flags = model.flags(idx)
+            assert not (flags & Qt.ItemFlag.ItemIsSelectable)
+
+
+def test_that_datatype_separators_are_never_set_as_default(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ert.gui.tools.plot.data_type_keys_widget.is_everest_application",
+        lambda: True,
+    )
+    widget = DataTypeKeysWidget(EVEREST_KEY_DEFS)
+    qtbot.addWidget(widget)
+    widget.selectDefault()
+    selected = widget.getSelectedItem()
+    assert selected is not None
+    assert isinstance(selected, PlotApiKeyDefinition)


### PR DESCRIPTION
In the Everest plotter the "Data types" list showed a flat mix of controls, objectives, constraints and aggregated objective values with no indication of which category each entry belonged to.

This is solved by introducing a non-selectable list item that gives the name of the datatype, in bold.

**Issue**
Resolves #12956 


**Approach**
Add non-selectable separator in list


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
