### PR TITLE
Restructure RFT response

### DIFF
--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -16,7 +16,7 @@ from ._observations import (
 )
 from ._shapes import CircleShapeConfig, ShapeRegistry
 from .parsing import ErrorInfo, ObservationConfigError
-from .rft_config import Point, RFTConfig, ZoneName
+from .rft_config import RFTConfig
 
 
 def create_observation_dataframes(
@@ -157,7 +157,6 @@ def _handle_rft_observation(
     rft_observation: RFTObservation,
     shape_registry: ShapeRegistry,
 ) -> pl.DataFrame:
-    location = (rft_observation.east, rft_observation.north, rft_observation.tvd)
     localization_radius = None
     shape = rft_observation.shape(shape_registry)
     localization_radius = (
@@ -165,12 +164,6 @@ def _handle_rft_observation(
         if shape is not None and isinstance(shape, CircleShapeConfig)
         else None
     )
-
-    location_arg: Point | tuple[Point, ZoneName] = location
-    if (zone := rft_observation.zone) is not None:
-        location_arg = (location, zone)
-    if location_arg not in rft_config.locations:
-        rft_config.locations.append(location_arg)
 
     data_to_read = rft_config.data_to_read
     if rft_observation.well not in data_to_read:
@@ -199,9 +192,9 @@ def _handle_rft_observation(
             "well": rft_observation.well,
             "date": rft_observation.date,
             "observation_key": rft_observation.name,
-            "east": pl.Series([location[0]], dtype=pl.Float32),
-            "north": pl.Series([location[1]], dtype=pl.Float32),
-            "tvd": pl.Series([location[2]], dtype=pl.Float32),
+            "east": pl.Series([rft_observation.east], dtype=pl.Float32),
+            "north": pl.Series([rft_observation.north], dtype=pl.Float32),
+            "tvd": pl.Series([rft_observation.tvd], dtype=pl.Float32),
             "md": pl.Series([rft_observation.md], dtype=pl.Float32),
             "zone": pl.Series([rft_observation.zone], dtype=pl.String),
             "observations": pl.Series([rft_observation.value], dtype=pl.Float32),

--- a/src/ert/config/derived_response_config.py
+++ b/src/ert/config/derived_response_config.py
@@ -17,9 +17,25 @@ class DerivedResponseConfig(BaseModel):
     @property
     @abstractmethod
     def match_key(self) -> list[str]:
-        """Identification columns for observations and responses. Along with
+        """Matching columns for observations and responses. Along with
         'response_key' they create the key on which response data should match
         observation data."""
+
+    @property
+    def index_key(self) -> list[str]:
+        """Identification columns for observations."""
+        return self.match_key
+
+    def index_column_expr(self) -> pl.Expr:
+        """Polars expression building the textual "index" column.
+
+        Concatenates `index_key` columns with ", ". Null components are
+        rendered as the literal "None" so positional meaning is preserved.
+        """
+        return pl.concat_str(
+            [pl.col(c).cast(pl.String).fill_null("None") for c in self.index_key],
+            separator=", ",
+        )
 
     def display_column(self, value: Any, column_name: str) -> str:
         return str(value)

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1220,7 +1220,6 @@ class ErtConfig(BaseModel):
                 ensemble_config.response_configs["rft"] = RFTConfig(
                     input_files=[summary_file_base_name],
                     data_to_read={},
-                    locations=[],
                     zonemap=cls_config.zonemap,
                 )
 

--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -39,10 +39,26 @@ class ResponseConfig(BaseModel):
     @property
     @abstractmethod
     def match_key(self) -> list[str]:
-        """Identification columns for observations and responses. Along with
+        """Matching columns for observations and responses. Along with
         'response_key' they create the key on which response data should match
         observation data. For example 'time' for summary and ['report_step','index'] for
         gen data."""
+
+    @property
+    def index_key(self) -> list[str]:
+        """Identification columns for observations."""
+        return self.match_key
+
+    def index_column_expr(self) -> pl.Expr:
+        """Polars expression building the textual "index" column.
+
+        Concatenates `index_key` columns with ", ". Null components are
+        rendered as the literal "None" so positional meaning is preserved.
+        """
+        return pl.concat_str(
+            [pl.col(c).cast(pl.String).fill_null("None") for c in self.index_key],
+            separator=", ",
+        )
 
     @classmethod
     @abstractmethod

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -9,7 +9,7 @@ import warnings
 from collections import defaultdict
 from dataclasses import InitVar, dataclass
 from pathlib import Path
-from typing import IO, Any, Literal, TypeAlias, cast
+from typing import IO, Any, Literal, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
@@ -133,34 +133,32 @@ class RFTConfig(ResponseConfig):
 
     @staticmethod
     def _map_locations_to_cells(
-        egrid_file: str | os.PathLike[str] | IO[Any], zoned_locations: list[_ZonedPoint]
-    ) -> dict[_ZonedPoint, GridIndex]:
+        egrid_file: str | os.PathLike[str] | IO[Any], locations: list[Point]
+    ) -> dict[Point, GridIndex]:
         """
         For each location, find the corresponding connected grid cell, if it exists.
         """
 
-        location_cell_map: dict[_ZonedPoint, GridIndex] = {}
-        if not zoned_locations:
+        location_cell_map: dict[Point, GridIndex] = {}
+        if not locations:
             return location_cell_map
         try:
             grid = CornerpointGrid.read_egrid(egrid_file)
         except (OSError, InvalidEgridFileError) as err:
             raise InvalidResponseFile(f"Could not read grid file: {err}") from err
 
-        for zoned_location, cell in zip(
-            zoned_locations,
-            grid.find_cell_containing_point(
-                [cast(Point, loc.point) for loc in zoned_locations]
-            ),
+        for location, cell in zip(
+            locations,
+            grid.find_cell_containing_point(locations),
             strict=True,
         ):
             if cell is None:
                 raise InvalidResponseFile(
-                    f"Did not find grid coordinate for location(s) {zoned_location}"
+                    f"Did not find grid coordinate for location(s) {location}"
                 )
             # cells returned by grid are 0-based, while zonemap
             # and RFTEntry.connections are 1-based, so unifying
-            location_cell_map[zoned_location] = (cell[0] + 1, cell[1] + 1, cell[2] + 1)
+            location_cell_map[location] = (cell[0] + 1, cell[1] + 1, cell[2] + 1)
         return location_cell_map
 
     @staticmethod
@@ -265,6 +263,19 @@ class RFTConfig(ResponseConfig):
 
         return rft_data
 
+    @staticmethod
+    def response_schema() -> dict[str, Any]:
+        return {
+            "response_key": pl.String,
+            "well": pl.String,
+            "date": pl.String,
+            "property": pl.String,
+            "time": pl.Date,
+            "depth": pl.Float32,
+            "values": pl.Float32,
+            "well_connection_cell": pl.Array(pl.Int64, 3),
+        }
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         """Reads the RFT values from <RUNPATH>/<ECLBASE>.RFT
 
@@ -305,8 +316,6 @@ class RFTConfig(ResponseConfig):
         if not rft_data:
             return pl.DataFrame(schema=schema)
 
-        location_metadata = self._obtain_location_metadata(run_path, iens, iter_)
-
         try:
             df = pl.concat(
                 [
@@ -335,27 +344,68 @@ class RFTConfig(ResponseConfig):
                 f"Could not find {err.args[0]} in RFTFile {rft_filepath}"
             ) from err
 
+        df.pipe(self._assert_schema, self.response_schema())
+
+        pseudo_observations = pl.DataFrame(
+            {
+                "east": pl.Series(
+                    [location.point[0] for location in self._zoned_locations],
+                    dtype=pl.Float32,
+                ),
+                "north": pl.Series(
+                    [location.point[1] for location in self._zoned_locations],
+                    dtype=pl.Float32,
+                ),
+                "tvd": pl.Series(
+                    [location.point[2] for location in self._zoned_locations],
+                    dtype=pl.Float32,
+                ),
+                "zone": pl.Series(
+                    [location.zone_name for location in self._zoned_locations],
+                    dtype=pl.String,
+                ),
+            }
+        )
+
+        location_metadata = self._obtain_location_metadata(
+            run_path, iens, iter_, pseudo_observations
+        )
+
         combined = self._combine_response_and_location_metadata(
-            df, location_metadata, iens, iter_
+            df, pseudo_observations, location_metadata, iens, iter_
         )
 
         return combined.pipe(self._assert_schema, schema)
+
+    @staticmethod
+    def location_metadata_schema() -> dict[str, Any]:
+        return {
+            "east": pl.Float32,
+            "north": pl.Float32,
+            "tvd": pl.Float32,
+            "actual_zones": pl.List(pl.String),
+            "well_connection_cell": pl.Array(pl.Int64, 3),
+        }
 
     def _obtain_location_metadata(
         self,
         run_path: str,
         iens: int,
         iter_: int,
+        observations: pl.DataFrame,
     ) -> pl.DataFrame:
         """
         Obtains location metadata for the observations from provided simulation run.
-        'location' and 'expected_zone' is data provided by the observations. 'location'
-        is a primary key, while 'expected_zone' is added for completeness.
-        'actual_zones' is a list of zones that the location belongs to according to the
-        zonemap, and 'actual_cell' is the grid cell that the location belongs to in
-        current simulation.
+        'east', 'north', and 'tvd' make a unique location. 'actual_zones' is a list of
+        zones that the location belongs to according to the zonemap, and
+        'well_connection_cell' is the grid cell that the location belongs to in current
+        simulation.
         """
-        zoned_locations = self._zoned_locations
+        locations: list[Point] = []
+        for row in observations.iter_rows(named=True):
+            location = (row["east"], row["north"], row["tvd"])
+            if location not in locations:
+                locations.append(location)
 
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
         grid_filepath = self._ergrid_filepath(rft_filepath)
@@ -366,42 +416,49 @@ class RFTConfig(ResponseConfig):
         else:
             zonemap = {}
 
-        location_cell_map = self._map_locations_to_cells(grid_filepath, zoned_locations)
+        location_cell_map = self._map_locations_to_cells(grid_filepath, locations)
 
         return pl.DataFrame(
             {
-                "location": pl.Series(
-                    [loc.point for loc in zoned_locations],
-                    dtype=pl.Array(pl.Float32, 3),
-                ),
-                "expected_zone": pl.Series(
-                    [loc.zone_name for loc in zoned_locations], dtype=pl.String
-                ),
-                "actual_zones": pl.Series(
-                    [
-                        zonemap.get(location_cell_map[loc][-1], [])
-                        for loc in zoned_locations
-                    ],
-                    dtype=pl.List(pl.String),
-                ),
-                "actual_cell": pl.Series(
-                    [location_cell_map[loc] for loc in zoned_locations],
-                    dtype=pl.Array(pl.Int64, 3),
-                ),
-            }
+                "east": [loc[0] for loc in locations],
+                "north": [loc[1] for loc in locations],
+                "tvd": [loc[2] for loc in locations],
+                "actual_zones": [
+                    zonemap.get(location_cell_map[loc][-1], []) for loc in locations
+                ],
+                "well_connection_cell": [location_cell_map[loc] for loc in locations],
+            },
+            schema=self.location_metadata_schema(),
         )
 
     @staticmethod
     def _combine_response_and_location_metadata(
         responses: pl.DataFrame,
+        observations: pl.DataFrame,
         location_metadata: pl.DataFrame,
         iens: int,
         iter_: int,
     ) -> pl.DataFrame:
-        result = responses.join(
+        observations_with_metadata = observations.join(
             location_metadata,
+            left_on=["east", "north", "tvd"],
+            right_on=["east", "north", "tvd"],
+            how="left",
+        ).select(
+            [
+                pl.col("zone").alias("expected_zone"),
+                "east",
+                "north",
+                "tvd",
+                "actual_zones",
+                "well_connection_cell",
+            ]
+        )
+
+        result = responses.join(
+            observations_with_metadata,
             left_on="well_connection_cell",
-            right_on="actual_cell",
+            right_on="well_connection_cell",
             how="left",
         )
 
@@ -413,9 +470,10 @@ class RFTConfig(ResponseConfig):
             pl.col("expected_zone").is_not_null() & ~is_zone_valid
         )
         for row in disabled_due_to_zone_mismatch.iter_rows(named=True):
+            location = (row["east"], row["north"], row["tvd"])
             warnings.warn(
                 PostExperimentWarning(
-                    f"An RFT observation with location {row['location']}, "
+                    f"An RFT observation with location {location}, "
                     f"in iteration {iter_}, realization {iens} did "
                     f"not match expected zone {row['expected_zone']}. The observation "
                     "was deactivated",
@@ -423,26 +481,20 @@ class RFTConfig(ResponseConfig):
                 stacklevel=2,
             )
         result = result.filter(is_zone_valid)
-
-        def location_to_coordinate(index: int, name: str) -> pl.Expr:
-            return (
-                pl.when(pl.col("location").is_null())
-                .then(None)
-                .otherwise(pl.col("location").arr.get(index))
-                .alias(name)
+        return (
+            result.rename({"expected_zone": "zone"})
+            .with_columns(
+                [
+                    pl.col("east").cast(pl.Float32),
+                    pl.col("north").cast(pl.Float32),
+                    pl.col("tvd").cast(pl.Float32),
+                    pl.col("well_connection_cell").arr.get(0).alias("i"),
+                    pl.col("well_connection_cell").arr.get(1).alias("j"),
+                    pl.col("well_connection_cell").arr.get(2).alias("k"),
+                ]
             )
-
-        return result.with_columns(
-            [
-                pl.col("expected_zone").alias("zone"),
-                location_to_coordinate(0, "east"),
-                location_to_coordinate(1, "north"),
-                location_to_coordinate(2, "tvd"),
-                pl.col("well_connection_cell").arr.get(0).alias("i"),
-                pl.col("well_connection_cell").arr.get(1).alias("j"),
-                pl.col("well_connection_cell").arr.get(2).alias("k"),
-            ]
-        ).drop(["location", "well_connection_cell", "expected_zone", "actual_zones"])
+            .drop(["well_connection_cell", "actual_zones"])
+        )
 
     @property
     def response_type(self) -> str:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -504,6 +504,10 @@ class RFTConfig(ResponseConfig):
     def match_key(self) -> list[str]:
         return ["east", "north", "tvd", "zone"]
 
+    @property
+    def index_key(self) -> list[str]:
+        return ["east", "north", "tvd", "zone"]
+
     @classmethod
     def from_config_dict(cls, config_dict: ConfigDict) -> RFTConfig | None:
         if rfts := config_dict.get(ConfigKeys.RFT, []):

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -289,32 +289,15 @@ class RFTConfig(ResponseConfig):
         Points which were constrained to be in a given zone, but were not contained
         in that zone, is not labeled, and instead a warning is emitted.
         """
-        schema: dict[str, Any] = {
-            "response_key": pl.String,
-            "well": pl.String,
-            "date": pl.String,
-            "property": pl.String,
-            "time": pl.Date,
-            "depth": pl.Float32,
-            "values": pl.Float32,
-            "zone": pl.String,
-            "east": pl.Float32,
-            "north": pl.Float32,
-            "tvd": pl.Float32,
-            "i": pl.Int64,
-            "j": pl.Int64,
-            "k": pl.Int64,
-        }
-
         if not self.data_to_read:
-            return pl.DataFrame(schema=schema)
+            return pl.DataFrame(schema=self.response_schema())
 
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]
         rft_data = self._scan_rft(rft_filepath)
 
         if not rft_data:
-            return pl.DataFrame(schema=schema)
+            return pl.DataFrame(schema=self.response_schema())
 
         try:
             df = pl.concat(
@@ -339,43 +322,11 @@ class RFTConfig(ResponseConfig):
                     if prop != "DEPTH" and len(vals) > 0
                 ]
             )
+            return df.pipe(self._assert_schema, self.response_schema())
         except KeyError as err:
             raise InvalidResponseFile(
                 f"Could not find {err.args[0]} in RFTFile {rft_filepath}"
             ) from err
-
-        df.pipe(self._assert_schema, self.response_schema())
-
-        pseudo_observations = pl.DataFrame(
-            {
-                "east": pl.Series(
-                    [location.point[0] for location in self._zoned_locations],
-                    dtype=pl.Float32,
-                ),
-                "north": pl.Series(
-                    [location.point[1] for location in self._zoned_locations],
-                    dtype=pl.Float32,
-                ),
-                "tvd": pl.Series(
-                    [location.point[2] for location in self._zoned_locations],
-                    dtype=pl.Float32,
-                ),
-                "zone": pl.Series(
-                    [location.zone_name for location in self._zoned_locations],
-                    dtype=pl.String,
-                ),
-            }
-        )
-
-        location_metadata = self._obtain_location_metadata(
-            run_path, iens, iter_, pseudo_observations
-        )
-
-        combined = self._combine_response_and_location_metadata(
-            df, pseudo_observations, location_metadata, iens, iter_
-        )
-
-        return combined.pipe(self._assert_schema, schema)
 
     @staticmethod
     def location_metadata_schema() -> dict[str, Any]:
@@ -387,7 +338,7 @@ class RFTConfig(ResponseConfig):
             "well_connection_cell": pl.Array(pl.Int64, 3),
         }
 
-    def _obtain_location_metadata(
+    def obtain_location_metadata(
         self,
         run_path: str,
         iens: int,
@@ -432,42 +383,40 @@ class RFTConfig(ResponseConfig):
         )
 
     @staticmethod
-    def _combine_response_and_location_metadata(
-        responses: pl.DataFrame,
+    def enrich_observations_with_metadata(
+        observations: pl.DataFrame,
+        location_metadata: pl.DataFrame,
+    ) -> pl.DataFrame:
+        observations_with_metadata = observations.join(
+            location_metadata,
+            on=["east", "north", "tvd"],
+            how="left",
+        ).with_columns(
+            [
+                pl.col("zone").alias("expected_zone"),
+            ]
+        )
+        return observations_with_metadata
+
+    @staticmethod
+    def is_zone_valid() -> pl.Expr:
+        return pl.col("expected_zone").is_null() | pl.col("expected_zone").is_in(
+            pl.col("actual_zones")
+        )
+
+    @staticmethod
+    def enrich_observations_with_metadata_and_warn_on_zone_mismatch(
         observations: pl.DataFrame,
         location_metadata: pl.DataFrame,
         iens: int,
         iter_: int,
     ) -> pl.DataFrame:
-        observations_with_metadata = observations.join(
-            location_metadata,
-            left_on=["east", "north", "tvd"],
-            right_on=["east", "north", "tvd"],
-            how="left",
-        ).select(
-            [
-                pl.col("zone").alias("expected_zone"),
-                "east",
-                "north",
-                "tvd",
-                "actual_zones",
-                "well_connection_cell",
-            ]
+        observations_with_metadata = RFTConfig.enrich_observations_with_metadata(
+            observations, location_metadata
         )
 
-        result = responses.join(
-            observations_with_metadata,
-            left_on="well_connection_cell",
-            right_on="well_connection_cell",
-            how="left",
-        )
-
-        is_zone_valid = pl.col("expected_zone").is_null() | pl.col(
-            "expected_zone"
-        ).is_in(pl.col("actual_zones"))
-
-        disabled_due_to_zone_mismatch = result.filter(
-            pl.col("expected_zone").is_not_null() & ~is_zone_valid
+        disabled_due_to_zone_mismatch = observations_with_metadata.filter(
+            ~RFTConfig.is_zone_valid()
         )
         for row in disabled_due_to_zone_mismatch.iter_rows(named=True):
             location = (row["east"], row["north"], row["tvd"])
@@ -480,21 +429,11 @@ class RFTConfig(ResponseConfig):
                 ),
                 stacklevel=2,
             )
-        result = result.filter(is_zone_valid)
-        return (
-            result.rename({"expected_zone": "zone"})
-            .with_columns(
-                [
-                    pl.col("east").cast(pl.Float32),
-                    pl.col("north").cast(pl.Float32),
-                    pl.col("tvd").cast(pl.Float32),
-                    pl.col("well_connection_cell").arr.get(0).alias("i"),
-                    pl.col("well_connection_cell").arr.get(1).alias("j"),
-                    pl.col("well_connection_cell").arr.get(2).alias("k"),
-                ]
-            )
-            .drop(["well_connection_cell", "actual_zones"])
+
+        result = observations_with_metadata.with_columns(
+            RFTConfig.is_zone_valid().alias("is_valid"),
         )
+        return result
 
     @property
     def response_type(self) -> str:
@@ -502,7 +441,7 @@ class RFTConfig(ResponseConfig):
 
     @property
     def match_key(self) -> list[str]:
-        return ["east", "north", "tvd", "zone"]
+        return ["well_connection_cell"]
 
     @property
     def index_key(self) -> list[str]:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -48,17 +48,6 @@ DateString: TypeAlias = str
 RFTProperty: TypeAlias = str
 
 
-@dataclass(frozen=True)
-class _ZonedPoint:
-    """A point optionally constrained to be in a given zone."""
-
-    point: tuple[float | None, float | None, float | None] = (None, None, None)
-    zone_name: ZoneName | None = None
-
-    def has_zone(self) -> bool:
-        return self.zone_name is not None
-
-
 class RFTConfig(ResponseConfig):
     """:term:`RFT` response from a :term:`reservoir simulator`.
 
@@ -71,8 +60,6 @@ class RFTConfig(ResponseConfig):
 
     Parameters:
         data_to_read: dictionary of the values that should be read from the rft file.
-        loations: list of optionally zone constrained points that the rft values should
-            be labeled with.
         zonemap: The mapping from grid layer index to zone name.
     """
 
@@ -82,15 +69,7 @@ class RFTConfig(ResponseConfig):
     data_to_read: dict[WellName, dict[DateString, list[RFTProperty]]] = Field(
         default_factory=dict
     )
-    locations: list[Point | tuple[Point, ZoneName]] = Field(default_factory=list)
     zonemap: Path | None = None
-
-    @property
-    def _zoned_locations(self) -> list[_ZonedPoint]:
-        return [
-            _ZonedPoint(*p) if isinstance(p[1], ZoneName) else _ZonedPoint(p)
-            for p in self.locations
-        ]
 
     @property
     def expected_input_files(self) -> list[str]:

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -31,6 +31,7 @@ from PyQt6.QtWidgets import (
 from ert import LibresFacade
 from ert.config.derived_response_config import DerivedResponseConfig
 from ert.config.response_config import ResponseConfig
+from ert.config.rft_config import RFTConfig
 from ert.storage import Ensemble, Experiment, RealizationStorageState
 from ert.warnings import capture_specific_warning
 
@@ -140,25 +141,37 @@ class _ObservationTreeWidgetItem(QTreeWidgetItem):
         self,
         parent: QTreeWidgetItem,
         observation_key: str,
-        observation_data: dict[str, object],
+        observation_data: pl.DataFrame,
         response_config: ResponseConfig | DerivedResponseConfig,
     ) -> None:
+        assert len(observation_data) == 1
         self.observation_key = observation_key
         self.observation_data = observation_data
         self.response_config = response_config
         super().__init__(parent, [self.display_label, observation_key])
 
-    @property
-    def match_key_data(self) -> dict[str, object]:
-        return {
-            col: self.observation_data[col] for col in self.response_config.match_key
-        }
+    def match_key_data(self, metadata: pl.DataFrame | None) -> dict[str, object]:
+        response_type = self.response_config.type
+        if response_type == "rft":
+            assert metadata is not None
+            observation_data = RFTConfig.enrich_observations_with_metadata(
+                self.observation_data, metadata
+            )
+            observation_data = observation_data.filter(RFTConfig.is_zone_valid())
+        else:
+            observation_data = self.observation_data
+
+        if observation_data.is_empty():
+            return {}
+        return observation_data.select(self.response_config.match_key).row(
+            0, named=True
+        )
 
     @property
     def index_key_data(self) -> dict[str, object]:
-        return {
-            col: self.observation_data[col] for col in self.response_config.index_key
-        }
+        return self.observation_data.select(self.response_config.index_key).row(
+            0, named=True
+        )
 
     @property
     def display_label(self) -> str:
@@ -300,8 +313,7 @@ class _EnsembleWidget(QWidget):
         ax = self._figure.add_subplot(111)
         ax.set_title(selected.observation_key)
         ax.grid(True)
-
-        obs = pl.DataFrame(selected.observation_data)
+        obs = selected.observation_data
         scaling_df = self._ensemble.load_observation_scaling_factors()
 
         def _try_render_scaled_obs() -> None:
@@ -334,34 +346,55 @@ class _EnsembleWidget(QWidget):
                 color="black",
             )
 
-        def _filter_by_match_key(df: pl.DataFrame) -> pl.DataFrame:
-            """
-            Filter df to match 'selected' observation on match keys.
-            """
-            mask = pl.lit(True)
-            for col, val in selected.match_key_data.items():
-                mask &= pl.col(col).eq_missing(val)
-            return df.filter(mask)
-
-        response_key = str(selected.observation_data["response_key"])
+        response_type = selected.response_config.type
+        response_key = str(obs["response_key"].item())
         reals_with_responses = tuple(
             self._ensemble.get_realization_list_with_responses()
         )
 
-        response_ds = (
-            self._ensemble.load_responses(
-                response_key,
-                reals_with_responses,
-            )
-            if reals_with_responses
-            and response_key in self._ensemble.experiment.response_key_to_response_type
-            else None
-        )
+        def _filter_by_match_key(
+            df: pl.DataFrame, observation_metadata: pl.DataFrame | None
+        ) -> pl.DataFrame:
+            """
+            Filter df to match 'selected' observation on match keys.
+            """
+            match_data = selected.match_key_data(observation_metadata)
+            if not match_data:
+                return df.filter(pl.lit(False))
+
+            mask = pl.lit(True)
+            for col, val in match_data.items():
+                mask &= pl.col(col).eq_missing(val)
+            return df.filter(mask)
+
+        def _load_and_filter_responses() -> pl.DataFrame | None:
+            assert self._ensemble is not None
+            ens = self._ensemble
+
+            if not reals_with_responses:
+                return None
+
+            if response_key not in ens.experiment.response_key_to_response_type:
+                return None
+
+            if response_type == "rft":
+                per_realization: list[pl.DataFrame] = []
+                for real in reals_with_responses:
+                    response = ens.load_responses(response_key, (real,))
+                    observation_metadata = ens.load_observation_location_metadata(real)
+                    res = _filter_by_match_key(response, observation_metadata)
+                    per_realization.append(res)
+                return pl.concat(per_realization)
+
+            responses = ens.load_responses(response_key, reals_with_responses)
+            return _filter_by_match_key(responses, None)
+
+        response_ds = _load_and_filter_responses()
 
         if response_ds is not None and not response_ds.is_empty():
-            response_ds_for_label = _filter_by_match_key(response_ds).rename(
-                {"values": "Responses"}
-            )[["response_key", "Responses"]]
+            response_ds_for_label = response_ds.rename({"values": "Responses"})[
+                ["response_key", "Responses"]
+            ]
 
             ax.errorbar(
                 x="Observation",
@@ -448,7 +481,7 @@ class _EnsembleWidget(QWidget):
                         pl.col("observation_key").eq(obs_key)
                     ).unique()
 
-                    for observation_data in obs_ds.to_dicts():
+                    for observation_data in obs_ds.iter_slices(n_rows=1):
                         _ObservationTreeWidgetItem(
                             root, obs_key, observation_data, response_config
                         )

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -155,21 +155,27 @@ class _ObservationTreeWidgetItem(QTreeWidgetItem):
         }
 
     @property
+    def index_key_data(self) -> dict[str, object]:
+        return {
+            col: self.observation_data[col] for col in self.response_config.index_key
+        }
+
+    @property
     def display_label(self) -> str:
         return ", ".join(
             self.response_config.display_column(val, col)
-            for col, val in self.match_key_data.items()
+            for col, val in self.index_key_data.items()
         )
 
     def __lt__(self, other: QTreeWidgetItem) -> bool:
         assert isinstance(other, _ObservationTreeWidgetItem)
-        assert self.response_config.match_key == other.response_config.match_key, (
+        assert self.response_config.index_key == other.response_config.index_key, (
             "Expecting items being compared to be of the same response type"
         )
 
         for val, other_val in zip(
-            self.match_key_data.values(),
-            other.match_key_data.values(),
+            self.index_key_data.values(),
+            other.index_key_data.values(),
             strict=True,
         ):
             if isinstance(val, (int, float)) and isinstance(other_val, (int, float)):
@@ -302,9 +308,7 @@ class _EnsembleWidget(QWidget):
             if scaling_df is None:
                 return None
 
-            index_col = pl.concat_str(
-                selected.response_config.match_key, separator=", "
-            )
+            index_col = selected.response_config.index_column_expr()
             joined = obs.with_columns(index_col.alias("_tmp_index")).join(
                 scaling_df,
                 how="left",

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from functools import cache, cached_property, lru_cache
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 import numpy as np
@@ -27,6 +27,7 @@ from ert.config import (
     ParameterConfig,
     SummaryConfig,
 )
+from ert.config.rft_config import RFTConfig
 from ert.exceptions import StorageError
 from ert.substitutions import substitute_runpath_name
 
@@ -924,6 +925,19 @@ class LocalEnsemble(BaseMode):
             for e in response_configs
         }
 
+    @require_write
+    def save_observation_location_metadata(
+        self, dataset: pl.DataFrame, realization: int
+    ) -> None:
+        filename = "rft_observation_location_metadata.parquet"
+        output_path = self._realization_dir(realization) / filename
+        self._storage._to_parquet_transaction(output_path, dataset)
+
+    def load_observation_location_metadata(self, realization: int) -> pl.DataFrame:
+        filename = "rft_observation_location_metadata.parquet"
+        ds_path = self._realization_dir(realization) / filename
+        return pl.read_parquet(ds_path)
+
     def get_observations_and_responses(
         self,
         selected_observations: Iterable[str],
@@ -972,17 +986,30 @@ class LocalEnsemble(BaseMode):
                     .with_columns([pl.col("response_key").cast(pl.Categorical)])
                 )
 
-                observed_cols = {
-                    k: observations_for_type[k].unique()
-                    for k in ["response_key", *response_cls.match_key]
-                }
-
                 reals = np.sort(iens_active_index).tolist()
 
                 # Load and join one realization at a time to reduce peak memory usage
                 first_columns: pl.DataFrame | None = None
                 realization_columns: list[pl.DataFrame] = []
                 for real in reals:
+                    if response_type == "rft":
+                        observation_metadata_in_realization = (
+                            self.load_observation_location_metadata(real)
+                        )
+                        observations = RFTConfig.enrich_observations_with_metadata_and_warn_on_zone_mismatch(  # noqa: E501
+                            observations_for_type,
+                            observation_metadata_in_realization,
+                            real,
+                            self.iteration,
+                        )
+                    else:
+                        observations = observations_for_type
+
+                    observed_cols = {
+                        k: observations[k].unique()
+                        for k in ["response_key", *response_cls.match_key]
+                    }
+
                     responses = self._load_responses_lazy(
                         response_type, (real,)
                     ).with_columns([pl.col("response_key").cast(pl.Categorical)])
@@ -1009,10 +1036,10 @@ class LocalEnsemble(BaseMode):
                         # to represent this. We are basically saying that
                         # for this realization, each observation points
                         # to a NaN response.
-                        joined = observations_for_type.with_columns(
+                        joined = observations.with_columns(
                             pl.Series(
                                 str(real),
-                                [np.nan] * len(observations_for_type),
+                                [np.nan] * len(observations),
                                 dtype=pl.Float32,
                             )
                         )
@@ -1021,7 +1048,7 @@ class LocalEnsemble(BaseMode):
                             "response_key",
                             *[k for k in response_cls.match_key if k != "time"],
                         ]
-                        joined = observations_for_type.sort(
+                        joined = observations.sort(
                             by=[*by_cols, "time"]
                         ).join_asof(
                             pivoted.sort(by=[*by_cols, "time"]),
@@ -1032,7 +1059,7 @@ class LocalEnsemble(BaseMode):
                             tolerance="1s",
                         )
                     else:
-                        joined = observations_for_type.join(
+                        joined = observations.join(
                             pivoted,
                             how="left",
                             on=["response_key", *response_cls.match_key],
@@ -1047,6 +1074,14 @@ class LocalEnsemble(BaseMode):
                     if "index" in joined.columns:
                         joined = joined.drop("index")
                     joined = joined.rename({"__tmp_index_key__": "index"})
+
+                    if "is_valid" in joined.columns:
+                        joined = joined.with_columns(
+                            pl.when(pl.col("is_valid"))
+                            .then(pl.col(str(real)))
+                            .otherwise(pl.lit(None, dtype=pl.Float32))
+                            .alias(str(real))
+                        )
 
                     if first_columns is None:
                         # The "leftmost" index columns are not yet collected.
@@ -1115,24 +1150,15 @@ class LocalEnsemble(BaseMode):
             except (KeyError, IndexError):
                 pass  # No summary data available, will use default
 
-        observations = rft_observations.with_columns(
+        pure_observations = rft_observations.with_columns(
             pl.int_range(pl.len()).over("well").alias("order"),
         )
-
-        join_keys = ["well", "date", "east", "north", "tvd"]
-        observed_values = {k: observations[k].unique() for k in join_keys}
 
         pivot_index = [
             "well",
             "date",
             "realization",
-            "response_zone",
-            "east",
-            "north",
-            "tvd",
-            "i",
-            "j",
-            "k",
+            "well_connection_cell",
         ]
 
         output_columns = [
@@ -1162,13 +1188,19 @@ class LocalEnsemble(BaseMode):
         result_frames: list[pl.DataFrame] = []
 
         for real in sorted(realizations):
-            responses = (
-                self.load_responses("rft", (real,))
-                .with_columns(
-                    pl.col("property").str.to_lowercase(),
-                )
-                .rename({"zone": "response_zone"})
+            responses = self.load_responses("rft", (real,)).with_columns(
+                pl.col("property").str.to_lowercase(),
             )
+            observation_metadata_in_realization = (
+                self.load_observation_location_metadata(real)
+            )
+            observations = RFTConfig.enrich_observations_with_metadata(
+                pure_observations,
+                observation_metadata_in_realization,
+            )
+
+            join_keys = ["well", "date", "well_connection_cell"]
+            observed_values = {k: observations[k].unique() for k in join_keys}
 
             for col, values in observed_values.items():
                 responses = responses.filter(
@@ -1199,14 +1231,15 @@ class LocalEnsemble(BaseMode):
                     nulls_equal=True,
                 )
                 .with_columns(
-                    pl.col("zone")
-                    .eq_missing(pl.col("response_zone"))
-                    .alias("valid_zone"),
+                    RFTConfig.is_zone_valid().alias("valid_zone"),
                     (1 - pl.col("sgas") - pl.col("swat")).alias("soil"),
                     pl.col("is_active").fill_null(False),
                     pl.col("date")
                     .replace_strict(date_to_report_step, default=0)
                     .alias("report_step"),
+                    pl.col("well_connection_cell").arr.get(0).alias("i"),
+                    pl.col("well_connection_cell").arr.get(1).alias("j"),
+                    pl.col("well_connection_cell").arr.get(2).alias("k"),
                 )
                 .select(output_columns)
             )
@@ -1695,6 +1728,21 @@ async def _write_responses_to_storage(
                 f"Loaded {config.type}",
                 extra={"Time": f"{(time.perf_counter() - start_time):.4f}s"},
             )
+
+            if config.type == "rft":
+                try:
+                    _write_observation_metadata(run_path, realization, ensemble)
+                    await asyncio.sleep(0)
+                except Exception as err:
+                    errors.append(str(err))
+                    logger.exception(
+                        "Unexpected exception while reading from runpath or "
+                        "writing RFT observation metadata "
+                        f"for realization {realization}",
+                        exc_info=err,
+                    )
+                    continue
+
             start_time = time.perf_counter()
             ensemble.save_response(config.type, ds, realization)
             await asyncio.sleep(0)
@@ -1719,6 +1767,29 @@ async def _write_responses_to_storage(
     if errors:
         return LoadResult.failure("\n".join(errors))
     return LoadResult.success()
+
+
+def _write_observation_metadata(
+    run_path: str,
+    realization: int,
+    ensemble: LocalEnsemble,
+) -> None:
+    """To quality control observations in the update step, additional
+    observation-related data from simulations must be obtained and saved in the storage.
+    As simulation files containing required information are not copied from runpath to
+    storage due to their size, extract of observation metadata must be stored
+    instead."""
+
+    rft_config = cast(RFTConfig, ensemble.experiment.response_configuration["rft"])
+    rft_observations = ensemble.experiment.observations.get("rft")
+    if rft_observations is None or rft_observations.is_empty():
+        return
+    location_metadata = rft_config.obtain_location_metadata(
+        run_path, realization, ensemble.iteration, rft_observations
+    )
+    output_path = ensemble._realization_dir(realization)
+    Path(output_path).mkdir(exist_ok=True)
+    ensemble.save_observation_location_metadata(location_metadata, realization)
 
 
 async def load_realization_parameters_and_responses(

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -933,10 +933,13 @@ class LocalEnsemble(BaseMode):
         corresponding simulated responses from an ensemble.
 
         The returned DataFrame includes an "index" column containing a
-        comma-separated string of the response type's match key values:
+        comma-separated string of the response type's index key values.
+        Missing components are rendered as the literal "None" so that
+        positional meaning is preserved:
         - Summary: "2024-01-15 00:00:00" (time)
         - GenData: "0, 42" (report_step, index)
         - RFT: "123.5, 456.7, 2500.0, ZONE_A" (east, north, tvd, zone)
+                or "123.5, 456.7, 2500.0, None" when zone is missing
         """
         known_observations = self.experiment.observation_keys
 
@@ -1036,21 +1039,14 @@ class LocalEnsemble(BaseMode):
                             nulls_equal=True,
                         )
 
-                    # Do not drop match keys which
-                    # overlap with localization attributes
-                    match_keys_to_drop = set(response_cls.match_key).difference(
-                        {"north", "east", "radius"}
+                    # Avoid potential collision with "index" column (it could be a part
+                    # of the index_key)
+                    joined = joined.with_columns(
+                        response_cls.index_column_expr().alias("__tmp_index_key__")
                     )
-                    joined = (
-                        joined.with_columns(
-                            pl.concat_str(response_cls.match_key, separator=", ").alias(
-                                "__tmp_index_key__"
-                                # Avoid potential collisions w/ match key
-                            )
-                        )
-                        .drop(match_keys_to_drop)
-                        .rename({"__tmp_index_key__": "index"})
-                    )
+                    if "index" in joined.columns:
+                        joined = joined.drop("index")
+                    joined = joined.rename({"__tmp_index_key__": "index"})
 
                     if first_columns is None:
                         # The "leftmost" index columns are not yet collected.

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 27
+_LOCAL_STORAGE_VERSION = 28
 
 
 class _Migrations(BaseModel):
@@ -517,6 +517,7 @@ class LocalStorage(BaseMode):
             to25,
             to26,
             to27,
+            to28,
         )
 
         try:
@@ -573,6 +574,7 @@ class LocalStorage(BaseMode):
                     24: to25,
                     25: to26,
                     26: to27,
+                    27: to28,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to28.py
+++ b/src/ert/storage/migration/to28.py
@@ -1,0 +1,264 @@
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+info = """Splits rft.parquet into 2 files. rft.parquet has response only data and
+       rft_observation_location_metadata.parquet has location related data."""
+
+logger = logging.getLogger(__name__)
+
+
+def original_response_schema() -> dict[str, Any]:
+    return {
+        "realization": pl.UInt16,
+        "response_key": pl.String,
+        "well": pl.String,
+        "date": pl.String,
+        "property": pl.String,
+        "time": pl.Date,
+        "depth": pl.Float32,
+        "values": pl.Float32,
+        "zone": pl.String,
+        "east": pl.Float32,
+        "north": pl.Float32,
+        "tvd": pl.Float32,
+        "i": pl.Int64,
+        "j": pl.Int64,
+        "k": pl.Int64,
+    }
+
+
+def observation_schema() -> dict[str, Any]:
+    return {
+        "response_key": pl.String,
+        "well": pl.String,
+        "date": pl.String,
+        "observation_key": pl.String,
+        "east": pl.Float32,
+        "north": pl.Float32,
+        "tvd": pl.Float32,
+        "md": pl.Float32,
+        "zone": pl.String,
+        "observations": pl.Float32,
+        "std": pl.Float32,
+        "radius": pl.Float32,
+    }
+
+
+def response_schema() -> dict[str, Any]:
+    return {
+        "realization": pl.UInt16,
+        "response_key": pl.String,
+        "well": pl.String,
+        "date": pl.String,
+        "property": pl.String,
+        "time": pl.Date,
+        "depth": pl.Float32,
+        "values": pl.Float32,
+        "well_connection_cell": pl.Array(pl.Int64, 3),
+    }
+
+
+def location_metadata_schema() -> dict[str, Any]:
+    return {
+        "east": pl.Float32,
+        "north": pl.Float32,
+        "tvd": pl.Float32,
+        "actual_zones": pl.List(pl.String),
+        "well_connection_cell": pl.Array(pl.Int64, 3),
+    }
+
+
+class InvalidSchemaError(Exception):
+    pass
+
+
+def check_well_connection_cell_consistency(
+    df: pl.DataFrame, group_cols: list[str]
+) -> None:
+    consistency_df = (
+        df.group_by(group_cols)
+        .agg(pl.col("well_connection_cell").n_unique().alias("n_unique_cells"))
+        .filter(pl.col("n_unique_cells") > 1)
+    )
+
+    if len(consistency_df) > 0:
+        error_msg = (
+            f"Unexpected: found {group_cols} combinations with inconsistent "
+            f"well_connection_cell values:\n{consistency_df}\n"
+            f"Each {group_cols} should map to exactly one well_connection_cell."
+        )
+        raise RuntimeError(error_msg)
+
+
+def _extract_response_df(original_rft_response: pl.DataFrame) -> pl.DataFrame:
+    rft_response_df = original_rft_response.select(
+        [
+            "realization",
+            "response_key",
+            "well",
+            "date",
+            "property",
+            "time",
+            "depth",
+            "values",
+            pl.concat_list(
+                pl.col("i").cast(pl.Int64),
+                pl.col("j").cast(pl.Int64),
+                pl.col("k").cast(pl.Int64),
+            )
+            .cast(pl.Array(pl.Int64, 3))
+            .alias("well_connection_cell"),
+        ]
+    ).unique(maintain_order=True)
+
+    well_date_depth_cols = ["well", "date", "depth"]
+    check_well_connection_cell_consistency(rft_response_df, well_date_depth_cols)
+    return rft_response_df
+
+
+def _extract_locations_in_response_df(
+    original_rft_response: pl.DataFrame,
+) -> pl.DataFrame:
+    locations_in_response_df = original_rft_response.select(
+        [
+            pl.col("east").cast(pl.Float32),
+            pl.col("north").cast(pl.Float32),
+            pl.col("tvd").cast(pl.Float32),
+            # actually simulated zone and well_connection_cell are lost,
+            # so if they were not equal to expected, they will be set to [] or None
+            pl.col("zone").alias("actual_zone"),
+            pl.concat_list(
+                pl.col("i").cast(pl.Int64),
+                pl.col("j").cast(pl.Int64),
+                pl.col("k").cast(pl.Int64),
+            )
+            .cast(pl.Array(pl.Int64, 3))
+            .alias("well_connection_cell"),
+        ]
+    )
+
+    locations_in_response_non_null_df = locations_in_response_df.filter(
+        pl.col("east").is_not_null()
+        | pl.col("north").is_not_null()
+        | pl.col("tvd").is_not_null()
+    )
+
+    location_cols = ["east", "north", "tvd"]
+    check_well_connection_cell_consistency(
+        locations_in_response_non_null_df, location_cols
+    )
+
+    return locations_in_response_non_null_df.group_by(location_cols).agg(
+        pl.col("actual_zone")
+        .filter(pl.col("actual_zone").is_not_null())
+        .unique()
+        .alias("actual_zones"),
+        pl.col("well_connection_cell").first().alias("well_connection_cell"),
+    )
+
+
+def transform(
+    observations_df: pl.DataFrame,
+    original_rft_response: pl.DataFrame,
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+
+    if original_rft_response.schema != original_response_schema():
+        raise InvalidSchemaError(
+            f"Unexpected schema for rft.parquet: {original_rft_response.schema}. "
+            f"Expected: {original_response_schema()}"
+        )
+
+    if observations_df.schema != observation_schema():
+        raise InvalidSchemaError(
+            f"Unexpected schema for observations: {observations_df.schema}. "
+            f"Expected: {observation_schema()}"
+        )
+
+    rft_response_df = _extract_response_df(original_rft_response)
+
+    if observations_df.is_empty():
+        empty_location_metadata_df = pl.DataFrame([], schema=location_metadata_schema())
+        return rft_response_df, empty_location_metadata_df
+
+    locations_in_response_df = _extract_locations_in_response_df(original_rft_response)
+
+    observed_locations_df = observations_df.select(
+        [
+            pl.col("east").cast(pl.Float32),
+            pl.col("north").cast(pl.Float32),
+            pl.col("tvd").cast(pl.Float32),
+        ]
+    ).unique(maintain_order=True)
+
+    locations_metadata_df = (
+        observed_locations_df.join(
+            locations_in_response_df,
+            on=["east", "north", "tvd"],
+            how="left",
+            coalesce=False,
+        )
+        .with_columns(
+            pl.col("actual_zones").fill_null(pl.lit([], dtype=pl.List(pl.String)))
+        )
+        .select(
+            [
+                "east",
+                "north",
+                "tvd",
+                "actual_zones",
+                "well_connection_cell",
+            ]
+        )
+        .cast(pl.Schema(location_metadata_schema()))
+        .unique(maintain_order=True)
+    )
+
+    return rft_response_df, locations_metadata_df
+
+
+def migrate(path: Path) -> None:
+    for rft_response_path in path.glob("ensembles/*/*/rft.parquet"):
+        ensemble_dir = rft_response_path.parent.parent
+        ensemble_index = json.loads(
+            (ensemble_dir / "index.json").read_text(encoding="utf-8")
+        )
+        experiment_id = ensemble_index["experiment_id"]
+
+        rft_obs_path = path / "experiments" / experiment_id / "observations" / "rft"
+        rft_obs_df = None
+        if not rft_obs_path.exists():
+            logger.warning(
+                f"Unexpected situation: RFT response exists at {rft_response_path}, "
+                f"but RFT observations are missing at {rft_obs_path}. "
+                "Assuming empty observations",
+                stacklevel=2,
+            )
+            rft_obs_df = pl.DataFrame(schema=observation_schema())
+        else:
+            rft_obs_df = pl.read_parquet(rft_obs_path)
+
+        original_rft_response_df = pl.read_parquet(rft_response_path)
+
+        try:
+            rft_response_df, location_metadata_df = transform(
+                rft_obs_df, original_rft_response_df
+            )
+            logger.info(f"Successfully transformed RFT response at {rft_response_path}")
+        except InvalidSchemaError as e:
+            logger.warning(
+                f"Schema error on migrating {rft_response_path}: {e}. "
+                "Using empty dataframes instead.",
+                stacklevel=2,
+            )
+            rft_response_df = pl.DataFrame(schema=response_schema())
+            location_metadata_df = pl.DataFrame(schema=location_metadata_schema())
+
+        location_metadata_path = (
+            rft_response_path.parent / "rft_observation_location_metadata.parquet"
+        )
+        rft_response_df.write_parquet(rft_response_path)
+        location_metadata_df.write_parquet(location_metadata_path)

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -354,7 +354,6 @@ def test_that_rft_config_is_created_from_observations():
         ),
     )
     assert rft_config.data_to_read == {"well": {"2013-03-31": ["PRESSURE"]}}
-    assert rft_config.locations == [(30.0, 71.0, 2000.0)]
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -556,7 +556,6 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={"*": {"*": ["*"]}},
-        locations=[(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)],
     )
     shape_registry = ShapeRegistry()
     shape_id = shape_registry.register(
@@ -582,50 +581,6 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
     assert "radius" in df.columns
     assert df["radius"].to_list() == [provided_radius]
     assert df["radius"].dtype == pl.Float32
-
-
-@pytest.mark.parametrize(
-    ("zones"),
-    [
-        pytest.param(
-            [None, "zone1"],
-            id="Location with no zone followed by location with zone",
-        ),
-        pytest.param(
-            ["zone1", None],
-            id="Location with zone followed by location without zone",
-        ),
-        pytest.param(
-            ["zone1", "zone2"],
-            id="Location with zone followed by location with another zone",
-        ),
-    ],
-)
-def test_that_handle_rft_observations_adds_locations_both_with_zone_and_without(zones):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["*"]}},
-    )
-
-    def make_observation(zone):
-        return RFTObservation(
-            name="NAME[0]",
-            well="WELL1",
-            date="2013-03-31",
-            value=294.0,
-            error=10.0,
-            property="PRESSURE",
-            north=71.0,
-            east=30.0,
-            tvd=2000.0,
-            zone=zone,
-        )
-
-    for zone in zones:
-        rft_observation = make_observation(zone)
-        _handle_rft_observation(rft_config, rft_observation, ShapeRegistry())
-
-    assert len(rft_config.locations) == 2
 
 
 def test_that_if_an_rft_observation_is_outside_the_zone_then_it_is_deactivated(

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1,6 +1,7 @@
 import io
 import os
 from io import BytesIO, StringIO
+from typing import cast
 
 import numpy as np
 import polars as pl
@@ -75,13 +76,13 @@ def mock_resfo_file(mocked_files):
     return inner
 
 
-def test_that_rfts_match_key_is_east_north_tvd_and_zone():
+def test_that_rfts_match_key_is_well_connection_cell():
     assert set(
         RFTConfig(
             input_files=["BASE.RFT"],
             data_to_read={"*": {"*": ["*"]}},
         ).match_key
-    ) == {"east", "north", "tvd", "zone"}
+    ) == {"well_connection_cell"}
 
 
 def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo_file):
@@ -101,13 +102,7 @@ def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo
         "time",
         "depth",
         "values",
-        "east",
-        "north",
-        "i",
-        "j",
-        "k",
-        "tvd",
-        "zone",
+        "well_connection_cell",
     }
 
 
@@ -125,13 +120,7 @@ def test_that_rft_with_empty_data_to_read_returns_empty_df(mock_resfo_file):
         "time",
         "depth",
         "values",
-        "east",
-        "north",
-        "i",
-        "j",
-        "k",
-        "tvd",
-        "zone",
+        "well_connection_cell",
     }
 
 
@@ -359,9 +348,30 @@ def egrid():
     ]
 
 
-def test_that_locations_are_found_in_corresponding_grid_and_added_to_response_dataframe(
-    mock_resfo_file, egrid
-):
+def test_that_locations_are_found_in_corresponding_grid(mock_resfo_file, egrid):
+    config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "BASE",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "OBS1",
+                        "WELL": "WELL2",
+                        "VALUE": "7",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.0,
+                        "EAST": 1.0,
+                        "TVD": 1.0,
+                    },
+                ],
+            ),
+        }
+    )
+
     mock_resfo_file(
         "/tmp/does_not_exist/BASE.EGRID",
         egrid,
@@ -374,15 +384,12 @@ def test_that_locations_are_found_in_corresponding_grid_and_added_to_response_da
             ("DEPTH   ", float_arr([0.1])),
         ],
     )
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["*"]}},
-        locations=[(1.0, 1.0, 1.0)],
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
+    data = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", 1, 1, observations
     )
-    data = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-    assert data["response_key"].to_list() == [
-        "WELL2:2000-01-01:PRESSURE",
-    ]
+
     assert data["north"].to_list() == [1.0]
     assert data["east"].to_list() == [1.0]
     assert data["tvd"].to_list() == [1.0]
@@ -391,6 +398,41 @@ def test_that_locations_are_found_in_corresponding_grid_and_added_to_response_da
 def test_that_multiple_locations_in_the_same_cell_creates_multiple_rows(
     mock_resfo_file, egrid
 ):
+    config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "BASE",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "OBS1",
+                        "WELL": "WELL2",
+                        "VALUE": "7",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.25,
+                        "EAST": 1.25,
+                        "TVD": 1.25,
+                    },
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "OBS2",
+                        "WELL": "WELL2",
+                        "VALUE": "8",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.5,
+                        "EAST": 1.5,
+                        "TVD": 1.5,
+                    },
+                ],
+            ),
+        }
+    )
+
     mock_resfo_file(
         "/tmp/does_not_exist/BASE.EGRID",
         egrid,
@@ -403,22 +445,18 @@ def test_that_multiple_locations_in_the_same_cell_creates_multiple_rows(
             ("DEPTH   ", float_arr([0.1])),
         ],
     )
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["*"]}},
-        locations=[(1.25, 1.25, 1.25), (1.5, 1.5, 1.5)],
+
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
+    data = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", 1, 1, observations
     )
-    data = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-    assert data["response_key"].to_list() == [
-        "WELL2:2000-01-01:PRESSURE",
-        "WELL2:2000-01-01:PRESSURE",
-    ]
     assert sorted(data["north"].to_list()) == [1.25, 1.5]
     assert sorted(data["east"].to_list()) == [1.25, 1.5]
     assert sorted(data["tvd"].to_list()) == [1.25, 1.5]
 
 
-def test_that_connection_mismatch_leads_to_nullified_location(mock_resfo_file, egrid):
+def test_that_connection_cells_are_processed_independently(mock_resfo_file, egrid):
     config = ErtConfig.from_dict(
         {
             "ECLBASE": "ECLBASE<IENS>",
@@ -459,10 +497,21 @@ def test_that_connection_mismatch_leads_to_nullified_location(mock_resfo_file, e
         ],
     )
 
-    res = config.ensemble_config.response_configs["rft"].read_from_file(
-        "/tmp/does_not_exist", 1, 1
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    iens = 1
+    iter_ = 1
+    responses = rft_config.read_from_file("/tmp/does_not_exist", iens, iter_)
+    observations = pl.DataFrame(config.observation_declarations)
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", iens, iter_, observations
     )
-    assert res["tvd"].to_list() == [None] * 3
+    assert responses["well_connection_cell"].to_list() == [
+        [5, 1, 1],
+        [5, 1, 2],
+        [5, 1, 3],
+    ]
+    assert observation_metadata["well_connection_cell"].to_list() == [[1, 1, 2]]
+    assert observation_metadata["actual_zones"].to_list() == [[]]
 
 
 def test_that_location_outside_of_the_grid_raises_invalid_response_file(
@@ -495,23 +544,11 @@ def test_that_location_outside_of_the_grid_raises_invalid_response_file(
         "/tmp/does_not_exist/ECLBASE1.EGRID",
         egrid,
     )
-    mock_resfo_file(
-        "/tmp/does_not_exist/ECLBASE1.RFT",
-        [
-            *cell_start(
-                date=(1, 1, 2000),
-                well_name="WELL",
-                ijks=[(1, 1, 1), (1, 1, 2), (1, 1, 3)],
-            ),
-            ("PRESSURE", float_arr([0.0, 1.0, 2.0])),
-            ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
-        ],
-    )
 
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
     with pytest.raises(InvalidResponseFile, match="Did not find grid coordinate"):
-        config.ensemble_config.response_configs["rft"].read_from_file(
-            "/tmp/does_not_exist", 1, 1
-        )
+        rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
 
 
 def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
@@ -631,40 +668,46 @@ def test_that_if_an_rft_observation_is_outside_the_zone_then_it_is_deactivated(
             ("DEPTH   ", float_arr([0.1])),
         ],
     )
+
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    iens = 1
+    iter_ = 1
+    observations = pl.DataFrame(config.observation_declarations)
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", iens, iter_, observations
+    )
+
     with pytest.warns(PostExperimentWarning, match="did not match expected zone"):
-        config.ensemble_config.response_configs["rft"].read_from_file(
-            "/tmp/does_not_exist", 1, 1
+        RFTConfig.enrich_observations_with_metadata_and_warn_on_zone_mismatch(
+            observations, observation_metadata, iens, iter_
         )
 
 
+@pytest.mark.filterwarnings("ignore:.*did not match expected zone")
 @pytest.mark.parametrize(
     ("point", "expected_values"),
     [
         pytest.param(
             (1.0, 1.0, 0.5),
             [
-                (0.0, 1.0, 1.0, 0.5, "zone1"),
-                (1.0, None, None, None, None),
-                (2.0, None, None, None, None),
+                (1.0, 1.0, 0.5, "zone1", ["zone1"], [1, 1, 1], True),
+                (1.0, 1.0, 0.5, "zone2", ["zone1"], [1, 1, 1], False),
             ],
             id="Point only in the zone of first observation",
         ),
         pytest.param(
             (1.0, 1.0, 1.5),
             [
-                (0.0, None, None, None, None),
-                (1.0, 1.0, 1.0, 1.5, "zone1"),
-                (1.0, 1.0, 1.0, 1.5, "zone2"),
-                (2.0, None, None, None, None),
+                (1.0, 1.0, 1.5, "zone1", ["zone1", "zone2"], [1, 1, 2], True),
+                (1.0, 1.0, 1.5, "zone2", ["zone1", "zone2"], [1, 1, 2], True),
             ],
             id="Point in the zone of both observations",
         ),
         pytest.param(
             (1.0, 1.0, 2.5),
             [
-                (0.0, None, None, None, None),
-                (1.0, None, None, None, None),
-                (2.0, 1.0, 1.0, 2.5, "zone2"),
+                (1.0, 1.0, 2.5, "zone1", ["zone2"], [1, 1, 3], False),
+                (1.0, 1.0, 2.5, "zone2", ["zone2"], [1, 1, 3], True),
             ],
             id="Point only in the zone of second observation",
         ),
@@ -729,17 +772,29 @@ def test_that_same_point_observations_with_different_zone_are_disabled_independe
             ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
         ],
     )
-    res = config.ensemble_config.response_configs["rft"].read_from_file(
-        "/tmp/does_not_exist", 1, 1
+
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
+    iens = 1
+    iter_ = 1
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", iens, iter_, observations
     )
+
+    res = RFTConfig.enrich_observations_with_metadata_and_warn_on_zone_mismatch(
+        observations, observation_metadata, iens, iter_
+    )
+
     assert (
         sorted(
             zip(
-                res["values"].to_list(),
                 res["east"].to_list(),
                 res["north"].to_list(),
                 res["tvd"].to_list(),
-                res["zone"].to_list(),
+                res["expected_zone"].to_list(),
+                res["actual_zones"].to_list(),
+                res["well_connection_cell"].to_list(),
+                res["is_valid"].to_list(),
                 strict=True,
             )
         )
@@ -805,22 +860,31 @@ def test_that_observation_without_zones_are_not_disabled_by_zone_check(
             ("DEPTH   ", float_arr([0.0, 1.0, 2.0])),
         ],
     )
-    res = config.ensemble_config.response_configs["rft"].read_from_file(
-        "/tmp/does_not_exist", 1, 1
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    iens = 1
+    iter_ = 1
+    observations = pl.DataFrame(config.observation_declarations)
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", iens, iter_, observations
     )
-    assert sorted(
+    with pytest.warns(PostExperimentWarning, match="did not match expected zone"):
+        res = RFTConfig.enrich_observations_with_metadata_and_warn_on_zone_mismatch(
+            observations, observation_metadata, iens, iter_
+        )
+    assert list(
         zip(
-            res["values"].to_list(),
             res["east"].to_list(),
             res["north"].to_list(),
             res["tvd"].to_list(),
-            res["zone"].to_list(),
+            res["expected_zone"].to_list(),
+            res["actual_zones"].to_list(),
+            res["well_connection_cell"].to_list(),
+            res["is_valid"].to_list(),
             strict=True,
         )
     ) == [
-        (0.0, 1.0, 1.0, 0.5, None),
-        (1.0, None, None, None, None),
-        (2.0, None, None, None, None),
+        (1.0, 1.0, 0.5, None, ["zone1"], [1, 1, 1], True),
+        (1.0, 1.0, 0.5, "zone2", ["zone1"], [1, 1, 1], False),
     ]
 
 
@@ -871,13 +935,13 @@ def test_that_when_the_zonemap_is_an_absolute_path_then_the_runpath_is_not_prepe
             ),
         }
     )
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
     with pytest.raises(
         ConfigValidationError,
         match="must be an integer, was this_is_an_invalid_zonemap",
     ):
-        config.ensemble_config.response_configs["rft"].read_from_file(
-            "/tmp/does_not_exist", 1, 1
-        )
+        rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
 
 
 @pytest.mark.parametrize(
@@ -943,15 +1007,19 @@ def test_that_substitutions_are_applied_to_zonemap_filename(
             ),
         }
     )
+
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
     with pytest.raises(
         ConfigValidationError,
         match="must be an integer, was zonemap_file_is_picked_correctly",
     ):
-        config.ensemble_config.response_configs["rft"].read_from_file(
-            "/tmp/does_not_exist", iens, iter_
+        rft_config.obtain_location_metadata(
+            "/tmp/does_not_exist", iens, iter_, observations
         )
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a RFT key but no forward model step")
 def test_that_missing_egrid_with_locations_raises_invalid_response_file(
     mock_resfo_file,
 ):
@@ -963,14 +1031,35 @@ def test_that_missing_egrid_with_locations_raises_invalid_response_file(
             ("DEPTH   ", float_arr([20.0])),
         ],
     )
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["PRESSURE"]}},
-        locations=[(1.0, 1.0, 1.0)],
+
+    config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "BASE.RFT",
+            "RFT": [{"WELL": "*", "DATE": "*", "PROPERTIES": "PRESSURE"}],
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "NAME",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.0,
+                        "EAST": 1.0,
+                        "TVD": 1.0,
+                    },
+                ],
+            ),
+        }
     )
 
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
     with pytest.raises(InvalidResponseFile):
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+        rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
 
 
 def test_that_missing_egrid_without_locations_is_ignored(mock_resfo_file):
@@ -987,8 +1076,8 @@ def test_that_missing_egrid_without_locations_is_ignored(mock_resfo_file):
         data_to_read={"*": {"*": ["PRESSURE"]}},
     )
 
-    data = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-    assert data["response_key"].to_list() == ["WELL:2000-01-01:PRESSURE"]
+    responses = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+    assert responses["response_key"].to_list() == ["WELL:2000-01-01:PRESSURE"]
 
 
 def test_that_zone_with_multiple_layers_produces_single_matching_row(
@@ -1039,10 +1128,14 @@ def test_that_zone_with_multiple_layers_produces_single_matching_row(
         ],
     )
 
-    res = config.ensemble_config.response_configs["rft"].read_from_file(
-        "/tmp/does_not_exist", 1, 1
+    rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
+    observations = pl.DataFrame(config.observation_declarations)
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", 1, 1, observations
     )
-    assert res["zone"].to_list().count("zone1") == 1
+
+    assert observation_metadata["well_connection_cell"].to_list() == [[1, 1, 2]]
+    assert observation_metadata["actual_zones"].to_list() == [["zone1"]]
 
 
 def test_that_non_matching_wells_are_ignored_silently(mock_resfo_file):

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -224,7 +224,7 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
                     },
                     {
                         "type": ObservationType.RFT,
-                        "name": "RFT_match_key_duplicate",
+                        "name": "RFT_index_key_duplicate",
                         "WELL": "WELL",
                         "VALUE": "700",
                         "ERROR": "0.1",
@@ -399,7 +399,7 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
         ),
     ],
 )
-def test_that_observations_are_identified_and_sorted_by_full_match_key(
+def test_that_observations_are_identified_and_sorted_by_full_index_key(
     qtbot, storage, tmp_path, observations, expected_name_order
 ):
     def patch_gen_obs_file(observations_list):

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import numpy as np
 import polars as pl
 import pytest
 from PyQt6.QtWidgets import (
@@ -7,6 +8,7 @@ from PyQt6.QtWidgets import (
 )
 
 from ert.config import ErtConfig, ObservationType
+from ert.config.rft_config import RFTConfig
 from ert.gui.tools.manage_experiments.storage_info_widget import (
     _EnsembleWidget,
     _EnsembleWidgetTabs,
@@ -33,6 +35,7 @@ def create_experiment_from_config(config: ErtConfig, storage):
     return experiment
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 def test_that_missing_response_for_observation_response_key_does_not_crash(
     qtbot, storage
 ):
@@ -86,6 +89,7 @@ def test_that_missing_response_for_observation_response_key_does_not_crash(
     assert len(ensemble_widget._figure.get_axes()) == 1
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
     date = datetime(year=2000, month=1, day=1)  # noqa: DTZ001
     key = "WWCT:OP1"
@@ -139,6 +143,7 @@ def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
     assert len(ensemble_widget._figure.get_axes()) == 1
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a RFT key but no forward model step")
 def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
     date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
     config = ErtConfig.from_dict(
@@ -168,8 +173,8 @@ def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
     experiment = create_experiment_from_config(config, storage)
     ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
 
-    def partial_rft_response() -> pl.DataFrame:
-        return pl.DataFrame(
+    def rft_response() -> pl.DataFrame:
+        df = pl.DataFrame(
             {
                 "response_key": ["WELL:2000-01-01:PRESSURE"],
                 "well": ["WELL"],
@@ -178,14 +183,33 @@ def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
                 "time": [date],
                 "depth": [0.0],
                 "values": [0.0],
-                "zone": None,
+                "well_connection_cell": pl.Series(
+                    [[7, 7, 8]], dtype=pl.Array(pl.Int64, 3)
+                ),
+            },
+            schema=RFTConfig.response_schema(),
+        )
+        RFTConfig._assert_schema(df, RFTConfig.response_schema())
+        return df
+
+    def location_metadata() -> pl.DataFrame:
+        df = pl.DataFrame(
+            {
                 "east": [10.0],
                 "north": [11.0],
                 "tvd": [12.0],
-            }
+                "actual_zones": [["zone100"]],
+                "well_connection_cell": pl.Series(
+                    [[7, 7, 8]], dtype=pl.Array(pl.Int64, 3)
+                ),
+            },
+            schema=RFTConfig.location_metadata_schema(),
         )
+        RFTConfig._assert_schema(df, RFTConfig.location_metadata_schema())
+        return df
 
-    ensemble.save_response("rft", partial_rft_response(), 0)
+    ensemble.save_response("rft", rft_response(), 0)
+    ensemble.save_observation_location_metadata(location_metadata(), 0)
 
     ensemble_widget = _EnsembleWidget()
     ensemble_widget.setEnsemble(ensemble)
@@ -199,6 +223,167 @@ def test_that_rft_experiment_without_a_zone_does_not_crash(qtbot, storage):
     assert len(plot[0].collections) == 2
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a RFT key but no forward model step")
+def test_that_many_realizations_in_rft_affect_responses_not_observation_tree(
+    qtbot, storage
+):
+    date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
+    zone_a = "zone_a"
+    zone_b = "zone_b"
+    zones1 = [zone_a]
+    zones2 = [zone_a, zone_b]
+    cell1 = [7, 7, 8]
+    cell2 = [7, 7, 9]
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "RFT": [{"WELL": "WELL", "DATE": "2000-01-01", "PROPERTIES": "PRESSURE"}],
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT1",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": date.isoformat(),
+                        "PROPERTY": "PRESSURE",
+                        "EAST": 10.0,
+                        "NORTH": 11.0,
+                        "TVD": 12.0,
+                        "ZONE": zone_b,
+                    },
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "RFT2",
+                        "WELL": "WELL",
+                        "VALUE": "800",
+                        "ERROR": "0.1",
+                        "DATE": date.isoformat(),
+                        "PROPERTY": "PRESSURE",
+                        "EAST": 15.0,
+                        "NORTH": 16.0,
+                        "TVD": 17.0,
+                        "ZONE": zone_b,
+                    },
+                ],
+            ),
+        }
+    )
+
+    def rft_response() -> pl.DataFrame:
+        df = pl.DataFrame(
+            {
+                "response_key": ["WELL:2000-01-01:PRESSURE"],
+                "well": ["WELL"],
+                "date": [date.isoformat()],
+                "property": ["PRESSURE"],
+                "time": [date],
+                "depth": [0.0],
+                "values": [0.0],
+                "well_connection_cell": pl.Series([cell1], dtype=pl.Array(pl.Int64, 3)),
+            },
+            schema=RFTConfig.response_schema(),
+        )
+        RFTConfig._assert_schema(df, RFTConfig.response_schema())
+        return df
+
+    def location_metadata(
+        *,
+        actual_zones: list[str],
+        well_connection_cell: list[int],
+    ) -> pl.DataFrame:
+        df = pl.DataFrame(
+            [
+                {
+                    "east": 10.0,
+                    "north": 11.0,
+                    "tvd": 12.0,
+                    "actual_zones": actual_zones,
+                    "well_connection_cell": well_connection_cell,
+                },
+                {
+                    "east": 15.0,
+                    "north": 16.0,
+                    "tvd": 17.0,
+                    "actual_zones": actual_zones,
+                    "well_connection_cell": well_connection_cell,
+                },
+            ],
+            schema=RFTConfig.location_metadata_schema(),
+        )
+        RFTConfig._assert_schema(df, RFTConfig.location_metadata_schema())
+        return df
+
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=4)
+
+    # realization 0: disabled due to zone mismatch
+    ensemble.save_response("rft", rft_response(), 0)
+    ensemble.save_observation_location_metadata(
+        location_metadata(actual_zones=zones1, well_connection_cell=cell1), 0
+    )
+
+    # realization 1: matching response
+    ensemble.save_response("rft", rft_response(), 1)
+    ensemble.save_observation_location_metadata(
+        location_metadata(actual_zones=zones2, well_connection_cell=cell1), 1
+    )
+
+    # realization 2: disabled due to both zones and well connection cell mismatch
+    ensemble.save_response("rft", rft_response(), 2)
+    ensemble.save_observation_location_metadata(
+        location_metadata(actual_zones=zones1, well_connection_cell=cell2), 2
+    )
+
+    # realization 3: disabled due to well connection cell mismatch
+    ensemble.save_response("rft", rft_response(), 3)
+    ensemble.save_observation_location_metadata(
+        location_metadata(actual_zones=zones2, well_connection_cell=cell2), 3
+    )
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    observation_widget = ensemble_widget.findChild(QTreeWidget)
+    top = observation_widget.topLevelItem(0)
+    assert top
+
+    def verify_observation_tree():
+        assert top.childCount() == 2
+        children = [
+            child.text(0)
+            for i in range(top.childCount())
+            if (child := top.child(i)) is not None
+        ]
+        expected_children = ["10.0, 11.0, 12.0, zone_b", "15.0, 16.0, 17.0, zone_b"]
+        assert children == expected_children, (
+            f"Expected observation names {expected_children}, but got {children}"
+        )
+
+    def verify_number_of_visualized_responses():
+        plot = ensemble_widget._figure.get_axes()
+        assert len(plot) == 1
+        collections = plot[0].collections
+        assert len(collections) == 2
+        strip_plot_response_collection = collections[-1]
+        displayed_responses = np.asarray(strip_plot_response_collection.get_offsets())
+        assert len(displayed_responses) == 1
+
+    verify_observation_tree()
+    observation_widget.setCurrentItem(top.child(0))
+    verify_number_of_visualized_responses()
+    observation_widget.setCurrentItem(top.child(1))
+    verify_number_of_visualized_responses()
+
+
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
     date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
     config = ErtConfig.from_dict(
@@ -255,6 +440,7 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
     assert top.childCount() == 2
 
 
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 @pytest.mark.parametrize(
     ("observations", "expected_name_order"),
     [

--- a/tests/ert/unit_tests/plugins/test_export_rft.py
+++ b/tests/ert/unit_tests/plugins/test_export_rft.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -48,28 +49,49 @@ def _create_rft_response_df(
     well: str = "WELL1",
     date: str = "2020-01-01",
     prop: str = "PRESSURE",
+    depth: float = 8000.0,
     value: float = 148.0,
-    east: float = 100.0,
-    north: float = 200.0,
-    tvd: float = 25.0,
-    zone: str | None = None,
+    i: int = 1,
+    j: int = 2,
+    k: int = 3,
 ) -> pl.DataFrame:
-    return pl.DataFrame(
+    time = datetime.strptime(date, "%Y-%m-%d").date()  # noqa: DTZ007
+    df = pl.DataFrame(
         {
             "response_key": [f"{well}:{date}:{prop}"],
             "well": [well],
             "date": [date],
             "property": [prop],
+            "time": [time],
+            "depth": pl.Series([depth], dtype=pl.Float32),
             "values": pl.Series([value], dtype=pl.Float32),
+            "well_connection_cell": pl.Series([(i, j, k)], dtype=pl.Array(pl.Int64, 3)),
+        }
+    )
+    return RFTConfig._assert_schema(df, RFTConfig.response_schema())
+
+
+def _create_rft_location_metadata_df(
+    *,
+    east: float = 100.0,
+    north: float = 200.0,
+    tvd: float = 25.0,
+    zone: str | None = None,
+    i: int = 1,
+    j: int = 2,
+    k: int = 3,
+) -> pl.DataFrame:
+    zones = [zone] if zone is not None else []
+    df = pl.DataFrame(
+        {
             "east": pl.Series([east], dtype=pl.Float32),
             "north": pl.Series([north], dtype=pl.Float32),
             "tvd": pl.Series([tvd], dtype=pl.Float32),
-            "zone": pl.Series([zone], dtype=pl.String),
-            "i": pl.Series([0], dtype=pl.Int32),
-            "j": pl.Series([0], dtype=pl.Int32),
-            "k": pl.Series([0], dtype=pl.Int32),
+            "actual_zones": pl.Series([zones], dtype=pl.List(pl.String)),
+            "well_connection_cell": pl.Series([(i, j, k)], dtype=pl.Array(pl.Int64, 3)),
         }
     )
+    return RFTConfig._assert_schema(df, RFTConfig.location_metadata_schema())
 
 
 def test_that_export_rft_job_is_registered_in_plugin_manager():
@@ -97,6 +119,9 @@ def test_that_export_rft_writes_csv_files_to_runpaths():
     with _create_rft_ensemble(ensemble_size=2) as ensemble:
         for i, (_, response) in enumerate(runpath_values):
             ensemble.save_response("rft", response, i)
+            ensemble.save_observation_location_metadata(
+                _create_rft_location_metadata_df(), i
+            )
 
         ExportRFTJob().run(
             _mock_runpath([str(rp) for rp, _ in runpath_values]), ensemble, []
@@ -122,7 +147,12 @@ def test_that_export_rft_uses_custom_filename():
     runpath0.mkdir()
 
     with _create_rft_ensemble(ensemble_size=1) as ensemble:
-        ensemble.save_response("rft", responses_real0, 0)
+        realization = 0
+        ensemble.save_response("rft", responses_real0, realization)
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(),
+            realization,
+        )
 
         ExportRFTJob().run(_mock_runpath([str(runpath0)]), ensemble, ["custom_rft.csv"])
 

--- a/tests/ert/unit_tests/storage/migration/test_to28.py
+++ b/tests/ert/unit_tests/storage/migration/test_to28.py
@@ -1,0 +1,1086 @@
+import datetime
+import json
+import re
+from typing import Any
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from ert.storage.migration.to28 import (
+    location_metadata_schema,
+    migrate,
+    observation_schema,
+    original_response_schema,
+    response_schema,
+    transform,
+)
+
+
+def _to_original_response(
+    responses: pl.DataFrame, observations: pl.DataFrame, location_metadata: pl.DataFrame
+) -> pl.DataFrame:
+    observations_with_metadata = (
+        observations.join(
+            location_metadata,
+            on=["east", "north", "tvd"],
+            how="left",
+        )
+        .select(
+            [
+                "east",
+                "north",
+                "tvd",
+                pl.col("zone").alias("expected_zone"),
+                "actual_zones",
+                "well_connection_cell",
+            ]
+        )
+        .unique(maintain_order=True)
+    )
+
+    result = responses.join(
+        observations_with_metadata,
+        on="well_connection_cell",
+        how="left",
+    )
+
+    is_zone_valid = pl.col("expected_zone").is_null() | pl.col("expected_zone").is_in(
+        pl.col("actual_zones")
+    )
+    result = result.filter(is_zone_valid)
+
+    return result.select(
+        [
+            "realization",
+            "response_key",
+            "well",
+            "date",
+            "property",
+            "time",
+            "depth",
+            "values",
+            pl.col("expected_zone").alias("zone"),
+            pl.col("east").cast(pl.Float32),
+            pl.col("north").cast(pl.Float32),
+            pl.col("tvd").cast(pl.Float32),
+            pl.col("well_connection_cell").arr.get(0).alias("i"),
+            pl.col("well_connection_cell").arr.get(1).alias("j"),
+            pl.col("well_connection_cell").arr.get(2).alias("k"),
+        ]
+    )
+
+
+def assert_schema(df: pl.DataFrame, schema: dict[str, Any]) -> pl.DataFrame:
+    if df.schema != schema:
+        msg = f"Expected schema {schema}, got {df.schema}."
+        raise AssertionError(msg)
+    return df
+
+
+def assert_roundtrip(
+    observations_df: pl.DataFrame, original_rft_response: pl.DataFrame
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    rft_response_df, location_metadata_df = transform(
+        observations_df, original_rft_response
+    )
+
+    assert_schema(rft_response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+
+    combined_df = _to_original_response(
+        rft_response_df, observations_df, location_metadata_df
+    )
+
+    assert_schema(combined_df, original_response_schema())
+    assert_frame_equal(combined_df, original_rft_response)
+
+    return rft_response_df, location_metadata_df
+
+
+base_date = datetime.date(2000, 1, 1)
+base_observation_truncated = {
+    "observation_key": "OBS1",
+    "response_key": "WELL:2000-01-01:PRESSURE",
+    "observations": 1500.0,
+    "east": 501.0,
+    "north": 1001.0,
+    "tvd": 901.0,
+    "zone": "zone1",
+}
+base_original_response_data = {
+    "realization": 0,
+    "response_key": "WELL:2000-01-01:PRESSURE",
+    "well": "WELL",
+    "date": base_date.isoformat(),
+    "property": "PRESSURE",
+    "time": base_date,
+    "depth": 1000.0,
+    "values": 200.0,
+    "zone": "zone1",
+    "east": 501.0,
+    "north": 1001.0,
+    "tvd": 901.0,
+    "i": 10,
+    "j": 11,
+    "k": 12,
+}
+
+expected_base_response_data = {
+    "realization": 0,
+    "response_key": "WELL:2000-01-01:PRESSURE",
+    "well": "WELL",
+    "date": base_date.isoformat(),
+    "property": "PRESSURE",
+    "time": base_date,
+    "depth": 1000.0,
+    "values": 200.0,
+    "well_connection_cell": [10, 11, 12],
+}
+
+expected_base_location_metadata_data = {
+    "east": 501.0,
+    "north": 1001.0,
+    "tvd": 901.0,
+    "actual_zones": ["zone1"],
+    "well_connection_cell": [10, 11, 12],
+}
+
+
+def setup_storage(tmp_path, original_response_df, observations_df):
+    experiment_hash = "experiment_hash"
+    ensemble_hash = "ensemble_hash"
+
+    root_path = tmp_path / "project"
+
+    ensemble_path = root_path / "ensembles" / ensemble_hash
+    ensemble_path.mkdir(parents=True)
+
+    realization_path = ensemble_path / "realization-0"
+    realization_path.mkdir(parents=True)
+
+    index_path = ensemble_path / "index.json"
+    index_path.write_text(
+        json.dumps({"experiment_id": experiment_hash}),
+        encoding="utf-8",
+    )
+
+    obs_path = root_path / "experiments" / experiment_hash / "observations"
+    obs_path.mkdir(parents=True)
+
+    rft_obs_path = obs_path / "rft"
+    response_path = realization_path / "rft.parquet"
+    location_metadata_path = (
+        realization_path / "rft_observation_location_metadata.parquet"
+    )
+
+    original_response_df.write_parquet(response_path)
+    if observations_df is not None:
+        observations_df.write_parquet(rft_obs_path)
+
+    return root_path, response_path, location_metadata_path
+
+
+def test_that_migrating_storage_to_28_uses_empty_dataframes_on_invalid_response_schema(
+    tmp_path, caplog
+):
+    obs_df = pl.DataFrame([{**base_observation_truncated}], schema=observation_schema())
+    original_response_df = pl.DataFrame(
+        {
+            "response_key": [],
+            "time": [],
+            "depth": [],
+            "values": [],
+            "east": [],
+            "north": [],
+            "tvd": [],
+        }
+    )
+
+    root, response_path, location_metadata_path = setup_storage(
+        tmp_path, original_response_df, obs_df
+    )
+
+    migrate(root)
+    warning = re.escape(
+        f"Schema error on migrating {response_path}: Unexpected schema for rft.parquet"
+    )
+    assert re.search(warning, caplog.text) is not None
+
+    response_df = pl.read_parquet(response_path)
+    location_metadata_df = pl.read_parquet(location_metadata_path)
+
+    expected_response_df = pl.DataFrame(schema=response_schema())
+    expected_location_metadata_df = pl.DataFrame(schema=location_metadata_schema())
+
+    assert_schema(response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+    assert_frame_equal(response_df, expected_response_df)
+    assert_frame_equal(location_metadata_df, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_migrates_on_missing_observations(
+    tmp_path, caplog
+):
+    obs_df = None
+    original_response_df = pl.DataFrame(
+        [{**base_original_response_data}], schema=original_response_schema()
+    )
+
+    root, response_path, location_metadata_path = setup_storage(
+        tmp_path, original_response_df, obs_df
+    )
+
+    migrate(root)
+
+    warning = "Assuming empty observations"
+    assert warning in caplog.text
+
+    response_df = pl.read_parquet(response_path)
+    location_metadata_df = pl.read_parquet(location_metadata_path)
+
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+    expected_location_metadata_df = pl.DataFrame(schema=location_metadata_schema())
+
+    assert_schema(response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+    assert_frame_equal(response_df, expected_response_df)
+    assert_frame_equal(location_metadata_df, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_uses_empty_dataframes_on_invalid_obs_schema(
+    tmp_path, caplog
+):
+    obs_df = pl.DataFrame(
+        {
+            "unexpected_column": "cat",
+            "north": 13.0,
+        }
+    )
+
+    original_response_df = pl.DataFrame(
+        [{**base_original_response_data}], schema=original_response_schema()
+    )
+
+    root, response_path, location_metadata_path = setup_storage(
+        tmp_path, original_response_df, obs_df
+    )
+
+    migrate(root)
+
+    warning = re.escape(
+        f"Schema error on migrating {response_path}: Unexpected schema for observations"
+    )
+    assert re.search(warning, caplog.text) is not None
+
+    response_df = pl.read_parquet(response_path)
+    location_metadata_df = pl.read_parquet(location_metadata_path)
+
+    expected_response_df = pl.DataFrame(schema=response_schema())
+    expected_location_metadata_df = pl.DataFrame(schema=location_metadata_schema())
+
+    assert_schema(response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+    assert_frame_equal(response_df, expected_response_df)
+    assert_frame_equal(location_metadata_df, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_does_not_fail_on_empty_dataframes(tmp_path):
+    obs_df = pl.DataFrame(schema=observation_schema())
+
+    original_response_df = pl.DataFrame(schema=original_response_schema())
+
+    root, response_path, location_metadata_path = setup_storage(
+        tmp_path, original_response_df, obs_df
+    )
+    migrate(root)
+
+    response_df = pl.read_parquet(response_path)
+    location_metadata_df = pl.read_parquet(location_metadata_path)
+
+    expected_response_df = pl.DataFrame(schema=response_schema())
+    expected_location_metadata_df = pl.DataFrame(schema=location_metadata_schema())
+
+    assert_schema(response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+    assert_frame_equal(response_df, expected_response_df)
+    assert_frame_equal(location_metadata_df, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_stores_responses_and_location_metadata(tmp_path):
+    obs_df = pl.DataFrame([{**base_observation_truncated}], schema=observation_schema())
+    original_response_df = pl.DataFrame(
+        [{**base_original_response_data}], schema=original_response_schema()
+    )
+
+    root, response_path, location_metadata_path = setup_storage(
+        tmp_path, original_response_df, obs_df
+    )
+    migrate(root)
+
+    response_df = pl.read_parquet(response_path)
+    location_metadata_df = pl.read_parquet(location_metadata_path)
+
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    assert_schema(response_df, response_schema())
+    assert_schema(location_metadata_df, location_metadata_schema())
+    assert_frame_equal(response_df, expected_response_df)
+    assert_frame_equal(location_metadata_df, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_keeps_roundtrip_intact():
+    observations_df = pl.DataFrame(
+        [{**base_observation_truncated}], schema=observation_schema()
+    )
+    original_rft_response = pl.DataFrame(
+        [{**base_original_response_data}], schema=original_response_schema()
+    )
+    assert_roundtrip(observations_df, original_rft_response)
+
+
+def test_that_migrating_storage_to_28_keeps_responses_independent_from_observations():
+    observation_property = "SURPRISE"
+    observation_response_key = f"WELL:2000-01-01:{observation_property}"
+    observation_tvd = 911.0
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "response_key": observation_response_key,
+                "tvd": observation_tvd,
+            }
+        ],
+        schema=observation_schema(),
+    )
+    # this response shouldn't have happened from provided observations. Making those
+    # inconsistent for the test. So no roundtrip, as it will fail.
+    original_rft_response = pl.DataFrame(
+        [{**base_original_response_data}], schema=original_response_schema()
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "tvd": observation_tvd,
+                "actual_zones": [],
+                "well_connection_cell": None,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = transform(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_merges_response_rows():
+    tvd1 = 901.0
+    tvd2 = 902.0
+    observations_df = pl.DataFrame(
+        [
+            {**base_observation_truncated, "observation_key": "OBS1", "tvd": tvd1},
+            {**base_observation_truncated, "observation_key": "OBS2", "tvd": tvd2},
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {**base_original_response_data, "tvd": tvd1},
+            {**base_original_response_data, "tvd": tvd2},
+        ],
+        schema=original_response_schema(),
+    )
+
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "tvd": tvd1,
+            },
+            {
+                **expected_base_location_metadata_data,
+                "tvd": tvd2,
+            },
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_merges_metadata_rows():
+    property1 = "PRESSURE"
+    property2 = "TEMPERATURE"
+    response_key1 = f"WELL:2000-01-01:{property1}"
+    response_key2 = f"WELL:2000-01-01:{property2}"
+    observation_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS1",
+                "response_key": response_key1,
+            },
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS2",
+                "response_key": response_key2,
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {
+                **base_original_response_data,
+                "response_key": response_key1,
+                "property": property1,
+            },
+            {
+                **base_original_response_data,
+                "response_key": response_key2,
+                "property": property2,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+                "response_key": response_key1,
+                "property": property1,
+            },
+            {
+                **expected_base_response_data,
+                "response_key": response_key2,
+                "property": property2,
+            },
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observation_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_gives_well_connection_only_to_fitting_location():
+    depth1 = 1000.0
+    depth2 = 1025.0
+    observations_df = pl.DataFrame(
+        [
+            {**base_observation_truncated},
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {**base_original_response_data, "depth": depth1, "k": 12},
+            {
+                **base_original_response_data,
+                "depth": depth2,
+                "k": 13,
+                "zone": None,
+                "east": None,
+                "north": None,
+                "tvd": None,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+                "depth": depth1,
+                "well_connection_cell": [10, 11, 12],
+            },
+            {
+                **expected_base_response_data,
+                "depth": depth2,
+                "well_connection_cell": [10, 11, 13],
+            },
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "well_connection_cell": [10, 11, 12],
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_restores_location_disabled_due_to_zone_mismatch():
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "zone": "zone_not_fitting_into_zonemap",
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame([], schema=original_response_schema())
+
+    expected_response_df = pl.DataFrame([], schema=response_schema())
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "actual_zones": [],
+                "well_connection_cell": None,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_uses_observations_for_data_on_missing_zone():
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "zone": None,
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {**base_original_response_data, "zone": None},
+        ],
+        schema=original_response_schema(),
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "actual_zones": [],
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_uses_observations_for_data_on_missing_cell():
+    observations_df = pl.DataFrame(
+        [
+            {**base_observation_truncated},
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {
+                **base_original_response_data,
+                "zone": None,
+                "east": None,
+                "north": None,
+                "tvd": None,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {
+                **expected_base_response_data,
+            }
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "actual_zones": [],
+                "well_connection_cell": None,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_uses_observations_for_data_on_missing_row():
+    observations_df = pl.DataFrame(
+        [
+            {**base_observation_truncated},
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame([], schema=original_response_schema())
+    expected_response_df = pl.DataFrame([], schema=response_schema())
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "actual_zones": [],
+                "well_connection_cell": None,
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_squashes_zones_in_metadata():
+    property1 = "PRESSURE"
+    property2 = "TEMPERATURE"
+    zone1 = "zone1"
+    zone2 = "zone2"
+    observations_df = pl.DataFrame(
+        [
+            {**base_observation_truncated, "zone": zone1},
+            {**base_observation_truncated, "zone": zone2},
+            {**base_observation_truncated, "zone": None},
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {**base_original_response_data, "zone": zone1, "property": property1},
+            {**base_original_response_data, "zone": zone2, "property": property1},
+            {**base_original_response_data, "zone": None, "property": property1},
+            {**base_original_response_data, "zone": zone1, "property": property2},
+            {**base_original_response_data, "zone": zone2, "property": property2},
+            {**base_original_response_data, "zone": None, "property": property2},
+        ],
+        schema=original_response_schema(),
+    )
+    expected_response_df = pl.DataFrame(
+        [
+            {**expected_base_response_data, "property": property1},
+            {**expected_base_response_data, "property": property2},
+        ],
+        schema=response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "actual_zones": [zone1, zone2],
+            }
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    response_ds, location_metadata_ds = assert_roundtrip(
+        observations_df, original_rft_response
+    )
+    assert_frame_equal(response_ds, expected_response_df)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_catches_well_inconsistency():
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {
+                **base_original_response_data,
+                "i": 10,
+                "j": 10,
+                "k": 1,
+            },
+            {
+                **base_original_response_data,
+                "i": 10,
+                "j": 10,
+                "k": 2,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+
+    msg = "['well', 'date', 'depth']"
+    msg += " combinations with inconsistent well_connection_cell values"
+    with pytest.raises(RuntimeError, match=re.escape(msg)):
+        transform(observations_df, original_rft_response)
+
+
+def test_that_migrating_storage_to_28_catches_location_inconsistency():
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {
+                **base_original_response_data,
+                "well": "WELL1",
+                "i": 10,
+                "j": 10,
+                "k": 1,
+            },
+            {
+                **base_original_response_data,
+                "well": "WELL2",
+                "i": 10,
+                "j": 10,
+                "k": 2,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+
+    msg = "['east', 'north', 'tvd']"
+    msg += " combinations with inconsistent well_connection_cell values"
+    with pytest.raises(RuntimeError, match=re.escape(msg)):
+        transform(observations_df, original_rft_response)
+
+
+def test_that_migrating_storage_to_28_does_not_fail_on_null_location_inconsistency():
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS1",
+                "east": "500.1",
+                "north": "1000.1",
+                "tvd": "900.1",
+                "zone": None,
+            },
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS2",
+                "east": "600.1",
+                "north": "1100.1",
+                "tvd": "900.1",
+                "zone": "zone1",
+            },
+        ],
+        schema=observation_schema(),
+    )
+    original_rft_response = pl.DataFrame(
+        [
+            {
+                **base_original_response_data,
+                "well": "WELL1",
+                "depth": 1000.0,
+                "zone": None,
+                "east": None,
+                "north": None,
+                "tvd": None,
+                "i": 10,
+                "j": 10,
+                "k": 1,
+            },
+            {
+                **base_original_response_data,
+                "well": "WELL1",
+                "depth": 1200.0,
+                "zone": None,
+                "east": "500.1",
+                "north": "1000.1",
+                "tvd": "900.1",
+                "i": 10,
+                "j": 10,
+                "k": 2,
+            },
+            {
+                **base_original_response_data,
+                "well": "WELL2",
+                "depth": 1000.0,
+                "zone": None,
+                "east": None,
+                "north": None,
+                "tvd": None,
+                "i": 20,
+                "j": 20,
+                "k": 1,
+            },
+            {
+                **base_original_response_data,
+                "well": "WELL2",
+                "depth": 1200.0,
+                "zone": "zone1",
+                "east": "600.1",
+                "north": "1100.1",
+                "tvd": "900.1",
+                "i": 20,
+                "j": 20,
+                "k": 2,
+            },
+        ],
+        schema=original_response_schema(),
+    )
+
+    expected_location_metadata_df = pl.DataFrame(
+        [
+            {
+                **expected_base_location_metadata_data,
+                "east": "500.1",
+                "north": "1000.1",
+                "tvd": "900.1",
+                "actual_zones": [],
+                "well_connection_cell": [10, 10, 2],
+            },
+            {
+                **expected_base_location_metadata_data,
+                "east": "600.1",
+                "north": "1100.1",
+                "tvd": "900.1",
+                "actual_zones": ["zone1"],
+                "well_connection_cell": [20, 20, 2],
+            },
+        ],
+        schema=location_metadata_schema(),
+    )
+
+    _, location_metadata_ds = assert_roundtrip(observations_df, original_rft_response)
+    assert_frame_equal(location_metadata_ds, expected_location_metadata_df)
+
+
+def test_that_migrating_storage_to_28_splits_large_dataframe():
+    date1 = datetime.date(2011, 1, 1)
+    date2 = datetime.date(2022, 2, 2)
+    response_key1 = f"WELL:{date1}:PRESSURE"
+    response_key2 = f"WELL:{date2}:PRESSURE"
+    zone1 = "zone1"
+    zone2 = "zone2"
+    tvd1 = 901.0
+    tvd2 = 1000.0
+    tvd3 = 902.0
+    depth0 = 800.0
+    depth1 = 900.0
+    depth2 = 1000.0
+    value0 = 200.0
+    value1 = 300.0
+    value2 = 400.0
+    ijk0 = [10, 11, 11]
+    ijk1 = [10, 11, 12]
+    ijk2 = [10, 11, 13]
+    observations_df = pl.DataFrame(
+        [
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS",
+                "response_key": response_key1,
+                "zone": zone1,
+                "tvd": tvd1,
+            },
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS2",
+                "response_key": response_key2,
+                "zone": zone2,
+                "tvd": tvd2,
+            },
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS_with_incorrect_zone",
+                "response_key": response_key1,
+                "zone": zone2,
+                "tvd": tvd1,
+            },  # disabled
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS_with_slightly_off_tvd",
+                "response_key": response_key1,
+                "zone": zone1,
+                "tvd": tvd3,
+            },
+            {
+                **base_observation_truncated,
+                "observation_key": "OBS_with_no_zone",
+                "response_key": response_key1,
+                "zone": None,
+                "tvd": tvd1,
+            },
+        ],
+        schema=observation_schema(),
+    )
+
+    def get_response_data(date: datetime.date) -> list[dict[str, Any]]:
+        response_key = f"WELL:{date}:PRESSURE"
+        return [
+            {
+                **base_original_response_data,
+                "response_key": response_key,
+                "time": date,
+                "depth": depth0,
+                "value": value0,
+                "date": date.isoformat(),
+                "zone": None,
+                "tvd": None,
+                "east": None,
+                "north": None,
+                "i": ijk0[0],
+                "j": ijk0[1],
+                "k": ijk0[2],
+            },
+            {
+                **base_original_response_data,
+                "response_key": response_key,
+                "time": date,
+                "depth": depth1,
+                "value": value1,
+                "date": date.isoformat(),
+                "zone": zone1,
+                "tvd": tvd1,
+                "i": ijk1[0],
+                "j": ijk1[1],
+                "k": ijk1[2],
+            },
+            {
+                **base_original_response_data,
+                "response_key": response_key,
+                "time": date,
+                "depth": depth1,
+                "value": value1,
+                "date": date.isoformat(),
+                "zone": zone1,
+                "tvd": tvd3,
+                "i": ijk1[0],
+                "j": ijk1[1],
+                "k": ijk1[2],
+            },
+            {
+                **base_original_response_data,
+                "response_key": response_key,
+                "time": date,
+                "depth": depth1,
+                "value": value1,
+                "date": date.isoformat(),
+                "zone": None,
+                "tvd": tvd1,
+                "i": ijk1[0],
+                "j": ijk1[1],
+                "k": ijk1[2],
+            },
+            {
+                **base_original_response_data,
+                "response_key": response_key,
+                "time": date,
+                "depth": depth2,
+                "value": value2,
+                "date": date.isoformat(),
+                "zone": zone2,
+                "tvd": tvd2,
+                "i": ijk2[0],
+                "j": ijk2[1],
+                "k": ijk2[2],
+            },
+        ]
+
+    original_rft_response = pl.DataFrame(
+        [*get_response_data(date1), *get_response_data(date2)],
+        schema=original_response_schema(),
+    )
+    assert_roundtrip(observations_df, original_rft_response)

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -1,6 +1,8 @@
+import asyncio
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import hypothesis.strategies as st
 import numpy as np
@@ -10,8 +12,10 @@ from hypothesis import given
 
 from ert.config import GenKwConfig, RFTConfig, SummaryConfig
 from ert.config._observations import RFTObservation
+from ert.config.response_config import InvalidResponseFile
 from ert.exceptions import StorageError
 from ert.storage import open_storage
+from ert.storage.local_ensemble import _write_responses_to_storage
 from ert.storage.mode import ModeError
 
 
@@ -258,7 +262,30 @@ def _create_rft_response_df(
     well: str = "WELL1",
     date: str = "2020-01-01",
     prop: str = "PRESSURE",
+    depth: float = 8000.0,
     value: float = 148.0,
+    i: int = 1,
+    j: int = 2,
+    k: int = 3,
+) -> pl.DataFrame:
+    time = datetime.strptime(date, "%Y-%m-%d").date()  # noqa: DTZ007
+    df = pl.DataFrame(
+        {
+            "response_key": [f"{well}:{date}:{prop}"],
+            "well": [well],
+            "date": [date],
+            "property": [prop],
+            "time": [time],
+            "depth": pl.Series([depth], dtype=pl.Float32),
+            "values": pl.Series([value], dtype=pl.Float32),
+            "well_connection_cell": pl.Series([(i, j, k)], dtype=pl.Array(pl.Int64, 3)),
+        }
+    )
+    return RFTConfig._assert_schema(df, RFTConfig.response_schema())
+
+
+def _create_rft_location_metadata_df(
+    *,
     east: float = 100.0,
     north: float = 200.0,
     tvd: float = 25.0,
@@ -267,22 +294,17 @@ def _create_rft_response_df(
     j: int = 2,
     k: int = 3,
 ) -> pl.DataFrame:
-    return pl.DataFrame(
+    zones = [zone] if zone is not None else []
+    df = pl.DataFrame(
         {
-            "response_key": [f"{well}:{date}:{prop}"],
-            "well": [well],
-            "date": [date],
-            "property": [prop],
-            "values": pl.Series([value], dtype=pl.Float32),
             "east": pl.Series([east], dtype=pl.Float32),
             "north": pl.Series([north], dtype=pl.Float32),
             "tvd": pl.Series([tvd], dtype=pl.Float32),
-            "zone": pl.Series([zone], dtype=pl.String),
-            "i": pl.Series([i], dtype=pl.Int32),
-            "j": pl.Series([j], dtype=pl.Int32),
-            "k": pl.Series([k], dtype=pl.Int32),
+            "actual_zones": pl.Series([zones], dtype=pl.List(pl.String)),
+            "well_connection_cell": pl.Series([(i, j, k)], dtype=pl.Array(pl.Int64, 3)),
         }
     )
+    return RFTConfig._assert_schema(df, RFTConfig.location_metadata_schema())
 
 
 @contextmanager
@@ -316,16 +338,21 @@ def test_that_get_rft_observations_and_responses_returns_joined_data():
     with _create_rft_ensemble(
         1, [_create_rft_observation(zone="Z1")], zonemap="1 Z1"
     ) as ensemble:
+        realization = 0
         ensemble.save_response(
             "rft",
             pl.concat(
                 [
-                    _create_rft_response_df(zone="Z1", prop="PRESSURE", value=148.0),
-                    _create_rft_response_df(zone="Z1", prop="SGAS", value=0.1),
-                    _create_rft_response_df(zone="Z1", prop="SWAT", value=0.2),
+                    _create_rft_response_df(prop="PRESSURE", value=148.0),
+                    _create_rft_response_df(prop="SGAS", value=0.1),
+                    _create_rft_response_df(prop="SWAT", value=0.2),
                 ]
             ),
-            0,
+            realization,
+        )
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(zone="Z1"),
+            realization,
         )
 
         result = ensemble.get_rft_observations_and_responses()
@@ -370,7 +397,13 @@ def test_that_get_rft_observations_is_active_based_on_matching_pressure_response
     ]
 
     with _create_rft_ensemble(1, observations) as ensemble:
-        ensemble.save_response("rft", pl.concat([_create_rft_response_df()]), 0)
+        realization = 0
+        ensemble.save_response(
+            "rft", pl.concat([_create_rft_response_df()]), realization
+        )
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(), realization
+        )
 
         result = ensemble.get_rft_observations_and_responses().sort(
             "true_vertical_depth"
@@ -401,17 +434,22 @@ def test_that_get_rft_observations_and_responses_sets_valid_zone_with_null_equal
         ),
     ]
 
+    realization = 0
     with _create_rft_ensemble(1, observations, zonemap="1 Z1\n2 Z2\n") as ensemble:
         ensemble.save_response(
             "rft",
+            _create_rft_response_df(),
+            realization,
+        )
+        ensemble.save_observation_location_metadata(
             pl.concat(
                 [
-                    _create_rft_response_df(zone="Z1", tvd=25.0),
-                    _create_rft_response_df(zone=None, tvd=30.0),
-                    _create_rft_response_df(zone="Z1", tvd=35.0),
+                    _create_rft_location_metadata_df(zone="Z1", tvd=25.0),
+                    _create_rft_location_metadata_df(zone=None, tvd=30.0),
+                    _create_rft_location_metadata_df(zone="Z1", tvd=35.0),
                 ]
             ),
-            0,
+            realization,
         )
 
         result = ensemble.get_rft_observations_and_responses().sort(
@@ -434,7 +472,14 @@ def test_that_get_rft_observations_and_responses_order_is_row_index_within_well(
     ]
 
     with _create_rft_ensemble(1, observations) as ensemble:
-        ensemble.save_response("rft", pl.concat([_create_rft_response_df()]), 0)
+        realization = 0
+        ensemble.save_response(
+            "rft", pl.concat([_create_rft_response_df()]), realization
+        )
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(),
+            realization,
+        )
 
         result = ensemble.get_rft_observations_and_responses().sort(
             ["well", "true_vertical_depth"]
@@ -461,6 +506,10 @@ def test_that_get_rft_observations_and_responses_handles_multiple_realizations(
         for i, r in enumerate(response_values):
             ensemble.save_response(
                 "rft", _create_rft_response_df(value=r, prop=prop), i
+            )
+            ensemble.save_observation_location_metadata(
+                _create_rft_location_metadata_df(),
+                i,
             )
 
         result = ensemble.get_rft_observations_and_responses().sort("realization")
@@ -491,10 +540,23 @@ def test_that_get_rft_observations_and_responses_raises_error_when_response_not_
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+def test_that_get_rft_observations_and_responses_raises_error_when_location_metadata_not_saved():  # noqa: E501
+    with _create_rft_ensemble(1, [_create_rft_observation()]) as ensemble:
+        ensemble.save_response("rft", _create_rft_response_df(), 0)
+        with pytest.raises(FileNotFoundError, match="observation_location_metadata"):
+            ensemble.get_rft_observations_and_responses()
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_adds_missing_saturation_columns():
+    realization = 0
     with _create_rft_ensemble(1, [_create_rft_observation()]) as ensemble:
         # Save a response that does not contain saturations
-        ensemble.save_response("rft", _create_rft_response_df(), 0)
+        ensemble.save_response("rft", _create_rft_response_df(), realization)
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(),
+            realization,
+        )
 
         result = ensemble.get_rft_observations_and_responses()
 
@@ -533,13 +595,92 @@ def test_that_get_rft_observations_and_responses_maps_report_step_from_summary_t
     )
 
     with _create_rft_ensemble(1, observations, with_summary=True) as ensemble:
-        ensemble.save_response("rft", rft_responses, 0)
-        ensemble.save_response("summary", summary_responses, 0)
+        realization = 0
+        ensemble.save_response("rft", rft_responses, realization)
+        ensemble.save_response("summary", summary_responses, realization)
+        ensemble.save_observation_location_metadata(
+            _create_rft_location_metadata_df(),
+            realization,
+        )
 
         result = ensemble.get_rft_observations_and_responses().sort("time")
 
         assert "report_step" in result.columns
         assert result["report_step"].to_list() == [1, 2]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_rft_artifacts_are_saved_atomically():
+    def read_from_file_mock(run_path, iens, iter_):
+        if iens in {0, 2}:
+            return _create_rft_response_df()
+        elif iens == 1:
+            raise InvalidResponseFile("Mock error for realization 1")
+
+    def location_metadata_mock(run_path, iens, iter_, observations):
+        if iens in {0, 1}:
+            return _create_rft_location_metadata_df()
+        elif iens == 2:
+            raise InvalidResponseFile("Mock error for realization 2")
+
+    async def run_test():
+        with (
+            patch.object(RFTConfig, "read_from_file", side_effect=read_from_file_mock),
+            patch.object(
+                RFTConfig,
+                "obtain_location_metadata",
+                side_effect=location_metadata_mock,
+            ),
+        ):
+            num_realizations = 3
+            observations = [
+                _create_rft_observation(),
+            ]
+
+            with _create_rft_ensemble(num_realizations, observations) as ensemble:
+                await _write_responses_to_storage("", 0, ensemble)
+                await _write_responses_to_storage("", 1, ensemble)
+                await _write_responses_to_storage("", 2, ensemble)
+
+                ensemble.load_responses("rft", (0,))
+                with pytest.raises(KeyError):
+                    ensemble.load_responses("rft", (1,))
+
+                with pytest.raises(KeyError):
+                    ensemble.load_responses("rft", (2,))
+
+                ensemble.load_observation_location_metadata(0)
+                with pytest.raises(FileNotFoundError):
+                    ensemble.load_observation_location_metadata(1)
+                with pytest.raises(FileNotFoundError):
+                    ensemble.load_observation_location_metadata(2)
+
+                assert ensemble.get_realization_list_with_responses() == [0]
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_location_metadata_file_is_not_created_when_no_observations():
+    def read_from_file_mock(run_path, iens, iter_):
+        return _create_rft_response_df()
+
+    async def run_test():
+        with (
+            patch.object(RFTConfig, "read_from_file", side_effect=read_from_file_mock),
+        ):
+            num_realizations = 1
+            observations = []
+
+            with _create_rft_ensemble(num_realizations, observations) as ensemble:
+                await _write_responses_to_storage("", 0, ensemble)
+
+                ensemble.load_responses("rft", (0,))
+                with pytest.raises(FileNotFoundError):
+                    ensemble.load_observation_location_metadata(0)
+                assert ensemble.get_realization_list_with_responses() == [0]
+
+    asyncio.run(run_test())
 
 
 def test_that_save_transition_data_writes_file_to_disk(tmp_path):

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -36,9 +36,14 @@ from ert.config import (
     SurfaceConfig,
 )
 from ert.config._create_observation_dataframes import create_observation_dataframes
-from ert.config._observations import BreakthroughObservation, GeneralObservation
+from ert.config._observations import (
+    BreakthroughObservation,
+    GeneralObservation,
+    RFTObservation,
+)
 from ert.config.design_matrix import DESIGN_MATRIX_GROUP
 from ert.config.distribution import DISTRIBUTION_CLASSES
+from ert.config.rft_config import RFTConfig
 from ert.dark_storage.common import ErtStoragePermissionError
 from ert.field_utils import ErtboxParameters
 from ert.sample_prior import sample_prior
@@ -1227,6 +1232,176 @@ def test_that_breakthrough_observations_and_responses_are_joined_in_endpoint(tmp
         assert obs_and_responses["observation_key"].to_list() == ["BRT_OP1"]
         assert obs_and_responses["index"].to_list() == ["0.2"]
         assert obs_and_responses["0"].to_list() == [-1.5]
+
+
+def rft_response(
+    *, values=100.0, well="WELL", well_connection_cell=(10, 10, 10)
+) -> pl.DataFrame:
+    date = datetime(2000, 1, 1).date()  # noqa: DTZ001
+    df = pl.DataFrame(
+        {
+            "response_key": [f"{well}:{date.isoformat()}:SWAT"],
+            "well": [well],
+            "date": [date.isoformat()],
+            "property": ["SWAT"],
+            "time": [date],
+            "depth": [1006.6],
+            "values": [values],
+            "well_connection_cell": pl.Series(
+                [well_connection_cell], dtype=pl.Array(pl.Int64, 3)
+            ),
+        },
+        schema=RFTConfig.response_schema(),
+    )
+    RFTConfig._assert_schema(df, RFTConfig.response_schema())
+    return df
+
+
+def rft_observation1(*, zone=None):
+    date = datetime(2000, 1, 1).date()  # noqa: DTZ001
+    return RFTObservation(
+        name="RFT_OBS1",
+        well="WELL",
+        date=date.isoformat(),
+        property="SWAT",
+        value=100.0,
+        error=10.0,
+        east=100.0,
+        north=105.0,
+        tvd=1000.0,
+        zone=zone,
+    )
+
+
+def rft_observation2(*, zone=None):
+    date = datetime(2000, 1, 1).date()  # noqa: DTZ001
+    return RFTObservation(
+        name="RFT_OBS2",
+        well="WELL",
+        date=date.isoformat(),
+        property="SWAT",
+        value=100.0,
+        error=10.0,
+        east=300.0,
+        north=405.0,
+        tvd=2000.0,
+        zone=zone,
+    )
+
+
+def location_metadata(*, zones1=("zone1",), zones2=("zone2",)) -> pl.DataFrame:
+    df = pl.DataFrame(
+        [
+            {
+                "east": 100.0,
+                "north": 105.0,
+                "tvd": 1000.0,
+                "actual_zones": zones1,
+                "well_connection_cell": [10, 10, 10],
+            },
+            {
+                "east": 300.0,
+                "north": 405.0,
+                "tvd": 2000.0,
+                "actual_zones": zones2,
+                "well_connection_cell": [10, 10, 10],
+            },
+        ],
+        schema=RFTConfig.location_metadata_schema(),
+    )
+    RFTConfig._assert_schema(df, RFTConfig.location_metadata_schema())
+    return df
+
+
+def test_that_get_observations_and_responses_applies_rft_metadata(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        rft_config = RFTConfig(
+            input_files=["BASE.RFT"],
+            data_to_read={"WELL": {"2000-01-01": ["SWAT"]}},
+        )
+
+        obs1 = rft_observation1()
+        obs2 = rft_observation2()
+
+        experiment = storage.create_experiment(
+            experiment_config={
+                "response_configuration": [rft_config.model_dump(mode="json")],
+                "observations": [
+                    obs1.model_dump(mode="json"),
+                    obs2.model_dump(mode="json"),
+                ],
+            }
+        )
+
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=2, iteration=0, name="prior"
+        )
+
+        ensemble.save_response("rft", rft_response(values=200.0), 0)
+        ensemble.save_observation_location_metadata(location_metadata(), 0)
+
+        ensemble.save_response("rft", rft_response(values=300.0), 1)
+        ensemble.save_observation_location_metadata(location_metadata(), 1)
+
+        iens_active_index = np.array([0, 1])
+        active_observations = ["RFT_OBS1"]
+
+        obs_and_responses = ensemble.get_observations_and_responses(
+            active_observations, iens_active_index
+        )
+
+        assert obs_and_responses["response_key"].to_list() == ["WELL:2000-01-01:SWAT"]
+        assert obs_and_responses["index"].to_list() == ["100.0, 105.0, 1000.0, None"]
+        assert obs_and_responses["observation_key"].to_list() == active_observations
+        assert obs_and_responses["0"].to_list() == [200.0]
+        assert obs_and_responses["1"].to_list() == [300.0]
+
+
+@pytest.mark.filterwarnings("ignore:.*did not match expected zone")
+def test_that_get_observations_and_responses_disables_observation(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        rft_config = RFTConfig(
+            input_files=["BASE.RFT"],
+            data_to_read={"WELL": {"2000-01-01": ["SWAT"]}},
+        )
+
+        obs1 = rft_observation1(zone="zone2")
+        obs2 = rft_observation2(zone="zone3")
+
+        experiment = storage.create_experiment(
+            experiment_config={
+                "response_configuration": [rft_config.model_dump(mode="json")],
+                "observations": [
+                    obs1.model_dump(mode="json"),
+                    obs2.model_dump(mode="json"),
+                ],
+            }
+        )
+
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=2, iteration=0, name="prior"
+        )
+
+        ensemble.save_response("rft", rft_response(values=200.0), 0)
+        ensemble.save_observation_location_metadata(
+            location_metadata(zones1=["zone1"], zones2=["zone3"]), 0
+        )
+
+        ensemble.save_response("rft", rft_response(values=300.0), 1)
+        ensemble.save_observation_location_metadata(
+            location_metadata(zones1=["zone2"], zones2=["zone3"]), 1
+        )
+
+        iens_active_index = np.array([0, 1])
+        active_observations = ["RFT_OBS1", "RFT_OBS2"]
+
+        obs_and_responses = ensemble.get_observations_and_responses(
+            active_observations, iens_active_index
+        )
+
+        assert obs_and_responses["observation_key"].to_list() == active_observations
+        assert obs_and_responses["0"].to_list() == [None, 200.0]
+        assert obs_and_responses["1"].to_list() == [300.0, 300.0]
 
 
 def add_to_name(prefix: str):


### PR DESCRIPTION
**Issue**
Relates to #12787

**Approach**
- Splits RFT response such that simulated zone and simulated well_connection_cell do not disappear during response joining observations, which will allow for better message on RFT disabled observation.
- Continues on previous PR work where split into RFT response and observation metadata has been done for the processing code itself. Now we also store the files.

Migration:
- Storage migration [instructions](https://ert.readthedocs.io/en/latest/developer_documentation/storage_migration.html) seem to be outdated, so I did the same thing recent migrations did. No test storages updated.
- I tried my best with figuring out all the possible cases, but I am sure I missed something somewhere... So good luck to us :smile:

---

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [x] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
