### PR TITLE
Forbid extra fields on observation base model

### DIFF
--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Literal, Self, assert_never
 
 import numpy as np
 import pandas as pd
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ert.validation import rangestring_to_list
 
@@ -34,7 +34,11 @@ class ErrorModes(StrEnum):
     RELMIN = "RELMIN"
 
 
-class _SummaryValues(BaseModel):
+class BaseObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _SummaryValues(BaseObservation):
     type: Literal["summary_observation"] = "summary_observation"
     name: str
     value: float
@@ -65,6 +69,9 @@ def _parse_date(date_str: str) -> datetime:
 
 
 class SummaryObservation(_SummaryValues):
+    error_mode: ErrorModes | None = Field(default=None, exclude=True)
+    error_min: float | None = Field(default=None, exclude=True)
+
     @classmethod
     def from_obs_dict(
         cls,
@@ -179,7 +186,7 @@ class SummaryObservation(_SummaryValues):
         return None
 
 
-class _GeneralObservation(BaseModel):
+class _GeneralObservation(BaseObservation):
     type: Literal["general_observation"] = "general_observation"
     name: str
     data: str
@@ -357,7 +364,7 @@ class GeneralObservation(_GeneralObservation):
         return None
 
 
-class RFTObservation(BaseModel):
+class RFTObservation(BaseObservation):
     """Represents an RFT (Repeat Formation Tester) observation.
 
     RFT observations are used to condition on pressure, saturation, or other
@@ -635,7 +642,7 @@ class RFTObservation(BaseModel):
         return None
 
 
-class BreakthroughObservation(BaseModel):
+class BreakthroughObservation(BaseObservation):
     type: Literal["breakthrough"] = "breakthrough"
     name: str
     key: str
@@ -852,12 +859,9 @@ def extract_localization_values(value: Mapping[str, Any]) -> tuple[float | None,
     east = value.get("EAST")
     north = value.get("NORTH")
     radius = value.get("RADIUS")
-    if east is not None:
-        validate_float(east, "EAST")
-    if north is not None:
-        validate_float(north, "NORTH")
-    if radius is not None:
-        validate_float(radius, "RADIUS")
+    east = validate_float(east, "EAST") if east is not None else None
+    north = validate_float(north, "NORTH") if north is not None else None
+    radius = validate_float(radius, "RADIUS") if radius is not None else None
     return east, north, radius
 
 

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -21,10 +21,6 @@ from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, ShapeReg
 from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config._observations import (
     DEFAULT_LOCALIZATION_RADIUS,
-    extract_localization_values,
-    make_observations,
-)
-from ert.config._observations import (
     BaseObservation,
     extract_localization_values,
     make_observations,

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -12,6 +12,7 @@ import pytest
 from hypothesis import assume, given
 from pandas import DataFrame
 from polars.testing import assert_frame_equal
+from pydantic import ValidationError
 from resdata.summary import Summary
 from resfo_utilities.testing import summaries
 
@@ -20,6 +21,11 @@ from ert.config import ConfigValidationError, ConfigWarning, ErtConfig, ShapeReg
 from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config._observations import (
     DEFAULT_LOCALIZATION_RADIUS,
+    extract_localization_values,
+    make_observations,
+)
+from ert.config._observations import (
+    BaseObservation,
     extract_localization_values,
     make_observations,
 )
@@ -2171,3 +2177,9 @@ def test_that_hours_are_rounded_to_closest_int_in_plot_observations():
         data=data,
         value_column="foo",
     )
+
+
+def test_that_base_observation_fails_validation_with_unknown_kwarg():
+
+    with pytest.raises(ValidationError):
+        BaseObservation(random_kwarg=42)

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -239,9 +239,7 @@ def test_plot_api_handles_urlescape(api_and_storage):
                     "date": date.isoformat(),
                     "value": 1.0,
                     "error": 1.0,
-                    "east": None,
-                    "north": None,
-                    "radius": None,
+                    "shape_id": None,
                 }
             ],
         }
@@ -388,9 +386,7 @@ def test_that_multiple_observations_are_parsed_correctly(api_and_storage):
                     "date": d.isoformat(),
                     "value": float(v),
                     "error": float(s),
-                    "east": None,
-                    "north": None,
-                    "radius": None,
+                    "shape_id": None,
                 }
                 for i, (d, v, s) in enumerate(
                     zip(
@@ -492,9 +488,7 @@ def test_that_response_key_has_observation_when_only_one_experiment_has_observat
                     "date": date.isoformat(),
                     "value": 1.0,
                     "error": 1.0,
-                    "east": None,
-                    "north": None,
-                    "radius": None,
+                    "shape_id": None,
                 }
             ],
         }
@@ -583,9 +577,7 @@ def test_that_response_keys_do_not_match_keys_that_are_substrings(
                     "date": date.isoformat(),
                     "value": value,
                     "error": error,
-                    "east": None,
-                    "north": None,
-                    "radius": None,
+                    "shape_id": None,
                 }
                 for name, value, error in [
                     (key, 0.2, 0.1),

--- a/tests/ert/unit_tests/plugins/test_export_rft.py
+++ b/tests/ert/unit_tests/plugins/test_export_rft.py
@@ -27,7 +27,6 @@ def _create_rft_ensemble(ensemble_size):
             error=5.0,
             north=200.0,
             east=100.0,
-            radius=None,
             tvd=25.0,
             md=50.0,
             zone=None,

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -246,7 +246,6 @@ def _create_rft_observation(
         error=error,
         north=north,
         east=east,
-        radius=None,
         tvd=tvd,
         md=md,
         zone=zone,

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -1309,8 +1309,6 @@ general_observations = st.builds(
     index=st.integers(min_value=1, max_value=10000),
     value=st.floats(allow_nan=False, allow_infinity=False),
     error=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
-    east=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
-    north=st.floats(allow_nan=False, allow_infinity=False, min_value=0.001),
 )
 observations = st.lists(
     general_observations,


### PR DESCRIPTION
# Conflicts:
#	tests/ert/unit_tests/config/test_observations.py

**Issue**
Resolves #13343 

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
