### PR TITLE
Constraint violation/improvement information to total batch objective-plot

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections.abc import Callable
+from enum import StrEnum
 from typing import Annotated, Any
 from urllib.parse import unquote
 from uuid import UUID
@@ -25,6 +26,13 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_STORAGE = Depends(get_storage)
 DEFAULT_BODY = Body(...)
+
+
+class RejectionReason(StrEnum):
+    NON_IMPROVEMENT = "non-improvement"
+    BOUND_CONSTRAINT_VIOLATION = "bound constraint violation"
+    INPUT_CONSTRAINT_VIOLATION = "input constraint violation"
+    OUTPUT_CONSTRAINT_VIOLATION = "output constraint violation"
 
 
 @router.get(
@@ -170,7 +178,10 @@ def data_for_response(
             return violation.drop("batch_id").to_numpy().max().item()
 
         CONSTRAINT_TOL = 1e-6
-        accepted_batches = []
+        accepted_batches: list[tuple[Ensemble, float]] = []
+        rejected_batches_with_value_and_reason: list[
+            tuple[Ensemble, float, RejectionReason]
+        ] = []
         max_total_objective = np.inf
         for current_ensemble in ensemble.experiment.ensembles_with_function_results:
             if current_ensemble.batch_objectives is None:
@@ -181,53 +192,109 @@ def data_for_response(
                 "total_objective_value"
             ].item()
 
-            bound_constraint_violation = constraint_violation_check(
+            bound_violation = constraint_violation_check(
                 current_ensemble.batch_bound_constraint_violations
             )
-            input_constraint_violation = constraint_violation_check(
+            input_violation = constraint_violation_check(
                 current_ensemble.batch_input_constraint_violations
             )
-            output_constraint_violation = constraint_violation_check(
+            output_violation = constraint_violation_check(
                 current_ensemble.batch_output_constraint_violations
             )
 
             if (
                 max(
-                    bound_constraint_violation,
-                    input_constraint_violation,
-                    output_constraint_violation,
+                    bound_violation,
+                    input_violation,
+                    output_violation,
                 )
                 < CONSTRAINT_TOL
                 and total_objective < max_total_objective
             ):
-                accepted_batches.append(current_ensemble)
+                accepted_batches.append(
+                    (
+                        current_ensemble,
+                        (max_total_objective - total_objective)
+                        if max_total_objective != np.inf
+                        else 0.0,
+                    )
+                )
                 max_total_objective = total_objective
+            elif total_objective >= max_total_objective:
+                rejected_batches_with_value_and_reason.append(
+                    (
+                        current_ensemble,
+                        total_objective - max_total_objective,
+                        RejectionReason.NON_IMPROVEMENT,
+                    )
+                )
+
+            else:
+                violations = {
+                    RejectionReason.BOUND_CONSTRAINT_VIOLATION: bound_violation,
+                    RejectionReason.INPUT_CONSTRAINT_VIOLATION: input_violation,
+                    RejectionReason.OUTPUT_CONSTRAINT_VIOLATION: output_violation,
+                }
+                rejection_reason = max(violations, key=lambda k: violations[k])
+                rejected_batches_with_value_and_reason.append(
+                    (
+                        current_ensemble,
+                        violations[rejection_reason],
+                        rejection_reason,
+                    )
+                )
 
         objective_value_df = ensemble.batch_objectives.clone().select(
             ["batch_id", "total_objective_value"]
         )
 
-        return (
-            objective_value_df.join(
-                pl.DataFrame(
-                    {
-                        "batch_id": [batch.iteration for batch in accepted_batches],
-                        "is_improvement": [True] * len(accepted_batches),
-                    }
-                ),
-                on="batch_id",
-                how="left",
-            )
-            .with_columns(pl.col("total_objective_value").neg())
-            .with_columns(pl.col("is_improvement").fill_null(False))
-            .to_pandas()
-            .astype(
+        improvement_df = objective_value_df.join(
+            pl.DataFrame(
                 {
-                    "batch_id": int,
-                    "total_objective_value": float,
-                    "is_improvement": bool,
+                    "batch_id": [batch.iteration for batch, _ in accepted_batches],
+                    "is_improvement": [True] * len(accepted_batches),
+                    "improvement_value": [value for _, value in accepted_batches],
+                }
+            ),
+            on="batch_id",
+            how="left",
+        ).with_columns(
+            pl.col("total_objective_value").neg(),
+            pl.col("is_improvement").fill_null(False),
+        )
+
+        if rejected_batches_with_value_and_reason:
+            batches, values, reasons = zip(
+                *rejected_batches_with_value_and_reason, strict=True
+            )
+            rejected_df = pl.DataFrame(
+                {
+                    "batch_id": [b.iteration for b in batches],
+                    "constraint_violation_value": list(values),
+                    "constraint_violation_type": [r.value for r in reasons],
                 }
             )
+            return (
+                improvement_df.join(rejected_df, on="batch_id", how="left")
+                .to_pandas()
+                .astype(
+                    {
+                        "batch_id": int,
+                        "total_objective_value": float,
+                        "is_improvement": bool,
+                        "improvement_value": float,
+                        "constraint_violation_value": float,
+                        "constraint_violation_type": str,
+                    }
+                )
+            )
+        return improvement_df.to_pandas().astype(
+            {
+                "batch_id": int,
+                "total_objective_value": float,
+                "is_improvement": bool,
+                "improvement_value": float,
+            }
         )
 
     response_key, response_type = _extract_response_type_and_key(

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -294,10 +294,13 @@ class PlotApi:
             ):
                 assert {"batch_id", "is_improvement"}.issubset(df.columns)
 
+                float_columns_names = (
+                    {"batch_id", "is_improvement", "constraint_violation_type"}
+                    if "constraint_violation_type" in df.columns
+                    else {"batch_id", "is_improvement"}
+                )
                 float_columns = [
-                    col
-                    for col in df.columns
-                    if col not in {"batch_id", "is_improvement"}
+                    col for col in df.columns if col not in float_columns_names
                 ]
 
                 return df.astype(
@@ -305,6 +308,14 @@ class PlotApi:
                     | {
                         "batch_id": int,
                         "is_improvement": bool,
+                        "improvement_value": float,
+                        "constraint_violation_type": str,
+                    }
+                    if "constraint_violation_type" in df.columns
+                    else {
+                        "batch_id": int,
+                        "is_improvement": bool,
+                        "improvement_value": float,
                     }
                 )
 

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -120,6 +120,7 @@ class CustomNavigationToolbar(NavigationToolbar2QT):
 
 class PlotWidget(QWidget):
     customizationTriggered = Signal()
+    _plotUpdateRequested = Signal()
     layerIndexChanged = Signal(int)
     updateLayerWidget = Signal(int)
     resetLayerWidget = Signal()
@@ -172,12 +173,32 @@ class PlotWidget(QWidget):
         self._log_checkbox.setVisible(False)
         self._log_checkbox.setToolTip("Toggle data domain to log scale and back")
         self._log_checkbox.clicked.connect(self.logLogScaleButtonUsage)
+        self._log_checkbox.toggled.connect(self._plotUpdateRequested)
 
-        log_checkbox_row = QHBoxLayout()
-        log_checkbox_row.addWidget(self._log_checkbox)
-        log_checkbox_row.setContentsMargins(16, 8, 16, 8)
-        log_checkbox_row.addStretch()
-        vbox.addLayout(log_checkbox_row)
+        self._extended_plot_information_checkbox = QCheckBox(
+            "Extended plot information", self
+        )
+        self._extended_plot_information_checkbox.setObjectName(
+            "extended_plot_information_checkbox"
+        )
+        self._extended_plot_information_checkbox.setCheckable(True)
+        self._extended_plot_information_checkbox.setVisible(False)
+        self._extended_plot_information_checkbox.setToolTip(
+            "Toggle extended plot information"
+        )
+        self._extended_plot_information_checkbox.clicked.connect(
+            self.logExtendedPlotInformationButtonUsage
+        )
+        self._extended_plot_information_checkbox.toggled.connect(
+            self._plotUpdateRequested
+        )
+
+        checkbox_row = QHBoxLayout()
+        checkbox_row.addWidget(self._log_checkbox)
+        checkbox_row.addWidget(self._extended_plot_information_checkbox)
+        checkbox_row.setContentsMargins(16, 8, 16, 8)
+        checkbox_row.addStretch()
+        vbox.addLayout(checkbox_row)
         vbox.addWidget(self._toolbar)
         vbox.addSpacing(8)
         self.setLayout(vbox)
@@ -189,7 +210,7 @@ class PlotWidget(QWidget):
 
     @property
     def plotUpdateRequested(self) -> pyqtBoundSignal:
-        return self._log_checkbox.toggled
+        return self._plotUpdateRequested
 
     def resetPlot(self) -> None:
         self._figure.clear()
@@ -215,6 +236,12 @@ class PlotWidget(QWidget):
         else:
             self._log_checkbox.setVisible(False)
 
+    def _sync_extended_plot_information_checkbox(self) -> None:
+        if type(self._plotter).__name__ == "EverestBatchObjectiveFunctionPlot":
+            self._extended_plot_information_checkbox.setVisible(True)
+        else:
+            self._extended_plot_information_checkbox.setVisible(False)
+
     @property
     def name(self) -> str:
         return self._name
@@ -222,6 +249,13 @@ class PlotWidget(QWidget):
     def logLogScaleButtonUsage(self) -> None:
         logger.info(f"Plotwidget utility used: 'Log scale button' in tab '{self.name}'")
         self._log_checkbox.clicked.disconnect()  # Log only once
+
+    def logExtendedPlotInformationButtonUsage(self) -> None:
+        logger.info(
+            "Plotwidget utility used: "
+            f"'Extended plot information button' in tab '{self.name}'"
+        )
+        self._extended_plot_information_checkbox.clicked.disconnect()  # Log only once
 
     def updatePlot(
         self,
@@ -235,12 +269,16 @@ class PlotWidget(QWidget):
         self.resetPlot()
         try:
             self._sync_log_checkbox(key_def)
+            self._sync_extended_plot_information_checkbox()
             plot_context.log_scale = (
                 self._log_checkbox.isVisible()
                 and self._log_checkbox.isChecked()
                 and self._negative_values_in_data is False
             )
-
+            plot_context.extended_plot_information = (
+                self._extended_plot_information_checkbox.isVisible()
+                and self._extended_plot_information_checkbox.isChecked()
+            )
             self._plotter.plot(
                 self._figure,
                 plot_context,

--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -46,6 +46,7 @@ class PlotContext:
         self._x_axis: str | None = None
         self._y_axis: str | None = None
         self._log_scale = False
+        self._extended_plot_information = False
 
     @property
     def flip_response_axis(self) -> bool:
@@ -114,6 +115,14 @@ class PlotContext:
 
     def setYLabel(self, value: str) -> None:
         self._plot_config.setYLabel(value)
+
+    @property
+    def extended_plot_information(self) -> bool:
+        return self._extended_plot_information
+
+    @extended_plot_information.setter
+    def extended_plot_information(self, value: bool) -> None:
+        self._extended_plot_information = value
 
     @property
     def log_scale(self) -> bool:

--- a/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
@@ -51,7 +51,6 @@ class EverestBatchObjectiveFunctionPlot:
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS
         plot_context.deactivateDateSupport()
-
         all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
 
         if not all_dfs:
@@ -59,26 +58,32 @@ class EverestBatchObjectiveFunctionPlot:
 
         combined = pd.concat(all_dfs, ignore_index=True)
 
-        if "is_improvement" in combined.columns:
-            value_col = next(
-                c
-                for c in combined.columns
-                if c not in {"batch_id", "realization", "is_improvement"}
-            )
-            data = combined.sort_values("batch_id")
+        value_col = next(
+            c
+            for c in combined.columns
+            if c
+            not in {
+                "batch_id",
+                "realization",
+                "is_improvement",
+                "constraint_violation_type",
+            }
+        )
+        data = combined.sort_values("batch_id")
 
-            color = config.nextColor()
+        color = config.nextColor()
 
-            improvement_data = data[data["is_improvement"]]
+        improvement_data = data[data["is_improvement"]]
 
-            lines = axes.plot(
-                improvement_data["batch_id"],
-                improvement_data[value_col],
-                "-o",
-                color=color,
-            )
+        lines = axes.plot(
+            improvement_data["batch_id"],
+            improvement_data[value_col],
+            "-o",
+            color=color,
+        )
 
-            rejected_data = data[~data["is_improvement"]]
+        rejected_data = data[~data["is_improvement"]]
+        if not rejected_data.empty:
             axes.scatter(
                 rejected_data["batch_id"],
                 rejected_data[value_col],
@@ -86,39 +91,68 @@ class EverestBatchObjectiveFunctionPlot:
                 s=20,
                 zorder=5,
             )
+            for _, row in rejected_data.iterrows():
+                batch_id = int(row["batch_id"])
+                val_type = row.get("constraint_violation_type", "N/A")
+                val = row.get("constraint_violation_value", float("nan"))
 
-            annotation_color = {True: color, False: "red"}
-            for _, row in data.iterrows():
                 axes.annotate(
-                    f"Batch {int(row['batch_id'])}",
+                    f"Batch {batch_id}\nViolation value: {val:.3g}\nType: {val_type}"
+                    if plot_context.extended_plot_information
+                    else f"Batch {batch_id}",
                     xy=(row["batch_id"], row[value_col]),
                     xytext=(5, -5),
                     textcoords="offset points",
-                    color=annotation_color[row["is_improvement"]],
+                    color="red",
                     verticalalignment="top",
                     horizontalalignment="left",
                 )
+                if plot_context.extended_plot_information:
+                    axes.margins(y=0.2, x=0.1)
 
-            config.addLegendItem("Accepted", lines[0])
-            config.addLegendItem(
-                "Rejected",
-                Line2D(
-                    [0], [0], marker="o", color="w", markerfacecolor="red", markersize=8
-                ),
+        annotation_color = {True: color, False: "red"}
+        for _, row in improvement_data.iterrows():
+            improvement_value = (
+                0
+                if row.get("improvement_value", float("nan")) == float("-inf")
+                else row.get("improvement_value", float("nan"))
             )
-
-            axes.spines["right"].set_visible(False)
-            axes.spines["left"].set_visible(False)
-            axes.spines["top"].set_visible(False)
-
-            axes.xaxis.set_major_locator(MaxNLocator(integer=True))
-
-            PlotTools.finalizePlot(
-                plot_context,
-                figure,
-                axes,
-                default_x_label="Batch iteration",
-                default_y_label="Aggregated objective value",
+            batch_id = int(row["batch_id"])
+            axes.annotate(
+                f"Batch {batch_id}\nImprovement value: {improvement_value:.3g}"
+                if plot_context.extended_plot_information
+                else f"Batch {batch_id}",
+                xy=(row["batch_id"], row[value_col]),
+                xytext=(5, -5),
+                textcoords="offset points",
+                color=annotation_color[row["is_improvement"]],
+                verticalalignment="top",
+                horizontalalignment="left",
             )
-            figure.tight_layout()
-            return
+            if plot_context.extended_plot_information:
+                axes.margins(y=0.2, x=0.1)
+
+        config.addLegendItem("Accepted", lines[0])
+        config.addLegendItem(
+            "Rejected",
+            Line2D(
+                [0], [0], marker="o", color="w", markerfacecolor="red", markersize=8
+            ),
+        )
+
+        axes.margins(y=0.2, x=0.1)
+
+        for spine in ("right", "left", "top"):
+            axes.spines[spine].set_visible(False)
+
+        axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        PlotTools.finalizePlot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Batch iteration",
+            default_y_label="Aggregated objective value",
+        )
+        figure.tight_layout()
+        return


### PR DESCRIPTION
**Issue**
Resolves #13407 


**Approach**

Added extended information to the total objective value plot by sending additional information with the data frame. Is part of the existing improvement-calculation from PR #13382, just additional fields to the DF. 

The extended plot-info contains information about the constraint violation (how large of a constraint violation or how much it didn't improve and the type of violation). For improvements it shows the difference between previous global best and now new best. 

The information is "opt-in" and is toggled on by checking the "Extended plot information"-box (copied from the Log-scale button for GaussianKDE-plot for ERT). The button is generic and can probably be used for other plots that could contain additional information/plots.
<img width="1962" height="955" alt="image" src="https://github.com/user-attachments/assets/c755e849-409f-4ca8-ba99-3852eaa88a2e" />
**Not toggled on**
<img width="1963" height="955" alt="image" src="https://github.com/user-attachments/assets/8d8b0986-34ba-4126-b9f4-5424de1a5d5b" />

**Toggled on** 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
