### PR TITLE
Implement parsing of bulk configuration of summary observations

### DIFF
--- a/docs/ert/reference/configuration/observations.rst
+++ b/docs/ert/reference/configuration/observations.rst
@@ -209,6 +209,94 @@ different from space. Thus, the following statement is equivalent to
 the previous:
 
 
+Bulk configuration of summary observations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Summary observations can also be created in bulk by the "SUMMARY"
+keyword. This will generate multiple summary observations from the
+same declaration, but requires a csv-file containing the attribute
+values for each summary observation.
+
+A minimal configuration for the "SUMMARY" keyword looks like:
+
+.. code-block:: none
+
+ SUMMARY {
+    VALUES = some_file.csv;
+ };
+
+Where the provided csv file will contain one row for each observation.
+Required columns to create summary observations are: keyword, value,
+error, date.
+
+Without these columns, the configuration is invalid, and Ert will raise
+an error.
+
+A csv file containing a single summary observation might look like:
+
+.. code-block:: none
+
+ keyword, value, error, date
+ FOPR, 1e6, 1e3, 2012-12-02
+
+
+It is also possible to provide optional columns: well, number, nx, ny,
+lgr_name, li, lj, lk - which may be required by certain keywords.
+
+The SUMMARY configuration can also configure WELLs. The WELL keyword
+inside a SUMMARY configuration is used to configure metadata about
+a well.
+
+The WELL keyword can contain two types of configuration: LOCALIZATION and
+BREAKTHROUGH.
+
+LOCALIZATION contains two required fields: NORTH and EAST, and optionally
+RADIUS. These localization attributes will be applied to all observations
+sharing the same well name as the WELL configuration.
+
+BREAKTHROUGH allows the user to define a BREAKTHROUGH observation for
+the given well. BREAKTHROUGH is configured like a regular
+BREAKTHROUGH_OBSERVATION - which requires the fields KEY, THRESHOLD, DATE
+and ERROR. BREAKTHROUGH will also inherit the LOCALIZATION values should
+they be defined for the well. Only one occurrence of BREAKTHROUGH can
+be configured per WELL.
+
+A SUMMARY configuration containing all of these elements may look like:
+
+.. code-block:: none
+
+ SUMMARY {
+    VALUES = some_file.csv;
+    WELL OP1 {
+        LOCALIZATION {
+            EAST   = 32.132;
+            NORTH  = 45.139;
+            RADIUS = 2500;
+        };
+        BREAKTHROUGH {
+            KEY       = WWCT;
+            THRESHOLD = 0.2;
+            DATE      = 2012-05-01;
+            ERROR     = 3;
+        };
+    };
+    WELL OP2 {
+        LOCALIZATION {
+            EAST   = 35.734;
+            NORTH  = 42.981;
+            RADIUS = 3000;
+        };
+    };
+ };
+
+.. code-block:: none
+
+ well,keyword, value, error, date, nx, ny, number
+ OP1, WOPR, 1e5, 1e3, 2012-01-03, , ,
+ OP1, BPR, 100, 7.5, 2012-01-07, 1, 2, 5
+ OP2, WOPR, 7e5, 1.2e3, 2012-02-05, , ,
+ ,FOPR, 1e6, 1e3, 2012-12-02, , ,
+
 .. _breakthrough_observation:
 
 BREAKTHROUGH_OBSERVATION keyword

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -169,7 +169,7 @@ class SummaryObservation(_SummaryValues):
         name = (
             observation_dict["name"]
             if observation_dict["name"] is not None
-            else f"{summary_key}:{date}"
+            else cls.default_name(summary_key, date)
         )
 
         obs_instance = cls(
@@ -191,6 +191,10 @@ class SummaryObservation(_SummaryValues):
         if self.shape_id is not None:
             return shape_registry.get(self.shape_id)
         return None
+
+    @classmethod
+    def default_name(cls, summary_key: str, date: str) -> str:
+        return f"{summary_key}:{date}"
 
 
 class _GeneralObservation(BaseObservation):

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import os
-import pathlib
+import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, Self, assert_never
+from pathlib import Path
+from typing import Annotated, Any, Literal, Self, assert_never, get_args, get_type_hints
 
 import numpy as np
 import pandas as pd
+import polars as pl
 from pydantic import BaseModel, ConfigDict, Field
+from resfo_utilities import InvalidSummaryKeyError, make_summary_key
 
 from ert.validation import rangestring_to_list
 
@@ -69,6 +73,23 @@ def _parse_date(date_str: str) -> datetime:
             return date
 
 
+def strip_dataframe_whitespaces(df: pl.DataFrame) -> pl.DataFrame:
+    df = df.rename({col: col.strip() for col in df.columns})
+    string_cols = [
+        col
+        for col, dtype in zip(df.columns, df.dtypes, strict=True)
+        if dtype == pl.String
+    ]
+    stripped_df = df.with_columns(
+        pl.when(pl.col(col).str.strip_chars() == "")  # noqa: PLC1901 the truth value of an Expr is ambiguous
+        .then(None)
+        .otherwise(pl.col(col).str.strip_chars())
+        .alias(col)
+        for col in string_cols
+    )
+    return stripped_df
+
+
 class SummaryObservation(_SummaryValues):
     error_mode: ErrorModes | None = Field(default=None, exclude=True)
     error_min: float | None = Field(default=None, exclude=True)
@@ -79,7 +100,12 @@ class SummaryObservation(_SummaryValues):
         directory: str,
         observation_dict: ObservationDict,
         shape_registry: ShapeRegistry,
-    ) -> list[Self]:
+    ) -> list[Self | BreakthroughObservation]:
+        if observation_dict["type"] is ObservationType.BULK_SUMMARY:
+            return cls.from_bulk_config_dict(
+                directory, observation_dict, shape_registry
+            )
+
         error_mode = ErrorModes.ABS
         summary_key = None
 
@@ -154,17 +180,7 @@ class SummaryObservation(_SummaryValues):
             case default:
                 assert_never(default)
 
-        # Register geometry if localization is present
-        shape_id = None
-        if east is not None and north is not None:
-            radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
-            shape_id = shape_registry.register(
-                CircleShapeConfig(
-                    east=east,
-                    north=north,
-                    radius=radius,
-                )
-            )
+        shape_id = cls.get_shape_id(east, north, radius, shape_registry)
 
         name = (
             observation_dict["name"]
@@ -186,6 +202,183 @@ class SummaryObservation(_SummaryValues):
         obs_instance.name = name
 
         return [obs_instance]
+
+    @classmethod
+    def from_bulk_config_dict(
+        cls,
+        directory: str,
+        observation_dict: ObservationDict,
+        shape_registry: ShapeRegistry,
+    ) -> list[Self | BreakthroughObservation]:
+        obs_instances: list[Self | BreakthroughObservation] = []
+        context: FileContextToken = observation_dict.context
+
+        required_csv_columns = ["keyword", "value", "error", "date"]
+
+        make_summary_key_optional_args = [
+            name
+            for name, param in inspect.signature(make_summary_key).parameters.items()
+            if param.default is not inspect.Parameter.empty
+        ]
+
+        csv_file = observation_dict.get("VALUES")
+        if csv_file is None:
+            raise _missing_value_error(context, "VALUES")
+        csv_path = _resolve_path(directory, csv_file)
+        try:
+            csv_df = pl.read_csv(
+                csv_path,
+                encoding="utf-8",
+            )
+        except (OSError, UnicodeDecodeError, pl.exceptions.PolarsError) as err:
+            raise ObservationConfigError.with_context(
+                f"Could not read VALUES csv file '{csv_path}': {err}",
+                context,
+            ) from err
+        csv_df = strip_dataframe_whitespaces(csv_df)
+
+        # Rename 'well' column to 'name' to match make_summary_key parameter names
+        if "well" in csv_df.columns:
+            csv_df = csv_df.rename({"well": "name"})
+
+        for col in csv_df.columns:
+            if col not in {
+                *required_csv_columns,
+                *make_summary_key_optional_args,
+            }:
+                raise _unknown_csv_column(context, col, csv_path)
+
+        for required_col in required_csv_columns:
+            if required_col not in csv_df.columns:
+                raise _missing_csv_column(context, required_col, csv_file)
+            if nan_values := [
+                str(i) for i, v in enumerate(csv_df[required_col]) if v is None
+            ]:
+                raise _missing_csv_value(context, required_col, nan_values, csv_path)
+
+        well_localization = {}
+
+        for kw, value in observation_dict.items():
+            match kw:
+                case "name" | "VALUES" | "type":
+                    pass
+                case _:
+                    if match := re.match(r"WELL (.+)", kw):
+                        well_name = match.group(1)
+                        for key_, value_ in value.items():
+                            match key_:
+                                case "LOCALIZATION":
+                                    validate_localization(value_, context)
+                                    east, north, radius = extract_localization_values(
+                                        value_
+                                    )
+                                    well_localization[well_name] = {
+                                        "east": east,
+                                        "north": north,
+                                        "radius": radius,
+                                    }
+                                case "BREAKTHROUGH":
+                                    breakthrough_context = context.update(
+                                        value="BREAKTHROUGH"
+                                    )
+                                    validate_nonempty_string(
+                                        value_.get("KEY"), "KEY", breakthrough_context
+                                    )
+                                    breakthrough_key = value_["KEY"]
+                                    breakthrough_key = (
+                                        breakthrough_key
+                                        if breakthrough_key.endswith(f":{well_name}")
+                                        else f"{breakthrough_key}:{well_name}"
+                                    )
+                                    breakthrough_obs_dict = ObservationDict(
+                                        {
+                                            **value_,
+                                        }
+                                        | {"KEY": breakthrough_key}
+                                        | (
+                                            {"LOCALIZATION": value["LOCALIZATION"]}
+                                            if "LOCALIZATION" in value
+                                            else {}
+                                        ),
+                                        context=breakthrough_context,
+                                    )
+                                    obs_instances.extend(
+                                        BreakthroughObservation.from_obs_dict(
+                                            directory,
+                                            breakthrough_obs_dict,
+                                            shape_registry,
+                                        )
+                                    )
+                    else:
+                        raise _unknown_key_error(str(kw), observation_dict.context)
+
+        for i, row in enumerate(csv_df.iter_rows(named=True)):
+            kw = validate_nonempty_string(row["keyword"], "keyword", context)
+
+            arg_type_hints = get_type_hints(make_summary_key)
+            optional_kw_args = {
+                kw_arg: validate_int(val, kw)
+                if (val := row.get(kw_arg)) is not None
+                and int in get_args(arg_type_hints.get(kw_arg))
+                else val
+                for kw_arg in make_summary_key_optional_args
+            }
+            try:
+                summary_key = make_summary_key(
+                    keyword=kw,
+                    **optional_kw_args,  # type: ignore[arg-type]
+                )
+            except InvalidSummaryKeyError as e:
+                raise _ill_configured_summary_key(kw, csv_file, i + 1, e) from e
+
+            validated_error = validate_positive_float(
+                row["error"], f"({summary_key}) ERROR", strictly_positive=True
+            )
+            validated_value = validate_float(row["value"], f"({summary_key}) VALUE")
+            date = row["date"]
+            standardized_date = _parse_date(date).isoformat()
+
+            loc_values = well_localization.get(row.get("name"), {})
+            shape_id = cls.get_shape_id(
+                loc_values.get("east"),
+                loc_values.get("north"),
+                loc_values.get("radius"),
+                shape_registry,
+            )
+
+            obs_instances.append(
+                cls(
+                    name=cls.default_name(summary_key, date),
+                    error=validated_error,
+                    key=summary_key,
+                    value=validated_value,
+                    shape_id=shape_id,
+                    date=standardized_date,
+                )
+            )
+
+        return obs_instances
+
+    @classmethod
+    def get_shape_id(
+        cls,
+        east: float | None,
+        north: float | None,
+        radius: float | None,
+        shape_registry: ShapeRegistry,
+    ) -> int | None:
+        # Register geometry if localization is present
+        shape_id = None
+        if east is not None and north is not None:
+            radius = radius if radius is not None else DEFAULT_LOCALIZATION_RADIUS
+            shape_id = shape_registry.register(
+                CircleShapeConfig(
+                    east=east,
+                    north=north,
+                    radius=radius,
+                )
+            )
+        return shape_id
 
     def shape(self, shape_registry: ShapeRegistry) -> ShapeConfig | None:
         if self.shape_id is not None:
@@ -442,7 +635,7 @@ class RFTObservation(BaseObservation):
         """
         if not os.path.isabs(filename):
             filename = os.path.join(directory, filename)
-        if not pathlib.Path(filename).exists():
+        if not Path(filename).exists():
             raise ObservationConfigError.with_context(
                 f"The CSV file ({filename}) does not exist or is not accessible.",
                 filename,
@@ -737,8 +930,8 @@ class BreakthroughObservation(BaseObservation):
             )
 
         name = (
-            obs_dict["name"]
-            if obs_dict["name"] is not None
+            obs_dict.get("name")
+            if obs_dict.get("name") is not None
             else f"BREAKTHROUGH:{summary_key}:{threshold}"
         )
         return [
@@ -773,6 +966,7 @@ _TYPE_TO_CLASS: dict[ObservationType, type[Observation]] = {
     ObservationType.GENERAL: GeneralObservation,
     ObservationType.RFT: RFTObservation,
     ObservationType.BREAKTHROUGH: BreakthroughObservation,
+    ObservationType.BULK_SUMMARY: SummaryObservation,
 }
 
 LOCALIZATION_KEYS = Literal["east", "north", "radius"]
@@ -832,6 +1026,18 @@ def validate_error_mode(inp: str) -> ErrorModes:
     raise ObservationConfigError.with_context(
         f'Unexpected ERROR_MODE {inp}. Failed to validate "{inp}"', inp
     )
+
+
+def validate_nonempty_string(val: str, key: str, context: FileContextToken) -> str:
+    if not val:
+        raise ObservationConfigError.with_context(
+            f'Required string value for key "{key}" is empty for {context!s}.',
+            context,
+        )
+    try:
+        return str(val)
+    except ValueError as err:
+        raise _conversion_error(key, val, "str") from err
 
 
 def validate_float(val: str, key: str) -> float:
@@ -925,10 +1131,40 @@ def _missing_value_error(
     )
 
 
+def _unknown_csv_column(
+    context: FileContextToken, column_name: str, path_str: str
+) -> ObservationConfigError:
+    if column_name == "name":
+        column_name = "well"
+    return ObservationConfigError.with_context(
+        f"Unrecognized column '{column_name}' "
+        f"in CSV file '{Path(path_str).name}' for {context!s}",
+        context,
+    )
+
+
+def _missing_csv_column(
+    context: FileContextToken, col: str, path_str: str
+) -> ObservationConfigError:
+    return ObservationConfigError.with_context(
+        f"Missing required column '{col}' in csv file '{Path(path_str).name}'", context
+    )
+
+
+def _missing_csv_value(
+    context: FileContextToken, col: str, rows: list[str], path_str: str
+) -> ObservationConfigError:
+    return ObservationConfigError.with_context(
+        f"Missing value for column '{col}' in row(s) {rows} "
+        f"in csv file '{Path(path_str).name}'",
+        context,
+    )
+
+
 def _resolve_path(directory: str, filename: str) -> str:
     if not os.path.isabs(filename):
         filename = os.path.join(directory, filename)
-    if not pathlib.Path(filename).exists():
+    if not Path(filename).exists():
         raise ObservationConfigError.with_context(
             f"The following keywords did not resolve to a valid path:\n {filename}",
             filename,
@@ -961,4 +1197,14 @@ def _invalid_rft_localization_key_error(
         f"The '{key}' keyword must be defined outside the LOCALIZATION section for "
         f"RFT observations - or in the CSV RFT configuration file.",
         context,
+    )
+
+
+def _ill_configured_summary_key(
+    key: str, csv_file: str, line_nr: int, e: InvalidSummaryKeyError
+) -> ObservationConfigError:
+    return ObservationConfigError(
+        f"Could not create summary key for "
+        f"keyword '{key}' in file '{csv_file}' (line {line_nr})\n"
+        f"Failed with message: '{e}'",
     )

--- a/src/ert/config/parsing/observations_parser.py
+++ b/src/ert/config/parsing/observations_parser.py
@@ -21,6 +21,7 @@ class ObservationType(StrEnum):
     GENERAL = "GENERAL_OBSERVATION"
     RFT = "RFT_OBSERVATION"
     BREAKTHROUGH = "BREAKTHROUGH_OBSERVATION"
+    BULK_SUMMARY = "SUMMARY"
 
 
 class ObservationDict(UserDict[str, Any]):
@@ -100,11 +101,11 @@ def parse_observations(content: str, filename: str) -> list[ObservationDict]:
                 )
             case UnexpectedToken(
                 token=unexpected_token,
-            ), ["TYPE"]:
+            ), ["BULK_TYPE", "TYPE"]:
                 message = (
                     f"Unknown observation type '{unexpected_token}', "
                     f"expected either 'RFT_OBSERVATION', 'GENERAL_OBSERVATION', "
-                    f"'SUMMARY_OBSERVATION' or 'HISTORY_OBSERVATION'."
+                    f"'SUMMARY_OBSERVATION', 'SUMMARY' or 'HISTORY_OBSERVATION'."
                 )
             case UnexpectedToken(token=unexpected_char, expected=allowed_chars), _:
                 unexpected_line = content.splitlines()[e.line - 1]
@@ -132,13 +133,15 @@ def parse_observations(content: str, filename: str) -> list[ObservationDict]:
 observations_parser = Lark(
     r"""
     start: observation*
-    observation: type OBSERVATION_NAME? object? ";"
+    observation: type OBSERVATION_NAME? object? ";" | bulk_type summary_object ";"
     TYPE: "HISTORY_OBSERVATION"
       | "SUMMARY_OBSERVATION"
       | "GENERAL_OBSERVATION"
       | "RFT_OBSERVATION"
       | "BREAKTHROUGH_OBSERVATION"
     type: TYPE
+    BULK_TYPE: "SUMMARY"
+    bulk_type: BULK_TYPE
     ?value: object
           | STRING
 
@@ -146,6 +149,7 @@ observations_parser = Lark(
     CHAR: /[^; \t\n{}=]/
     STRING : CHAR+
     OBSERVATION_NAME : CHAR+
+    WELL_NAME : CHAR+
     PARAMETER_NAME : CHAR+
     object : "{" [(declaration";")*] "}"
     ?declaration: "SEGMENT" STRING object -> segment
@@ -153,6 +157,11 @@ observations_parser = Lark(
                 | pair
     pair   : PARAMETER_NAME "=" value
 
+    summary_object : "{" [(summary_declaration";")*] "}"
+    ?summary_declaration: "BREAKTHROUGH" object -> breakthrough
+                | "WELL" WELL_NAME summary_object -> well
+                | "LOCALIZATION" object -> localization
+                | pair
 
     %import common.WS
     %ignore WS
@@ -169,7 +178,7 @@ class TreeToObservations(Transformer[FileContextToken, list[ObservationDict]]):
 
     @staticmethod
     @no_type_check
-    def observation(tree):
+    def observation(tree) -> ObservationDict:
         context_token = tree[0].children[0]
         observation_type = ObservationType(context_token)
 
@@ -217,7 +226,28 @@ class TreeToObservations(Transformer[FileContextToken, list[ObservationDict]]):
 
     @staticmethod
     @no_type_check
+    def well(tree):
+        # Keys must be unique, therefore we append well name to WELL
+        return (f"WELL {tree[0]}", tree[1])
+
+    @staticmethod
+    @no_type_check
+    def breakthrough(tree):
+        return ("BREAKTHROUGH", tree[0])
+
+    @staticmethod
+    @no_type_check
     def object(tree):
+        return TreeToObservations._object(tree)
+
+    @staticmethod
+    @no_type_check
+    def summary_object(tree):
+        return TreeToObservations._object(tree)
+
+    @staticmethod
+    @no_type_check
+    def _object(tree):
         keys = set()
         error_list: list[ErrorInfo] = []
         for key, *_ in tree:

--- a/tests/ert/unit_tests/config/test_bulk_summary_config.py
+++ b/tests/ert/unit_tests/config/test_bulk_summary_config.py
@@ -1,0 +1,698 @@
+import math
+from datetime import datetime
+from pathlib import Path
+from textwrap import dedent
+
+import hypothesis.strategies as st
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from polars.testing import assert_frame_equal
+
+from ert.config import ConfigValidationError, ErtConfig
+from ert.config._create_observation_dataframes import create_observation_dataframes
+from ert.config._observations import strip_dataframe_whitespaces
+from tests.ert.unit_tests.config.test_summary_config import create_observations
+
+
+def config():
+    return """
+    NUM_REALIZATIONS 3
+    ECLBASE ECLIPSE_CASE_%d
+    OBS_CONFIG observations
+    GEN_KW KW_NAME template.txt kw.txt prior.txt
+    RANDOM_SEED 1234
+    """
+
+
+def csv_content():
+    return dedent(
+        """
+        well, keyword, value, error, date
+        OP1, WOPR, 1e6, 1.0, 2012-02-01
+        ,FOPR, 3e6, 3.0, 2012-03-01
+        OP2, WGPR, 1e8, 2.0, 2012-04-01"""
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_summary_observations_can_be_initialized_from_bulk_configuration():
+    bulk_obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                KEY = WWCT;
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                ERROR = 0.2;
+            };
+        };
+        WELL OP2 {
+            LOCALIZATION {
+                EAST = 10;
+                NORTH = 20;
+                RADIUS = 2500;
+            };
+        };
+    };"""
+
+    regular_obs_config = """
+    SUMMARY_OBSERVATION {
+        KEY = WOPR:OP1;
+        VALUE = 1e6;
+        ERROR = 1.0;
+        DATE = 2012-02-01;
+        LOCALIZATION {
+            EAST = 4.5;
+            NORTH = 12.5;
+            RADIUS = 3000;
+        };
+    };
+    SUMMARY_OBSERVATION {
+        KEY = FOPR;
+        VALUE = 3e6;
+        ERROR = 3.0;
+        DATE = 2012-03-01;
+    };
+    SUMMARY_OBSERVATION {
+        KEY = WGPR:OP2;
+        VALUE = 1e8;
+        ERROR = 2.0;
+        DATE = 2012-04-01;
+        LOCALIZATION {
+            EAST = 10.0;
+            NORTH = 20.0;
+            RADIUS = 2500;
+        };
+    };
+    BREAKTHROUGH_OBSERVATION {
+        KEY = WWCT:OP1;
+        THRESHOLD = 0.5;
+        DATE = 2020-01-01;
+        ERROR = 0.2;
+            LOCALIZATION {
+            EAST = 4.5;
+            NORTH = 12.5;
+            RADIUS = 3000;
+        };
+    };
+    """
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+
+    bulk_config_observations = create_observations(config(), bulk_obs_config)
+    regular_observations = create_observations(config(), regular_obs_config)
+
+    assert regular_observations.keys() == bulk_config_observations.keys()
+    for obs_type, obs_df in regular_observations.items():
+        assert obs_df.equals(bulk_config_observations[obs_type])
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_misconfigured_breakthrough_in_summary_gets_breakthrough_label_in_error():
+    misconfigured_breakthrough_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                KEY = WWCT:OP1;
+                -- DATE = 2020-01-01;
+                ERROR = 0.2;
+            };
+        };
+    };"""
+
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=r'Line 2 \(Column 5-12\): Missing item "DATE" in BREAKTHROUGH',
+    ):
+        create_observations(config(), misconfigured_breakthrough_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_bulk_summary_config_can_be_initialized_without_localization():
+    misconfigured_breakthrough_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };"""
+
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+    obs = create_observations(config(), misconfigured_breakthrough_config)
+    for loc_kw in ["east", "north", "radius"]:
+        assert list(obs["summary"][loc_kw]) == [None, None, None]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_missing_values_in_bulk_summary_config_raises_config_error():
+    config_without_values = """
+    SUMMARY {
+        WELL OP1 {};
+    };"""
+
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=r'Line 2 \(Column 5-12\): Missing item "VALUES" in SUMMARY',
+    ):
+        create_observations(config(), config_without_values)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_multiple_bulk_summary_configs_can_be_in_the_same_config():
+    multiple_summary_config = 2 * (
+        """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT;
+                ERROR = 0.2;
+            };
+        };
+    };
+    """
+    )
+
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+
+    obs = create_observations(config(), multiple_summary_config)
+    assert len(obs["breakthrough"]) == 2
+    assert len(obs["summary"]) == 6
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_breakthrough_can_be_instantiated_with_well_localization_through_summary_bulk_config():  # noqa: E501
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT;
+                ERROR = 0.2;
+            };
+            LOCALIZATION {
+                EAST=10;
+                NORTH=20;
+                RADIUS=30;
+            };
+        };
+    };
+    """
+    csv_content = dedent(
+        """well, keyword, value, error, date
+        OP1, WOPR, 1e6, 1.0, 2012-02-01
+        ,FOPR, 3e6, 3.0, 2012-03-01"""
+    )
+    Path("summary_values.csv").write_text(csv_content, encoding="utf-8")
+    brt_obs = create_observations(config(), obs_config)["breakthrough"]
+    assert brt_obs["east"].to_list() == [10]
+    assert brt_obs["north"].to_list() == [20]
+    assert brt_obs["radius"].to_list() == [30]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_breakthrough_can_be_instantiated_without_well_localization_through_summary_bulk_config():  # noqa: E501
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT;
+                ERROR = 0.2;
+            };
+        };
+    };
+    """
+    csv_content = dedent(
+        """well, keyword, value, error, date
+        OP1, WOPR, 1e6, 1.0, 2012-02-01
+        ,FOPR, 3e6, 3.0, 2012-03-01"""
+    )
+    Path("summary_values.csv").write_text(csv_content, encoding="utf-8")
+    create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_summary_bulk_config_resolves_csv_in_subdirectory():
+    obs_config = """
+    SUMMARY {
+        VALUES = subdir/summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT;
+                ERROR = 0.2;
+            };
+        };
+    };
+    """
+    Path("subdir").mkdir()
+    Path("subdir/summary_values.csv").write_text(csv_content(), encoding="utf-8")
+
+    obs = create_observations(config(), obs_config)
+    assert len(obs["summary"]) == 3
+    assert len(obs["breakthrough"]) == 1
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_summary_bulk_config_resolves_csv_in_subdirectory_from_main_config():
+    summary_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT;
+                ERROR = 0.2;
+            };
+        };
+    };
+    """
+    ert_config = """
+    NUM_REALIZATIONS 3
+    ECLBASE ECLIPSE_CASE_%d
+    OBS_CONFIG subdir/observations
+    GEN_KW KW_NAME template.txt kw.txt prior.txt
+    RANDOM_SEED 1234
+    """
+    Path("subdir").mkdir()
+    Path("subdir/observations").write_text(summary_config, encoding="utf-8")
+    Path("subdir/summary_values.csv").write_text(csv_content(), encoding="utf-8")
+    Path("config.ert").write_text(ert_config, encoding="utf-8")
+    Path("template.txt").write_text("MY_KEYWORD <MY_KEYWORD>", encoding="utf-8")
+    Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
+
+    ert_conf = ErtConfig.from_file("config.ert")
+    obs = create_observation_dataframes(
+        ert_conf.observation_declarations, None, ert_conf.shape_registry
+    )
+    assert len(obs["summary"]) == 3
+    assert len(obs["breakthrough"]) == 1
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_breakthrough_in_bulk_summary_config_doesnt_append_well_name_if_well_name_is_in_breakthrough_key():  # noqa: E501
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST = 4.5;
+                NORTH = 12.5;
+                RADIUS = 3000;
+            };
+            BREAKTHROUGH {
+                THRESHOLD = 0.5;
+                DATE = 2020-01-01;
+                KEY = WWCT:OP1;
+                ERROR = 0.2;
+            };
+        };
+    };
+    """
+    Path("summary_values.csv").write_text(csv_content(), encoding="utf-8")
+
+    obs = create_observations(config(), obs_config)
+    assert obs["breakthrough"]["response_key"].to_list() == ["BREAKTHROUGH:WWCT:OP1"]
+
+
+@pytest.mark.parametrize("error", [-100, -0.5, 0])
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_error_value_raises_config_validation_error_if_not_strictly_positive(
+    error,
+):
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    csv_content = dedent(
+        f"""well, keyword, value, error, date
+        OP1, WOPR, 1e6, {error}, 2012-02-01"""
+    )
+    Path("summary_values.csv").write_text(csv_content, encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=(
+            rf'Failed to validate "{error}" in \(WOPR:OP1\) ERROR={error}. '
+            r"\(WOPR:OP1\) ERROR must be given a strictly positive value."
+        ),
+    ):
+        create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("well_name", ["OP-1", "OP:1", "OP.1", "OP_1-A.B:C"])
+def test_that_summary_bulk_config_obs_receives_expected_name_given_special_characters(
+    well_name,
+):
+    obs_config = (
+        """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        """
+        f"WELL {well_name + '{};'}"
+        "};"
+    )
+    wopr_date = "2012-02-01"
+    fopr_date = "2020-01-01"
+
+    special_csv = dedent(
+        f"""well, keyword, value, error, date
+        {well_name}, WOPR, 1e6, 1.0, {wopr_date}
+        ,FOPR, 3e6, 3.0, {fopr_date}"""
+    )
+    Path("summary_values.csv").write_text(special_csv, encoding="utf-8")
+
+    obs = create_observations(config(), obs_config)
+    assert len(obs["summary"]) == 2
+    assert obs["summary"]["observation_key"].to_list() == [
+        f"WOPR:{well_name}:{wopr_date}",
+        f"FOPR:{fopr_date}",
+    ]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_summary_bulk_config_raises_error_regarding_required_csv_columns():
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    csv_content = dedent(
+        """keyword, error, date
+        FOPR, 1, 2012-02-01"""
+    )
+    Path("summary_values.csv").write_text(csv_content, encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=r"Line 2 \(Column 5-12\): Missing required column "
+        "'value' in csv file 'summary_values.csv'",
+    ):
+        create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_optional_csv_columns_are_included_in_summary_observation_name():
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    csv_content = dedent(
+        """\
+        well, keyword, value, error, date, number, nx, ny
+        OP1, BPR, 1e6, 1.0, 2012-02-01, 1234, 10, 10
+        OP1, COFR, 2e6, 2.0, 2012-03-01, 42, 10, 10"""
+    )
+    Path("summary_values.csv").write_text(csv_content, encoding="utf-8")
+    obs = create_observations(config(), obs_config)
+    names = obs["summary"]["observation_key"].to_list()
+    assert names == ["BPR:4,4,13:2012-02-01", "COFR:OP1:2,5,1:2012-03-01"]
+
+
+@given(
+    keyword=st.text(
+        min_size=1,
+        max_size=8,
+        alphabet=st.characters(categories=("L", "N", "P"), exclude_characters=","),
+    )
+)
+@pytest.mark.usefixtures("use_tmpdir")
+@settings(max_examples=10)
+def test_that_fully_populated_csv_does_not_crash_given_arbitrary_keyword(keyword):
+    """We expect that when all columns are populated, there should not exist a keyword
+    which would crash given too few columns."""
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    csv_columns = (
+        "well, keyword, value, error, date, number, nx, ny, lgr_name, li, lj, lk"
+    )
+    csv_row = f"OP1, {keyword}, 1e6, 1.0, 2012-02-01, 10, 1, 1, foo, 1, 1, 1"
+    csv_content_ = f"{csv_columns}\n{csv_row}"
+
+    Path("summary_values.csv").write_text(csv_content_, encoding="utf-8")
+    create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_ill_configured_keyword_raises_config_validation_error():
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    csv_content_ = """well, keyword, value, error, date
+        "OP1, BPR, 1e6, 1.0, 2012-02-01"""
+
+    Path("summary_values.csv").write_text(csv_content_, encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=r"Could not create summary key for keyword 'BPR' in file "
+        r"'summary_values.csv' \(line 1\)",
+    ):
+        create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_duplicate_wells_raises_config_validation_error():
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+        WELL OP1 {};
+    };
+    """
+
+    with pytest.raises(
+        ConfigValidationError,
+        match=r"Observation contains duplicate key WELL OP1",
+    ):
+        create_observations(config(), obs_config)
+
+
+def test_that_strip_dataframe_whitespaces_strips_column_names():
+    df = pl.DataFrame({" col1 ": ["a"], "  col2": ["b"], "col3  ": ["c"]})
+    result = strip_dataframe_whitespaces(df)
+    assert result.columns == ["col1", "col2", "col3"]
+
+
+def test_that_strip_dataframe_whitespaces_strips_string_columns():
+    df = pl.DataFrame({"col1": [" hello "], "col2": ["  world  "]})
+    result = strip_dataframe_whitespaces(df)
+    assert result["col1"].to_list() == ["hello"]
+    assert result["col2"].to_list() == ["world"]
+
+
+def test_that_strip_dataframe_whitespaces_preserves_non_string_columns():
+    df = pl.DataFrame({"name": [" foo "], "value": [42], "rate": [math.pi]})
+    result = strip_dataframe_whitespaces(df)
+    assert result["name"].to_list() == ["foo"]
+    assert result["value"].to_list() == [42]
+    assert result["rate"].to_list() == [math.pi]
+
+
+def test_that_strip_dataframe_whitespaces_converts_empty_strings_to_none():
+    df = pl.DataFrame({"col1": ["  ", "", " x "], "col2": ["a", "   ", "b"]})
+    result = strip_dataframe_whitespaces(df)
+    assert result["col1"].to_list() == [None, None, "x"]
+    assert result["col2"].to_list() == ["a", None, "b"]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_docs_setup_results_in_expected_observation_dataframes():
+    """This test replicates the example made in observations.rst, ensuring
+    that our documentation is a working happy path."""
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {
+            LOCALIZATION {
+                EAST   = 32.132;
+                NORTH  = 45.139;
+                RADIUS = 2500;
+            };
+            BREAKTHROUGH {
+                KEY       = WWCT;
+                THRESHOLD = 0.2;
+                DATE      = 2012-05-01;
+                ERROR     = 3;
+            };
+        };
+        WELL OP2 {
+            LOCALIZATION {
+                EAST   = 35.734;
+                NORTH  = 42.981;
+                RADIUS = 3000;
+            };
+        };
+    };"""
+    csv_content_ = """ well,keyword, value, error, date, nx, ny, number
+     OP1, WOPR, 1e5, 1e3, 2012-01-03, , ,
+     OP1, BPR, 1e5, 1e3, 2012-01-07, 1, 1, 3
+     OP2, WOPR, 7e5, 1.2e3, 2012-02-05, , ,
+     ,FOPR, 1e6, 1e3, 2012-12-02, , ,"""
+    Path("summary_values.csv").write_text(csv_content_, encoding="utf-8")
+    result = create_observations(config(), obs_config)
+
+    expected_summary = pl.DataFrame(
+        {
+            "response_key": ["WOPR:OP1", "BPR:1,1,3", "WOPR:OP2", "FOPR"],
+            "observation_key": [
+                "WOPR:OP1:2012-01-03",
+                "BPR:1,1,3:2012-01-07",
+                "WOPR:OP2:2012-02-05",
+                "FOPR:2012-12-02",
+            ],
+            "time": [
+                datetime.fromisoformat("2012-01-03"),
+                datetime.fromisoformat("2012-01-07"),
+                datetime.fromisoformat("2012-02-05"),
+                datetime.fromisoformat("2012-12-02"),
+            ],
+            "observations": [1e5, 1e5, 7e5, 1e6],
+            "std": [1e3, 1e3, 1.2e3, 1e3],
+            "east": [32.132, 32.132, 35.734001, None],
+            "north": [45.139, 45.139, 42.980999, None],
+            "radius": [2500.0, 2500.0, 3000.0, None],
+        },
+        schema={
+            "response_key": pl.Utf8,
+            "observation_key": pl.Utf8,
+            "time": pl.Datetime("ms"),
+            "observations": pl.Float32,
+            "std": pl.Float32,
+            "east": pl.Float32,
+            "north": pl.Float32,
+            "radius": pl.Float32,
+        },
+    )
+    assert_frame_equal(result["summary"], expected_summary)
+
+    expected_breakthrough = pl.DataFrame(
+        {
+            "observation_key": ["BREAKTHROUGH:WWCT:OP1:0.2"],
+            "response_key": ["BREAKTHROUGH:WWCT:OP1"],
+            "time": [datetime.fromisoformat("2012-05-01")],
+            "observations": [0.0],
+            "threshold": [0.2],
+            "std": [3.0],
+            "east": [32.132],
+            "north": [45.139],
+            "radius": [2500.0],
+        },
+        schema={
+            "observation_key": pl.Utf8,
+            "response_key": pl.Utf8,
+            "time": pl.Datetime("ms"),
+            "observations": pl.Float32,
+            "threshold": pl.Float64,
+            "std": pl.Float32,
+            "east": pl.Float32,
+            "north": pl.Float32,
+            "radius": pl.Float32,
+        },
+    )
+    assert_frame_equal(result["breakthrough"], expected_breakthrough)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize(
+    "missing_col",
+    ["keyword", "value", "error", "date"],
+)
+def test_that_missing_value_in_required_column_raises_config_error(missing_col):
+    """If a required column has missing values in the csv, the error message
+    reports the column name, offending row numbers, and filename."""
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+    };
+    """
+    complete_row = {
+        "keyword": "BAR",
+        "value": "1e6",
+        "error": "1e3",
+        "date": "2012-01-01",
+    }
+    rows = [
+        {**complete_row, missing_col: ""},
+        {**complete_row},
+        {**complete_row, missing_col: ""},
+    ]
+    columns = list(complete_row)
+    csv_content_ = ",".join(columns) + "\n"
+    csv_content_ += "\n".join(",".join(row[c] for c in columns) for row in rows) + "\n"
+
+    Path("summary_values.csv").write_text(csv_content_, encoding="utf-8")
+    with pytest.raises(
+        ConfigValidationError,
+        match=(
+            rf"Missing value for column '{missing_col}' "
+            rf"in row\(s\) \['0', '2'\] in csv file 'summary_values.csv'"
+        ),
+    ):
+        create_observations(config(), obs_config)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_invalid_csv_file_raises_config_error():
+    obs_config = """
+    SUMMARY {
+        VALUES = summary_values.csv;
+        WELL OP1 {};
+    };
+    """
+    Path("summary_values.csv").write_bytes(b"\x80\x81\x82\xff\xfe\x00\x01")
+    with pytest.raises(
+        ConfigValidationError,
+        match=(
+            r"Could not read VALUES csv file "
+            r"'.*summary_values\.csv': 'utf-8' codec can't decode byte"
+        ),
+    ):
+        create_observations(config(), obs_config)

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -72,7 +72,19 @@ def test_that_read_file_does_not_raise_unexpected_exceptions_on_missing_director
         ).read_from_file(str(tmp_path / "DOES_NOT_EXIST"), 1, 0)
 
 
-def create_summary_observation(loc_config_lines):
+def create_observations(config, obs_config):
+    Path("config.ert").write_text(config, encoding="utf-8")
+    Path("observations").write_text(obs_config, encoding="utf-8")
+    Path("template.txt").write_text("MY_KEYWORD <MY_KEYWORD>", encoding="utf-8")
+    Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
+
+    ert_config = ErtConfig.from_file("config.ert")
+    return create_observation_dataframes(
+        ert_config.observation_declarations, None, ert_config.shape_registry
+    )
+
+
+def create_localization_summary_observation(loc_config_lines):
     config = dedent(
         """
     NUM_REALIZATIONS 3
@@ -96,15 +108,7 @@ def create_summary_observation(loc_config_lines):
         };
         """
     )
-    Path("config.ert").write_text(config, encoding="utf-8")
-    Path("observations").write_text(obs_config, encoding="utf-8")
-    Path("template.txt").write_text("MY_KEYWORD <MY_KEYWORD>", encoding="utf-8")
-    Path("prior.txt").write_text("MY_KEYWORD NORMAL 0 1", encoding="utf-8")
-
-    ert_config = ErtConfig.from_file("config.ert")
-    return create_observation_dataframes(
-        ert_config.observation_declarations, None, ert_config.shape_registry
-    )["summary"]
+    return create_observations(config, obs_config)["summary"]
 
 
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
@@ -112,7 +116,7 @@ def test_that_summary_observations_can_be_instantiated_with_localization(
     tmpdir,
 ):
     with tmpdir.as_cwd():
-        summary_observations = create_summary_observation(
+        summary_observations = create_localization_summary_observation(
             """
             LOCALIZATION {
                 EAST   = 10;
@@ -134,7 +138,7 @@ def test_that_summary_observations_without_radius_gets_defaulted(
     tmpdir,
 ):
     with tmpdir.as_cwd():
-        summary_observations = create_summary_observation(
+        summary_observations = create_localization_summary_observation(
             """
             LOCALIZATION {
                 EAST   = 10;
@@ -166,7 +170,9 @@ def test_that_summary_observations_raises_error_when_east_or_north_are_undefined
     )
 
     with pytest.raises(ConfigValidationError) as e, tmpdir.as_cwd():
-        create_summary_observation("LOCALIZATION {" + loc_config_lines + "};")
+        create_localization_summary_observation(
+            "LOCALIZATION {" + loc_config_lines + "};"
+        )
     for kw in missing_keywords:
         assert f'Missing item "{kw}" in LOCALIZATION for SUMMARY_OBSERVATION' in str(
             e.value
@@ -184,7 +190,7 @@ def test_that_summary_observations_raises_error_given_unknown_localization_key(
         ),
         tmpdir.as_cwd(),
     ):
-        create_summary_observation("LOCALIZATION {FOO = BAZ;};")
+        create_localization_summary_observation("LOCALIZATION {FOO = BAZ;};")
 
 
 @pytest.mark.usefixtures("copy_snake_oil_case")
@@ -223,7 +229,9 @@ def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internal
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key but no forward model")
 def test_that_defaulted_summary_obs_values_have_type_float32(tmpdir):
     with tmpdir.as_cwd():
-        summary_observations = create_summary_observation(loc_config_lines="")
+        summary_observations = create_localization_summary_observation(
+            loc_config_lines=""
+        )
     assert summary_observations["east"].dtype == pl.Float32
     assert summary_observations["north"].dtype == pl.Float32
     assert summary_observations["radius"].dtype == pl.Float32


### PR DESCRIPTION
This change will allow users to define summary observations in bulk.

This change has one assumption that there is only one BREAKTHROUGH observation per well. This might need to be revisited.

**Issue**
Resolves #12943 

All the summary observations in snake_oil can now have a shared configuration like:

```
SUMMARY {
    VALUES = summary_values.csv;
    WELL OP1 {
        LOCALIZATION {
            EAST = 10;
            NORTH = 20;
            RADIUS = 2000;
        };
    };
};
```
With csv file:
```
well, keyword, value, error, date
OP1, WOPR, 0.1, 0.05, 2010-03-31
OP1, WOPR, 0.7, 0.07, 2010-12-26
OP1, WOPR, 0.5, 0.05, 2011-12-21
OP1, WOPR, 0.3, 0.075, 2012-12-15
OP1, WOPR, 0.2, 0.035, 2013-12-10
OP1, WOPR, 0.015, 0.01, 2015-03-15
```

**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
