### PR TITLE
Filter ensemble list based on plot type

### DIFF
--- a/src/ert/dark_storage/endpoints/ensembles.py
+++ b/src/ert/dark_storage/endpoints/ensembles.py
@@ -31,6 +31,8 @@ def get_ensemble(
             "name": ensemble.name,
             "experiment_name": ensemble.experiment.name,
             "started_at": ensemble.started_at,
+            "has_func_eval": ensemble.batch_objectives is not None,
+            "has_gradient": ensemble.batch_objective_gradient is not None,
         },
         size=ensemble.ensemble_size,
         realization_storage_states=Counter(

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -39,6 +39,8 @@ class EnsembleObject:
     hidden: bool
     experiment_name: str
     started_at: str
+    has_func_eval: bool = False
+    has_gradient: bool = False
 
 
 class PlotApiKeyDefinition(NamedTuple):
@@ -119,6 +121,14 @@ class PlotApi:
                                 hidden=ensemble_name.startswith(".")
                                 or ensemble_undefined,
                                 started_at=ensemble_started_at,
+                                has_func_eval=bool(
+                                    response_json["userdata"].get(
+                                        "has_func_eval", False
+                                    )
+                                ),
+                                has_gradient=bool(
+                                    response_json["userdata"].get("has_gradient", False)
+                                ),
                             )
                         )
             except IndexError as exc:

--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -57,6 +57,13 @@ class EnsembleSelectionWidget(QWidget):
             self.ensembleSelectionChanged.emit
         )
 
+    def apply_ensemble_filtering(
+        self, require_func_eval: bool, require_gradient: bool
+    ) -> None:
+        self._selected_ensembles.apply_ensemble_filtering(
+            require_func_eval, require_gradient
+        )
+
     def get_selected_ensembles(self) -> list[EnsembleObject]:
         return self._selected_ensembles.get_checked_ensembles()
 
@@ -118,11 +125,34 @@ class EnsembleSelectListWidget(QListWidget):
         self.setItemDelegate(CustomItemDelegate())
         self.itemClicked.connect(self.slot_toggle_plot)
 
+    def apply_ensemble_filtering(
+        self, require_func_eval: bool, require_gradient: bool
+    ) -> None:
+        for index in range(self._ensemble_count):
+            if (item := self.item(index)) is None:
+                raise ValueError(
+                    f"Expected ensemble at index {index} in ensemble selection list"
+                )
+            ensemble: EnsembleObject = item.data(
+                EnsembleSelectListWidgetItemDataRole.ENSEMBLE
+            )
+            hidden = (require_func_eval and not ensemble.has_func_eval) or (
+                require_gradient and not ensemble.has_gradient
+            )
+            item.setHidden(hidden)
+            if hidden and item.data(Qt.ItemDataRole.CheckStateRole):
+                self.release_color(
+                    item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX)
+                )
+                item.setData(Qt.ItemDataRole.CheckStateRole, False)
+
     def get_checked_ensembles(self) -> list[EnsembleObject]:
         def _iter() -> Iterator[EnsembleObject]:
             for index in range(self._ensemble_count):
-                item = self.item(index)
-                assert item is not None
+                if (item := self.item(index)) is None:
+                    raise ValueError(
+                        f"Expected ensemble at index {index} in ensemble selection list"
+                    )
                 if item.data(Qt.ItemDataRole.CheckStateRole):
                     yield item.data(EnsembleSelectListWidgetItemDataRole.ENSEMBLE)
 
@@ -131,8 +161,10 @@ class EnsembleSelectListWidget(QListWidget):
     def get_checked_color_indexes(self) -> list[int]:
         def _iter() -> Iterator[int]:
             for index in range(self._ensemble_count):
-                item = self.item(index)
-                assert item is not None
+                if (item := self.item(index)) is None:
+                    raise ValueError(
+                        f"Expected ensemble at index {index} in ensemble selection list"
+                    )
                 if item.data(Qt.ItemDataRole.CheckStateRole):
                     yield item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX)
 

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -327,7 +327,17 @@ class PlotWindow(QMainWindow):
 
         is_gradient_plot = plot_widget.name == EVEREST_GRADIENTS_PLOT
         is_controls_plot = plot_widget.name == EVEREST_CONTROLS_PLOT
+        is_objective_plot = plot_widget.name in {
+            EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT,
+            EVEREST_OBJECTIVE_FUNCTION_PLOT,
+        }
+        is_everest_ensemble = plot_widget.name == ENSEMBLE and self.is_everest
         self._everest_dock.setVisible(is_gradient_plot or is_controls_plot)
+
+        self._ensemble_selection_widget.apply_ensemble_filtering(
+            require_func_eval=is_objective_plot or is_everest_ensemble,
+            require_gradient=is_gradient_plot,
+        )
 
         if (
             plot_widget._plotter.dimensionality == key_def.dimensionality

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -154,6 +154,8 @@ def test_get_summary_response(
     expected_userdata = {
         "name": "default_0",
         "experiment_name": "ensemble-experiment",
+        "has_func_eval": False,
+        "has_gradient": False,
     }
     assert all(
         userdata[key] == expected_userdata[key]


### PR DESCRIPTION
Ensembles without gradients or func evals
should not be avalible for selection,
if the current plot require func eval/gradient

**Issue**
Resolves #13324 
Resolves #12945 (I think) 


**Approach**
Adds additional information to the fetched ensemble `userdata` if the ensemble contains gradient or function evaluation. 

Based on the info, filters out perturbation batches for summary and objective-based plots, since they rely on func_eval and plotting perturbed batches can be misleading/no data to display. Same goes for plots requiring gradient, but vice versa. 

If ensemble has both (speculative = `true` or `batch_0`) it still works as normal and is included for selection for both plots. 

`wellrates_experiment` with `speculative = false`:
<img width="959" height="685" alt="Screenshot 2026-04-29 at 15 06 47" src="https://github.com/user-attachments/assets/98b5e82e-41fe-49a3-ab0d-27809fedbd82" />
<img width="970" height="677" alt="Screenshot 2026-04-29 at 15 07 00" src="https://github.com/user-attachments/assets/a51b84fa-26ad-488b-932e-bc1018a57794" />
<img width="962" height="679" alt="Screenshot 2026-04-29 at 15 07 11" src="https://github.com/user-attachments/assets/71e42ca3-91d3-4ab3-9608-88869defcfe1" />




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
