### PR TITLE
Make x-axis discrete for gradient plot

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -25,6 +25,9 @@ class PlotContext:
         INDEX_AXIS,
         VALUE_AXIS,
     ]
+    PLOT_TYPES: ClassVar[list[str]] = [
+        "BAR",
+    ]
 
     def __init__(
         self,
@@ -47,6 +50,8 @@ class PlotContext:
         self._y_axis: str | None = None
         self._log_scale = False
         self._extended_plot_information = False
+
+        self._plot_type: str | None = None
 
     @property
     def flip_response_axis(self) -> bool:
@@ -109,6 +114,18 @@ class PlotContext:
                 f"Axis: '{value}' is not one of: {PlotContext.AXIS_TYPES}"
             )
         self._y_axis = value
+
+    @property
+    def plot_type(self) -> str | None:
+        return self._plot_type
+
+    @plot_type.setter
+    def plot_type(self, value: str) -> None:
+        if value not in PlotContext.PLOT_TYPES:
+            raise UserWarning(
+                f"Plot type: '{value}' is not one of: {PlotContext.PLOT_TYPES}"
+            )
+        self._plot_type = value
 
     def setXLabel(self, value: str) -> None:
         self._plot_config.setXLabel(value)

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -50,6 +50,7 @@ class EverestGradientsPlot:
 
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.plot_type = "BAR"
         plot_context.deactivateDateSupport()
 
         response_key = key_def.key if key_def else "Response"
@@ -76,6 +77,11 @@ class EverestGradientsPlot:
         batch_ids = sorted(combined["batch_id"].unique())
 
         pos = np.arange(len(batch_ids))
+        for idx, x in enumerate(pos):
+            if idx % 2 == 0:
+                axes.axvspan(x - 0.5, x + 0.5, color="grey", alpha=0.07)
+        for edge in np.arange(pos[0] - 0.5, pos[-1] + 1.0, 1.0):
+            axes.axvline(edge, color="grey", linewidth=0.8, linestyle="--", alpha=0.4)
         n_controls = len(self.selected_controls)
         bar_width = 0.8 / n_controls
 
@@ -101,7 +107,7 @@ class EverestGradientsPlot:
             config.addLegendItem(control, bars[0])
         axes.axhline(0, color="black", linewidth=1.0, alpha=0.3)
         axes.set_xticks(pos)
-        axes.set_xticklabels([str(b) for b in batch_ids], rotation=0)
+        axes.set_xticklabels([f"Batch {b}" for b in batch_ids], rotation=0)
         axes.yaxis.set_major_formatter(ConditionalAxisFormatter())
         axes.spines["right"].set_visible(False)
         axes.spines["left"].set_visible(False)
@@ -111,6 +117,6 @@ class EverestGradientsPlot:
             plot_context,
             figure,
             axes,
-            default_x_label="Batch iteration",
+            default_x_label="",
             default_y_label="Gradient",
         )

--- a/src/ert/gui/tools/plot/plottery/plots/plot_tools.py
+++ b/src/ert/gui/tools/plot/plottery/plots/plot_tools.py
@@ -61,7 +61,10 @@ class PlotTools:
     def showGrid(axes: Axes, plot_context: PlotContext) -> None:
         config = plot_context.plotConfig()
         if config.isGridEnabled():
-            axes.grid(visible=True, color="black", alpha=0.4)
+            if plot_context.plot_type == "BAR":
+                axes.grid(axis="y", color="black", alpha=0.1)
+            else:
+                axes.grid(visible=True, color="black", alpha=0.4)
 
     @staticmethod
     def showLegend(axes: Axes, plot_context: PlotContext) -> None:


### PR DESCRIPTION
Extended plot context to allow unique grid styles, but still allow finalizePlots() to be used

**Issue**
Resolves #13451


**Approach**
Removed y-axis lines, added transparent background with dotted lines between to better illustrate different batches. Renamed ticks to better illustrate discrete, but still indicates rank. 

Extended plot context with plot type such that multiple grid styles can be supported and still use `finalizePlots()` and toggle grid functionality from customize-widget
<img width="1916" height="1000" alt="image" src="https://github.com/user-attachments/assets/c47b9f22-75f4-4210-990d-c13d45cdebc6" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

