### PR TITLE
Add support for labels on-hover for bar plots

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum, auto
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
@@ -8,6 +9,12 @@ if TYPE_CHECKING:
     from ert.gui.tools.plot.plot_api import EnsembleObject
 
     from .plot_config import PlotConfig
+
+
+class PlotType(StrEnum):
+    LINE = auto()
+    BAR = auto()
+    SCATTER = auto()
 
 
 class PlotContext:
@@ -24,9 +31,6 @@ class PlotContext:
         DENSITY_AXIS,
         INDEX_AXIS,
         VALUE_AXIS,
-    ]
-    PLOT_TYPES: ClassVar[list[str]] = [
-        "BAR",
     ]
 
     def __init__(
@@ -51,7 +55,7 @@ class PlotContext:
         self._log_scale = False
         self._extended_plot_information = False
 
-        self._plot_type: str | None = None
+        self._plot_type: PlotType | None = None
 
     @property
     def flip_response_axis(self) -> bool:
@@ -116,15 +120,11 @@ class PlotContext:
         self._y_axis = value
 
     @property
-    def plot_type(self) -> str | None:
+    def plot_type(self) -> PlotType | None:
         return self._plot_type
 
     @plot_type.setter
-    def plot_type(self, value: str) -> None:
-        if value not in PlotContext.PLOT_TYPES:
-            raise UserWarning(
-                f"Plot type: '{value}' is not one of: {PlotContext.PLOT_TYPES}"
-            )
+    def plot_type(self, value: PlotType) -> None:
         self._plot_type = value
 
     def setXLabel(self, value: str) -> None:

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from ert.gui.tools.plot.plottery.plot_context import PlotType
+
 from .plot_tools import ConditionalAxisFormatter, PlotTools
 
 if TYPE_CHECKING:
@@ -50,7 +52,7 @@ class EverestGradientsPlot:
 
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS
-        plot_context.plot_type = "BAR"
+        plot_context.plot_type = PlotType.BAR
         plot_context.deactivateDateSupport()
 
         response_key = key_def.key if key_def else "Response"
@@ -85,6 +87,8 @@ class EverestGradientsPlot:
         n_controls = len(self.selected_controls)
         bar_width = 0.8 / n_controls
 
+        bar_containers = []
+
         for i, control in enumerate(self.selected_controls):
             color = colors[i % len(colors)][0]
             values = []
@@ -105,6 +109,8 @@ class EverestGradientsPlot:
                 alpha=0.7,
             )
             config.addLegendItem(control, bars[0])
+            bar_containers.append(bars)
+
         axes.axhline(0, color="black", linewidth=1.0, alpha=0.3)
         axes.set_xticks(pos)
         axes.set_xticklabels([f"Batch {b}" for b in batch_ids], rotation=0)
@@ -112,6 +118,15 @@ class EverestGradientsPlot:
         axes.spines["right"].set_visible(False)
         axes.spines["left"].set_visible(False)
         axes.spines["top"].set_visible(False)
+
+        bar_labels = [
+            f"batch {batch}\n{control}"
+            for batch in batch_ids
+            for control in self.selected_controls
+        ]
+        PlotTools.labels_on_hover(
+            axes, plot_context, figure, data=bar_containers, labels=bar_labels
+        )
 
         PlotTools.finalizePlot(
             plot_context,

--- a/src/ert/gui/tools/plot/plottery/plots/plot_tools.py
+++ b/src/ert/gui/tools/plot/plottery/plots/plot_tools.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import logging
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.ticker as mticker
+from matplotlib.backend_bases import Event
+from matplotlib.text import Annotation
 
+from ert.gui.tools.plot.plottery.plot_context import PlotType
+
+logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from datetime import date
 
@@ -61,7 +67,7 @@ class PlotTools:
     def showGrid(axes: Axes, plot_context: PlotContext) -> None:
         config = plot_context.plotConfig()
         if config.isGridEnabled():
-            if plot_context.plot_type == "BAR":
+            if plot_context.plot_type == PlotType.BAR:
                 axes.grid(axis="y", color="black", alpha=0.1)
             else:
                 axes.grid(visible=True, color="black", alpha=0.4)
@@ -163,3 +169,62 @@ class PlotTools:
 
         if config.yLabel() is None:
             config.setYLabel(default_y_label)
+
+    @staticmethod
+    def labels_on_hover(
+        axes: Axes,
+        plot_context: PlotContext,
+        figure: Figure,
+        **kawgs: Any,
+    ) -> None:
+        hover_box = axes.annotate(
+            "",
+            xy=(0, 0),
+            xytext=(-30, 10),
+            textcoords="offset points",
+            bbox={"boxstyle": "round,pad=0.5", "fc": "white", "alpha": 0.7},
+        )
+        hover_box.set_visible(False)
+
+        if plot_context.plot_type == PlotType.BAR:
+            try:
+                data = kawgs["data"]
+                labels = kawgs["labels"]
+                figure.canvas.mpl_connect(
+                    "motion_notify_event",
+                    lambda event: PlotTools.__on_hover_bar_group(
+                        event, axes, hover_box, figure, data, labels
+                    ),
+                )
+            except KeyError:
+                logger.warning("Missing 'data' or 'labels' for bar hover labels")
+                return
+        else:
+            raise NotImplementedError(
+                f"Hover labels not implemented for: {plot_context.plot_type}"
+            )
+
+    @staticmethod
+    def __on_hover_bar_group(
+        event: Event,
+        axes: Axes,
+        hover_box: Annotation,
+        figure: Figure,
+        data: list[Any],
+        labels: list[str],
+    ) -> None:
+        if event.inaxes == axes:  # type: ignore
+            for bar_container_idx, bars in enumerate(data):
+                for bar_idx, bar in enumerate(bars):
+                    if bar.contains(event)[0]:
+                        value = bar.get_height()
+
+                        hover_box.xy = (event.xdata, event.ydata)  # type: ignore
+                        idx = bar_idx * len(data) + bar_container_idx
+                        hover_box.set_text(f"{labels[idx]}\nValue: {value:.3g}")
+                        hover_box.set_visible(True)
+                        figure.canvas.draw_idle()
+                        return
+
+        hover_box.set_visible(False)
+        figure.canvas.draw_idle()


### PR DESCRIPTION
**Issue**
Resolves #13474

Add support for on-hover labels for bar plots. `PlotTools` have been updated with a new method that takes care of on-hover labeling and its currently only supported for bar plots, but the template is outlined for different type of plots.

### Math Func example
<img width="1612" height="1128" alt="image" src="https://github.com/user-attachments/assets/517ebd4b-ad38-43f9-80d2-756e25184976" />

### Egg example
<img width="1370" height="899" alt="image" src="https://github.com/user-attachments/assets/a28d61ca-f641-47b1-9938-af281920ce1f" />
