### PR TITLE
Migrate observation report to parquet as blob artifact

### DIFF
--- a/src/ert/analysis/_enif_update.py
+++ b/src/ert/analysis/_enif_update.py
@@ -100,7 +100,7 @@ def enif_update(
                 data=smoother_snapshot.csv,
                 extra=smoother_snapshot.extra,
             ),
-            posterior_id=str(posterior_storage.id),
+            ensemble_id=str(posterior_storage.id),
         )
     )
     return smoother_snapshot

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -444,7 +444,7 @@ def smoother_update(
                 data=smoother_snapshot.csv,
                 extra=smoother_snapshot.extra,
             ),
-            posterior_id=str(posterior_storage.id),
+            ensemble_id=str(posterior_storage.id),
         )
     )
     return smoother_snapshot

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -72,4 +72,4 @@ class AnalysisErrorEvent(AnalysisEvent):
 class AnalysisCompleteEvent(AnalysisEvent):
     event_type: Literal["AnalysisCompleteEvent"] = "AnalysisCompleteEvent"
     data: DataSection
-    posterior_id: str
+    ensemble_id: str

--- a/src/ert/run_models/update_run_model.py
+++ b/src/ert/run_models/update_run_model.py
@@ -1,6 +1,9 @@
 import dataclasses
 import functools
+import io
 import uuid
+
+import polars as pl
 
 from ert.analysis import build_strategy_map, smoother_update
 from ert.analysis._update_commons import ErtAnalysisError
@@ -185,10 +188,14 @@ class UpdateRunModel(RunModel, UpdateRunModelConfig):
                     )
                 )
             case AnalysisCompleteEvent():
-                self._storage.get_ensemble(event.posterior_id).save_transition_data(
-                    f"{AnalysisCompleteEvent.__name__}_{uuid.uuid4().hex[:8]}.json",
-                    event.model_dump_json(),
-                )
+                ensemble = self._storage.get_ensemble(event.ensemble_id)
+                buf = io.BytesIO()
+                pl.DataFrame(
+                    event.data.data,
+                    schema=event.data.header,
+                    orient="row",
+                ).write_parquet(buf)
+                ensemble.save_blob(buf.getvalue())
                 self.send_event(
                     RunModelUpdateEndEvent(
                         iteration=iteration, run_id=run_id, data=event.data

--- a/src/ert/storage/blob_data.py
+++ b/src/ert/storage/blob_data.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlobType(StrEnum):
+    OBSERVATION_REPORT = "observation_report"
+
+
+class BlobStorageData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    blob_type: BlobType
+    uri: str
+    file_size: int
+    ensemble_id: str

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import os
 import time
+import uuid
 from collections import Counter
 from collections.abc import Iterable
 from datetime import UTC, datetime
@@ -32,6 +33,7 @@ from ert.config.rft_config import RFTConfig
 from ert.exceptions import StorageError
 from ert.substitutions import substitute_runpath_name
 
+from .blob_data import BlobStorageData, BlobType
 from .load_status import LoadResult
 from .mode import BaseMode, Mode, require_write
 from .realization_storage_state import RealizationStorageState
@@ -51,7 +53,7 @@ class EverestRealizationInfo(TypedDict):
 
 
 SCALAR_FILENAME = "SCALAR"
-TRANSITION_DATA_DIR = "transition"
+BLOB_DATA_DIR = "blobs"
 
 
 class BatchDataframes(TypedDict, total=False):
@@ -1306,10 +1308,24 @@ class LocalEnsemble(BaseMode):
         )
 
     @require_write
-    def save_transition_data(self, file_name: str, data: str) -> None:
-        path = self._path / TRANSITION_DATA_DIR / file_name
-        Path.mkdir(path.parent, exist_ok=True)
-        self._storage._write_transaction(path, data.encode("utf-8"))
+    def save_blob(
+        self, data: bytes, blob_type: BlobType = BlobType.OBSERVATION_REPORT
+    ) -> None:
+        blob_dir = self._path / BLOB_DATA_DIR
+        blob_dir.mkdir(parents=True, exist_ok=True)
+        blob_id = uuid.uuid4().hex[:8]
+        parquet_path = blob_dir / f"{blob_id}.parquet"
+        self._storage._write_transaction(parquet_path, data)
+        blob_data = BlobStorageData(
+            blob_type=blob_type,
+            uri=f"{blob_id}.parquet",
+            file_size=len(data),
+            ensemble_id=str(self.id),
+        )
+        self._storage._write_transaction(
+            blob_dir / f"{blob_id}.json",
+            blob_data.model_dump_json(indent=2).encode("utf-8"),
+        )
 
     @require_write
     def save_batch_dataframes(self, dataframes: BatchDataframes) -> None:

--- a/tests/ert/unit_tests/run_models/test_update_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_update_run_model.py
@@ -1,6 +1,8 @@
-import json
+import io
 import uuid
 from unittest.mock import MagicMock
+
+import polars as pl
 
 from ert.analysis.event import AnalysisCompleteEvent, DataSection
 from ert.run_models.update_run_model import UpdateRunModel
@@ -10,27 +12,27 @@ def test_that_send_smoother_event_persists_observation_report_on_analysis_comple
     model = MagicMock(spec=UpdateRunModel)
     model._storage = MagicMock()
     mock_ensemble = MagicMock()
+    ensemble_id = str(uuid.uuid4())
+    mock_ensemble.id = uuid.UUID(ensemble_id)
     model._storage.get_ensemble.return_value = mock_ensemble
 
-    posterior_id = str(uuid.uuid4())
     data_section = DataSection(
         header=["observation_key", "status"],
         data=[("OBS_1", "Active"), ("OBS_2", "Deactivated, outlier")],
     )
-    event = AnalysisCompleteEvent(data=data_section, posterior_id=posterior_id)
+    event = AnalysisCompleteEvent(data=data_section, ensemble_id=ensemble_id)
 
     UpdateRunModel.send_smoother_event(
         model, iteration=0, run_id=uuid.uuid4(), event=event
     )
 
-    model._storage.get_ensemble.assert_called_once_with(posterior_id)
-    mock_ensemble.save_transition_data.assert_called_once()
+    model._storage.get_ensemble.assert_called_once_with(ensemble_id)
+    mock_ensemble.save_blob.assert_called_once()
 
-    _, saved_json = mock_ensemble.save_transition_data.call_args[0]
-    parsed = json.loads(saved_json)
-    assert parsed["posterior_id"] == posterior_id
-    assert parsed["data"]["header"] == ["observation_key", "status"]
-    assert parsed["data"]["data"] == [
-        ["OBS_1", "Active"],
-        ["OBS_2", "Deactivated, outlier"],
-    ]
+    saved_bytes = mock_ensemble.save_blob.call_args[0][0]
+    assert isinstance(saved_bytes, bytes)
+    saved_df = pl.read_parquet(io.BytesIO(saved_bytes))
+    assert saved_df.columns == ["observation_key", "status"]
+    assert len(saved_df) == 2
+    assert saved_df["observation_key"].to_list() == ["OBS_1", "OBS_2"]
+    assert saved_df["status"].to_list() == ["Active", "Deactivated, outlier"]

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -1,4 +1,6 @@
 import asyncio
+import io
+import json
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -687,41 +689,54 @@ def test_that_location_metadata_file_is_not_created_when_no_observations():
     asyncio.run(run_test())
 
 
-def test_that_save_transition_data_writes_file_to_disk(tmp_path):
-    with open_storage(tmp_path, mode="w") as storage:
-        experiment = storage.create_experiment()
-        ensemble = storage.create_ensemble(
-            experiment, ensemble_size=1, iteration=0, name="prior"
-        )
-
-        ensemble.save_transition_data("report.json", '{"key": "value"}')
-
-        written = (ensemble._path / "transition" / "report.json").read_text(
-            encoding="utf-8"
-        )
-        assert written == '{"key": "value"}'
-
-
-def test_that_save_transition_data_creates_transition_directory(tmp_path):
-    with open_storage(tmp_path, mode="w") as storage:
-        experiment = storage.create_experiment()
-        ensemble = storage.create_ensemble(
-            experiment, ensemble_size=1, iteration=0, name="prior"
-        )
-
-        transition_dir = ensemble._path / "transition"
-        assert not transition_dir.exists()
-
-        ensemble.save_transition_data("report.json", "data")
-        assert transition_dir.is_dir()
-
-
-def test_that_save_transition_data_raises_in_read_mode(tmp_path):
+def test_that_save_blob_raises_in_read_mode(tmp_path):
     with open_storage(tmp_path, mode="w") as storage:
         experiment = storage.create_experiment()
         storage.create_ensemble(experiment, ensemble_size=1, iteration=0, name="prior")
 
     with open_storage(tmp_path, mode="r") as storage:
         ensemble = next(iter(storage.ensembles))
+        buf = io.BytesIO()
+        pl.DataFrame({"x": [1]}).write_parquet(buf)
         with pytest.raises(ModeError):
-            ensemble.save_transition_data("report.json", "data")
+            ensemble.save_blob(buf.getvalue())
+
+
+def test_that_save_blob_writes_parquet_and_json_to_disk(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=1, iteration=0, name="prior"
+        )
+
+        df = pl.DataFrame(
+            {
+                "observation_key": ["OBS_1", "OBS_2"],
+                "status": ["Active", "Deactivated, outlier"],
+                "value": [1.5, 2.0],
+            }
+        )
+        buf = io.BytesIO()
+        df.write_parquet(buf)
+
+        ensemble.save_blob(buf.getvalue())
+
+        blob_dir = ensemble._path / "blobs"
+
+        assert blob_dir.is_dir(), "Expected blob directory to be created"
+
+        parquet_files = list(blob_dir.glob("*.parquet"))
+        json_files = list(blob_dir.glob("*.json"))
+        assert len(parquet_files) == 1
+        assert len(json_files) == 1
+
+        loaded_df = pl.read_parquet(parquet_files[0])
+        assert loaded_df.columns == ["observation_key", "status", "value"]
+        assert len(loaded_df) == 2
+        assert loaded_df["observation_key"][0] == "OBS_1"
+
+        metadata = json.loads(json_files[0].read_text(encoding="utf-8"))
+        assert metadata["blob_type"] == "observation_report"
+        assert metadata["uri"].endswith(".parquet")
+        assert metadata["file_size"] > 0
+        assert metadata["ensemble_id"] == str(ensemble.id)


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/13484


**Approach**
Ensemble storage will contain a blobs folder to persist different update related artifacts.
This migrates observation report into the blob.

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
