### PR TITLE
Disable log scale for negative or non-unique values for Histograms

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -203,7 +203,7 @@ class PlotWidget(QWidget):
         vbox.addSpacing(8)
         self.setLayout(vbox)
 
-        self._negative_values_in_data = False
+        self._log_scale_valid_values = True
         self.resetPlot()
 
     @property
@@ -221,7 +221,7 @@ class PlotWidget(QWidget):
                 "DistributionPlot",
                 "GaussianKDEPlot",
             }
-            and self._negative_values_in_data is False
+            and self._log_scale_valid_values
         ):
             if key_def is not None:
                 a = key_def.parameter
@@ -271,7 +271,7 @@ class PlotWidget(QWidget):
             plot_context.log_scale = (
                 self._log_checkbox.isVisible()
                 and self._log_checkbox.isChecked()
-                and self._negative_values_in_data is False
+                and self._log_scale_valid_values
             )
             plot_context.extended_plot_information = (
                 self._extended_plot_information_checkbox.isVisible()

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -415,15 +415,20 @@ class PlotWindow(QMainWindow):
                     elif result is not None:
                         ensemble_to_data_map[ensemble] = result
 
-            negative_values_in_data = False
+            log_scale_valid_values = True
             if key_def.parameter is not None and key_def.parameter.type == "gen_kw":
                 for data in ensemble_to_data_map.values():
                     numeric = data.select_dtypes(include=["number"])
-                    if not numeric.empty and numeric.le(0).any().any():
-                        negative_values_in_data = True
+                    # Need non-unique check to disable log scale for
+                    # single realization runs, even though the
+                    # distribution is not set as CONSTANT
+                    if not numeric.empty and (
+                        numeric.le(0).any().any() or numeric.nunique().le(1).all()
+                    ):
+                        log_scale_valid_values = False
                         break
 
-            plot_widget._negative_values_in_data = negative_values_in_data
+            plot_widget._log_scale_valid_values = log_scale_valid_values
             observations = pd.DataFrame()
             if key_def.observations and selected_ensembles:
                 try:

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -188,9 +188,6 @@ def _plotHistogram(
     if minimum is not None and maximum is not None:
         # Ensure we have at least 2 bin edges to create 1 bin
         effective_bin_count = max(bin_count + 1, 2)
-        if minimum == maximum:
-            minimum -= 0.5
-            maximum += 0.5
         if use_log_scale:
             bins = _histogramLogBins(effective_bin_count, minimum, maximum)  # type: ignore
             axes.set_xscale("log")


### PR DESCRIPTION

**Issue**
Resolves #12527 


**Approach**
Set log scale button visibility to `False` for non-unique values, as the type checking of
`distribution == "CONST"` does not catch non-unique values (e.g single realization runs).

Removed +- 0.5 in `_plotHistogram()`, as this is condition will never be met since `min == max` and transformation already completed previously in `plotHistogram()`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
