### PR TITLE
Add extra=forbid to pydantic basemodels in ert dark storage and cleanup

### DIFF
--- a/src/ert/dark_storage/client/_session.py
+++ b/src/ert/dark_storage/client/_session.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, ValidationError
 
 
-class ErtClientConnectionInfo(BaseModel):
+class ErtClientConnectionInfo(BaseModel, extra="forbid"):
     base_url: str
     auth_token: str | None = None
     cert: str | bool = False

--- a/src/ert/dark_storage/json_schema/ensemble.py
+++ b/src/ert/dark_storage/json_schema/ensemble.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from ert.storage.realization_storage_state import RealizationStorageState
 
 
-class _Ensemble(BaseModel):
+class _Ensemble(BaseModel, extra="forbid"):
     size: int
     active_realizations: list[int] = []
 

--- a/src/ert/dark_storage/json_schema/prior.py
+++ b/src/ert/dark_storage/json_schema/prior.py
@@ -1,9 +1,13 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
-class PriorConst(BaseModel):
+class PriorBaseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class PriorConst(PriorBaseModel):
     """
     Constant parameter prior
     """
@@ -12,7 +16,7 @@ class PriorConst(BaseModel):
     value: float
 
 
-class PriorTrig(BaseModel):
+class PriorTrig(PriorBaseModel):
     """
     Triangular distribution parameter prior
     """
@@ -23,7 +27,7 @@ class PriorTrig(BaseModel):
     mode: float
 
 
-class PriorNormal(BaseModel):
+class PriorNormal(PriorBaseModel):
     """
     Normal distribution parameter prior
     """
@@ -33,7 +37,7 @@ class PriorNormal(BaseModel):
     std: float
 
 
-class PriorLogNormal(BaseModel):
+class PriorLogNormal(PriorBaseModel):
     """
     Log-normal distribution parameter prior
     """
@@ -43,7 +47,7 @@ class PriorLogNormal(BaseModel):
     std: float
 
 
-class PriorErtTruncNormal(BaseModel):
+class PriorErtTruncNormal(PriorBaseModel):
     """
     ERT Truncated normal distribution parameter prior
 
@@ -59,7 +63,7 @@ class PriorErtTruncNormal(BaseModel):
     max: float
 
 
-class PriorStdNormal(BaseModel):
+class PriorStdNormal(PriorBaseModel):
     """
     Standard normal distribution parameter prior
 
@@ -69,7 +73,7 @@ class PriorStdNormal(BaseModel):
     function: Literal["stdnormal"] = "stdnormal"
 
 
-class PriorUniform(BaseModel):
+class PriorUniform(PriorBaseModel):
     """
     Uniform distribution parameter prior
     """
@@ -79,7 +83,7 @@ class PriorUniform(BaseModel):
     max: float
 
 
-class PriorErtDUniform(BaseModel):
+class PriorErtDUniform(PriorBaseModel):
     """
     ERT Discrete uniform distribution parameter prior
 
@@ -96,7 +100,7 @@ class PriorErtDUniform(BaseModel):
     max: float
 
 
-class PriorLogUniform(BaseModel):
+class PriorLogUniform(PriorBaseModel):
     """
     Logarithmic uniform distribution parameter prior
     """
@@ -106,7 +110,7 @@ class PriorLogUniform(BaseModel):
     max: float
 
 
-class PriorErtErf(BaseModel):
+class PriorErtErf(PriorBaseModel):
     """
     ERT Error function distribution parameter prior
     """
@@ -118,7 +122,7 @@ class PriorErtErf(BaseModel):
     width: float
 
 
-class PriorErtDErf(BaseModel):
+class PriorErtDErf(PriorBaseModel):
     """
     ERT Discrete error function distribution parameter prior
     """


### PR DESCRIPTION
**Issue**
Resolves #13499


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
