### PR TITLE
Remove comments from path lines, not supported

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -78,8 +78,8 @@ jobs:
       with:
         name: test-images-${{ github.run_number }}-${{ github.run_id }}-${{ inputs.python-version }}
         path: |
-          /tmp/tmp*/**/*.png  # Images must be moved manually to the correct location
-          /tmp/test_docs_screenshots/**/*.png  # Contains the correct directory structure
+          /tmp/tmp*/**/*.png
+          /tmp/test_docs_screenshots/**/*.png
 
     - name: CLI Test
       if: inputs.test-type == 'cli-tests'


### PR DESCRIPTION
The comment prohibited the action from finding any files at all.

**Issue**
Resolves bug in GHA


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
