### PR TITLE
Fix CI bug introduced in 8b42f64b49b0f418da572e02ee30b095cafb93fc

### DIFF
--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -227,7 +227,7 @@ class GuiEvaluator:
                 tmp_img_storage = (
                     Path("/tmp/test_docs_screenshots") / self.example_folder
                 )
-                tmp_img_storage.mkdir(exist_ok=True)
+                tmp_img_storage.mkdir(exist_ok=True, parents=True)
                 full_image_path = tmp_img_storage / name
 
             shutil.copy(temp_image_path, full_image_path)


### PR DESCRIPTION
os.makedirs was translated into Path.mkdir() without parents=True, which is default for os.makedirs

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
