### PR TITLE
Extract screenshot testing to standalone workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,6 +85,19 @@ jobs:
       test-type: ${{ matrix.test-type }}
     secrets: inherit
 
+  test-screenshots:
+    needs: [run-pre-commit, check-typing]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.12' ]
+        os: [ ubuntu-latest ]
+    uses: ./.github/workflows/test_screenshots.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+    secrets: inherit
+
   test-slurm:
     needs: [run-pre-commit, check-typing]
     strategy:

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -70,17 +70,6 @@ jobs:
         chmod 700 storage
         rm storage
 
-
-    - name: Upload updated screenshot images from failed image comparison test
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: ${{ failure() }}
-      continue-on-error: true
-      with:
-        name: test-images-${{ github.run_number }}-${{ github.run_id }}-${{ inputs.python-version }}
-        path: |
-          /tmp/tmp*/**/*.png
-          /tmp/test_docs_screenshots/**/*.png
-
     - name: CLI Test
       if: inputs.test-type == 'cli-tests'
       run: |

--- a/.github/workflows/test_ert_with_site_config.yml
+++ b/.github/workflows/test_ert_with_site_config.yml
@@ -91,8 +91,3 @@ jobs:
         if: matrix.test-type == 'rapid-tests'
         run: |
           uv run just rapid-tests
-
-      - name: GUI screenshot tests
-        if: matrix.test-type == 'gui-tests'
-        run: |
-          uv run pytest tests/ert/ui_tests/gui/test_docs_screenshots.py

--- a/.github/workflows/test_screenshots.yml
+++ b/.github/workflows/test_screenshots.yml
@@ -1,0 +1,68 @@
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+      python-version:
+        type: string
+
+permissions:
+   contents: read
+
+env:
+  UV_FROZEN: true
+
+jobs:
+  test-screenshots:
+    name: Run screenshot tests
+    timeout-minutes: 20
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: ./.github/actions/install_dependencies_qt
+      with:
+        os: ${{ inputs.os }}
+
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      id: setup_python
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
+        prune-cache: false
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install ert
+      run: |
+        uv sync --group dev
+
+    - name: Run screenshot tests
+      run: |
+        uv run just screenshot-comparison-test
+
+    - name: Pack updated screenshot in case of failure
+      if: ${{ failure() }}
+      run: |
+        uv run just pack_updated_screenshots
+
+    - name: Upload updated screenshot images from failed image comparison test
+      id: upload-screenshot-images
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      continue-on-error: true
+      with:
+        name: updated-screenshots-${{ github.run_number }}-${{ github.run_id }}-${{ inputs.python-version }}
+        path: updated-screenshots
+
+    - name: User instructions for fetching updated screenshots
+      if: ${{ failure() && steps.upload-screenshot-images.outputs.artifact-id != '' }}
+      run: |
+        echo " * Ensure gh command line utility is installed"
+        echo " * Do 'gh auth login' if you are not authenticated yet"
+        echo "$ rm -rf .tmp; gh run download ${{ github.run_id }} -D .tmp -n updated-screenshots-${{ github.run_number }}-${{ github.run_id }}-${{ inputs.python-version }}; cp -a .tmp/* ."
+        echo " * Then review your local changes and commit+squash them."

--- a/justfile
+++ b/justfile
@@ -33,8 +33,33 @@ continuous_tests:
 fuzz:
     OMP_NUM_THREADS=1 pytest {{pytest_args}} -m "fuzzing" --hypothesis-profile=fuzz tests/ert
 
+screenshot-comparison-test:
+    rm -rf /tmp/test_docs_screenshots
+    pytest --mpl --mpl-results-path=pytest-mpl_results -v -m "mpl_image_compare or screenshot_test" tests
+
+pack_updated_screenshots:
+    #!/bin/bash
+    staging="updated-screenshots"
+    mkdir -p "$staging"
+    for test_dir in pytest-mpl_results/*/; do
+      # Filenames from pytest-mpl need a lot of massaging in order to
+      # reconstruct the directory structure:
+      full_dotted_name=$(basename "$test_dir")
+      updated_img="${test_dir}/result.png"
+      filename="${full_dotted_name##*.}.png"
+      path_with_test_func_name="${full_dotted_name%.*}"
+      path_dots="${path_with_test_func_name%.*}"
+      rel_path="${path_dots//.//}"
+      target_dir="$staging/$rel_path/baseline"
+      mkdir -p $staging/$rel_path/baseline
+      cp "$updated_img" "$target_dir/$filename"
+      echo "Mapped $full_dotted_name -> $target_dir/$filename"
+    done
+    [ -d "/tmp/test_docs_screenshots" ] && cp -r /tmp/test_docs_screenshots/* "$staging"
+    find "$staging" -type f -exec ls -l {} +
+
 ert-gui-tests:
-    pytest {{pytest_args}} --mpl tests/ert/ui_tests/gui tests/ert/unit_tests/gui/plottery
+    pytest {{pytest_args}} tests/ert/ui_tests/gui -m "not (mpl_image_compare or screenshot_test)"
 
 ert-cli-tests:
     pytest {{pytest_args}} tests/ert/ui_tests/cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ markers = [
     "out_of_memory",
     "requires_eclipse",
     "requires_window_manager",
+    "screenshot_test",
     "script",
     "slow",
     "unreliable",

--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -320,8 +320,8 @@ def open_gui_with_docs_example(monkeypatch, tmp_path, source_root: Path, request
         yield gui
 
 
+@pytest.mark.screenshot_test
 @pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
-@pytest.mark.skip_mac_ci
 @pytest.mark.parametrize(
     "open_gui_with_docs_example",
     [
@@ -362,7 +362,7 @@ def test_that_poly_new_minimal_screenshots_are_up_to_date(
     assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
 
 
-@pytest.mark.skip_mac_ci
+@pytest.mark.screenshot_test
 @pytest.mark.parametrize(
     "open_gui_with_docs_example",
     [
@@ -387,7 +387,7 @@ def test_that_poly_new_with_simple_script_screenshots_are_up_to_date(
     assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
 
 
-@pytest.mark.skip_mac_ci
+@pytest.mark.screenshot_test
 @pytest.mark.parametrize(
     "open_gui_with_docs_example",
     [
@@ -426,7 +426,7 @@ def test_that_poly_new_with_results_screenshots_are_up_to_date(
     assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
 
 
-@pytest.mark.skip_mac_ci
+@pytest.mark.screenshot_test
 @pytest.mark.parametrize(
     "open_gui_with_docs_example",
     [
@@ -480,7 +480,7 @@ def test_that_poly_new_with_observations_screenshots_are_up_to_date(
     assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
 
 
-@pytest.mark.skip_mac_ci
+@pytest.mark.screenshot_test
 @pytest.mark.parametrize(
     "open_gui_with_docs_example",
     [


### PR DESCRIPTION
All mismatching screenshots are now bundled together into an artifact that the user can fetch and merge into the repository.

This aligns the behaviour from pytest-mpl with the behaviour of the custom made test_docs_screenshot.py in that whatever is produced in CI can be regarded as the truth we want to commit to the repository.

**Issue**
Resolves #13440


**Approach**
🧠 ✖️ ⌛ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
