### PR TITLE
Add extra=forbid to pydantic basemodels in ert storage and cleanup

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -74,7 +74,7 @@ class BatchDataframes(TypedDict, total=False):
     batch_constraint_gradient: pl.DataFrame | None
 
 
-class _Index(BaseModel):
+class _Index(BaseModel, extra="forbid"):
     id: UUID
     experiment_id: UUID
     ensemble_size: int
@@ -86,7 +86,7 @@ class _Index(BaseModel):
     is_improvement: bool | None = None
 
 
-class _Failure(BaseModel):
+class _Failure(BaseModel, extra="forbid"):
     type: RealizationStorageState
     message: str
     time: datetime

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -105,12 +105,12 @@ class ExperimentConfig(TypedDict, total=False):
     experiment_name: str
 
 
-class ExperimentStatus(BaseModel):
+class ExperimentStatus(BaseModel, extra="forbid"):
     message: str = Field(default="")
     status: ExperimentState = Field(default=ExperimentState.pending)
 
 
-class _Index(BaseModel):
+class _Index(BaseModel, extra="forbid"):
     id: UUID
     name: str
     # An experiment may point to ensembles that are originated

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -34,14 +34,14 @@ logger = logging.getLogger(__name__)
 _LOCAL_STORAGE_VERSION = 29
 
 
-class _Migrations(BaseModel):
+class _Migrations(BaseModel, extra="forbid"):
     ert_version: str = __version__
     timestamp: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
     name: str
     version_range: tuple[int, int]
 
 
-class _Index(BaseModel):
+class _Index(BaseModel, extra="forbid"):
     version: int = _LOCAL_STORAGE_VERSION
     migrations: MutableSequence[_Migrations] = Field(default_factory=list)
 

--- a/tests/ert/performance_tests/test_create_run_path_performance.py
+++ b/tests/ert/performance_tests/test_create_run_path_performance.py
@@ -75,7 +75,7 @@ def test_create_run_path_load_scalar_keys_performance(
     with open_storage(storage_path, mode="w") as storage:
         exp = storage.create_experiment(
             experiment_config={
-                "parameter_configs": [
+                "parameter_configuration": [
                     pc.model_dump(mode="json") for pc in parameter_configs
                 ]
             },

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -340,7 +340,11 @@ def test_that_load_scalars_handles_many_genkw_keys(benchmark, tmp_path):
 
     with open_storage(storage_path, mode="w") as storage:
         exp = storage.create_experiment(
-            experiment_config={"parameter_configs": parameter_configs},
+            experiment_config={
+                "parameter_configuration": [
+                    pc.model_dump(mode="json") for pc in parameter_configs
+                ]
+            },
             name="perf-exp",
         )
         ensemble = exp.create_ensemble(ensemble_size=reals, name="default")


### PR DESCRIPTION
**Issue**
Resolves #13520 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
