### PR TITLE
Resolve and enforce ruff rule FBT002 on boolean trap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ select = [
     "F",     # pyflakes
     "FA",
     "FAST",
+    "FBT002",
     "FIX",
     "FLY",
     "FURB",  # refurb

--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -109,7 +109,7 @@ def _wait_for_retry() -> None:
     time.sleep(FILE_RETRY_TIME)
 
 
-def _read_fm_description_file(retry: bool = True) -> "ForwardModelDescriptionJSON":
+def _read_fm_description_file(*, retry: bool = True) -> "ForwardModelDescriptionJSON":
     try:
         return json.loads(
             Path(FORWARD_MODEL_DESCRIPTION_FILE).read_text(encoding="utf-8")

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -258,6 +258,7 @@ def build_strategy_map(
     parameters: Iterable[str],
     param_configs: Mapping[str, ParameterConfig],
     enkf_truncation: float,
+    *,
     distance_localization: bool = False,
     localization: bool = False,
     correlation_threshold: Callable[[int], float] | None = None,

--- a/src/ert/cli/monitor.py
+++ b/src/ert/cli/monitor.py
@@ -57,7 +57,7 @@ class Monitor:
 
     dot = "■ "
 
-    def __init__(self, out: TextIO = sys.stdout, color_always: bool = False) -> None:
+    def __init__(self, out: TextIO = sys.stdout, *, color_always: bool = False) -> None:
         self._out = out
         self._snapshots: dict[int, EnsembleSnapshot] = {}
         self._start_time: datetime.datetime | None = None

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -845,7 +845,7 @@ def validate_int(val: str, key: str) -> int:
 
 
 def validate_positive_float(
-    val: str, key: str, strictly_positive: bool = False
+    val: str, key: str, *, strictly_positive: bool = False
 ) -> float:
     v = validate_float(val, key)
     if v < 0 or (v <= 0 and strictly_positive):

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -130,6 +130,7 @@ def create_forward_model_json(
     context: dict[str, str],
     forward_model_steps: list[SiteOrUserForwardModelStep],
     run_id: str | None,
+    *,
     iens: int = 0,
     itr: int = 0,
     user_config_file: str | None = "",

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -142,6 +142,7 @@ _parser = Lark(grammar, propagate_positions=True, parser="lalr")
 def _substitute_token(
     defines: Defines,
     token: FileContextToken,
+    *,
     expand_env: bool = True,
 ) -> FileContextToken:
     current: FileContextToken = token
@@ -252,13 +253,15 @@ def _substitute_args(
 ) -> list[Arg]:
     def substitute_arglist_tuple(tup: ArgPair) -> ArgPair:
         key, value = tup
-        substituted_value = _substitute_token(defines, value, constraints.expand_envvar)
+        substituted_value = _substitute_token(
+            defines, value, expand_env=constraints.expand_envvar
+        )
 
         return [key, substituted_value]
 
     def substitute_arg(arg: Arg) -> Arg:
         if isinstance(arg, FileContextToken):
-            return _substitute_token(defines, arg, constraints.expand_envvar)
+            return _substitute_token(defines, arg, expand_env=constraints.expand_envvar)
 
         if isinstance(arg, list):
             # It is a list of keyword tuples

--- a/src/ert/ensemble_evaluator/config.py
+++ b/src/ert/ensemble_evaluator/config.py
@@ -24,6 +24,7 @@ def get_machine_name() -> str:
 class EvaluatorServerConfig:
     def __init__(
         self,
+        *,
         port_range: tuple[int, int] | None = PORT_RANGE,
         use_token: bool = True,
         host: str | None = None,

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -40,6 +40,7 @@ class EnsembleSelector(QComboBox):
     def __init__(
         self,
         notifier: ErtNotifier,
+        *,
         update_ert: bool = True,
         filters: Iterable[Callable[[Iterable[Ensemble]], Iterable[Ensemble]]] = (),
     ) -> None:

--- a/src/ert/gui/ertwidgets/models/activerealizationsmodel.py
+++ b/src/ert/gui/ertwidgets/models/activerealizationsmodel.py
@@ -8,7 +8,7 @@ from .valuemodel import ValueModel
 
 
 class ActiveRealizationsModel(ValueModel):
-    def __init__(self, ensemble_size: int, show_default: bool = True) -> None:
+    def __init__(self, ensemble_size: int, *, show_default: bool = True) -> None:
         self.default_value = f"0-{ensemble_size - 1:d}" if show_default else None
         self.ensemble_size = ensemble_size
         ValueModel.__init__(self, self.default_value)

--- a/src/ert/gui/ertwidgets/models/path_model.py
+++ b/src/ert/gui/ertwidgets/models/path_model.py
@@ -5,6 +5,7 @@ class PathModel(ValueModel):
     def __init__(
         self,
         default_path: str,
+        *,
         is_required: bool = True,
         must_be_a_directory: bool = False,
         must_be_a_file: bool = True,

--- a/src/ert/gui/ertwidgets/stringbox.py
+++ b/src/ert/gui/ertwidgets/stringbox.py
@@ -24,6 +24,7 @@ class StringBox(QLineEdit):
         self,
         model: TextModel,
         default_string: str = "",
+        *,
         continuous_update: bool = False,
         placeholder_text: str = "",
         minimum_width: int = 250,

--- a/src/ert/gui/experiments/combobox_with_description.py
+++ b/src/ert/gui/experiments/combobox_with_description.py
@@ -26,6 +26,7 @@ class _ComboBoxItemWidget(QWidget):
         self,
         label: str,
         description: str,
+        *,
         enabled: bool = True,
         parent: QWidget | None = None,
         group: str | None = None,
@@ -97,7 +98,9 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
                 color = COLOR_HIGHLIGHT_DARK
             painter.fillRect(option.rect, color)
 
-        widget = _ComboBoxItemWidget(label, description, is_enabled, group=group)
+        widget = _ComboBoxItemWidget(
+            label, description, enabled=is_enabled, group=group
+        )
         widget.setStyle(option.widget.style())
         widget.resize(option.rect.size())
 

--- a/src/ert/gui/experiments/experiment_client.py
+++ b/src/ert/gui/experiments/experiment_client.py
@@ -116,6 +116,7 @@ class ExperimentClient:
     def create_run_model_api(self) -> RunModelAPI:
         def start_fn(
             evaluator_server_config: EvaluatorServerConfig,
+            *,
             rerun_failed_realizations: bool = False,
         ) -> None:
             pass

--- a/src/ert/gui/experiments/experiment_panel.py
+++ b/src/ert/gui/experiments/experiment_panel.py
@@ -59,7 +59,10 @@ def create_md_table(kv: dict[str, str], output: str) -> str:
 
 
 def get_simulation_thread(
-    model: Any, rerun_failed_realizations: bool = False, use_ipc_protocol: bool = False
+    model: Any,
+    *,
+    rerun_failed_realizations: bool = False,
+    use_ipc_protocol: bool = False,
 ) -> ErtThread:
     evaluator_server_config = EvaluatorServerConfig(use_ipc_protocol=use_ipc_protocol)
 
@@ -422,14 +425,16 @@ class ExperimentPanel(QWidget):
         self._experiment_done = False
         self.run_button.setEnabled(self._experiment_done)
 
-        def start_simulation_thread(rerun_failed_realizations: bool = False) -> None:
+        def start_simulation_thread(*, rerun_failed_realizations: bool = False) -> None:
             simulation_thread = get_simulation_thread(
                 self._model,
-                rerun_failed_realizations,
+                rerun_failed_realizations=rerun_failed_realizations,
                 use_ipc_protocol=self.config.queue_config.queue_system
                 == QueueSystem.LOCAL,
             )
-            self._dialog.setup_event_monitoring(rerun_failed_realizations)
+            self._dialog.setup_event_monitoring(
+                rerun_failed_realizations=rerun_failed_realizations
+            )
             simulation_thread.start()
             self._notifier.set_is_experiment_running(True)
 

--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -455,7 +455,9 @@ class RunDialog(QFrame):
                 text += f", assigned to host: {exec_hosts}"
             self._fm_step_label.setText(text)
 
-    def setup_event_monitoring(self, rerun_failed_realizations: bool = False) -> None:
+    def setup_event_monitoring(
+        self, *, rerun_failed_realizations: bool = False
+    ) -> None:
         self.flag_experiment_done = False
         if rerun_failed_realizations is False:
             self._snapshot_model.reset()

--- a/src/ert/gui/experiments/view/update.py
+++ b/src/ert/gui/experiments/view/update.py
@@ -185,7 +185,7 @@ class UpdateWidget(QWidget):
     def iteration(self) -> int:
         return self._iteration
 
-    def _insert_status_message(self, message: str, detail: bool = False) -> None:
+    def _insert_status_message(self, message: str, *, detail: bool = False) -> None:
         if detail:
             self._msg_list.append(f'<span style="color: gray;">{message}</span>')
         else:

--- a/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
+++ b/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
@@ -111,17 +111,21 @@ class PlotCustomizer(QObject):
 
         self._emitChangedSignal()
 
-    def _revertCustomization(self, plot_config: PlotConfig, emit: bool = True) -> None:
+    def _revertCustomization(
+        self, plot_config: PlotConfig, *, emit: bool = True
+    ) -> None:
         if self._customization_dialog is not None:
             for customization_view in self._customization_dialog:
                 customization_view.revertCustomization(plot_config)
 
-        self._emitChangedSignal(emit)
+        self._emitChangedSignal(emit=emit)
 
-    def _emitChangedSignal(self, emit: bool = True) -> None:
+    def _emitChangedSignal(self, *, emit: bool = True) -> None:
         history = self._getPlotConfigHistory()
         self._customization_dialog.setUndoRedoCopyState(
-            history.isUndoPossible(), history.isRedoPossible(), self.isCopyPossible()
+            undo=history.isUndoPossible(),
+            redo=history.isRedoPossible(),
+            copy=self.isCopyPossible(),
         )
 
         if emit:
@@ -337,7 +341,9 @@ class CustomizePlotDialog(QDialog):
         for attribute_name in self._tab_order:
             yield self._tab_map[attribute_name]
 
-    def setUndoRedoCopyState(self, undo: bool, redo: bool, copy: bool = False) -> None:
+    def setUndoRedoCopyState(
+        self, *, undo: bool, redo: bool, copy: bool = False
+    ) -> None:
         self._undo_button.setEnabled(undo)
         self._redo_button.setEnabled(redo)
         self._copy_from_button.setEnabled(copy)

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -62,6 +62,7 @@ class CustomNavigationToolbar(NavigationToolbar2QT):
         self,
         canvas: FigureCanvas,
         parent: QWidget | None,
+        *,
         coordinates: bool = True,
     ) -> None:
         super().__init__(canvas, parent, coordinates)  # type: ignore

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -300,7 +300,7 @@ class PlotWindow(QMainWindow):
         self.updatePlot()
         self.logPlotTabUsage(self._central_tab.tabText(index))
 
-    def logPlotTabUsage(self, tab_name: str, default: bool = False) -> None:
+    def logPlotTabUsage(self, tab_name: str, *, default: bool = False) -> None:
         msg = f"Plotwindow tab used: {tab_name}" + (" (default tab)" if default else "")
         logger.info(msg)
 
@@ -552,6 +552,7 @@ class PlotWindow(QMainWindow):
         | EverestControlsPlot
         | EverestGradientsPlot
         | EverestObjectiveFunctionPlot,
+        *,
         enabled: bool = True,
     ) -> None:
         plot_widget = PlotWidget(name, plotter)

--- a/src/ert/gui/tools/plot/plottery/plot_style.py
+++ b/src/ert/gui/tools/plot/plottery/plot_style.py
@@ -2,6 +2,7 @@ class PlotStyle:
     def __init__(
         self,
         name: str,
+        *,
         color: str | None = "#000000",
         alpha: float = 1.0,
         line_style: str = "-",
@@ -23,7 +24,7 @@ class PlotStyle:
         self._is_copy = False
 
     def copyStyleFrom(
-        self, other: "PlotStyle", copy_enabled_state: bool = False
+        self, other: "PlotStyle", *, copy_enabled_state: bool = False
     ) -> None:
         self.color = other.color
         self.alpha = other.alpha

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -129,9 +129,9 @@ def plotHistogram(
                         config.histogramStyle(),
                         data[ensemble.id],
                         bin_count,
-                        plot_context.log_scale,
-                        minimum,
-                        maximum,
+                        use_log_scale=plot_context.log_scale,
+                        minimum=minimum,
+                        maximum=maximum,
                     ),
                 )
 
@@ -180,6 +180,7 @@ def _plotHistogram(
     style: PlotStyle,
     data: pd.DataFrame,
     bin_count: int,
+    *,
     use_log_scale: bool = False,
     minimum: float | None = None,
     maximum: float | None = None,

--- a/src/ert/gui/tools/plot/plottery/plots/statistics.py
+++ b/src/ert/gui/tools/plot/plottery/plots/statistics.py
@@ -169,7 +169,7 @@ def _plotPercentiles(
         data["std+"].values,
         data["std-"].values,
         0.5,
-        plot_config.flip_response_axis,
+        inverted=plot_config.flip_response_axis,
     )
 
     style = plot_config.getStatisticsStyle("min-max")
@@ -180,7 +180,7 @@ def _plotPercentiles(
         data["Maximum"].values,
         data["Minimum"].values,
         0.5,
-        plot_config.flip_response_axis,
+        inverted=plot_config.flip_response_axis,
     )
 
     style = plot_config.getStatisticsStyle("p10-p90")
@@ -191,7 +191,7 @@ def _plotPercentiles(
         data["p90"].values,
         data["p10"].values,
         0.5,
-        plot_config.flip_response_axis,
+        inverted=plot_config.flip_response_axis,
     )
 
     style = plot_config.getStatisticsStyle("p33-p67")
@@ -202,7 +202,7 @@ def _plotPercentiles(
         data["p67"].values,
         data["p33"].values,
         0.5,
-        plot_config.flip_response_axis,
+        inverted=plot_config.flip_response_axis,
     )
 
 
@@ -213,6 +213,7 @@ def _plotPercentile(
     top_line_data: npt.ArrayLike,
     bottom_line_data: npt.ArrayLike,
     alpha_multiplier: float,
+    *,
     inverted: bool = False,
 ) -> None:
     alpha = style.alpha

--- a/src/ert/gui/tools/plot/widgets/filter_popup.py
+++ b/src/ert/gui/tools/plot/widgets/filter_popup.py
@@ -56,7 +56,7 @@ class FilterPopup(QDialog):
         self.setLayout(layout)
         self.adjustSize()
 
-    def addFilterItem(self, name: str, id_: str, value: bool = True) -> None:
+    def addFilterItem(self, name: str, id_: str, *, value: bool = True) -> None:
         self.filter_items[id_] = value
 
         check_box = QCheckBox(name)

--- a/src/ert/gui/tools/plugins/plugins_tool.py
+++ b/src/ert/gui/tools/plugins/plugins_tool.py
@@ -29,7 +29,7 @@ class PluginsTool(Tool):
         super().__init__(
             "Plugins",
             load_icon("widgets.svg"),
-            enabled,
+            enabled=enabled,
             popup_menu=True,
         )
 

--- a/src/ert/gui/tools/tool.py
+++ b/src/ert/gui/tools/tool.py
@@ -7,6 +7,7 @@ class Tool:
         self,
         name: str,
         icon: QIcon,
+        *,
         enabled: bool = True,
         checkable: bool = False,
         popup_menu: bool = False,

--- a/src/ert/gui/tools/workflows/workflows_tool.py
+++ b/src/ert/gui/tools/workflows/workflows_tool.py
@@ -22,7 +22,7 @@ class WorkflowsTool(Tool):
         super().__init__(
             "Run workflow",
             load_icon("playlist_play.svg"),
-            enabled,
+            enabled=enabled,
         )
 
     @override

--- a/src/ert/libres_facade.py
+++ b/src/ert/libres_facade.py
@@ -75,7 +75,7 @@ class LibresFacade:
 
     @classmethod
     def from_config_file(
-        cls, config_file: str, read_only: bool = False
+        cls, config_file: str, *, read_only: bool = False
     ) -> LibresFacade:
         return cls(
             ErtConfig.with_plugins(get_site_plugins()).from_file(config_file),

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -215,6 +215,7 @@ class ErtPluginManager(pluggy.PluginManager):
     @staticmethod
     def _merge_dicts(
         list_of_dicts: list[PluginResponse[dict[str, V]]],
+        *,
         include_plugin_data: Literal[True],
     ) -> dict[str, tuple[V, PluginMetadata]]:
         pass
@@ -223,6 +224,7 @@ class ErtPluginManager(pluggy.PluginManager):
     @staticmethod
     def _merge_dicts(
         list_of_dicts: list[PluginResponse[dict[str, V]]],
+        *,
         include_plugin_data: Literal[False] = False,
     ) -> dict[str, V]:
         pass
@@ -230,6 +232,7 @@ class ErtPluginManager(pluggy.PluginManager):
     @staticmethod
     def _merge_dicts(
         list_of_dicts: list[PluginResponse[dict[str, V]]],
+        *,
         include_plugin_data: bool = False,
     ) -> dict[str, V] | dict[str, tuple[V, PluginMetadata]]:
         list_of_dicts.reverse()

--- a/src/ert/resources/forward_models/run_reservoirsimulator.py
+++ b/src/ert/resources/forward_models/run_reservoirsimulator.py
@@ -144,6 +144,7 @@ class RunReservoirSimulator:
         simulator: Simulators,
         version: str | None,
         ecl_case: Path | str,
+        *,
         num_cpu: int = 1,
         check_status: bool = True,
         summary_conversion: bool = False,

--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -45,6 +45,7 @@ class EnsembleExperiment(InitialEnsembleRunModel, EnsembleExperimentConfig):
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -33,6 +33,7 @@ class EnsembleSmoother(InitialEnsembleRunModel, UpdateRunModel, EnsembleSmoother
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/evaluate_ensemble.py
+++ b/src/ert/run_models/evaluate_ensemble.py
@@ -42,6 +42,7 @@ class EvaluateEnsemble(RunModel, EvaluateEnsembleConfig):
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -609,6 +609,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
     def start_simulations_thread(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         failed = False
@@ -839,6 +840,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -37,6 +37,7 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -94,6 +94,7 @@ def create_model(
 def _merge_parameters(
     design_matrix: DesignMatrix | None,
     parameter_configs: list[ParameterConfig],
+    *,
     require_updateable_param: bool = False,
 ) -> tuple[list[ParameterConfig], DictEncodedDataFrame | None]:
     if design_matrix is None:

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -80,6 +80,7 @@ class MultipleDataAssimilation(
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         self.log_at_startup()

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -155,6 +155,7 @@ class StartSimulationsThreadFn(Protocol):
     def __call__(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None: ...
 
@@ -424,6 +425,7 @@ class RunModel(RunModelConfig, ABC):
     def start_simulations_thread(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None:
         failed = False
@@ -514,6 +516,7 @@ class RunModel(RunModelConfig, ABC):
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
+        *,
         rerun_failed_realizations: bool = False,
     ) -> None: ...
 

--- a/src/ert/scheduler/driver.py
+++ b/src/ert/scheduler/driver.py
@@ -107,6 +107,7 @@ class Driver(ABC):
     @staticmethod
     async def _execute_with_retry(
         cmd_with_args: list[str],
+        *,
         retry_on_empty_stdout: bool | None = False,
         retry_codes: Iterable[int] = (),
         accept_codes: Iterable[int] = (),

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -175,6 +175,7 @@ def _generate_authentication() -> str:
 
 def run_server(
     args: argparse.Namespace | None = None,
+    *,
     debug: bool = False,
     uvicorn_config: uvicorn.Config | None = None,
 ) -> None:

--- a/src/ert/services/ert_server.py
+++ b/src/ert/services/ert_server.py
@@ -209,6 +209,7 @@ class ErtServerController:
     def __init__(
         self,
         storage_path: str,
+        *,
         timeout: int = 120,
         parent_pid: int | None = None,
         connection_info: ErtServerConnectionInfo | None = None,
@@ -353,6 +354,7 @@ class ErtServerController:
     def start_server(
         cls,
         project: Path,
+        *,
         parent_pid: int | None = None,
         verbose: bool = False,
         timeout: int | None = None,

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -513,6 +513,7 @@ class LocalEnsemble(BaseMode):
         self,
         keys: list[str] | None = None,
         realizations: int | npt.NDArray[np.int_] | None = None,
+        *,
         transformed: bool = False,
     ) -> pl.DataFrame:
         if keys is None:
@@ -571,6 +572,7 @@ class LocalEnsemble(BaseMode):
         self,
         group: str,
         realizations: int | npt.NDArray[np.int_] | None = None,
+        *,
         transformed: bool = False,
     ) -> xr.Dataset | pl.DataFrame:
         """
@@ -591,7 +593,7 @@ class LocalEnsemble(BaseMode):
         cardinality = next(cfg.cardinality for cfg in cfgs)
         if cardinality == ParameterCardinality.multiple_configs_per_ensemble_dataset:
             return self.load_scalar_keys(
-                [cfg.name for cfg in cfgs], realizations, transformed
+                [cfg.name for cfg in cfgs], realizations, transformed=transformed
             )
         return self._load_dataset(
             group,

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -65,6 +65,7 @@ class LocalStorage(BaseMode):
         self,
         path: str | os.PathLike[str],
         mode: Mode,
+        *,
         stage_for_migration: bool = False,
     ) -> None:
         """
@@ -137,7 +138,7 @@ class LocalStorage(BaseMode):
     @staticmethod
     def perform_migration(path: Path) -> None:
         if LocalStorage.check_migration_needed(path):
-            with LocalStorage(path, Mode("w"), True) as storage:
+            with LocalStorage(path, Mode("w"), stage_for_migration=True) as storage:
                 storage._migrate(storage.version)
                 storage.reload()
 

--- a/src/ert/substitutions.py
+++ b/src/ert/substitutions.py
@@ -16,6 +16,7 @@ class Substitutions(UserDict[str, str]):
         to_substitute: str,
         context: str = "",
         max_iterations: int = 1000,
+        *,
         warn_max_iter: bool = True,
     ) -> str:
         """Perform a search-replace on the first argument
@@ -24,7 +25,13 @@ class Substitutions(UserDict[str, str]):
         emitted during substitution.
 
         """
-        return _substitute(self, to_substitute, context, max_iterations, warn_max_iter)
+        return _substitute(
+            self,
+            to_substitute,
+            context=context,
+            max_iterations=max_iterations,
+            warn_max_iter=warn_max_iter,
+        )
 
     def real_iter_substituter(self, realization: int, iteration: int) -> Self:
         extra_data = {
@@ -63,6 +70,7 @@ class Substitutions(UserDict[str, str]):
 def _substitute(
     substitutions: Mapping[str, str],
     to_substitute: str,
+    *,
     context: str = "",
     max_iterations: int = 1000,
     warn_max_iter: bool = True,

--- a/src/ert/utils/__init__.py
+++ b/src/ert/utils/__init__.py
@@ -36,7 +36,7 @@ def log_duration(
     return decorator
 
 
-def makedirs_if_needed(path: Path, roll_if_exists: bool = False) -> None:
+def makedirs_if_needed(path: Path, *, roll_if_exists: bool = False) -> None:
     if path.is_dir():
         if not roll_if_exists:
             return

--- a/src/ert/validation/argument_definition.py
+++ b/src/ert/validation/argument_definition.py
@@ -4,7 +4,7 @@ from .validation_status import ValidationStatus
 class ArgumentDefinition:
     MISSING_ARGUMENT = "Missing argument!"
 
-    def __init__(self, optional: bool = False) -> None:
+    def __init__(self, *, optional: bool = False) -> None:
         super().__init__()
         self.__optional = optional
 

--- a/src/ert/validation/string_definition.py
+++ b/src/ert/validation/string_definition.py
@@ -7,6 +7,7 @@ class StringDefinition:
 
     def __init__(
         self,
+        *,
         optional: bool = False,
         required: list[str] | None = None,
         invalid: list[str] | None = None,

--- a/src/everest/api/everest_data_api.py
+++ b/src/everest/api/everest_data_api.py
@@ -11,7 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 class EverestDataAPI:
-    def __init__(self, config: EverestConfig, filter_out_gradient: bool = True) -> None:
+    def __init__(
+        self, config: EverestConfig, *, filter_out_gradient: bool = True
+    ) -> None:
         self._config = config
         assert config.storage_dir.exists()
         self._experiment = EverestStorage.get_everest_experiment(config.storage_dir)

--- a/src/everest/bin/kill_script.py
+++ b/src/everest/bin/kill_script.py
@@ -56,7 +56,7 @@ def _build_args_parser() -> argparse.ArgumentParser:
     return arg_parser
 
 
-def _handle_keyboard_interrupt(signal: int, _: Any, after: bool = False) -> None:
+def _handle_keyboard_interrupt(signal: int, _: Any, *, after: bool = False) -> None:
     if after:
         print(
             f"KeyboardInterrupt (ID: {signal}) has been caught, "

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -1092,7 +1092,7 @@ to read summary data from forward model, do:
             parser.error(f"Loading config file <{config_path}> failed with: {e}")
 
     def write_to_file(
-        self, output_file: str | Path | TextIO, drop_config_path: bool = False
+        self, output_file: str | Path | TextIO, *, drop_config_path: bool = False
     ) -> None:
         dictconf = self.to_dict()
         if drop_config_path:
@@ -1103,7 +1103,10 @@ to read summary data from forward model, do:
 
     @staticmethod
     def write_dict_to_file(
-        config: dict[str, Any], output_file: Path | TextIO, safe_and_pure: bool = True
+        config: dict[str, Any],
+        output_file: Path | TextIO,
+        *,
+        safe_and_pure: bool = True,
     ) -> None:
         yaml = YAML(typ="safe", pure=True) if safe_and_pure else YAML()
         yaml.indent(mapping=2, sequence=4, offset=2)

--- a/src/everest/config_file_loader.py
+++ b/src/everest/config_file_loader.py
@@ -29,7 +29,7 @@ ERT_CONFIG_TEMPLATES = {
 }
 
 
-def load_yaml(file_name: str, safe: bool = False) -> dict[str, Any]:
+def load_yaml(file_name: str, *, safe: bool = False) -> dict[str, Any]:
     input_data = Path(file_name).read_text(encoding="utf-8").splitlines()
     try:
         yaml = YAML(typ="safe", pure=True) if safe else YAML()

--- a/tests/ert/handle_run_path_dialog.py
+++ b/tests/ert/handle_run_path_dialog.py
@@ -18,6 +18,7 @@ def handle_run_path_error_dialog(gui: ErtMainWindow, qtbot: QtBot):
 def handle_run_path_dialog(
     gui: ErtMainWindow,
     qtbot: QtBot,
+    *,
     delete_run_path: bool = True,
     expect_error: bool = False,
 ):

--- a/tests/ert/ui_tests/cli/test_restarting_esmda.py
+++ b/tests/ert/ui_tests/cli/test_restarting_esmda.py
@@ -58,7 +58,7 @@ def poly_eval() -> str:
 
 @pytest.fixture
 def observations() -> Callable[[bool], str]:
-    def observations(restart: bool = False):
+    def observations(*, restart: bool = False):
         if restart:
             return dedent(
                 """

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -265,7 +265,9 @@ def _ensemble_experiment_has_run(
 
 @pytest.fixture(name="run_experiment", scope="module")
 def run_experiment_fixture(request):
-    def func(experiment_mode, gui, wait_done=True, check_realizations=True, **kwargs):
+    def func(
+        experiment_mode, gui, *, wait_done=True, check_realizations=True, **kwargs
+    ):
         """
         Runs experiment.
 

--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -141,7 +141,7 @@ class ExampleFolders(StrEnum):
 
 
 def run_experiment(
-    qtbot: QtBot, experiment_mode: RunModel, gui: QWidget, click_done: bool = True
+    qtbot: QtBot, experiment_mode: RunModel, gui: QWidget, *, click_done: bool = True
 ) -> None:
     # Select correct experiment in the simulation panel
     experiment_panel = get_child(gui, ExperimentPanel)

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -821,7 +821,7 @@ def test_that_simulation_status_button_adds_menu_on_subsequent_runs(
     gui = opened_main_window_poly
 
     def find_and_click_button(
-        button_name: str, should_click: bool, expected_enabled_state: bool
+        button_name: str, *, should_click: bool, expected_enabled_state: bool
     ):
         button = gui.findChild(SidebarToolButton, button_name)
         assert button
@@ -829,7 +829,7 @@ def test_that_simulation_status_button_adds_menu_on_subsequent_runs(
         if should_click:
             qtbot.mouseClick(button, Qt.MouseButton.LeftButton)
 
-    def find_and_check_selected(button_name: str, expected_selected_state: bool):
+    def find_and_check_selected(button_name: str, *, expected_selected_state: bool):
         button = gui.findChild(SidebarToolButton, button_name)
         assert button
         assert button.isChecked() == expected_selected_state
@@ -847,18 +847,26 @@ def test_that_simulation_status_button_adds_menu_on_subsequent_runs(
         qtbot.wait_until(lambda: dialog.is_experiment_done() is True, timeout=15000)
 
     # not clickable since no simulations started yet
-    find_and_click_button("button_Experiment_status", False, False)
-    find_and_click_button("button_Start_experiment", True, True)
+    find_and_click_button(
+        "button_Experiment_status", should_click=False, expected_enabled_state=False
+    )
+    find_and_click_button(
+        "button_Start_experiment", should_click=True, expected_enabled_state=True
+    )
 
     run_experiment()
     wait_for_simulation_completed()
 
     # just toggle to see if next button yields intended change
-    find_and_click_button("button_Start_experiment", True, True)
+    find_and_click_button(
+        "button_Start_experiment", should_click=True, expected_enabled_state=True
+    )
     experiments_panel = wait_for_child(gui, qtbot, ExperimentPanel)
     qtbot.wait_until(lambda: not experiments_panel.isHidden(), timeout=5000)
 
-    find_and_click_button("button_Experiment_status", True, True)
+    find_and_click_button(
+        "button_Experiment_status", should_click=True, expected_enabled_state=True
+    )
     run_dialog = wait_for_child(gui, qtbot, RunDialog)
     qtbot.wait_until(lambda: not run_dialog.isHidden(), timeout=5000)
 
@@ -868,24 +876,34 @@ def test_that_simulation_status_button_adds_menu_on_subsequent_runs(
     )
     assert button_simulation_status.menu() is None
 
-    find_and_click_button("button_Start_experiment", True, True)
-    QTimer.singleShot(500, lambda: handle_run_path_dialog(gui, qtbot, True))
+    find_and_click_button(
+        "button_Start_experiment", should_click=True, expected_enabled_state=True
+    )
+    QTimer.singleShot(
+        500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
+    )
     run_experiment()
     wait_for_simulation_completed()
 
     # verify menu available
     assert len(button_simulation_status.menu().actions()) == 2
 
-    find_and_click_button("button_Start_experiment", True, True)
-    QTimer.singleShot(500, lambda: handle_run_path_dialog(gui, qtbot, True))
+    find_and_click_button(
+        "button_Start_experiment", should_click=True, expected_enabled_state=True
+    )
+    QTimer.singleShot(
+        500, lambda: handle_run_path_dialog(gui, qtbot, delete_run_path=True)
+    )
     run_experiment()
     wait_for_simulation_completed()
 
     # click on something else just to shift focus
-    find_and_click_button("button_Start_experiment", True, True)
+    find_and_click_button(
+        "button_Start_experiment", should_click=True, expected_enabled_state=True
+    )
     # verify correct button in focus
-    find_and_check_selected("button_Start_experiment", True)
-    find_and_check_selected("button_Experiment_status", False)
+    find_and_check_selected("button_Start_experiment", expected_selected_state=True)
+    find_and_check_selected("button_Experiment_status", expected_selected_state=False)
 
     assert len(button_simulation_status.menu().actions()) == 3
     for choice in button_simulation_status.menu().actions():
@@ -893,8 +911,12 @@ def test_that_simulation_status_button_adds_menu_on_subsequent_runs(
 
         # verify correct button in focus when selecting from drop-down
         choice.trigger()
-        find_and_check_selected("button_Start_experiment", False)
-        find_and_check_selected("button_Experiment_status", True)
+        find_and_check_selected(
+            "button_Start_experiment", expected_selected_state=False
+        )
+        find_and_check_selected(
+            "button_Experiment_status", expected_selected_state=True
+        )
 
 
 def test_that_visible_experiment_label_matches_bold_simulation_menu_action(

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -748,6 +748,7 @@ def setup_dataframe_for_compute_observation_statuses(
     overspread_responses: set[int],
     collapsed_responses: set[int],
     expected_statuses,
+    *,
     use_outlier_settings=True,
 ):
     alpha = 0.1

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -301,7 +301,7 @@ class ErtConfigValues:
     observations: list[Observation]
     egrid: EGrid
 
-    def to_config_dict(self, config_file, cwd, all_defines=True):
+    def to_config_dict(self, config_file, cwd, *, all_defines=True):
         result = {
             ConfigKeys.FORWARD_MODEL: self.forward_model,
             ConfigKeys.NUM_REALIZATIONS: self.num_realizations,

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -90,7 +90,7 @@ def run_simulator(summary_values=SUMMARY_VALUES):
 
 
 def make_refcase_observations(
-    obs_config_contents, parse=True, extra_config=None, summary_values=SUMMARY_VALUES
+    obs_config_contents, *, parse=True, extra_config=None, summary_values=SUMMARY_VALUES
 ):
     extra_config = extra_config or ""
     run_simulator(summary_values=summary_values)

--- a/tests/ert/unit_tests/gui/plottery/test_histogram.py
+++ b/tests/ert/unit_tests/gui/plottery/test_histogram.py
@@ -110,7 +110,7 @@ def test_histogram_plot_for_constant_distribution(monkeypatch):
         ANY,
         ANY,
         ANY,
-        ANY,
-        min_value,
-        max_value,
+        use_log_scale=ANY,
+        minimum=min_value,
+        maximum=max_value,
     )

--- a/tests/ert/unit_tests/gui/plottery/test_plot_style.py
+++ b/tests/ert/unit_tests/gui/plottery/test_plot_style.py
@@ -92,7 +92,9 @@ def test_plot_style_builtin_checks():
 
 
 def test_plot_style_copy_style():
-    style = PlotStyle("Test", "red", 0.5, ".", "o", 2.5)
+    style = PlotStyle(
+        "Test", color="red", alpha=0.5, line_style=".", marker="o", width=2.5
+    )
     style.setEnabled(False)
 
     copy_style = PlotStyle("Copy")

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -308,7 +308,9 @@ def _create_rft_location_metadata_df(
 
 
 @contextmanager
-def _create_rft_ensemble(ensemble_size, observations, with_summary=False, zonemap=None):
+def _create_rft_ensemble(
+    ensemble_size, observations, *, with_summary=False, zonemap=None
+):
     if zonemap is not None:
         zonemap_file = Path("zonemap.txt")
         zonemap_file.write_text(zonemap, encoding="utf-8")

--- a/tests/ert/unit_tests/test_utils.py
+++ b/tests/ert/unit_tests/test_utils.py
@@ -44,11 +44,11 @@ def test_makedirs_roll_existing(change_to_tmpdir):
     assert len(list(cwd.iterdir())) == 1
 
     # run makedirs_if_needed again, verify old dir rolled
-    makedirs_if_needed(output_dir, True)
+    makedirs_if_needed(output_dir, roll_if_exists=True)
     assert output_dir.is_dir()
     assert len(list(cwd.iterdir())) == 2
 
     # run makedirs_if_needed again, verify old dir rolled
-    makedirs_if_needed(output_dir, True)
+    makedirs_if_needed(output_dir, roll_if_exists=True)
     assert output_dir.is_dir()
     assert len(list(cwd.iterdir())) == 3


### PR DESCRIPTION
Using booleans for positionals is an anti-pattern. One bug was found during the resolution of this ruff issue.

Solved by adding a '*' to function signature to explicitly separate positional and keyword arguments, and update calling lines accordingly.

**Issue**
Resolves 83 ruff issues on https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
