### PR TITLE
Use correct argument naming in Combobox

### DIFF
--- a/src/ert/gui/experiments/combobox_with_description.py
+++ b/src/ert/gui/experiments/combobox_with_description.py
@@ -112,7 +112,7 @@ class _ComboBoxWithDescriptionDelegate(QStyledItemDelegate):
         group = index.data(GROUP_TITLE_ROLE)
         adjustment = QSize(0, 20) if group else QSize(0, 0)
 
-        widget = _ComboBoxItemWidget(label, description, group)
+        widget = _ComboBoxItemWidget(label, description, group=group)
         return widget.sizeHint() + adjustment
 
 


### PR DESCRIPTION
The group argument was provided as a positional argument and would be interpreted as the 'enable' argument. This leads to false colours seemingly.

This bug is an example of the boolean trap.

**Issue**
A bug never observed in the GUI or reported, but based on code inspection, it is a definite bug.

**Approach**
Solve existing ruff issues

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
