### PR TITLE
Fix lsf_driver bhist summary causing polling to hang

### DIFF
--- a/src/ert/scheduler/lsf_driver.py
+++ b/src/ert/scheduler/lsf_driver.py
@@ -251,6 +251,11 @@ def filter_job_ids_on_submission_time(
     }
 
 
+class BhistProcessingFinishedSentinel:
+    """This sentinel is put when we are finishing polling, so
+    that the bhist processing task can also finish gracefully."""
+
+
 class LsfDriver(Driver):
     def __init__(
         self,
@@ -303,6 +308,10 @@ class LsfDriver(Driver):
         self._bhist_cache: dict[str, dict[str, int]] | None = None
         self._bhist_required_cache_age: float = 4
         self._bhist_cache_timestamp: float = time.time()
+        self._bhist_job_history_processing_queue: asyncio.Queue[
+            str | BhistProcessingFinishedSentinel
+        ] = asyncio.Queue()
+        self._bhist_job_history_processing_task: asyncio.Task[None] | None = None
 
         self._submit_locks: MutableMapping[int, asyncio.Lock] = {}
 
@@ -573,7 +582,7 @@ class LsfDriver(Driver):
             if isinstance(event, FinishedEvent):
                 del self._jobs[job_id]
                 del self._iens2jobid[iens]
-                await self._log_bhist_job_summary(job_id)
+                await self._schedule_log_bhist_history(job_id)
             await self.event_queue.put(event)
 
     async def _get_exit_code(self, job_id: str) -> int:
@@ -609,7 +618,7 @@ class LsfDriver(Driver):
 
         return LSF_FAILED_JOB
 
-    async def _log_bhist_job_summary(self, job_id: str) -> None:
+    async def _log_bhist_job_history(self, job_id: str) -> None:
         bhist_with_args: list[str] = [
             str(self._bhist_cmd),
             "-l",  # long format
@@ -623,6 +632,26 @@ class LsfDriver(Driver):
             log_to_debug=False,
         )
         logger.info(f"Output from bhist -l: {process_message}")
+
+    async def _schedule_log_bhist_history(self, job_id: str) -> None:
+        await self._bhist_job_history_processing_queue.put(job_id)
+        if (
+            self._bhist_job_history_processing_task is None
+            or self._bhist_job_history_processing_task.done()
+        ):
+            self._bhist_job_history_processing_task = asyncio.create_task(
+                self._process_bhist_job_history(), name="lsf-bhist-history-worker"
+            )
+
+    async def _process_bhist_job_history(self) -> None:
+        while True:
+            job_id = await self._bhist_job_history_processing_queue.get()
+            try:
+                if isinstance(job_id, BhistProcessingFinishedSentinel):
+                    return
+                await self._log_bhist_job_history(job_id)
+            finally:
+                self._bhist_job_history_processing_queue.task_done()
 
     async def _poll_once_by_bhist(
         self, missing_job_ids: Iterable[str]
@@ -702,7 +731,21 @@ class LsfDriver(Driver):
         )
 
     async def finish(self) -> None:
-        pass
+        if self._bhist_job_history_processing_task is None:
+            return
+        try:
+            await asyncio.wait_for(
+                self._bhist_job_history_processing_queue.join(), timeout=60
+            )
+            self._bhist_job_history_processing_queue.put_nowait(
+                BhistProcessingFinishedSentinel()
+            )
+            await self._bhist_job_history_processing_task
+            self._bhist_job_history_processing_task = None
+        except TimeoutError:
+            logger.error(
+                "Timeout while waiting for bhist history processing queue to finish"
+            )
 
     def read_stdout_and_stderr_files(
         self, runpath: str, job_name: str, num_characters_to_read_from_end: int = 300

--- a/tests/ert/unit_tests/scheduler/test_lsf_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_lsf_driver.py
@@ -158,13 +158,15 @@ async def test_events_produced_from_jobstate_updates(
         self._iens2jobid[iens] = "1"
 
     driver.submit = mocked_submit.__get__(driver)
-    driver._dump_bhist_job_summary_to_runpath = AsyncMock()
+    driver._log_bhist_job_history = AsyncMock()
     await driver.submit(0, "_")
 
     # Replicate the behaviour of multiple calls to poll()
     for statestr in jobstate_sequence:
         jobstate = _parse_jobs_dict({"1": statestr})["1"]
         await driver._process_job_update("1", jobstate)
+
+    await driver.finish()
 
     events = []
     while not driver.event_queue.empty():
@@ -195,6 +197,38 @@ async def test_events_produced_from_jobstate_updates(
         assert len(events) <= 2  # The StartedEvent is not required
         assert events[-1] == FinishedEvent(iens=0, returncode=exit_code)
         assert "1" not in driver._jobs
+
+
+@pytest.mark.timeout(10)
+async def test_that_hanging_bhist_history_does_not_block_finished_event():
+    """This is a regression test to make sure that if bhist hangs for some reason,
+    job_updates are still processed and we get the finished event."""
+    driver = LsfDriver()
+    driver._jobs["1"] = JobData(
+        iens=0,
+        job_state=RunningJob(job_state="RUN"),
+        submitted_timestamp=time.time(),
+    )
+    driver._iens2jobid[0] = "1"
+    bhist_event = asyncio.Event()
+
+    async def never_ending_bhist_history(_job_id: str) -> None:
+        await bhist_event.wait()
+
+    driver._log_bhist_job_history = AsyncMock(side_effect=never_ending_bhist_history)
+
+    await asyncio.wait_for(
+        driver._process_job_update("1", FinishedJobSuccess(job_state="DONE")), timeout=5
+    )
+
+    assert await asyncio.wait_for(driver.event_queue.get(), timeout=5) == FinishedEvent(
+        iens=0, returncode=0
+    )
+    assert driver._bhist_job_history_processing_task is not None
+    assert not driver._bhist_job_history_processing_task.done()
+    bhist_event.set()
+    await driver.finish()
+    driver._log_bhist_job_history.assert_awaited_once_with("1")
 
 
 @pytest.mark.usefixtures("capturing_bsub")
@@ -580,7 +614,7 @@ async def test_faulty_bjobs(monkeypatch, tmp_path, bjobs_script, expectation):
         bjobs_script=bjobs_script,
     )
     driver = LsfDriver()
-    driver._log_bhist_job_summary = AsyncMock()
+    driver._log_bhist_job_history = AsyncMock()
     with expectation:
         await driver.submit(0, "sleep")
         await asyncio.wait_for(poll(driver, {0}), timeout=1)


### PR DESCRIPTION
In https://github.com/equinor/ert/pull/12977 we introduced some logging to automatically kill hanging cluster jobs, but it seems to be too many hits for runs with fast-running experiments (especially big_poly). Some investigation showed that jobs were marked as finished upto 2 minutes AFTER they were actually finished, so there was something in process_job_updates that was hanging... 


**Issue**
The hanging is caused by _log_bhist_summary calling the `bhist -l` command for every job that finished in the polling batch, blocking bjobs from being called. If a lot of jobs were to finish in the same batch, the polling would wait for INITIAL_BATCH_DURATION = (bhist-call-duration * num_jobs_that_finished) + 2s sleep. This would snowball over time, as the next batch would be even larger because the polling period would be even greater. 

**Approach**
This commit fixes the hanging by running _log_bhist_summary in a different asyncio.Task, so it won't block the bjobs polling task.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
