### PR TITLE
Extend darkstorage observation endpoint

### DIFF
--- a/src/ert/dark_storage/endpoints/observations.py
+++ b/src/ert/dark_storage/endpoints/observations.py
@@ -41,6 +41,7 @@ def get_observations(
             north=observation["north"],
             radius=observation["radius"],
             name=observation["name"],
+            response_key=observation["response_key"],
         )
         for observation in _get_observations(experiment)
     ]
@@ -91,6 +92,7 @@ async def get_observations_for_response(
             north=obs["north"],
             radius=obs["radius"],
             name=obs["name"],
+            response_key=obs["response_key"],
         )
         for obs in obss
     ]
@@ -146,6 +148,7 @@ def _get_observations(
             observations.append(
                 {
                     "name": obs_key[0],
+                    "response_key": obs_df["response_key"].to_list(),
                     "values": values,
                     "errors": obs_df["errors"].to_list(),
                     "x_axis": obs_df["x_axis"].to_list(),

--- a/src/ert/dark_storage/json_schema/observation.py
+++ b/src/ert/dark_storage/json_schema/observation.py
@@ -27,6 +27,7 @@ class ObservationTransformationOut(_ObservationTransformation):
 @dataclass
 class _Observation:
     name: str
+    response_key: list[str]
     errors: list[float]
     values: list[float]
     x_axis: list[Any]


### PR DESCRIPTION
We wish to use this endpoint to query ert for wellnames. However, it currently only contains observation name, which does not necessarily contain the summary key.

This change extends the endpoint to explicitly contain the summary key.

**Issue**
Resolves #13542


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
