### PR TITLE
Assimilate unlocated observations in distance localization

### DIFF
--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -45,34 +45,32 @@ class DistanceLocalizationUpdate:
         self._obs_loc: ObservationLocations | None = None
         self._smoother: LocalizedESMDA | None = None
         self._ensemble_size: int = 0
+        self._num_obs: int = 0
+        self._location_mask: npt.NDArray[np.bool_] | None = None
 
     def prepare(self, obs_context: ObservationContext) -> None:
-        if obs_context.observation_locations is None:
-            raise RuntimeError(
-                "Distance localization requires observation_locations in context"
-            )
         self._obs_loc = obs_context.observation_locations
         self._ensemble_size = obs_context.ensemble_size
+        self._num_obs = obs_context.num_observations
 
-        mask = self._obs_loc.location_mask
-        responses = obs_context.responses[mask, :]
-        obs_values = obs_context.observation_values[mask]
-        obs_errors = obs_context.observation_errors[mask]
-        observation_perturbations = obs_context.observation_perturbations[mask, :]
+        if self._obs_loc is None:
+            self._location_mask = np.zeros(self._num_obs, dtype=bool)
+        else:
+            self._location_mask = self._obs_loc.location_mask
 
         self._smoother = LocalizedESMDA(
-            covariance=obs_errors**2,
-            observations=obs_values,
+            covariance=obs_context.observation_errors**2,
+            observations=obs_context.observation_values,
             alpha=1,
             # Observation perturbations are supplied explicitly below, so no
             # smoother RNG is used.
             seed=None,
         )
         self._smoother.prepare_assimilation(
-            Y=responses,
+            Y=obs_context.responses,
             truncation=self._enkf_truncation,
             overwrite=False,
-            observation_perturbations=observation_perturbations,
+            observation_perturbations=obs_context.observation_perturbations,
         )
 
     def update(
@@ -81,16 +79,18 @@ class DistanceLocalizationUpdate:
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
     ) -> npt.NDArray[np.floating]:
-        if self._obs_loc is None or self._smoother is None:
+        if self._smoother is None or self._location_mask is None:
             raise RuntimeError("prepare() must be called before update()")
 
         num_params = param_ensemble.shape[0]
+        num_located_obs = int(np.count_nonzero(self._location_mask))
         self._progress_callback(
             AnalysisStatusEvent(
                 msg=f"Updating {param_config.name} ({param_config.type.upper()}) "
                 f"using distance-based localization, "
                 f"{num_params} parameters, "
-                f"{self._obs_loc.xpos.shape[0]} observations, "
+                f"{self._num_obs} observations "
+                f"({num_located_obs} with locations), "
                 f"{self._ensemble_size} realizations"
             )
         )
@@ -114,13 +114,35 @@ class DistanceLocalizationUpdate:
 
         return result
 
+    def _full_localization_matrix(
+        self,
+        num_params: int,
+        located_rho: npt.NDArray[np.floating] | None,
+    ) -> npt.NDArray[np.floating]:
+        assert self._location_mask is not None
+
+        rho = np.ones((num_params, self._num_obs), dtype=np.float64)
+        if located_rho is not None:
+            rho[:, self._location_mask] = located_rho
+        return rho
+
     def _update_field(
         self,
         param_ensemble: npt.NDArray[np.floating],
         param_config: Field,
     ) -> npt.NDArray[np.floating]:
-        assert self._obs_loc is not None
         assert self._smoother is not None
+        assert self._location_mask is not None
+
+        num_params = param_ensemble.shape[0]
+        # No located observations; use global assimilation
+        if not self._location_mask.any():
+            return self._smoother.assimilate_batch(
+                X=param_ensemble,
+                overwrite=True,
+            )
+
+        assert self._obs_loc is not None
 
         ertbox = param_config.ertbox_params
         if ertbox.xinc is None:
@@ -161,7 +183,8 @@ class DistanceLocalizationUpdate:
 
         # Expand 2D rho (nx*ny, nobs) to 3D by repeating each xy cell across nz layers
         rho_2d = rho_matrix.reshape(ertbox.nx * ertbox.ny, -1)
-        rho_full = np.repeat(rho_2d, ertbox.nz, axis=0) if ertbox.nz > 1 else rho_2d
+        rho_located = np.repeat(rho_2d, ertbox.nz, axis=0) if ertbox.nz > 1 else rho_2d
+        rho_full = self._full_localization_matrix(num_params, rho_located)
 
         def localization_callback(
             K: npt.NDArray[np.floating],
@@ -179,8 +202,18 @@ class DistanceLocalizationUpdate:
         param_ensemble: npt.NDArray[np.floating],
         param_config: SurfaceConfig,
     ) -> npt.NDArray[np.floating]:
-        assert self._obs_loc is not None
         assert self._smoother is not None
+        assert self._location_mask is not None
+
+        num_params = param_ensemble.shape[0]
+        # No located observations; use global assimilation
+        if not self._location_mask.any():
+            return self._smoother.assimilate_batch(
+                X=param_ensemble,
+                overwrite=True,
+            )
+
+        assert self._obs_loc is not None
 
         xpos, ypos = transform_positions_to_local_field_coordinates(
             (param_config.xori, param_config.yori),
@@ -213,11 +246,12 @@ class DistanceLocalizationUpdate:
         )
 
         rho_flat = rho_matrix.reshape(-1, rho_matrix.shape[-1])
+        rho_full = self._full_localization_matrix(num_params, rho_flat)
 
         def localization_callback(
             K: npt.NDArray[np.floating],
         ) -> npt.NDArray[np.floating]:
-            return K * rho_flat
+            return K * rho_full
 
         return self._smoother.assimilate_batch(
             X=param_ensemble,

--- a/tests/ert/unit_tests/analysis/test_distance_localization.py
+++ b/tests/ert/unit_tests/analysis/test_distance_localization.py
@@ -1,17 +1,60 @@
+import iterative_ensemble_smoother as ies
 import numpy as np
+import pytest
 
 from ert.analysis._update_strategies._distance import DistanceLocalizationUpdate
 from ert.analysis._update_strategies._protocol import (
     ObservationContext,
     ObservationLocations,
 )
-from ert.config import Field
+from ert.config import Field, SurfaceConfig
 from ert.field_utils import AxisOrientation, ErtboxParameters, FieldFileFormat
 from ert.storage import open_storage
 
 
 def _noop_callback(_event: object) -> None:
     pass
+
+
+def _field_config(nx: int, ny: int, nz: int) -> Field:
+    return Field(
+        name="TEST_FIELD",
+        ertbox_params=ErtboxParameters(
+            nx=nx,
+            ny=ny,
+            nz=nz,
+            xinc=1.0,
+            yinc=1.0,
+            origin=(0.0, 0.0),
+            rotation_angle=0.0,
+            axis_orientation=AxisOrientation.LEFT_HANDED,
+        ),
+        file_format=FieldFileFormat.ROFF,
+        forward_init_file="init_%d.roff",
+        forward_init=False,
+        update=True,
+        output_file="output.roff",
+        grid_file="dummy.grdecl",
+    )
+
+
+def _surface_config(ncol: int, nrow: int) -> SurfaceConfig:
+    return SurfaceConfig(
+        name="TEST_SURFACE",
+        forward_init=False,
+        update=True,
+        ncol=ncol,
+        nrow=nrow,
+        xori=0.0,
+        yori=0.0,
+        xinc=1.0,
+        yinc=1.0,
+        rotation=0.0,
+        yflip=1,
+        forward_init_file="init_%d.irap",
+        output_file="output.irap",
+        base_surface_path="base.irap",
+    )
 
 
 def test_that_distance_localization_updates_all_z_layers_at_observation_xy(
@@ -134,3 +177,182 @@ def test_that_distance_localization_updates_all_z_layers_at_observation_xy(
         assert posterior_var < prior_var, (
             f"Variance not reduced at z-layer {iz} of observation cell."
         )
+
+
+@pytest.mark.parametrize(
+    ("param_type", "param_config", "n_params"),
+    [
+        (Field, _field_config(3, 3, 1), 9),
+        (SurfaceConfig, _surface_config(3, 3), 9),
+    ],
+)
+def test_that_unlocated_observations_are_assimilated_globally_for_distance_update(
+    param_type,
+    param_config,
+    n_params,
+):
+    n_real = 30
+    rng = np.random.default_rng(123)
+    param_ensemble = rng.standard_normal((n_params, n_real))
+
+    responses = np.vstack(
+        [
+            param_ensemble[0],
+            param_ensemble[-1],
+        ]
+    )
+    obs_values = np.array([3.0, -2.0])
+    obs_errors = np.array([0.2, 0.3])
+    observation_perturbations = (
+        rng.standard_normal(size=responses.shape) * obs_errors[:, np.newaxis]
+    )
+
+    obs_context = ObservationContext(
+        responses=responses,
+        observation_values=obs_values,
+        observation_errors=obs_errors,
+        observation_perturbations=observation_perturbations,
+        observation_locations=None,
+    )
+
+    updater = DistanceLocalizationUpdate(
+        enkf_truncation=0.99,
+        param_type=param_type,
+        progress_callback=_noop_callback,
+    )
+    updater.prepare(obs_context)
+
+    posterior = updater.update(
+        param_ensemble=param_ensemble.copy(),
+        param_config=param_config,
+        non_zero_variance_mask=np.ones(n_params, dtype=bool),
+    )
+
+    smoother = ies.ESMDA(
+        covariance=obs_errors**2,
+        observations=obs_values,
+        alpha=1,
+        seed=None,
+    )
+    smoother.prepare_assimilation(
+        Y=responses,
+        truncation=0.99,
+        overwrite=False,
+        observation_perturbations=observation_perturbations,
+    )
+    expected = smoother.assimilate_batch(X=param_ensemble.copy(), overwrite=True)
+
+    np.testing.assert_allclose(posterior, expected)
+
+
+def test_that_mixed_unlocated_observations_update_distant_field_parameters():
+    """
+    Verifies that unlocated observations (location_mask=False) update all
+    correlated parameters globally, even when mixed with located observations
+    that use distance localization. The distant cell (3, 3) is outside the
+    correlation range of the located observation at (0.5, 0.5), but should
+    still be updated because it correlates with the unlocated observation.
+    """
+    nx, ny, nz = 4, 4, 1
+    n_params = nx * ny * nz
+    n_real = 40
+    rng = np.random.default_rng(321)
+    param_ensemble = rng.standard_normal((n_params, n_real))
+
+    prior_3d = param_ensemble.reshape(nx, ny, nz, n_real)
+    distant_x, distant_y = 3, 3
+    responses = np.vstack(
+        [
+            prior_3d[0, 0, 0, :],
+            prior_3d[distant_x, distant_y, 0, :],
+        ]
+    )
+    obs_values = np.array([2.0, -4.0])
+    obs_errors = np.array([0.1, 0.1])
+    observation_perturbations = (
+        rng.standard_normal(size=responses.shape) * obs_errors[:, np.newaxis]
+    )
+
+    obs_context = ObservationContext(
+        responses=responses,
+        observation_values=obs_values,
+        observation_errors=obs_errors,
+        observation_perturbations=observation_perturbations,
+        observation_locations=ObservationLocations(
+            xpos=np.array([0.5]),
+            ypos=np.array([0.5]),
+            main_range=np.array([1.0]),
+            location_mask=np.array([True, False]),
+        ),
+    )
+
+    updater = DistanceLocalizationUpdate(
+        enkf_truncation=0.99,
+        param_type=Field,
+        progress_callback=_noop_callback,
+    )
+    updater.prepare(obs_context)
+
+    posterior = updater.update(
+        param_ensemble=param_ensemble.copy(),
+        param_config=_field_config(nx, ny, nz),
+        non_zero_variance_mask=np.ones(n_params, dtype=bool),
+    )
+
+    posterior_3d = posterior.reshape(nx, ny, nz, n_real)
+    assert not np.allclose(
+        posterior_3d[distant_x, distant_y, 0, :], prior_3d[distant_x, distant_y, 0, :]
+    )
+
+
+def test_that_mixed_unlocated_observations_update_distant_surface_parameters():
+    ncol, nrow = 4, 4
+    n_params = ncol * nrow
+    n_real = 40
+    rng = np.random.default_rng(321)
+    param_ensemble = rng.standard_normal((n_params, n_real))
+
+    prior_2d = param_ensemble.reshape(ncol, nrow, n_real)
+    distant_x, distant_y = 3, 3
+    responses = np.vstack(
+        [
+            prior_2d[0, 0, :],
+            prior_2d[distant_x, distant_y, :],
+        ]
+    )
+    obs_values = np.array([2.0, -4.0])
+    obs_errors = np.array([0.1, 0.1])
+    observation_perturbations = (
+        rng.standard_normal(size=responses.shape) * obs_errors[:, np.newaxis]
+    )
+
+    obs_context = ObservationContext(
+        responses=responses,
+        observation_values=obs_values,
+        observation_errors=obs_errors,
+        observation_perturbations=observation_perturbations,
+        observation_locations=ObservationLocations(
+            xpos=np.array([0.5]),
+            ypos=np.array([0.5]),
+            main_range=np.array([1.0]),
+            location_mask=np.array([True, False]),
+        ),
+    )
+
+    updater = DistanceLocalizationUpdate(
+        enkf_truncation=0.99,
+        param_type=SurfaceConfig,
+        progress_callback=_noop_callback,
+    )
+    updater.prepare(obs_context)
+
+    posterior = updater.update(
+        param_ensemble=param_ensemble.copy(),
+        param_config=_surface_config(ncol, nrow),
+        non_zero_variance_mask=np.ones(n_params, dtype=bool),
+    )
+
+    posterior_2d = posterior.reshape(ncol, nrow, n_real)
+    assert not np.allclose(
+        posterior_2d[distant_x, distant_y, :], prior_2d[distant_x, distant_y, :]
+    )


### PR DESCRIPTION
Keep observations without coordinate data in the localized assimilation path by treating them as globally applicable. This avoids dropping unlocated observations when distance localization is enabled while preserving distance weights for observations that do have coordinates.

**Issue**
Resolves #13039 


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
