### PR TITLE
Align misfit plot palette with other plots

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/misfits.py
+++ b/src/ert/gui/tools/plot/plottery/plots/misfits.py
@@ -72,16 +72,17 @@ class MisfitsPlot:
         axes.set_axis_off()
 
     @staticmethod
-    def _make_ensemble_colors(
+    def _map_ensembles_to_colours(
         sorted_ensemble_keys: list[tuple[str, str]],
+        colour_list: list[tuple[str, float]],  # tuples of hex and alpha values
     ) -> dict[tuple[str, str], str]:
         """
         Build a consistent color map and figure-level legend
-        used by all misfit plots
+        used by all misfit plots. Alpha values are dropped.
         """
-        colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         return {
-            key: colors[i % len(colors)] for i, key in enumerate(sorted_ensemble_keys)
+            key: colour_list[i % len(colour_list)][0]
+            for i, key in enumerate(sorted_ensemble_keys)
         }
 
     @staticmethod
@@ -209,7 +210,9 @@ class MisfitsPlot:
         distinct_gendata_index = all_misfits["key_index"].unique().sort().to_list()
         num_gendata_index = len(distinct_gendata_index)
 
-        color_map = self._make_ensemble_colors(sorted_ensemble_keys)
+        color_map = self._map_ensembles_to_colours(
+            sorted_ensemble_keys, plot_context.plotConfig().lineColorCycle()
+        )
         self._draw_legend(
             figure=figure,
             ensemble_colors=color_map,
@@ -335,7 +338,9 @@ class MisfitsPlot:
 
         # Prepare ensemble colors and draw the legend
         sorted_ensemble_keys = sorted(data_with_misfits.keys())
-        color_map = self._make_ensemble_colors(sorted_ensemble_keys)
+        color_map = self._map_ensembles_to_colours(
+            sorted_ensemble_keys, plot_context.plotConfig().lineColorCycle()
+        )
         self._draw_legend(
             figure=figure,
             ensemble_colors=color_map,


### PR DESCRIPTION
This changes the misfit plot from using the 'tab10' colour palette built into matplotlib into the default (currently viridis) colour palette chosen in PlotConfig.

**Issue**
Resolves #13471 


**Approach**
:brain:

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
