### PR TITLE
Fix evergrowing dropdown list in customize plot dialog

### DIFF
--- a/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
+++ b/src/ert/gui/tools/plot/customize/customize_plot_dialog.py
@@ -301,8 +301,9 @@ class CustomizePlotDialog(QDialog):
         if dialog.exec():
             self.copySettingsToOthers.emit(dialog.getSelectedKeys())
 
-    def addCopyableKey(self, key: str | QListWidgetItem) -> None:
-        self._popup_list.addItem(key)
+    def addCopyableKey(self, key: str) -> None:
+        if not self._popup_list.findItems(key, Qt.MatchFlag.MatchExactly):
+            self._popup_list.addItem(key)
 
     def keySelected(self, list_widget_item: QListWidgetItem) -> None:
         self.copySettings.emit(str(list_widget_item.text()))


### PR DESCRIPTION
**Issue**
Manual backport to solve #13278 

**Approach**


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
