### PR TITLE
Consistent ensemble-selection-widget placement

### DIFF
--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -308,15 +308,15 @@ class PlotWindow(QMainWindow):
             self._everest_controls_group = create_group_box(
                 "Select control(s)", self._everest_control_selection_widget
             )
-            ensemble_group = create_group_box(
+            self._ensemble_group = create_group_box(
                 "Select ensemble(s)", self._ensemble_selection_widget
             )
 
             right_container = QWidget()
             right_layout = QVBoxLayout()
             right_layout.setContentsMargins(0, 0, 0, 0)
+            right_layout.addWidget(self._ensemble_group)
             right_layout.addWidget(self._everest_controls_group)
-            right_layout.addWidget(ensemble_group)
             right_container.setLayout(right_layout)
 
             right_dock = QDockWidget()


### PR DESCRIPTION
**Issue**
Resolves #13580


**Approach**
🤔 💡 👨‍💻 

Added `self` to `ensemble_group` to avoid merge conflicts with #13579

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

