### PR TITLE
Replace os.path.join with pathlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,7 @@ select = [
     "PTH101",
     "PTH109",
     "PTH110",
+    "PTH118",
     "PTH123",
     "PYI",
     "Q",

--- a/src/_ert/forward_model_runner/io/__init__.py
+++ b/src/_ert/forward_model_runner/io/__init__.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 
 def check_executable(fname: str | None) -> str:
@@ -13,18 +14,18 @@ def check_executable(fname: str | None) -> str:
     """
     if not fname:
         return "No executable provided!"
-    fname = os.path.expanduser(fname)
+    filepath = Path(fname).expanduser()
 
-    potential_executables = [os.path.abspath(fname)]
-    if not os.path.isabs(fname):
+    potential_executables = [filepath.resolve()]
+    if not filepath.is_absolute():
         potential_executables += [
-            os.path.join(location, fname)
+            Path(location) / filepath
             for location in os.environ["PATH"].split(os.pathsep)
         ]
 
-    if not any(map(os.path.isfile, potential_executables)):
-        return f"{fname} is not a file!"
+    if not any(path.is_file() for path in potential_executables):
+        return f"{filepath} is not a file!"
 
-    if not any(os.access(fn, os.X_OK) for fn in potential_executables):
-        return f"{fname} is not an executable!"
+    if not any(os.access(path, os.X_OK) for path in potential_executables):
+        return f"{filepath} is not an executable!"
     return ""

--- a/src/_ert/forward_model_runner/reporting/file.py
+++ b/src/_ert/forward_model_runner/reporting/file.py
@@ -194,7 +194,7 @@ class File(Reporter):
                 if Path(fm_step.std_err).exists():
                     stderr = Path(fm_step.std_err).read_text(encoding="utf-8")
                     if stderr:
-                        stderr_file = os.path.join(Path.cwd(), fm_step.std_err)
+                        stderr_file = Path.cwd() / fm_step.std_err
                     else:
                         stderr = f"Empty stderr from {fm_step.name()}\n"
                 else:

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-import os
 import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
@@ -605,7 +604,7 @@ class RFTObservation(BaseObservation):
         cls,
         directory: str,
         observation_dict: ObservationDict,
-        filename: str,
+        filename: str | Path,
         shape_registry: ShapeRegistry,
         observed_property: str = "PRESSURE",
         radius: float | None = None,
@@ -632,9 +631,10 @@ class RFTObservation(BaseObservation):
                 lacks required columns, or contains invalid observation values
                 (value=-1 and error=0).
         """
-        if not os.path.isabs(filename):
-            filename = os.path.join(directory, filename)
-        if not Path(filename).exists():
+        filename = Path(filename)
+        if not filename.is_absolute():
+            filename = Path(directory) / filename
+        if not filename.exists():
             raise ObservationConfigError.with_context(
                 f"The CSV file ({filename}) does not exist or is not accessible.",
                 filename,
@@ -1161,14 +1161,15 @@ def _missing_csv_value(
 
 
 def _resolve_path(directory: str, filename: str) -> str:
-    if not os.path.isabs(filename):
-        filename = os.path.join(directory, filename)
-    if not Path(filename).exists():
+    filepath: Path = Path(filename)
+    if not filepath.is_absolute():
+        filepath = Path(directory) / filepath
+    if not filepath.exists():
         raise ObservationConfigError.with_context(
             f"The following keywords did not resolve to a valid path:\n {filename}",
             filename,
         )
-    return filename
+    return str(filepath)
 
 
 def _conversion_error(token: str, value: Any, type_name: str) -> ObservationConfigError:

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -383,10 +383,10 @@ def workflow_jobs_from_dict(
             errors.append(ErrorInfo(message=str(err)).set_context(user_workflow_job[0]))
 
     for user_job_path in user_installed_workflow_job_dir_info:
-        for user_job_file in _get_files_in_directory(user_job_path, errors):
+        for user_job_file in _get_files_in_directory(Path(user_job_path), errors):
             try:
                 user_job = workflow_job_from_file(
-                    config_file=user_job_file, origin="user"
+                    config_file=str(user_job_file), origin="user"
                 )
                 name = user_job.name
                 if name in workflow_jobs:
@@ -615,13 +615,13 @@ def installed_forward_model_steps_from_dict(
         fm_steps[name] = new_fm_step
 
     for fm_step_path in config_dict.get(ConfigKeys.INSTALL_JOB_DIRECTORY, []):
-        for file_name in _get_files_in_directory(fm_step_path, errors):
+        for file_name in _get_files_in_directory(Path(fm_step_path), errors):
             if not path.isfile(file_name):
                 continue
             try:
-                config_contents = read_file(file_name)
+                config_contents = read_file(str(file_name))
                 new_fm_step = forward_model_step_from_config_contents(
-                    config_contents, config_file=file_name
+                    config_contents, config_file=str(file_name)
                 )
             except ConfigValidationError as e:
                 errors.append(e)
@@ -998,7 +998,7 @@ class ErtConfig(BaseModel):
         substitutions["<RUNPATH_FILE>"] = runpath_file
         config_dir = substitutions.get("<CONFIG_PATH>", "")
         config_file = substitutions.get("<CONFIG_FILE>", "no_config")
-        config_file_path = path.join(config_dir, config_file)
+        config_file_path = Path(config_dir) / config_file
 
         errors = cls._validate_dict(config_dict, config_file)
 
@@ -1217,7 +1217,7 @@ class ErtConfig(BaseModel):
                     config_dict,
                 ),
                 runpath_config=model_config,
-                user_config_file=config_file_path,
+                user_config_file=str(config_file_path),
                 observation_declarations=list(obs_configs),
                 zonemap=zonemap,
                 shape_registry=shape_registry,
@@ -1432,16 +1432,17 @@ class ErtConfig(BaseModel):
         content_dict: ConfigDict, config_dir: str
     ) -> None:
         if ConfigKeys.ENSPATH not in content_dict:
-            content_dict[ConfigKeys.ENSPATH] = path.join(
-                config_dir, ErtConfig.DEFAULT_ENSPATH
+            content_dict[ConfigKeys.ENSPATH] = str(
+                Path(config_dir) / ErtConfig.DEFAULT_ENSPATH
             )
+
         if ConfigKeys.RUNPATH_FILE not in content_dict:
-            content_dict[ConfigKeys.RUNPATH_FILE] = path.join(
-                config_dir, ErtConfig.DEFAULT_RUNPATH_FILE
+            content_dict[ConfigKeys.RUNPATH_FILE] = str(
+                Path(config_dir) / ErtConfig.DEFAULT_RUNPATH_FILE
             )
         elif not path.isabs(content_dict[ConfigKeys.RUNPATH_FILE]):
-            content_dict[ConfigKeys.RUNPATH_FILE] = path.normpath(
-                path.join(config_dir, content_dict[ConfigKeys.RUNPATH_FILE])
+            content_dict[ConfigKeys.RUNPATH_FILE] = str(
+                (Path(config_dir) / content_dict[ConfigKeys.RUNPATH_FILE]).resolve()
             )
 
     @classmethod
@@ -1497,24 +1498,19 @@ def _split_string_into_sections(string: str, section_length: int) -> list[str]:
 
 
 def _get_files_in_directory(
-    job_path: str, errors: list[ErrorInfo | ConfigValidationError]
-) -> list[str]:
-    if not path.isdir(job_path):
+    job_path: Path, errors: list[ErrorInfo | ConfigValidationError]
+) -> list[Path]:
+    if not job_path.is_dir():
         errors.append(
             ConfigValidationError(
-                f"Unable to locate job directory {job_path!r}", job_path
+                f"Unable to locate job directory {job_path}", str(job_path)
             )
         )
         return []
-    files = list(
-        filter(
-            path.isfile,
-            (path.abspath(path.join(job_path, f)) for f in os.listdir(job_path)),
-        )
-    )
+    files = [path.resolve() for path in job_path.iterdir() if path.is_file()]
 
     if files == []:
-        ConfigWarning.warn(f"No files found in job directory {job_path}", job_path)
+        ConfigWarning.warn(f"No files found in job directory {job_path}", str(job_path))
     return files
 
 

--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -420,16 +419,16 @@ class LegacyGeneralObservation(_LegacyGeneralObservation):
                     setattr(output, str(key).lower(), value)
                 case "OBS_FILE" | "INDEX_FILE":
                     assert not isinstance(key, tuple)
-                    filename = value
-                    if not os.path.isabs(filename):
-                        filename = os.path.join(directory, filename)
-                    if not Path(filename).exists():
+                    filename = Path(value)
+                    if not filename.is_absolute():
+                        filename = Path(directory) / filename
+                    if not filename.exists():
                         raise ObservationConfigError.with_context(
                             "The following keywords did not"
                             f" resolve to a valid path:\n {key}",
                             value,
                         )
-                    setattr(output, str(key).lower(), filename)
+                    setattr(output, str(key).lower(), str(filename))
                 case "DATA":
                     output.data = value
                 case _:

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -214,12 +214,9 @@ class SchemaItem:
                         absolute_path = Path(potential_executable)
                         is_command = True
                     else:
-                        absolute_path = None
-
-                if absolute_path is None:
-                    raise ConfigValidationError.with_context(
-                        f"Could not find executable {token.value!r}", token
-                    )
+                        raise ConfigValidationError.with_context(
+                            f"Could not find executable {token.value!r}", token
+                        )
 
                 if os.path.isdir(absolute_path):
                     raise ConfigValidationError.with_context(

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -1,8 +1,8 @@
 import os
-import pathlib
 import shutil
 from collections.abc import Callable, Mapping, Sequence
 from enum import EnumType
+from pathlib import Path
 from typing import Any, TypeVar
 
 from pydantic import ConfigDict, Field, NonNegativeInt, PositiveInt
@@ -168,10 +168,8 @@ class SchemaItem:
                 | SchemaItemType.EXISTING_PATH_INLINE
             ):
                 path: str | None = str(token)
-                if not os.path.isabs(token):
-                    path = os.path.normpath(
-                        os.path.join(os.path.dirname(token.filename), token)
-                    )
+                if not Path(token).is_absolute():
+                    path = str((Path(token.filename).parent / token).resolve())
                 if val_type != SchemaItemType.PATH:
                     if val_type == SchemaItemType.EXISTING_FILE and not os.path.isfile(
                         str(path)
@@ -180,7 +178,7 @@ class SchemaItem:
                             f"{self.kw} {token} is not a file.",
                             token,
                         )
-                    if not pathlib.Path(str(path)).exists():
+                    if not Path(str(path)).exists():
                         err = f'Cannot find file or directory "{token.value}". '
                         if path != token:
                             err += f"The configured value was {path!r} "
@@ -203,15 +201,19 @@ class SchemaItem:
                     )
                 return token.update(path)
             case SchemaItemType.EXECUTABLE:
-                absolute_path: str | None
+                absolute_path: Path | None
                 is_command = False
-                if not os.path.isabs(token):
+                if not Path(token).is_absolute():
                     # Try relative
-                    absolute_path = os.path.abspath(os.path.join(cwd, token))
+                    absolute_path = (Path(cwd) / token).resolve()
                 else:
-                    absolute_path = token
-                if not pathlib.Path(absolute_path).exists():
-                    absolute_path = shutil.which(token)
+                    absolute_path = Path(token)
+                if not absolute_path.exists():
+                    absolute_path = (
+                        Path(shutil.which(str(token)))
+                        if shutil.which(str(token)) and token
+                        else None
+                    )
                     is_command = True
 
                 if absolute_path is None:
@@ -229,13 +231,13 @@ class SchemaItem:
                 if not os.access(absolute_path, os.X_OK):
                     context = (
                         f"{token.value!r} which was resolved to {absolute_path!r}"
-                        if token.value != absolute_path
+                        if token.value != str(absolute_path)
                         else f"{token.value!r}"
                     )
                     raise ConfigValidationError.with_context(
                         f"File not executable: {context}", token
                     )
-                return token if is_command else token.update(value=absolute_path)
+                return token if is_command else token.update(value=str(absolute_path))
             case SchemaItemType():
                 return token
             case EnumType():

--- a/src/ert/config/parsing/config_schema_item.py
+++ b/src/ert/config/parsing/config_schema_item.py
@@ -209,12 +209,12 @@ class SchemaItem:
                 else:
                     absolute_path = Path(token)
                 if not absolute_path.exists():
-                    absolute_path = (
-                        Path(shutil.which(str(token)))
-                        if shutil.which(str(token)) and token
-                        else None
-                    )
-                    is_command = True
+                    potential_executable = shutil.which(token)
+                    if potential_executable is not None:
+                        absolute_path = Path(potential_executable)
+                        is_command = True
+                    else:
+                        absolute_path = None
 
                 if absolute_path is None:
                     raise ConfigValidationError.with_context(

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -326,7 +326,7 @@ def _handle_includes(
     if current_included_file is None:
         current_included_file = IncludedFile(included_from=None, filename=config_file)
 
-    config_dir = os.path.dirname(config_file)
+    config_dir: Path = Path(config_file).parent
     to_include = []
 
     errors = []
@@ -350,14 +350,12 @@ def _handle_includes(
                 )
 
                 args = args[0:1]
-            file_to_include = _substitute_token(defines, args[0])
+            file_to_include: FileContextToken = _substitute_token(defines, args[0])
 
-            if not os.path.isabs(file_to_include):
+            if not Path(file_to_include).is_absolute():
                 file_to_include = FileContextToken(
                     file_to_include.update(
-                        value=os.path.normpath(
-                            os.path.join(config_dir, file_to_include)
-                        ),
+                        value=str((config_dir / file_to_include).resolve())
                     ),
                     filename=file_to_include.filename,
                 )

--- a/src/ert/plugins/hook_implementations/jobs.py
+++ b/src/ert/plugins/hook_implementations/jobs.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from jinja2 import Template
 
@@ -8,21 +8,15 @@ from ert.shared import ert_share_path
 
 def _get_jobs_from_directories(directories: list[str]) -> dict[str, str]:
     share_path = ert_share_path()
-    directories = [
-        Template(directory).render(ERT_SHARE_PATH=share_path, ERT_UI_MODE="gui")
+    rendered_directories = [
+        Path(Template(directory).render(ERT_SHARE_PATH=share_path, ERT_UI_MODE="gui"))
         for directory in directories
     ]
 
     all_files = []
-    for directory in directories:
-        all_files.extend(
-            [
-                os.path.join(directory, f)
-                for f in os.listdir(directory)
-                if os.path.isfile(os.path.join(directory, f))
-            ]
-        )
-    return {os.path.basename(path): path for path in all_files}
+    for directory in rendered_directories:
+        all_files.extend([file for file in directory.iterdir() if file.is_file()])
+    return {path.name: str(path) for path in all_files}
 
 
 @ert.plugin(name="ert")

--- a/src/ert/resources/shell_scripts/careful_copy_file.py
+++ b/src/ert/resources/shell_scripts/careful_copy_file.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 import os
-import pathlib
 import shutil
 import sys
+from pathlib import Path
 
 
 def careful_copy_file(src: str, target: str | None = None) -> None:
     if target is None:
         target = os.path.basename(src)
-    if pathlib.Path(target).exists():
+    if Path(target).exists():
         print(f"File: {target} already present - not updated")
         return
     if os.path.isfile(src):
         if os.path.isdir(target):
-            target_file = os.path.join(target, os.path.basename(src))
+            target_file = str(Path(target) / Path(src).name)
             shutil.copyfile(src, target_file)
             print(f"Copying file '{src}' -> '{target_file}'")
         else:
@@ -22,7 +22,7 @@ def careful_copy_file(src: str, target: str | None = None) -> None:
                 os.makedirs(target_path)
                 print(f"Creating directory '{target_path}' ")
             if os.path.isdir(target):
-                target_file = os.path.join(target, os.path.basename(src))
+                target_file = str(Path(target) / Path(src).name)
             else:
                 target_file = target
 

--- a/src/ert/resources/shell_scripts/copy_directory.py
+++ b/src/ert/resources/shell_scripts/copy_directory.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import sys
+from pathlib import Path
 
 from make_directory import mkdir  # type: ignore
 
@@ -17,7 +18,7 @@ def copy_directory(src_path: str, target_path: str) -> None:
 
         print(f"Copying directory structure {src_path} -> {target_path}")
         if os.path.isdir(target_path):
-            target_path = os.path.join(target_path, src_basename)
+            target_path = str(Path(target_path) / src_basename)
         try:
             shutil.copytree(src_path, target_path, dirs_exist_ok=True)
         except shutil.Error as err:

--- a/src/ert/resources/shell_scripts/copy_file.py
+++ b/src/ert/resources/shell_scripts/copy_file.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import sys
+from pathlib import Path
 
 
 def copy_file(src: str, target: str | None = None) -> None:
@@ -10,7 +11,7 @@ def copy_file(src: str, target: str | None = None) -> None:
             target = os.path.basename(src)
 
         if os.path.isdir(target):
-            target_file = os.path.join(target, os.path.basename(src))
+            target_file = str(Path(target) / Path(src).name)
             shutil.copyfile(src, target_file)
             print(f"Copying file '{src}' -> '{target_file}'")
         else:
@@ -19,7 +20,7 @@ def copy_file(src: str, target: str | None = None) -> None:
                 os.makedirs(target_path)
                 print(f"Creating directory '{target_path}' ")
             if os.path.isdir(target):
-                target_file = os.path.join(target, os.path.basename(src))
+                target_file = str(Path(target) / Path(src).name)
             else:
                 target_file = target
 

--- a/src/ert/resources/shell_scripts/delete_directory.py
+++ b/src/ert/resources/shell_scripts/delete_directory.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import os
-import pathlib
 import sys
+from pathlib import Path
 
 
-def delete_file(filename: str) -> None:
+def delete_file(filename: str | Path) -> None:
     stat_info = os.lstat(filename)
     uid = stat_info.st_uid
     if uid == os.getuid():
@@ -42,15 +42,15 @@ def delete_directory(path: str) -> None:
     """
     Will ignore if you are not owner.
     """
-    if pathlib.Path(path).exists():
+    if Path(path).exists():
         if os.path.isdir(path):
             for root, dirs, files in os.walk(path, topdown=False, followlinks=False):
                 if not os.path.islink(root):
                     for file in files:
-                        delete_file(os.path.join(root, file))
+                        delete_file(Path(root) / file)
 
                     for dir_ in dirs:
-                        delete_empty_directory(os.path.join(root, dir_))
+                        delete_empty_directory(str(Path(root) / dir_))
 
         else:
             raise OSError(f"Entry:'{path}' is not a directory")

--- a/src/ert/resources/shell_scripts/move_file.py
+++ b/src/ert/resources/shell_scripts/move_file.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python
-import os
 import shutil
 import sys
+from pathlib import Path
 
 
-def move_file(src_file: str, target: str) -> None:
+def move_file(src_file: str | Path, target: str | Path) -> None:
     """
     Will raise IOError if src_file is not a file.
 
     """
-    if os.path.isfile(src_file):
+    src_file = Path(src_file)
+    target = Path(target)
+    if src_file.is_file():
         # shutil.move works best (as unix mv) when target is a file.
-        if os.path.isdir(target):
-            target = os.path.join(target, os.path.basename(src_file))
+        if target.is_dir():
+            target /= src_file.name
         shutil.move(src_file, target)
     else:
         raise OSError(f"Input argument {src_file} is not an existing file")

--- a/src/ert/resources/shell_scripts/symlink.py
+++ b/src/ert/resources/shell_scripts/symlink.py
@@ -14,14 +14,14 @@ def symlink(target: str, link_name: str) -> None:
     """
     link_path, _ = os.path.split(link_name)
     if len(link_path) == 0:
-        target_check = target
+        target_check = Path(target)
     else:
         if not os.path.isdir(link_path):
             print(f"Creating directory for link: {link_path}")
             os.makedirs(link_path)
-        target_check = os.path.join(link_path, target)
+        target_check = Path(link_path) / target
 
-    if not Path(target_check).exists():
+    if not target_check.exists():
         raise OSError(
             f"{target} (target) and {link_name} (link_name) requested, "
             f"which implies that {target_check} must exist, but it does not."

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -250,9 +250,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
         if status_queue is None:
             status_queue = queue.SimpleQueue()
 
-        runpath_file: Path = Path(
-            os.path.join(everest_config.output_dir, ".res_runpath_list")
-        )
+        runpath_file: Path = Path(everest_config.output_dir) / ".res_runpath_list"
 
         assert everest_config.config_file is not None
         config_file: Path = Path(everest_config.config_path)

--- a/src/ert/storage/migration/to8.py
+++ b/src/ert/storage/migration/to8.py
@@ -121,7 +121,7 @@ def _migrate_observations_to_grouped_parquet(path: Path) -> None:
         if not (experiment / "observations").exists():
             os.makedirs(experiment / "observations")
 
-        obs_keys = os.listdir(os.path.join(experiment, "observations"))
+        obs_keys = os.listdir(Path(experiment) / "observations")
 
         if len(set(obs_keys) - {"summary", "gen_data"}) == 0:
             # Observations are already migrated, likely from .to4 migrations

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -979,7 +979,7 @@ to read summary data from forward model, do:
         if cfgdir is None:
             return path
 
-        return os.path.join(cfgdir, path)
+        return str(Path(cfgdir) / path)
 
     @property
     def simulation_dir(self) -> str:
@@ -988,11 +988,10 @@ to read summary data from forward model, do:
         if os.path.isabs(path):
             return path
 
-        cfgdir = self.output_dir
-        return os.path.join(cfgdir, path)
+        return str(Path(self.output_dir) / path)
 
     def _get_output_subdirectory(self, subdirname: str) -> str:
-        return os.path.join(os.path.abspath(self.output_dir), subdirname)
+        return str(Path(self.output_dir).resolve() / subdirname)
 
     @property
     def optimization_output_dir(self) -> str:

--- a/src/everest/config/install_data_config.py
+++ b/src/everest/config/install_data_config.py
@@ -139,7 +139,7 @@ class InstallDataConfig(BaseModel, extra="forbid"):
         if self.source is not None:
             source = self.source.replace("<CONFIG_PATH>", config_directory)
             if not os.path.isabs(source):
-                source = os.path.join(config_directory, source)
+                source = str(Path(config_directory) / source)
 
             is_dir = _is_dir_all_model(source, model_realizations)
 

--- a/src/everest/config/server_config.py
+++ b/src/everest/config/server_config.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
@@ -86,4 +86,4 @@ class ServerConfig(BaseModel, extra="forbid"):
     def get_session_dir(output_dir: str) -> str:
         """Return path to the session directory containing information about the
         certificates and host information"""
-        return os.path.join(os.path.abspath(output_dir), SESSION_DIR)
+        return str(Path(output_dir).resolve() / SESSION_DIR)

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -228,7 +228,7 @@ def check_path_valid(path: Any) -> None:
     root = os.path.sep
     for dirname in str(path).split(os.path.sep):
         try:
-            os.lstat(os.path.join(root, dirname))
+            os.lstat(Path(root) / dirname)
 
         except OSError as e:
             if e.errno in {errno.ENAMETOOLONG, errno.ERANGE}:
@@ -262,9 +262,9 @@ def check_for_duplicate_names(
 
 
 def as_abs_path(path: str, config_dir: str) -> str:
-    if os.path.isabs(path):
+    if Path(path).is_absolute():
         return path
-    return os.path.realpath(os.path.join(config_dir, path))
+    return str((Path(config_dir) / path).resolve())
 
 
 def expand_model_id_paths(path_source: str, realizations: list[int]) -> list[str]:
@@ -294,7 +294,7 @@ def check_path_exists(
         pre, pos = path_source.split("<CONFIG_PATH>")
         if pos and pos[0] == "/":
             pos = pos[1:]
-            path_source = os.path.join(pre, config_dir, pos)
+            path_source = str(Path(pre) / config_dir / pos)
 
     expanded_paths = expand_model_id_paths(str(path_source), realizations)
     for exp_path in [as_abs_path(p, str(config_dir)) for p in expanded_paths]:

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -98,7 +98,7 @@ settings.register_profile(
 
 
 @pytest.fixture(scope="session", name="source_root")
-def fixture_source_root():
+def fixture_source_root() -> Path:
     return SOURCE_DIR
 
 
@@ -122,11 +122,11 @@ def maximize_ulimits():
 
 
 @pytest.fixture(name="setup_case")
-def fixture_setup_case(tmp_path_factory, source_root, monkeypatch):
+def fixture_setup_case(tmp_path_factory, source_root: Path, monkeypatch):
     def copy_case(path, config_file):
         tmp_path = tmp_path_factory.mktemp(path.replace("/", "-"))
         shutil.copytree(
-            os.path.join(source_root, "test-data/ert", path), tmp_path / "test_data"
+            source_root / "test-data" / "ert" / path, tmp_path / "test_data"
         )
         monkeypatch.chdir(tmp_path / "test_data")
         return ErtConfig.from_file(config_file)
@@ -182,11 +182,11 @@ def minimum_case(use_tmpdir):
 
 
 @pytest.fixture(name="copy_case")
-def fixture_copy_case(tmp_path_factory, source_root, monkeypatch):
+def fixture_copy_case(tmp_path_factory, source_root: Path, monkeypatch):
     def _copy_case(path):
         tmp_path = tmp_path_factory.mktemp(path.replace("/", "-"))
         shutil.copytree(
-            os.path.join(source_root, "test-data/ert", path),
+            source_root / "test-data" / "ert" / path,
             tmp_path / "test_data",
             ignore=shutil.ignore_patterns("storage", "poly_out"),
         )
@@ -376,10 +376,8 @@ def _qt_excepthook(monkeypatch):
     monkeypatch.setattr(sys, "excepthook", excepthook)
 
 
-def _run_snake_oil(source_root):
-    shutil.copytree(
-        os.path.join(source_root, "test-data/ert", "snake_oil"), "test_data"
-    )
+def _run_snake_oil(source_root: Path):
+    shutil.copytree(source_root / "test-data" / "ert" / "snake_oil", "test_data")
     os.chdir("test_data")
     with fileinput.input("snake_oil.ert", inplace=True) as fin:
         for line in fin:
@@ -403,10 +401,8 @@ def _run_snake_oil(source_root):
     run_cli(parsed)
 
 
-def _run_heat_equation(source_root, run_mode):
-    shutil.copytree(
-        os.path.join(source_root, "test-data", "ert", "heat_equation"), "test_data"
-    )
+def _run_heat_equation(source_root: Path, run_mode):
+    shutil.copytree(source_root / "test-data" / "ert" / "heat_equation", "test_data")
     os.chdir("test_data")
     with Path("config.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
@@ -424,7 +420,7 @@ def _run_heat_equation(source_root, run_mode):
 
 
 @pytest.fixture
-def _shared_snake_oil_case(request, monkeypatch, source_root):
+def _shared_snake_oil_case(request, monkeypatch, source_root: Path):
     """This fixture will run the snake_oil case to populate storage,
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
@@ -442,7 +438,7 @@ def _shared_snake_oil_case(request, monkeypatch, source_root):
 
 
 @pytest.fixture
-def _shared_heat_equation_es(request, monkeypatch, source_root):
+def _shared_heat_equation_es(request, monkeypatch, source_root: Path):
     """This fixture will run the heat_equation case to populate storage,
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
@@ -460,7 +456,7 @@ def _shared_heat_equation_es(request, monkeypatch, source_root):
 
 
 @pytest.fixture
-def _shared_heat_equation_esmda(request, monkeypatch, source_root):
+def _shared_heat_equation_esmda(request, monkeypatch, source_root: Path):
     """This fixture will run the heat_equation case to populate storage,
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
@@ -478,7 +474,7 @@ def _shared_heat_equation_esmda(request, monkeypatch, source_root):
 
 
 @pytest.fixture
-def _shared_heat_equation_enif(request, monkeypatch, source_root):
+def _shared_heat_equation_enif(request, monkeypatch, source_root: Path):
     """This fixture will run the heat_equation case to populate storage,
     this is quite slow, but the results will be cached. If something comes
     out of sync, clear the cache and start again.
@@ -523,8 +519,8 @@ def snake_oil_default_storage(snake_oil_case_storage):
 
 
 @pytest.fixture(scope="session")
-def block_storage_path(source_root):
-    path = source_root / "test-data/ert/block_storage/snake_oil"
+def block_storage_path(source_root: Path):
+    path = source_root / "test-data" / "ert" / "block_storage" / "snake_oil"
     if not path.is_dir():
         pytest.skip(
             "'test-data/ert/block_storage' has not been checked out.\n"

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -143,7 +143,7 @@ def test_that_unopenable_observation_config_fails_gracefully():
     )
     line_with_observation_config = content_lines[index_line_with_observation_config]
     observation_config_rel_path = line_with_observation_config.split(" ")[1]
-    observation_config_abs_path = os.path.join(Path.cwd(), observation_config_rel_path)
+    observation_config_abs_path = Path.cwd() / observation_config_rel_path
     Path(observation_config_abs_path).chmod(0o000)
 
     with pytest.raises(

--- a/tests/ert/ui_tests/cli/test_update_with_rft_observations.py
+++ b/tests/ert/ui_tests/cli/test_update_with_rft_observations.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
 from pathlib import Path
 
@@ -16,7 +15,7 @@ from .run_cli import run_cli
 @pytest.mark.slow
 @pytest.mark.skipif(not shutil.which("flow"), reason="flow not available")
 def test_that_rft_example_with_rft_observation_keyword_yelds_same_result_as_gendata_rft(
-    use_tmpdir, source_root, snapshot, request
+    use_tmpdir, source_root: Path, snapshot, request
 ):
     """
     Created snapshot of rft pressures by using the GENDATA_RFT in combination
@@ -26,9 +25,7 @@ def test_that_rft_example_with_rft_observation_keyword_yelds_same_result_as_gend
     Note that the snapshot might depend on version of Flow. Snapshot values
     were changed upon the release of Flow 2026.04
     """
-    shutil.copytree(
-        os.path.join(source_root, "test-data", "ert", "rft_example"), "test-data"
-    )
+    shutil.copytree(source_root / "test-data" / "ert" / "rft_example", "test-data")
     run_cli(ENSEMBLE_SMOOTHER_MODE, "--disable-monitoring", "test-data/rft.ert")
     pressure = {}
     for file in sorted(Path("spe1_out").rglob("*.RFT")):

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -1,7 +1,6 @@
 import contextlib
 import fileinput
 import os
-import os.path
 import shutil
 import stat
 from collections.abc import Iterator
@@ -72,10 +71,10 @@ def opened_main_window_poly(
 
 
 def _new_poly_example(
-    source_root, destination, num_realizations: int = DEFAULT_NUM_REALIZATIONS
+    source_root: Path, destination, num_realizations: int = DEFAULT_NUM_REALIZATIONS
 ):
     shutil.copytree(
-        os.path.join(source_root, "test-data", "ert", "poly_example"),
+        source_root / "test-data" / "ert" / "poly_example",
         destination,
         dirs_exist_ok=True,
     )

--- a/tests/ert/unit_tests/config/config_dict_generator.py
+++ b/tests/ert/unit_tests/config/config_dict_generator.py
@@ -651,8 +651,7 @@ def config_generators(draw, use_eclbase=booleans):
         note(f"Using tmp dir: {tmp!s}")
         with tmp.as_cwd():
             config_values.run_template = [
-                [os.path.join(tmp, src), target]
-                for src, target in config_values.run_template
+                [str(tmp / src), target] for src, target in config_values.run_template
             ]
             for key in [
                 "runpath",
@@ -661,9 +660,7 @@ def config_generators(draw, use_eclbase=booleans):
                 "obs_config",
                 "data_file",
             ]:
-                setattr(
-                    config_values, key, os.path.join(tmp, getattr(config_values, key))
-                )
+                setattr(config_values, key, str(tmp / getattr(config_values, key)))
             for dirname in should_exist_directories:
                 if not os.path.isdir(dirname):
                     os.mkdir(dirname)

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import os
-import os.path
 import stat
 from pathlib import Path
 from textwrap import dedent
@@ -212,8 +211,8 @@ def validate_forward_model(forward_model, forward_model_config):
 
 def generate_step_from_dict(forward_model_config):
     forward_model_config = copy.deepcopy(forward_model_config)
-    forward_model_config["executable"] = os.path.join(
-        Path.cwd(), forward_model_config["executable"]
+    forward_model_config["executable"] = str(
+        Path.cwd() / forward_model_config["executable"]
     )
     forward_model = _generate_step(
         forward_model_config["name"],

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -488,7 +488,7 @@ def test_default_ens_path():
     dict_set_ens_path = ErtConfig.from_dict(
         {
             ConfigKeys.NUM_REALIZATIONS: 1,
-            "ENSPATH": os.path.join(Path.cwd(), "storage"),
+            "ENSPATH": str(Path.cwd() / "storage"),
         }
     ).ens_path
 
@@ -670,10 +670,10 @@ def test_that_magic_strings_get_substituted_in_workflow():
         script <ZERO>
         """
     )
-    script_file_path = os.path.join(Path.cwd(), "script")
-    workflow_file_path = os.path.join(Path.cwd(), "workflow")
-    Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
-    Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
+    script_file_path = Path.cwd() / "script"
+    workflow_file_path = Path.cwd() / "workflow"
+    script_file_path.write_text(script_file_contents, encoding="utf-8")
+    workflow_file_path.write_text(workflow_file_contents, encoding="utf-8")
 
     Path("script.py").write_text(
         dedent(
@@ -1424,10 +1424,10 @@ def test_parsing_workflow_with_multiple_args():
         script <ZERO>
         """
     )
-    script_file_path = os.path.join(Path.cwd(), "script")
-    workflow_file_path = os.path.join(Path.cwd(), "workflow")
-    Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
-    Path(workflow_file_path).write_text(workflow_file_contents, encoding="utf-8")
+    script_file_path = Path.cwd() / "script"
+    workflow_file_path = Path.cwd() / "workflow"
+    script_file_path.write_text(script_file_contents, encoding="utf-8")
+    workflow_file_path.write_text(workflow_file_contents, encoding="utf-8")
 
     Path("script.py").write_text(
         dedent(
@@ -1986,9 +1986,9 @@ def test_parsing_define_within_workflow():
         """
     )
 
-    script_file_path = os.path.join(Path.cwd(), "script")
-    workflow_file_path = os.path.join(Path.cwd(), "workflow")
-    workflow2_file_path = os.path.join(Path.cwd(), "workflow2")
+    script_file_path = Path.cwd() / "script"
+    workflow_file_path = Path.cwd() / "workflow"
+    workflow2_file_path = Path.cwd() / "workflow2"
 
     Path(script_file_path).write_text(script_file_contents, encoding="utf-8")
 
@@ -2214,8 +2214,8 @@ def test_run_template_raises_configvalidationerror_with_more_than_two_arguments(
 
 @pytest.fixture
 def setup_workflow_file():
-    workflow_file_path = os.path.join(Path.cwd(), "workflow")
-    Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
+    workflow_file_path = Path.cwd() / "workflow"
+    workflow_file_path.write_text("TEST_SCRIPT", encoding="utf-8")
 
     Path("config.ert").write_text(
         dedent(
@@ -2309,8 +2309,8 @@ def test_ert_script_hook_pre_experiment_essettings_fails():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_ert_script_hook_valid_essettings_succeed():
-    workflow_file_path = os.path.join(Path.cwd(), "workflow")
-    Path(workflow_file_path).write_text("TEST_SCRIPT", encoding="utf-8")
+    workflow_file_path = Path.cwd() / "workflow"
+    workflow_file_path.write_text("TEST_SCRIPT", encoding="utf-8")
 
     Path("config.ert").write_text(
         dedent(

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import os.path
 import shutil
 import stat
 from argparse import ArgumentParser
@@ -51,7 +50,7 @@ def test_load_forward_model():
     assert fm_step.stdout_file is None
     assert fm_step.stderr_file is None
 
-    assert fm_step.executable == os.path.join(Path.cwd(), "script.sh")
+    assert fm_step.executable == str(Path.cwd() / "script.sh")
     assert os.access(fm_step.executable, os.X_OK)
 
     assert fm_step.min_arg is None

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_step.py
@@ -177,7 +177,7 @@ def test_run_fails_using_exit_bash_builtin():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_but_missing():
-    executable = os.path.join(Path.cwd(), "this/is/not/a/file")
+    executable = str(Path.cwd() / "this" / "is" / "not" / "a" / "file")
     fmstep = ForwardModelStep(
         {
             "name": "TEST_EXECUTABLE_NOT_FOUND",
@@ -195,16 +195,16 @@ def test_run_with_defined_executable_but_missing():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_empty_executable():
-    empty_executable = os.path.join(Path.cwd(), "foo")
-    with Path(empty_executable).open("a", encoding="utf-8"):
+    empty_executable = Path.cwd() / "foo"
+    with empty_executable.open("a", encoding="utf-8"):
         pass
     st = os.stat(empty_executable)
-    Path(empty_executable).chmod(st.st_mode | stat.S_IEXEC)
+    empty_executable.chmod(st.st_mode | stat.S_IEXEC)
 
     fmstep = ForwardModelStep(
         {
             "name": "TEST_EXECUTABLE_NOT_EXECUTABLE",
-            "executable": empty_executable,
+            "executable": str(empty_executable),
             "stdout": "mkdir_out",
             "stderr": "mkdir_err",
         },
@@ -221,14 +221,14 @@ def test_run_with_empty_executable():
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_run_with_defined_executable_no_exec_bit():
-    non_executable = os.path.join(Path.cwd(), "foo")
-    with Path(non_executable).open("a", encoding="utf-8"):
+    non_executable = Path.cwd() / "foo"
+    with non_executable.open("a", encoding="utf-8"):
         pass
 
     fmstep = ForwardModelStep(
         {
             "name": "TEST_EXECUTABLE_NOT_EXECUTABLE",
-            "executable": non_executable,
+            "executable": str(non_executable),
             "stdout": "mkdir_out",
             "stderr": "mkdir_err",
         },

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -39,7 +39,7 @@ def api(tmpdir, source_root, monkeypatch):
 
     with tmpdir.as_cwd():
         test_data_root = source_root / "test-data" / "ert"
-        test_data_dir = os.path.join(test_data_root, "snake_oil")
+        test_data_dir = test_data_root / "snake_oil"
         shutil.copytree(test_data_dir, "test_data")
         os.chdir("test_data")
         yield PlotApi(test_data_dir)

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -41,10 +41,6 @@ mkdir = import_from_location(
     "make_directory",
     SHELL_SCRIPTS / "make_directory.py",
 ).mkdir
-careful_copy_file = import_from_location(
-    "careful_copy",
-    SHELL_SCRIPTS / "careful_copy_file.py",
-).careful_copy_file
 copy_directory = import_from_location(
     "careful_copy",
     SHELL_SCRIPTS / "copy_directory.py",

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -26,46 +26,48 @@ def pushd(path):
         os.chdir(cwd0)
 
 
+SHELL_SCRIPTS = SOURCE_DIR / "src" / "ert" / "resources" / "shell_scripts"
+
 symlink = import_from_location(
     "symlink",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/symlink.py"),
+    SHELL_SCRIPTS / "symlink.py",
 ).symlink
 
 careful_copy_file = import_from_location(
     "careful_copy",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/careful_copy_file.py"),
+    SHELL_SCRIPTS / "careful_copy_file.py",
 ).careful_copy_file
 mkdir = import_from_location(
     "make_directory",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/make_directory.py"),
+    SHELL_SCRIPTS / "make_directory.py",
 ).mkdir
 careful_copy_file = import_from_location(
     "careful_copy",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/careful_copy_file.py"),
+    SHELL_SCRIPTS / "careful_copy_file.py",
 ).careful_copy_file
 copy_directory = import_from_location(
     "careful_copy",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/copy_directory.py"),
+    SHELL_SCRIPTS / "copy_directory.py",
 ).copy_directory
 copy_file = import_from_location(
     "copy_file",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/copy_file.py"),
+    SHELL_SCRIPTS / "copy_file.py",
 ).copy_file
 delete_directory = import_from_location(
     "delete_directory",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/delete_directory.py"),
+    SHELL_SCRIPTS / "delete_directory.py",
 ).delete_directory
 delete_file = import_from_location(
     "delete_file",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/delete_file.py"),
+    SHELL_SCRIPTS / "delete_file.py",
 ).delete_file
 move_directory = import_from_location(
     "move_directory",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/move_directory.py"),
+    SHELL_SCRIPTS / "move_directory.py",
 ).move_directory
 move_file = import_from_location(
     "move_file",
-    os.path.join(SOURCE_DIR, "src/ert/resources/shell_scripts/move_file.py"),
+    SHELL_SCRIPTS / "move_file.py",
 ).move_file
 
 

--- a/tests/ert/unit_tests/resources/test_templating.py
+++ b/tests/ert/unit_tests/resources/test_templating.py
@@ -1,6 +1,5 @@
 import importlib
 import json
-import os
 import subprocess
 from pathlib import Path
 
@@ -19,10 +18,7 @@ from ._import_from_location import import_from_location
 
 template_render = import_from_location(
     "template_render",
-    os.path.join(
-        SOURCE_DIR,
-        "src/ert/resources/forward_models/template_render.py",
-    ),
+    SOURCE_DIR / "src" / "ert" / "resources" / "forward_models" / "template_render.py",
 )
 
 render_template = template_render.render_template

--- a/tests/ert/unit_tests/run_models/conftest.py
+++ b/tests/ert/unit_tests/run_models/conftest.py
@@ -1,15 +1,10 @@
-import os
-
 import pytest
 
 
 @pytest.fixture
 def create_dummy_run_path(tmp_path, monkeypatch):
-    run_path = os.path.join(tmp_path, "out")
-    os.mkdir(run_path)
-    os.mkdir(os.path.join(run_path, "realization-0"))
-    os.mkdir(os.path.join(run_path, "realization-0/iter-0"))
-    os.mkdir(os.path.join(run_path, "realization-1"))
-    os.mkdir(os.path.join(run_path, "realization-1/iter-0"))
-    os.mkdir(os.path.join(run_path, "realization-1/iter-1"))
+    run_path = tmp_path / "out"
+    (run_path / "realization-0" / "iter-0").mkdir(parents=True)
+    (run_path / "realization-1" / "iter-0").mkdir(parents=True)
+    (run_path / "realization-1" / "iter-1").mkdir(parents=True)
     return monkeypatch.chdir(tmp_path)

--- a/tests/everest/test_config_file_loader.py
+++ b/tests/everest/test_config_file_loader.py
@@ -100,7 +100,7 @@ def test_configpath_in_defs(tmp_path, monkeypatch):
     loaded_config = EverestConfig.load_file(str(config_file_path))
 
     expected_definitions_after_load = {
-        "local_jobs_folder": os.path.join(current_working_directory, "jobs"),
+        "local_jobs_folder": str(current_working_directory / "jobs"),
     }
 
     assert expected_definitions_after_load == loaded_config.definitions
@@ -108,7 +108,7 @@ def test_configpath_in_defs(tmp_path, monkeypatch):
 
 def test_dependent_definitions(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    current_working_directory = str(Path.cwd())
+    current_working_directory = Path.cwd()
 
     definitions_for_initial_config_object = {
         "numeric_key": 1,
@@ -136,8 +136,8 @@ def test_dependent_definitions(tmp_path, monkeypatch):
     expected_defs = {
         "numeric_key": 1,
         "bool_key": True,
-        "local_jobs_folder": os.path.join(current_working_directory, "jobs"),
-        **dict.fromkeys(all_chars, current_working_directory),
+        "local_jobs_folder": str(current_working_directory / "jobs"),
+        **dict.fromkeys(all_chars, str(current_working_directory)),
     }
 
     assert expected_defs == loaded_config.definitions

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -53,10 +53,10 @@ def test_save_running_config(
     config.write_to_file("config.yml")
 
     everest_entry(["config.yml", "--skip-prompt"])
-    saved_config_path = os.path.join(config.output_dir, "config.yml")
+    saved_config_path = Path(config.output_dir) / "config.yml"
 
-    assert Path(saved_config_path).exists()
-    shutil.move(saved_config_path, os.path.join(Path.cwd(), "saved_config.yml"))
+    assert saved_config_path.exists()
+    shutil.move(saved_config_path, Path.cwd() / "saved_config.yml")
 
     new_config = EverestConfig.load_file("saved_config.yml")
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -45,26 +45,27 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     everest_config.write_to_file("config_minimal.yml")
     start_everest(["everest", "run", "config_minimal.yml", "--skip-prompt"])
 
-    everest_output_path = os.path.join(Path.cwd(), "everest_output")
-    everest_logs_dir_path = everest_config.log_dir
-    everserver_log_path = os.path.join(everest_logs_dir_path, "everserver.log")
-    everest_log_path = os.path.join(everest_logs_dir_path, "everest.log")
-    forward_model_log_path = os.path.join(everest_logs_dir_path, "forward_models.log")
+    everest_output_path = Path.cwd() / "everest_output"
+    everest_logs_dir_path = Path(everest_config.log_dir)
+    everserver_log_path = everest_logs_dir_path / "everserver.log"
+    everest_log_path = everest_logs_dir_path / "everest.log"
+    forward_model_log_path = everest_logs_dir_path / "forward_models.log"
 
-    assert Path(everest_output_path).exists()
-    assert Path(everest_logs_dir_path).exists()
-    assert Path(forward_model_log_path).exists()
-    assert Path(everest_log_path).exists()
-    assert Path(everserver_log_path).exists()
+    assert everest_output_path.exists()
+    assert everest_logs_dir_path.exists()
+    assert forward_model_log_path.exists()
+    assert everest_log_path.exists()
+    assert everserver_log_path.exists()
 
-    assert "everest.detached.everserver INFO: Output directory:" in Path(
-        everest_log_path
-    ).read_text(encoding="utf-8")
-    assert "Process exited with status code 1" in Path(
-        forward_model_log_path
-    ).read_text(encoding="utf-8")
+    assert (
+        "everest.detached.everserver INFO: Output directory:"
+        in everest_log_path.read_text(encoding="utf-8")
+    )
+    assert "Process exited with status code 1" in forward_model_log_path.read_text(
+        encoding="utf-8"
+    )
 
-    endpoint_logs = Path(everserver_log_path).read_text(encoding="utf-8")
+    endpoint_logs = everserver_log_path.read_text(encoding="utf-8")
     # Avoid cases where optimization finished before we get a chance to check that
     # the everest server has started
     if endpoint_logs:

--- a/tests/everest/test_repo_configs.py
+++ b/tests/everest/test_repo_configs.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from ropt.workflow import find_backend_plugin
@@ -6,18 +6,13 @@ from ropt.workflow import find_backend_plugin
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
 
 
-def _get_all_files(folder):
-    return [
-        os.path.join(root, filename)
-        for root, _, files in os.walk(folder)
-        for filename in files
-    ]
+def _get_all_files(folder: Path) -> list[Path]:
+    return [path for path in folder.rglob("*") if path.is_file()]
 
 
 @pytest.mark.slow
 def test_all_repo_configs():
-    repo_dir = os.path.join(os.path.dirname(__file__), "..")
-    repo_dir = os.path.realpath(repo_dir)
+    repo_dir = Path(__file__).parent.parent.resolve()
 
     data_folders = (
         "examples/eightcells/everest/input",
@@ -25,28 +20,29 @@ def test_all_repo_configs():
     )
 
     config_folders = (
-        "examples",
-        "everest",
-        "tests",
+        repo_dir / "examples",
+        repo_dir / "everest",
+        repo_dir / "tests",
     )
-    config_folders = map(lambda fn: os.path.join(repo_dir, fn), config_folders)  # noqa E731
 
-    def is_yaml(fn):
+    def is_yaml(fn: str):
         return fn.endswith(".yml")
 
-    def is_data(fn):
+    def is_data(fn: str):
         return any(df in fn for df in data_folders)
 
-    def is_config(fn):
+    def is_config(fn: str):
         return is_yaml(fn) and not is_data(fn) and "invalid" not in fn
 
-    config_files = [fn for cdir in config_folders for fn in _get_all_files(cdir)]
+    config_files: list[str] = [
+        str(fn) for cdir in config_folders for fn in _get_all_files(cdir)
+    ]
     config_files = filter(is_config, config_files)
 
     if find_backend_plugin("scipy/default") is None:
-        config_files = [f for f in config_files if "scipy" not in f]
+        config_files = [f for f in config_files if "scipy" not in str(f)]
 
     config_files = list(config_files)
     for config_file in config_files:
-        config = yaml_file_to_substituted_config_dict(config_file)
+        config = yaml_file_to_substituted_config_dict(str(config_file))
         assert config is not None

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -120,7 +120,7 @@ def test_install_data_no_init(tmp_path, source, target, symlink, cmd, monkeypatc
         runmodel = EverestRunModel.create(ever_config, runtime_plugins=site_plugins)
 
     matching_fm_step = next(fm for fm in runmodel.forward_model_steps if fm.name == cmd)
-    assert matching_fm_step.arglist == [f"./{source}", target]
+    assert matching_fm_step.arglist == [source, target]
 
 
 def test_workflow_job(tmp_path, monkeypatch):

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 
 import jinja2
@@ -58,10 +57,7 @@ DUAL_INPUT_TMPL = "{{ well_drill_north.PROD1 }} vs {{ well_drill_south.PROD1 }}"
 
 template_render = import_from_location(
     "template_render",
-    os.path.join(
-        SOURCE_DIR,
-        "src/ert/resources/forward_models/template_render.py",
-    ),
+    SOURCE_DIR / "src" / "ert" / "resources" / "forward_models" / "template_render.py",
 )
 
 

--- a/tests/everest/utils/utils.py
+++ b/tests/everest/utils/utils.py
@@ -1,7 +1,7 @@
 import contextlib
-import os
 import sys
 from io import StringIO
+from pathlib import Path
 from textwrap import dedent
 
 import yaml
@@ -34,8 +34,8 @@ def everest_config_with_defaults(**kwargs) -> EverestConfig:
     return EverestConfig.with_plugins(yaml.safe_load(MIN_CONFIG) | {**kwargs})  # type: ignore
 
 
-def relpath(*path):
-    return os.path.join(os.path.dirname(os.path.dirname(__file__)), *path)
+def relpath(*path) -> Path:
+    return Path(__file__).resolve().parent.parent.joinpath(*path)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
**Issue**
Resolves https://docs.astral.sh/ruff/rules/os-path-join/


**Approach**
Try limiting the changes to only replacing `os.path.join` and accepting that there are lots of obvious pathlib improvements that still can be done to the changed lines - leave these for later for easier review. The main motive is to be able to add PTH118 as a ruff rule as soon as possible, and then do more.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
