### PR TITLE
Skip flaky slurm test on mac

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_slurm_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_slurm_driver.py
@@ -39,6 +39,7 @@ def capturing_sbatch(monkeypatch, tmp_path):
     sbatch_path.chmod(sbatch_path.stat().st_mode | stat.S_IEXEC)
 
 
+@pytest.mark.skip_mac_ci
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize(
     ("sbatch_script", "scontrol_script", "sacct_script", "exit_code"),


### PR DESCRIPTION
This test is flaky (but only observed on local mac hardware).

It seems like it is hanging at process.communicate() for _run_sacct() due to the amount of work done on local cpu. A solution could be to increase the timeout, but we can also just skip the test on Mac as it is not flaky on Linux.

**Issue**
Resolves #13381


**Approach**
skip


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
