### PR TITLE
Explicitly cast breakthrough threshold value to Float64

### DIFF
--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -222,7 +222,7 @@ def _handle_breakthrough_observation(
             "response_key": f"BREAKTHROUGH:{obs_config.key}",
             "time": pl.Series([obs_config.date]).dt.cast_time_unit("ms"),
             "observations": pl.Series([0], dtype=pl.Float32),
-            "threshold": obs_config.threshold,
+            "threshold": pl.Series([obs_config.threshold], dtype=pl.Float64),
             "std": pl.Series([obs_config.error], dtype=pl.Float32),
             "east": pl.Series([east], dtype=pl.Float32),
             "north": pl.Series([north], dtype=pl.Float32),


### PR DESCRIPTION
**Issue**
Resolves #13525 

After attempting to cast this value to float32 and discovering the small problems it caused, I landed on just explicitly cast it to float64 instead.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
