### PR TITLE
Have run_dialog fixture wait for experiment done before teardown

### DIFF
--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -152,7 +152,8 @@ def run_dialog(qtbot: QtBot, use_tmpdir, mock_set_env_key, monkeypatch):
     qtbot.waitUntil(lambda: gui.findChild(RunDialog) is not None, timeout=5000)
     run_dialog = gui.findChild(RunDialog)
     assert run_dialog
-    return run_dialog
+    yield run_dialog
+    qtbot.waitUntil(lambda: run_dialog.is_experiment_done() is True, timeout=10000)
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
**Issue**
Resolves #13475


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
