### PR TITLE
Write analysis CSV reports without pandas to reduce memory usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ types = [
     "types-tqdm",
     "types-psutil",
     "types-setuptools",
+    "types-tabulate",
     "types-networkx",
 ]
 

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import csv
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-import pandas as pd
 from pydantic import BaseModel, ConfigDict
+from tabulate import tabulate
 
 
 class AnalysisEvent(BaseModel):
@@ -49,12 +50,21 @@ class DataSection:
         fname = re.sub(r"(?u)[^-\w]", "", fname)
         f_path = output_path / fname
         f_path.parent.mkdir(parents=True, exist_ok=True)
-        df = pd.DataFrame(self.data, columns=self.header)
         with f_path.with_suffix(".report").open("w", encoding="utf-8") as fout:
             if self.extra:
                 fout.writelines(f"{k}: {v}\n" for k, v in self.extra.items())
-            fout.write(df.to_markdown(tablefmt="simple_outline", floatfmt=".4f"))
-        df.to_csv(f_path.with_suffix(".csv"))
+            fout.write(
+                tabulate(
+                    self.data,
+                    headers=self.header,
+                    tablefmt="simple_outline",
+                    floatfmt=".4f",
+                )
+            )
+        with f_path.with_suffix(".csv").open("w", encoding="utf-8", newline="") as fout:
+            writer = csv.writer(fout, lineterminator="\n")
+            writer.writerow(self.header)
+            writer.writerows(self.data)
 
 
 class AnalysisDataEvent(AnalysisEvent):

--- a/uv.lock
+++ b/uv.lock
@@ -1191,6 +1191,7 @@ types = [
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
+    { name = "types-tabulate" },
     { name = "types-tqdm" },
 ]
 
@@ -1302,6 +1303,7 @@ types = [
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
+    { name = "types-tabulate" },
     { name = "types-tqdm" },
 ]
 
@@ -6091,6 +6093,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/53/8c7ca2263165f13b493f5258a317acb09cab02742e816c38cd5fe6f09e5a/types_setuptools-82.0.0.20260508.tar.gz", hash = "sha256:e76ade6f42ba9b4211636b84b65a8e55948a67ffe81f9a44e66b8af93d57e77e", size = 44919, upload-time = "2026-05-08T04:47:48.32Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/67/f49414a00fc61a4bc64bd0ff879bb230818b68e62c5cf91fc7c098912aac/types_setuptools-82.0.0.20260508-py3-none-any.whl", hash = "sha256:ba1d863bbd11526d7232bca8d5a4aebe1d38fa1677a550f47a2692b7d5776900", size = 68395, upload-time = "2026-05-08T04:47:47.391Z" },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.10.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/af/c100d86897d3fdb010d8f813569fa80355b5cb553f51080e37d4f3c451bb/types_tabulate-0.10.0.20260508.tar.gz", hash = "sha256:8e51f159e8b24976849706ae2ed1dc9adba8ebbd080b17e494ebb66a8cc92c74", size = 8395, upload-time = "2026-05-08T04:47:58.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/36/443b700f54a585cf8ed4e76d8ad08b12df6914f8782a2788ecd0d8491519/types_tabulate-0.10.0.20260508-py3-none-any.whl", hash = "sha256:b1e1a2d0456fbd655a71690b09a7aaeffdf2978d32049184ea436492aa51d20a", size = 8137, upload-time = "2026-05-08T04:47:57.872Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

Before fix:

<img width="1106" height="450" alt="heat-eq-with-pandas" src="https://github.com/user-attachments/assets/580f5d14-9011-496f-967a-39c054fe2b1d" />

After fix:

<img width="1106" height="450" alt="heat-eq-no-pandas" src="https://github.com/user-attachments/assets/490a4cc2-2570-4b83-a301-84df2d26636f" />

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
