### PR TITLE
Fix test_that_run_dialog_clears_warnings_when_rerun

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,12 @@ def env_save():
         (key, val) for key, val in os.environ.items() if key not in exceptions
     ]
     set_xor = set(environment_pre).symmetric_difference(set(environment_post))
-    assert len(set_xor) == 0, f"Detected differences in environment: {set_xor}"
+    set_pre_post = set(environment_pre).difference(set(environment_post))
+    set_post_pre = set(environment_post).difference(set(environment_pre))
+    assert len(set_xor) == 0, (
+        f"Detected differences in environment: {set_xor}. "
+        f"Pre-post: {set_pre_post}, post-pre: {set_post_pre}"
+    )
 
 
 @pytest.fixture

--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -52,10 +52,13 @@ from ert.run_models.event import (
     RunPathCreatedEvent,
     StartingTotalRunPathCreationEvent,
 )
+from ert.run_models.run_model import RunModel
 from ert.scheduler.job import Job
 from tests.ert import SnapshotBuilder
 from tests.ert.handle_run_path_dialog import handle_run_path_dialog
 from tests.ert.ui_tests.gui.conftest import wait_for_child
+
+_original_run_ensemble_evaluator_async = RunModel.run_ensemble_evaluator_async
 
 
 @pytest.fixture
@@ -1042,10 +1045,17 @@ def test_that_run_dialog_clears_warnings_when_rerun(
     monkeypatch.setattr(
         QMessageBox, "exec", value=lambda _: QMessageBox.StandardButton.Ok
     )
-    run_dialog.rerun_failed_realizations()
-    qtbot.wait_until(run_dialog.is_experiment_done, timeout=5000)
+    assert run_dialog.is_experiment_done()
 
-    assert len(run_dialog.post_experiment_warnings) == 0
+    with patch(
+        "ert.run_models.run_model.RunModel.run_ensemble_evaluator_async",
+        _original_run_ensemble_evaluator_async,
+    ):
+        run_dialog.rerun_failed_realizations()
+        assert not run_dialog.is_experiment_done()
+        qtbot.wait_until(run_dialog.is_experiment_done, timeout=5000)
+
+        assert len(run_dialog.post_experiment_warnings) == 0
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
Resolves #13475 

<details><summary>1. Why the test was wrong - it isn't actually a flaky test, it just causes flakiness</summary>

The idea of the test is to setup an environment where first run has a warning and then rerun failed realizations proving that warnings are cleared.

However the test is wrong - it uses `event_queue` to set up the test, but the same event queue gets reused when experiment is rerun. Events from this fake queue are fired alongside real realization run that we want to test. So we end up with one `WarningEvent` and two `EndEvent`s fired.

The problem seems to be that fake queue `EndEvent` (or real `EndEvent`) arrives and unblocks the test and finishes it while `WarningEvent` is still not processed.

1. `WarningEvent` arrives after
`assert len(run_dialog.post_experiment_warnings) == 0`
is long passed.
So the test never failed and situation was never caught.

To see that this is what happens add `time.sleep(2)` [to the](https://github.com/equinor/ert/blob/969bdafc43801b1cfdc5c04064add811e9bcafc9/src/ert/run_models/run_model.py#L434) `finally` block of `start_simulations_thread` in `run_model.py` before `send_event`.
As `WarningEvent` now arrives before any `EndEvent`, assertion fails.

2. Test could proceed due to fake `EndEvent`, which meant that we were not waiting for real `EndEvent`. But the run daemon thread was already dispatched.
It could start and finish during the test run itself, or between other tests were run or it could pollute environment settings of other tests, causing intermittent failures.

Dropping event_queue mock for the real failed realizations rerun should fix all the problems.

~We won't talk about who screwed it up in the first place~ :innocent: :smile:

</details>

<details><summary>2. How it was discovered</summary>
After a lot of attempts to setup useful metrics and reproduce the flakiness, I finally got lucky today:

https://github.com/achaikou/ert/actions/runs/26219133905/job/77149218583 

```
_ ERROR at teardown of test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] _
...
        set_xor = set(environment_pre).symmetric_difference(set(environment_post))
>       assert len(set_xor) == 0, f"Detected differences in environment: {set_xor}"
E       AssertionError: Detected differences in environment: {('_ERT_ENSEMBLE_ID', '21f22528-6864-46e0-8547-20a11d47e6bc'), ('_ERT_EXPERIMENT_ID', '090df07c-6cd1-4c07-84ca-c8581cbe5b91')}
E       assert 2 == 0
E        +  where 2 = len({('_ERT_ENSEMBLE_ID', '21f22528-6864-46e0-8547-20a11d47e6bc'), ('_ERT_EXPERIMENT_ID', '090df07c-6cd1-4c07-84ca-c8581cbe5b91')})

---------------------------- Captured stdout setup -----------------------------
...

print end event: [tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] (setup) (test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events])]_ERT_ENSEMBLE_ID=21f22528-6864-46e0-8547-20a11d47e6bc, THREAD_NAME=tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] (call) (test_that_run_dialog_clears_warnings_when_rerun[one warning issued])_ert_gui_simulation_thread, TIMESTAMP=1779357765.2315013
```

Interesting thing is that print out of the test `test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events]` contains the thread name that I gave the thread when it starts.
It is not the test itself, but `test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued]` - showing that error is coming from the test which starts a run-away experiment without waiting for it to finish.

</details>

<details><summary>3. What likely proves this issue is responsible for all recent intermittent "environment" test errors we've seen.</summary>

If we see the previous test in the same `xdist` group to which failing test belonged, we would see a pattern.

1. The previous test in the group is `test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued]`
Should mean that run was dispatched after the bad test teardown finished and environment was affected by the start of the next test.

https://github.com/equinor/ert/actions/runs/25323198550/job/74237477180?pr=13416
```

[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] 
[gw2] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] 
```

https://github.com/equinor/ert/actions/runs/25719964904/job/75518902066?pr=13543

```
[gw1] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw1] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_runpath_creation_events_add_update_and_remove_tab 
[gw1] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_runpath_creation_events_add_update_and_remove_tab 
```

https://github.com/equinor/ert/actions/runs/26081137423/job/76683094372

```
[gw3] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw3] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] 
[gw3] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events] 
```


https://github.com/achaikou/ert/actions/runs/25911182710/job/76156452440

```
[gw3] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw3] PASSED tests/ert/unit_tests/gui/experiments/view/test_realization.py::test_delegate_drawing_count 
[gw3] ERROR tests/ert/unit_tests/gui/experiments/view/test_realization.py::test_delegate_drawing_count 
```

2. The failing test is `test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued]` itself

https://github.com/equinor/ert/actions/runs/26081137423/job/76683094354

```
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw2] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued]  
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_runpath_creation_events_add_update_and_remove_tab 
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_terminating_experiment_during_hooked_workflows_stops_run_dialog 
[gw2] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_terminating_experiment_during_hooked_workflows_stops_run_dialog 
```

- So run starts in the first test, spoiling the post-env variables
- does not affect the second test - which does not override experiment and ensemble ids variables
- In the third test values are still set, but runaway run finally finishes or variables are overridden and cleared at the end by the test itself, causing it to error.

Same goes there https://github.com/equinor/ert/actions/runs/26097814844/job/76740548699?pr=13581

Only that second test didn't fail because environment is mocked, so variable values survived from start to end.

```
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued] 
[gw2] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_run_dialog_clears_warnings_when_rerun[one warning issued]  
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_experiment_with_a_scheduler_warning_event_shows_a_warning_dialog[scheduler_warning_event_between_snapshot_events]  
[gw2] [ 54%] PASSED tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_terminating_experiment_during_hooked_workflows_stops_run_dialog 
[gw2] [ 54%] ERROR tests/ert/unit_tests/gui/experiments/test_run_dialog.py::test_that_terminating_experiment_during_hooked_workflows_stops_run_dialog 
```

</details>

----
- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
