### PR TITLE
Draw observation radii on field standard-deviation plots

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.config import ParameterConfig
-    from ert.storage import Ensemble
+    from ert.storage import Ensemble, Experiment
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +213,12 @@ def perform_ensemble_update(
             xpos=filtered_data["east"].to_numpy()[has_location],
             ypos=filtered_data["north"].to_numpy()[has_location],
             main_range=filtered_data["radius"].to_numpy()[has_location],
+            observation_key=filtered_data["observation_key"]
+            .to_numpy()[has_location]
+            .astype(str),
+            observation_index=filtered_data["index"]
+            .to_numpy()[has_location]
+            .astype(str),
             location_mask=has_location,
         )
 
@@ -285,6 +291,7 @@ def build_strategy_map(
     correlation_threshold: Callable[[int], float],
     *,
     progress_callback: Callable[[AnalysisEvent], None] | None = None,
+    experiment: Experiment | None = None,
 ) -> dict[str, UpdateStrategy]:
     """Build a mapping from parameter group names to update strategies.
 
@@ -317,11 +324,11 @@ def build_strategy_map(
     strategy_map: dict[str, UpdateStrategy] = {}
 
     field_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, Field, progress_callback
+        enkf_truncation, Field, progress_callback, experiment=experiment
     )
 
     surface_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, SurfaceConfig, progress_callback
+        enkf_truncation, SurfaceConfig, progress_callback, experiment=experiment
     )
 
     global_strategy = GlobalESUpdate(
@@ -333,6 +340,7 @@ def build_strategy_map(
         correlation_threshold,
         enkf_truncation,
         progress_callback,
+        experiment=experiment,
     )
 
     for param_name in parameters:

--- a/src/ert/analysis/_update_strategies/_adaptive.py
+++ b/src/ert/analysis/_update_strategies/_adaptive.py
@@ -11,9 +11,11 @@ from typing import TYPE_CHECKING
 import humanize
 import numpy as np
 import psutil
+import scipy.sparse as sp
 from iterative_ensemble_smoother import AdaptiveESMDA
 
 from ert.analysis.event import AnalysisEvent, AnalysisStatusEvent
+from ert.storage import SparseMatrixArtifact
 
 from ._batching import calculate_localization_batch_size, split_by_batch_size
 
@@ -21,6 +23,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.config import ParameterConfig
+    from ert.storage import Experiment
 
     from ._protocol import ObservationContext
 
@@ -31,6 +34,9 @@ logger = logging.getLogger(__name__)
 RESERVED_CPU_CORES = 2
 NUM_JOBS_ADAPTIVE_LOC = max(
     1, ((psutil.cpu_count(logical=False) or 1) - RESERVED_CPU_CORES)
+)
+ADAPTIVE_THRESHOLDED_CROSS_COVARIANCE_ARTIFACT = (
+    "adaptive_localization/{parameter_group}/thresholded_cross_covariance"
 )
 
 
@@ -63,10 +69,12 @@ class AdaptiveLocalizationUpdate:
         correlation_threshold: Callable[[int], float],
         enkf_truncation: float,
         progress_callback: Callable[[AnalysisEvent], None],
+        experiment: Experiment | None = None,
     ) -> None:
         self._correlation_threshold_fn = correlation_threshold
         self._enkf_truncation = enkf_truncation
         self._progress_callback = progress_callback
+        self._experiment = experiment
         self._smoother: AdaptiveESMDA | None = None
         self._num_obs: int = 0
         self._ensemble_size: int = 0
@@ -146,17 +154,26 @@ class AdaptiveLocalizationUpdate:
         )
 
         threshold = self._correlation_threshold_fn(self._ensemble_size)
+        thresholded_blocks: list[sp.csr_array] = []
+        thresholded_block_rows: list[npt.NDArray[np.int_]] = []
 
         def correlation_callback(
             corr_XY: npt.NDArray[np.float64],
             observations_per_parameter: npt.NDArray[np.int_],
         ) -> npt.NDArray[np.bool_]:
-            return np.abs(corr_XY) > threshold
+            mask = np.abs(corr_XY) > threshold
+            thresholded_blocks.append(
+                sp.csr_array(np.where(mask, corr_XY, 0.0), dtype=np.float32)
+            )
+            return mask
 
         start_time = time.perf_counter()
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
+            if update_idx.size == 0:
+                continue
             X_local = param_ensemble[update_idx, :]
+            thresholded_block_rows.append(update_idx)
 
             param_ensemble[update_idx, :] = self._smoother.assimilate_batch(
                 X=X_local,
@@ -165,6 +182,14 @@ class AdaptiveLocalizationUpdate:
                 n_jobs=NUM_JOBS_ADAPTIVE_LOC,
             )
         elapsed = time.perf_counter() - start_time
+
+        self._save_thresholded_cross_covariance(
+            param_config.name,
+            num_params,
+            threshold,
+            thresholded_blocks,
+            thresholded_block_rows,
+        )
 
         self._progress_callback(
             AnalysisStatusEvent(
@@ -175,3 +200,35 @@ class AdaptiveLocalizationUpdate:
         )
 
         return param_ensemble
+
+    def _save_thresholded_cross_covariance(
+        self,
+        parameter_group: str,
+        num_params: int,
+        threshold: float,
+        blocks: list[sp.csr_array],
+        block_rows: list[npt.NDArray[np.int_]],
+    ) -> None:
+        if self._experiment is None or not blocks:
+            return
+
+        matrix = sp.lil_array((num_params, self._num_obs), dtype=np.float32)
+        updated_rows = np.concatenate(block_rows).astype(np.int64, copy=False)
+        for rows, block in zip(block_rows, blocks, strict=True):
+            matrix[rows, :] = block
+
+        self._experiment.save_sparse_matrix(
+            ADAPTIVE_THRESHOLDED_CROSS_COVARIANCE_ARTIFACT.format(
+                parameter_group=parameter_group
+            ),
+            SparseMatrixArtifact(
+                matrix=matrix.tocsr(),
+                metadata={
+                    "parameter_group": np.asarray(parameter_group),
+                    "threshold": np.asarray(threshold, dtype=np.float64),
+                    "num_parameters": np.asarray(num_params, dtype=np.int64),
+                    "num_observations": np.asarray(self._num_obs, dtype=np.int64),
+                    "updated_parameter_indices": updated_rows,
+                },
+            ),
+        )

--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import humanize
 import numpy as np
+import scipy.sparse as sp
 from iterative_ensemble_smoother import LocalizedESMDA
 
 from ert.analysis.event import AnalysisEvent, AnalysisStatusEvent
@@ -19,6 +20,7 @@ from ert.field_utils import (
     transform_local_ellipse_angle_to_local_coords,
     transform_positions_to_local_field_coordinates,
 )
+from ert.storage import SparseMatrixArtifact
 
 from ._batching import calculate_localization_batch_size, split_by_batch_size
 from ._protocol import ObservationLocations
@@ -27,6 +29,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.config import ParameterConfig
+    from ert.storage import Experiment
 
     from ._protocol import ObservationContext
 
@@ -39,10 +42,12 @@ class DistanceLocalizationUpdate:
         enkf_truncation: float,
         param_type: type[Field | SurfaceConfig],
         progress_callback: Callable[[AnalysisEvent], None],
+        experiment: Experiment | None = None,
     ) -> None:
         self._enkf_truncation = enkf_truncation
         self._param_type = param_type
         self._progress_callback = progress_callback
+        self._experiment = experiment
         self._obs_loc: ObservationLocations | None = None
         self._smoother: LocalizedESMDA | None = None
         self._ensemble_size: int = 0
@@ -137,6 +142,90 @@ class DistanceLocalizationUpdate:
             rho[:, self._location_mask] = located_rho.astype(np.float32, copy=False)
         return rho
 
+    def _load_rho(
+        self,
+        parameter_group: str,
+        nx: int,
+        ny: int,
+    ) -> sp.csr_array | None:
+        if self._experiment is None or self._obs_loc is None:
+            return None
+        artifact = self._experiment.load_sparse_matrix(
+            f"localization/{parameter_group}"
+        )
+        if artifact is None:
+            return None
+        rho = artifact.matrix
+        grid_shape = tuple(artifact.metadata["grid_shape"])
+        if grid_shape != (nx, ny):
+            raise ValueError(
+                f"Stored localization matrix for parameter group {parameter_group!r} "
+                f"has grid shape {grid_shape}, expected {(nx, ny)}"
+            )
+        expected_num_rows = nx * ny
+        if rho.shape[0] != expected_num_rows:
+            raise ValueError(
+                f"Stored localization matrix for parameter group {parameter_group!r} "
+                f"has {rho.shape[0]} grid rows, "
+                f"expected {expected_num_rows}"
+            )
+
+        stored_observation_key = artifact.metadata["observation_key"].astype(str)
+        stored_observation_index = artifact.metadata["observation_index"].astype(str)
+        if len(stored_observation_key) != rho.shape[1]:
+            raise ValueError(
+                f"Stored localization matrix for parameter group {parameter_group!r} "
+                f"has {rho.shape[1]} observation columns, "
+                f"but {len(stored_observation_key)} observation keys"
+            )
+        if len(stored_observation_index) != rho.shape[1]:
+            raise ValueError(
+                f"Stored localization matrix for parameter group {parameter_group!r} "
+                f"has {rho.shape[1]} observation columns, "
+                f"but {len(stored_observation_index)} observation indices"
+            )
+
+        stored_columns = {
+            (key, index): column
+            for column, (key, index) in enumerate(
+                zip(stored_observation_key, stored_observation_index, strict=True)
+            )
+        }
+        columns: list[int] = []
+        for key, index in zip(
+            self._obs_loc.observation_key.astype(str),
+            self._obs_loc.observation_index.astype(str),
+            strict=True,
+        ):
+            column = stored_columns.get((key, index))
+            if column is None:
+                return None
+            columns.append(column)
+        if columns == list(range(rho.shape[1])):
+            return rho
+        return rho[:, columns]
+
+    def _save_rho(
+        self,
+        parameter_group: str,
+        rho_matrix: sp.csr_array,
+        nx: int,
+        ny: int,
+    ) -> None:
+        if self._experiment is None or self._obs_loc is None:
+            return
+        self._experiment.save_sparse_matrix(
+            f"localization/{parameter_group}",
+            SparseMatrixArtifact(
+                matrix=rho_matrix.astype(np.float32),
+                metadata={
+                    "grid_shape": np.asarray((nx, ny), dtype=np.int64),
+                    "observation_key": self._obs_loc.observation_key,
+                    "observation_index": self._obs_loc.observation_index,
+                },
+            ),
+        )
+
     def _update_field(
         self,
         param_ensemble: npt.NDArray[np.floating],
@@ -182,20 +271,23 @@ class DistanceLocalizationUpdate:
             np.zeros_like(self._obs_loc.main_range),
         )
 
-        rho_matrix = calc_rho_for_2d_grid_layer(
-            nx=ertbox.nx,
-            ny=ertbox.ny,
-            xinc=ertbox.xinc,
-            yinc=ertbox.yinc,
-            obs_xpos=xpos,
-            obs_ypos=ypos,
-            obs_main_range=self._obs_loc.main_range,
-            obs_perp_range=self._obs_loc.main_range,
-            obs_anisotropy_angle=ellipse_rotation,
-            axis_orientation=ertbox.axis_orientation,
-        )
-
-        rho_2d = rho_matrix.reshape(ertbox.nx * ertbox.ny, -1)
+        rho_matrix = self._load_rho(param_config.name, ertbox.nx, ertbox.ny)
+        if rho_matrix is None:
+            rho_matrix = sp.csr_array(
+                calc_rho_for_2d_grid_layer(
+                    nx=ertbox.nx,
+                    ny=ertbox.ny,
+                    xinc=ertbox.xinc,
+                    yinc=ertbox.yinc,
+                    obs_xpos=xpos,
+                    obs_ypos=ypos,
+                    obs_main_range=self._obs_loc.main_range,
+                    obs_perp_range=self._obs_loc.main_range,
+                    obs_anisotropy_angle=ellipse_rotation,
+                    axis_orientation=ertbox.axis_orientation,
+                ).reshape(ertbox.nx * ertbox.ny, -1)
+            )
+            self._save_rho(param_config.name, rho_matrix, ertbox.nx, ertbox.ny)
 
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
@@ -203,7 +295,7 @@ class DistanceLocalizationUpdate:
                 continue
             xy_idx = update_idx // ertbox.nz
             rho_batch = self._full_localization_matrix(
-                len(update_idx), rho_2d[xy_idx, :]
+                len(update_idx), rho_matrix[xy_idx, :].toarray()
             )
 
             def localization_callback(
@@ -259,26 +351,33 @@ class DistanceLocalizationUpdate:
                 f"Expected SurfaceConfig.yflip == 1, got {param_config.yflip}"
             )
 
-        rho_matrix = calc_rho_for_2d_grid_layer(
-            nx=param_config.ncol,
-            ny=param_config.nrow,
-            xinc=param_config.xinc,
-            yinc=param_config.yinc,
-            obs_xpos=xpos,
-            obs_ypos=ypos,
-            obs_main_range=self._obs_loc.main_range,
-            obs_perp_range=self._obs_loc.main_range,
-            obs_anisotropy_angle=rotation_angle,
-            axis_orientation=AxisOrientation.LEFT_HANDED,
+        rho_matrix = self._load_rho(
+            param_config.name, param_config.ncol, param_config.nrow
         )
-
-        rho_flat = rho_matrix.reshape(-1, rho_matrix.shape[-1])
+        if rho_matrix is None:
+            rho_matrix = sp.csr_array(
+                calc_rho_for_2d_grid_layer(
+                    nx=param_config.ncol,
+                    ny=param_config.nrow,
+                    xinc=param_config.xinc,
+                    yinc=param_config.yinc,
+                    obs_xpos=xpos,
+                    obs_ypos=ypos,
+                    obs_main_range=self._obs_loc.main_range,
+                    obs_perp_range=self._obs_loc.main_range,
+                    obs_anisotropy_angle=rotation_angle,
+                    axis_orientation=AxisOrientation.LEFT_HANDED,
+                ).reshape(param_config.ncol * param_config.nrow, -1)
+            )
+            self._save_rho(
+                param_config.name, rho_matrix, param_config.ncol, param_config.nrow
+            )
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
             if update_idx.size == 0:
                 continue
             rho_batch = self._full_localization_matrix(
-                len(update_idx), rho_flat[update_idx, :]
+                len(update_idx), rho_matrix[update_idx, :].toarray()
             )
 
             def localization_callback(

--- a/src/ert/analysis/_update_strategies/_protocol.py
+++ b/src/ert/analysis/_update_strategies/_protocol.py
@@ -101,6 +101,12 @@ class ObservationLocations:
     main_range: npt.NDArray[np.floating]
     """Correlation range (radius) for each observation."""
 
+    observation_key: npt.NDArray[np.str_]
+    """Observation keys for observations with location data."""
+
+    observation_index: npt.NDArray[np.str_]
+    """Observation indices for observations with location data."""
+
     location_mask: npt.NDArray[np.bool_]
     """Boolean mask indicating which observations have valid location data."""
 

--- a/src/ert/dark_storage/endpoints/parameters.py
+++ b/src/ert/dark_storage/endpoints/parameters.py
@@ -77,6 +77,42 @@ def get_parameter_std_dev(
     return Response(content=buffer.getvalue(), media_type="application/octet-stream")
 
 
+@router.get("/ensembles/{ensemble_id}/parameters/{key}/localization")
+def get_parameter_localization(
+    *,
+    storage: Storage = DEFAULT_STORAGE,
+    ensemble_id: UUID,
+    key: str,
+    observation_key: str,
+    observation_index: str,
+) -> Response:
+    key = unquote(key)
+    with reraise_as_http_errors(logger):
+        ensemble = storage.get_ensemble(ensemble_id)
+        artifact = ensemble.experiment.load_sparse_matrix(f"localization/{key}")
+
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Localization matrix not found")
+
+    observation_keys = artifact.metadata["observation_key"].astype(str)
+    observation_indices = artifact.metadata["observation_index"].astype(str)
+    matches = np.flatnonzero(
+        (observation_keys == observation_key)
+        & (observation_indices == observation_index)
+    )
+    if matches.size == 0:
+        raise HTTPException(
+            status_code=404, detail="Localization observation not found"
+        )
+
+    nx, ny = artifact.metadata["grid_shape"]
+    buffer = io.BytesIO()
+    # Convert only the selected sparse observation column to dense for serialization.
+    rho = artifact.matrix[:, int(matches[0])].toarray().reshape(nx, ny)
+    np.save(buffer, rho.astype(np.float32))
+    return Response(content=buffer.getvalue(), media_type="application/octet-stream")
+
+
 def data_for_parameter(ensemble: Ensemble, key: str) -> pd.DataFrame:
     param_info = ensemble.experiment.parameter_info.get(key)
 

--- a/src/ert/gui/tools/plot/observation_locations.py
+++ b/src/ert/gui/tools/plot/observation_locations.py
@@ -45,5 +45,9 @@ def transform_observation_locations(
             return ObservationPlotLocations(
                 x=xpos[inside_box].astype(np.float32),
                 y=ypos[inside_box].astype(np.float32),
+                radius_x=np.ones(inside_box.sum(), dtype=np.float64),
+                radius_y=np.ones(inside_box.sum(), dtype=np.float64),
+                observation_key=np.full(inside_box.sum(), "", dtype=str),
+                observation_index=np.full(inside_box.sum(), "", dtype=str),
             )
     return None

--- a/src/ert/gui/tools/plot/plot_api.py
+++ b/src/ert/gui/tools/plot/plot_api.py
@@ -437,6 +437,8 @@ class PlotApi:
                         (
                             pd.DataFrame(
                                 {
+                                    "observation_key": obs["name"],
+                                    "observation_index": obs["x_axis"],
                                     "east": obs["east"],
                                     "north": obs["north"],
                                     "radius": obs["radius"],
@@ -580,3 +582,28 @@ class PlotApi:
                 # Deserialize the numpy array
                 return np.load(io.BytesIO(http_response.content))
             return np.array([])
+
+    def localization_for_parameter(
+        self,
+        key: str,
+        ensemble_id: str,
+        observation_key: str,
+        observation_index: str,
+    ) -> npt.NDArray[np.float32] | None:
+        ensemble = self._get_ensemble_by_id(ensemble_id)
+        if not ensemble:
+            return None
+
+        with create_ertserver_client(self.ens_path) as client:
+            http_response = client.get(
+                f"/ensembles/{ensemble.id}/parameters/{PlotApi.escape(key)}/localization",
+                params={
+                    "observation_key": observation_key,
+                    "observation_index": observation_index,
+                },
+                timeout=self._timeout,
+            )
+
+            if http_response.status_code != 200:
+                return None
+            return np.load(io.BytesIO(http_response.content))

--- a/src/ert/gui/tools/plot/plot_types.py
+++ b/src/ert/gui/tools/plot/plot_types.py
@@ -1,12 +1,86 @@
-from __future__ import annotations
-
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
+
+from ert.field_utils import (
+    AxisOrientation,
+    ErtboxParameters,
+    transform_positions_to_local_field_coordinates,
+)
 
 
 @dataclass(frozen=True)
 class ObservationPlotLocations:
-    x: npt.NDArray[np.float32]
-    y: npt.NDArray[np.float32]
+    x: npt.NDArray[np.float64]
+    y: npt.NDArray[np.float64]
+    radius_x: npt.NDArray[np.float64]
+    radius_y: npt.NDArray[np.float64]
+    observation_key: npt.NDArray[np.str_]
+    observation_index: npt.NDArray[np.str_]
+
+
+def transform_observation_locations(
+    obs_loc_df: pd.DataFrame, ertbox_params: ErtboxParameters
+) -> ObservationPlotLocations | None:
+    """Return observation plot geometry and identity columns for localized obs."""
+    if (
+        ertbox_params.origin is not None
+        and ertbox_params.rotation_angle is not None
+        and ertbox_params.xinc is not None
+        and ertbox_params.yinc is not None
+        and not obs_loc_df.empty
+    ):
+        xpos, ypos = transform_positions_to_local_field_coordinates(
+            ertbox_params.origin,
+            ertbox_params.rotation_angle,
+            obs_loc_df["east"].to_numpy(dtype=np.float64),
+            obs_loc_df["north"].to_numpy(dtype=np.float64),
+        )
+        xpos /= ertbox_params.xinc
+        ypos /= ertbox_params.yinc
+        height, width = (
+            ertbox_params.ny,
+            ertbox_params.nx,
+        )
+        if ertbox_params.axis_orientation == AxisOrientation.RIGHT_HANDED:
+            ypos = height - ypos
+
+        radius = obs_loc_df["radius"].to_numpy(dtype=np.float64)
+        radius_x = radius / ertbox_params.xinc
+        radius_y = radius / ertbox_params.yinc
+
+        inside_box = (
+            np.isfinite(xpos)
+            & np.isfinite(ypos)
+            & np.isfinite(radius_x)
+            & np.isfinite(radius_y)
+            & (xpos >= 0)
+            & (xpos < width)
+            & (ypos >= 0)
+            & (ypos < height)
+        )
+        if inside_box.any():
+            observation_key = obs_loc_df.get(
+                "observation_key", pd.Series("", index=obs_loc_df.index)
+            ).to_numpy(dtype=str)
+            observation_index = obs_loc_df.get(
+                "observation_index", pd.Series("", index=obs_loc_df.index)
+            ).to_numpy(dtype=str)
+            return ObservationPlotLocations(
+                x=xpos[inside_box],
+                y=ypos[inside_box],
+                radius_x=radius_x[inside_box],
+                radius_y=radius_y[inside_box],
+                observation_key=observation_key[inside_box],
+                observation_index=observation_index[inside_box],
+            )
+    return None
+
+
+LocalizationProvider: TypeAlias = Callable[
+    [str, str, str, str], npt.NDArray[np.float32] | None
+]

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -30,7 +30,7 @@ from ert.config.gen_kw_config import GenKwConfig
 from ert.gui.icon_utils import load_icon
 
 from .plot_api import EnsembleObject, PlotApiKeyDefinition
-from .plot_types import ObservationPlotLocations
+from .plot_types import LocalizationProvider, ObservationPlotLocations
 
 if TYPE_CHECKING:
     from .plottery import PlotContext
@@ -52,6 +52,7 @@ class Plotter(Protocol):
         observations: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None: ...
 
@@ -252,6 +253,7 @@ class PlotWidget(QWidget):
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
         key_def: PlotApiKeyDefinition | None = None,
+        localization_provider: LocalizationProvider | None = None,
     ) -> None:
         self.resetPlot()
         try:  # noqa: PLW0717
@@ -273,7 +275,8 @@ class PlotWidget(QWidget):
                 observations,
                 std_dev_images,
                 obs_loc,
-                key_def,
+                localization_provider=localization_provider,
+                key_def=key_def,
             )
             self._canvas.draw()
         except Exception as e:

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -37,7 +37,7 @@ from .data_type_keys_widget import DataTypeKeysWidget
 from .observation_locations import transform_observation_locations
 from .plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
 from .plot_ensemble_selection_widget import EnsembleSelectionWidget
-from .plot_types import ObservationPlotLocations
+from .plot_types import ObservationPlotLocations, transform_observation_locations
 from .plot_widget import Plotter, PlotWidget
 from .plottery import PlotConfig, PlotContext
 from .plottery.plots import (
@@ -570,6 +570,11 @@ class PlotWindow(QMainWindow):
                 std_dev_images,
                 obs_loc,
                 key_def,
+                localization_provider=(
+                    self._api.localization_for_parameter
+                    if obs_loc is not None
+                    else None
+                ),
             )
 
     def _updateCustomizer(

--- a/src/ert/gui/tools/plot/plottery/plots/cesp.py
+++ b/src/ert/gui/tools/plot/plottery/plots/cesp.py
@@ -9,6 +9,7 @@ from matplotlib.patches import Rectangle
 from typing_extensions import TypedDict
 
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 
 from .plot_tools import ConditionalAxisFormatter, PlotTools
 
@@ -48,6 +49,7 @@ class CrossEnsembleStatisticsPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         plotCrossEnsembleStatistics(

--- a/src/ert/gui/tools/plot/plottery/plots/distribution.py
+++ b/src/ert/gui/tools/plot/plottery/plots/distribution.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 
 from .plot_tools import ConditionalAxisFormatter, PlotTools
 
@@ -31,6 +32,7 @@ class DistributionPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         plotDistribution(figure, plot_context, ensemble_to_data_map, observation_data)

--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -7,6 +7,7 @@ import pandas as pd
 from matplotlib.lines import Line2D
 from resfo_utilities import is_rate
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.tools.plot.plottery.plot_context import PlotType
 from ert.gui.utils import is_everest_application
 
@@ -37,6 +38,7 @@ class EnsemblePlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         is_everest = is_everest_application()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
@@ -6,6 +6,8 @@ import pandas as pd
 from matplotlib.lines import Line2D
 from matplotlib.ticker import MaxNLocator
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
+
 from .plot_tools import PlotTools
 
 if TYPE_CHECKING:
@@ -44,6 +46,7 @@ class EverestBatchObjectiveFunctionPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         config = plot_context.plotConfig()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_constraints_plot.py
@@ -6,6 +6,7 @@ import pandas as pd
 from matplotlib.patches import Patch
 from matplotlib.ticker import MaxNLocator
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.utils import LEGEND_THRESHOLD
 
 from .plot_tools import PlotTools
@@ -45,6 +46,7 @@ class EverestConstraintsPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         config = plot_context.plotConfig()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from matplotlib.ticker import MaxNLocator
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.tools.plot.plottery.plot_context import PlotType
 from ert.gui.utils import LEGEND_THRESHOLD
 
@@ -49,6 +50,7 @@ class EverestControlsPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         config = plot_context.plotConfig()

--- a/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_gradients_plot.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.tools.plot.plottery.plot_context import PlotType
 
 from .plot_tools import ConditionalAxisFormatter, PlotTools
@@ -36,6 +37,7 @@ class EverestGradientsPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         axes = figure.add_subplot(111)

--- a/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_objective_function_plot.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from matplotlib.ticker import MaxNLocator
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.tools.plot.plottery.plot_context import PlotType
 from ert.gui.utils import LEGEND_THRESHOLD
 
@@ -45,6 +46,7 @@ class EverestObjectiveFunctionPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         config = plot_context.plotConfig()

--- a/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
+++ b/src/ert/gui/tools/plot/plottery/plots/gaussian_kde.py
@@ -7,6 +7,7 @@ import pandas as pd
 from scipy.stats import gaussian_kde
 
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 
 from .plot_tools import ConditionalAxisFormatter, PlotTools
 
@@ -32,6 +33,7 @@ class GaussianKDEPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         plotGaussianKDE(figure, plot_context, ensemble_to_data_map, observation_data)

--- a/src/ert/gui/tools/plot/plottery/plots/histogram.py
+++ b/src/ert/gui/tools/plot/plottery/plots/histogram.py
@@ -9,6 +9,7 @@ import pandas as pd
 from matplotlib.patches import Rectangle
 
 from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.shared.status.utils import convert_to_numeric
 
 from .plot_tools import ConditionalAxisFormatter, PlotTools
@@ -35,6 +36,7 @@ class HistogramPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         plotHistogram(figure, plot_context, ensemble_to_data_map)

--- a/src/ert/gui/tools/plot/plottery/plots/misfits.py
+++ b/src/ert/gui/tools/plot/plottery/plots/misfits.py
@@ -10,6 +10,8 @@ import seaborn as sns
 from matplotlib import pyplot as plt
 from matplotlib.lines import Line2D
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
+
 if TYPE_CHECKING:
     import numpy.typing as npt
     from matplotlib.figure import Figure
@@ -156,6 +158,7 @@ class MisfitsPlot:
         observation_data: pd.DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         assert key_def is not None

--- a/src/ert/gui/tools/plot/plottery/plots/statistics.py
+++ b/src/ert/gui/tools/plot/plottery/plots/statistics.py
@@ -7,6 +7,7 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
 from pandas import DataFrame
 
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 from ert.gui.tools.plot.plottery import PlotConfig, PlotContext, PlotStyle
 
 from .history import plotHistory
@@ -35,6 +36,7 @@ class StatisticsPlot:
         observation_data: DataFrame,
         std_dev_images: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         config = plot_context.plotConfig()

--- a/src/ert/gui/tools/plot/plottery/plots/std_dev.py
+++ b/src/ert/gui/tools/plot/plottery/plots/std_dev.py
@@ -1,25 +1,40 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from matplotlib.colors import LinearSegmentedColormap, to_rgba
 from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from ert.gui.tools.plot.plot_types import ObservationPlotLocations
+from ert.field_utils.field_utils import gaspari_cohn
+from ert.gui.tools.plot.plot_types import LocalizationProvider, ObservationPlotLocations
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.backend_bases import MouseEvent
+
     from ert.gui.tools.plot.plot_api import EnsembleObject, PlotApiKeyDefinition
     from ert.gui.tools.plot.plottery import PlotContext
 
 
 class StdDevPlot:
+    _PICK_RADIUS_PIXELS = 8.0
+    # Show localization rho as increasing opacity over a fixed orange color.
+    _LOCALIZATION_RHO_CMAP = LinearSegmentedColormap.from_list(
+        "ert_localization_rho",
+        [(*to_rgba("#ffb000")[:3], 0.0), (*to_rgba("#ffb000")[:3], 0.35)],
+    )
+
     def __init__(self) -> None:
         self.dimensionality = 3
         self.requires_observations = False
+        self._selected_observation_artists: dict[Any, list[Any]] = {}
+        self._observation_click_callback_ids: dict[Any, list[int]] = {}
 
     def plot(
         self,
@@ -29,9 +44,12 @@ class StdDevPlot:
         observation_data: pd.DataFrame,
         std_dev_data: dict[str, npt.NDArray[np.float32]],
         obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         ensembles = plot_context.ensembles()
+        self._clear_observation_callbacks(figure)
+        self._selected_observation_artists.clear()
         if (ensemble_count := len(ensembles)) == 0:
             return
         layer = plot_context.layer
@@ -63,21 +81,37 @@ class StdDevPlot:
                     vmin = min(vmin, float(np.min(data)))
                     vmax = max(vmax, float(np.max(data)))
 
-                    im = ax_heat.imshow(data, cmap="viridis", aspect="equal")
+                    im = ax_heat.imshow(data.T, cmap="viridis", aspect="equal")
 
                     if obs_loc is not None:
-                        xs = obs_loc.x - 0.5
-                        ys = obs_loc.y - 0.5
+                        xs = obs_loc.x.astype(np.float32) - 0.5
+                        ys = obs_loc.y.astype(np.float32) - 0.5
 
                         ax_heat.scatter(
                             xs,
                             ys,
-                            c="red",
+                            c="tab:orange",
                             marker="o",
                             edgecolors="black",
                             linewidths=0.5,
                             label="Observations",
+                            zorder=4,
                         )
+                        callback_id = figure.canvas.mpl_connect(
+                            "button_press_event",
+                            partial(
+                                self._on_observation_click,
+                                ax=ax_heat,
+                                data_shape=data.shape,
+                                parameter_key=plot_context.key(),
+                                ensemble_id=ensemble.id,
+                                obs_loc=obs_loc,
+                                localization_provider=localization_provider,
+                            ),
+                        )
+                        self._observation_click_callback_ids.setdefault(
+                            figure.canvas, []
+                        ).append(callback_id)
                     heatmaps.append(im)
 
                     ax_box.boxplot(data.flatten(), orientation="vertical", widths=0.5)
@@ -135,6 +169,143 @@ class StdDevPlot:
             if padding > 0.0:
                 for ax_box in boxplot_axes:
                     ax_box.set_ylim(vmin - padding, vmax + padding)
+
+    @staticmethod
+    def _localization_overlay(
+        data_shape: tuple[int, ...],
+        observation: npt.NDArray[np.float32],
+    ) -> npt.NDArray[np.float32]:
+        x, y, radius_x, radius_y = observation[:4].astype(np.float32)
+        nx, ny = data_shape[:2]
+        x_grid, y_grid = np.meshgrid(
+            np.linspace(0, nx - 1, nx, dtype=np.float32),
+            np.linspace(0, ny - 1, ny, dtype=np.float32),
+        )
+        distance = np.hypot(
+            (x_grid - (x - 0.5)) / radius_x,
+            (y_grid - (y - 0.5)) / radius_y,
+        )
+        taper = gaspari_cohn(distance).astype(np.float32)
+        overlay = np.zeros((*taper.shape, 4), dtype=np.float32)
+        overlay[..., :3] = to_rgba("#ffb000")[:3]
+        overlay[..., 3] = taper * 0.35
+        return overlay
+
+    def _on_observation_click(
+        self,
+        event: MouseEvent,
+        ax: Axes,
+        data_shape: tuple[int, ...],
+        parameter_key: str,
+        ensemble_id: str,
+        obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None,
+    ) -> None:
+        if event.inaxes != ax or event.xdata is None or event.ydata is None:
+            self._clear_selected_observation(ax)
+            if event.canvas is not None:
+                event.canvas.draw_idle()
+            return
+
+        assert obs_loc is not None
+        obs_xy = np.column_stack((obs_loc.x, obs_loc.y)).astype(np.float32) - 0.5
+        display_points = ax.transData.transform(obs_xy)
+        distances = np.hypot(
+            display_points[:, 0] - event.x, display_points[:, 1] - event.y
+        )
+        index = int(np.argmin(distances))
+        if distances[index] > self._PICK_RADIUS_PIXELS:
+            self._clear_selected_observation(ax)
+            if event.canvas is not None:
+                event.canvas.draw_idle()
+            return
+
+        self._draw_selected_observation(
+            ax,
+            data_shape,
+            parameter_key,
+            ensemble_id,
+            index,
+            obs_loc,
+            localization_provider,
+        )
+        if event.canvas is not None:
+            event.canvas.draw_idle()
+
+    def _clear_selected_observation(self, ax: Axes) -> None:
+        for artist in self._selected_observation_artists.pop(ax, []):
+            artist.remove()
+
+    def _clear_observation_callbacks(self, figure: Figure) -> None:
+        for callback_id in self._observation_click_callback_ids.pop(figure.canvas, []):
+            figure.canvas.mpl_disconnect(callback_id)
+
+    def _draw_selected_observation(
+        self,
+        ax: Axes,
+        data_shape: tuple[int, ...],
+        parameter_key: str,
+        ensemble_id: str,
+        observation_index: int,
+        obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None = None,
+    ) -> None:
+        self._clear_selected_observation(ax)
+        assert obs_loc is not None
+        radius_x = obs_loc.radius_x[observation_index]
+        radius_y = obs_loc.radius_y[observation_index]
+        if radius_x <= 0.0 or radius_y <= 0.0:
+            return
+        rho = self._rho_for_observation(
+            parameter_key,
+            ensemble_id,
+            observation_index,
+            obs_loc,
+            localization_provider,
+        )
+        overlay = ax.imshow(
+            rho.T
+            if rho is not None
+            else self._localization_overlay(
+                data_shape,
+                np.array(
+                    [
+                        obs_loc.x[observation_index],
+                        obs_loc.y[observation_index],
+                        radius_x,
+                        radius_y,
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+            aspect="equal",
+            cmap=self._LOCALIZATION_RHO_CMAP if rho is not None else None,
+            interpolation="bilinear",
+            extent=(-0.5, data_shape[0] - 0.5, data_shape[1] - 0.5, -0.5),
+            vmin=0.0 if rho is not None else None,
+            vmax=1.0 if rho is not None else None,
+            zorder=2,
+        )
+        ax.set_xlim(-0.5, data_shape[0] - 0.5)
+        ax.set_ylim(data_shape[1] - 0.5, -0.5)
+        self._selected_observation_artists[ax] = [overlay]
+
+    @staticmethod
+    def _rho_for_observation(
+        parameter_key: str,
+        ensemble_id: str,
+        observation_index: int,
+        obs_loc: ObservationPlotLocations | None,
+        localization_provider: LocalizationProvider | None,
+    ) -> npt.NDArray[np.float32] | None:
+        if localization_provider is None or obs_loc is None:
+            return None
+        return localization_provider(
+            parameter_key,
+            ensemble_id,
+            obs_loc.observation_key[observation_index],
+            obs_loc.observation_index[observation_index],
+        )
 
     @staticmethod
     def _colorbar(mappable: Any) -> Any:

--- a/src/ert/run_models/update_run_model.py
+++ b/src/ert/run_models/update_run_model.py
@@ -67,6 +67,7 @@ class UpdateRunModel(RunModel, UpdateRunModelConfig):
             enkf_truncation=self.analysis_settings.enkf_truncation,
             correlation_threshold=self.analysis_settings.correlation_threshold,
             progress_callback=progress_callback,
+            experiment=posterior.experiment,
         )
 
         smoother_update(

--- a/src/ert/storage/__init__.py
+++ b/src/ert/storage/__init__.py
@@ -4,7 +4,12 @@ import os
 from pathlib import Path
 
 from .local_ensemble import LocalEnsemble, load_realization_parameters_and_responses
-from .local_experiment import ExperimentState, ExperimentStatus, LocalExperiment
+from .local_experiment import (
+    ExperimentState,
+    ExperimentStatus,
+    LocalExperiment,
+    SparseMatrixArtifact,
+)
 from .local_storage import LocalStorage, local_storage_set_ert_config
 from .mode import Mode, ModeLiteral
 from .realization_storage_state import RealizationStorageState
@@ -61,6 +66,7 @@ __all__ = [
     "ExperimentStatus",
     "Mode",
     "RealizationStorageState",
+    "SparseMatrixArtifact",
     "Storage",
     "load_realization_parameters_and_responses",
     "local_storage_set_ert_config",

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import logging
 import shutil
 from collections.abc import Generator
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum, auto
 from functools import cached_property
@@ -12,7 +14,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID
 
+import numpy as np
+import numpy.typing as npt
 import polars as pl
+import scipy.sparse as sp
 from pydantic import BaseModel, Field, TypeAdapter
 from surfio import IrapSurface
 from typing_extensions import TypedDict
@@ -34,6 +39,7 @@ from ert.config._create_observation_dataframes import create_observation_datafra
 from ert.config._observations import Observation
 from ert.config.response_config import DerivedResponseConfig
 
+from .local_ensemble import _escape_filename
 from .mode import BaseMode, Mode, require_write
 
 if TYPE_CHECKING:
@@ -41,6 +47,12 @@ if TYPE_CHECKING:
     from .local_storage import LocalStorage
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SparseMatrixArtifact:
+    matrix: sp.csr_array
+    metadata: dict[str, npt.NDArray[Any]]
 
 
 class ExperimentState(StrEnum):
@@ -146,6 +158,8 @@ class LocalExperiment(BaseMode):
 
     _templates_file = Path("templates.json")
     _index_file = Path("index.json")
+    _localization_dir = Path("localization")
+    _sparse_matrices_dir = Path("sparse_matrices")
 
     def __init__(
         self,
@@ -409,6 +423,45 @@ class LocalExperiment(BaseMode):
         """
 
         return IrapSurface.from_ascii_file(self.mount_point / f"{name}.irap")
+
+    @require_write
+    def save_sparse_matrix(
+        self, name: str, sparse_matrix: SparseMatrixArtifact
+    ) -> None:
+        output_dir = self.mount_point / self._sparse_matrices_dir
+        output_dir.mkdir(exist_ok=True)
+        escaped_name = _escape_filename(name)
+        path = output_dir / f"{escaped_name}.npz"
+        metadata_path = output_dir / f"{escaped_name}.metadata.npz"
+
+        matrix = sparse_matrix.matrix
+        buffer = io.BytesIO()
+        sp.save_npz(buffer, matrix, compressed=True)
+        self._storage._write_transaction(path, buffer.getvalue())
+
+        metadata_buffer = io.BytesIO()
+        np.savez_compressed(
+            metadata_buffer,
+            sparse_shape=np.asarray(matrix.shape, dtype=np.int64),
+            **sparse_matrix.metadata,
+        )
+        self._storage._write_transaction(metadata_path, metadata_buffer.getvalue())
+
+    def load_sparse_matrix(self, name: str) -> SparseMatrixArtifact | None:
+        escaped_name = _escape_filename(name)
+        path = self.mount_point / self._sparse_matrices_dir / f"{escaped_name}.npz"
+        metadata_path = (
+            self.mount_point
+            / self._sparse_matrices_dir
+            / f"{escaped_name}.metadata.npz"
+        )
+        if not path.exists() or not metadata_path.exists():
+            return None
+
+        matrix = sp.load_npz(path)
+        with np.load(metadata_path, allow_pickle=False) as archive:
+            metadata = {key: archive[key] for key in archive.files}
+        return SparseMatrixArtifact(matrix=sp.csr_array(matrix), metadata=metadata)
 
     @cached_property
     def parameter_configuration(self) -> dict[str, ParameterConfig]:

--- a/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_distance_localization.py
@@ -75,6 +75,7 @@ def test_that_distance_localization_reduces_posterior_variance():
         experiment = storage.get_experiment_by_name("heat_dl")
         prior = experiment.get_ensemble_by_name("iter-0")
         posterior = experiment.get_ensemble_by_name("iter-1")
+        assert experiment.load_sparse_matrix("localization/COND") is not None
 
         assert_stronger_variance_reduction_at_observation_location(
             prior, posterior, "COND", obs_pos=(25, 25), unobserved_pos=(5, 5)

--- a/tests/ert/unit_tests/analysis/test_adaptive_localization.py
+++ b/tests/ert/unit_tests/analysis/test_adaptive_localization.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from ert.analysis._update_strategies._adaptive import (
+    ADAPTIVE_THRESHOLDED_CROSS_COVARIANCE_ARTIFACT,
+    AdaptiveLocalizationUpdate,
+)
+from ert.analysis._update_strategies._protocol import ObservationContext
+from ert.config import GenKwConfig
+from ert.config.parameter_config import LocalizationType
+from ert.storage import SparseMatrixArtifact
+
+
+def _noop_callback(_event: object) -> None:
+    pass
+
+
+@dataclass
+class _Experiment:
+    sparse_matrices: dict[str, SparseMatrixArtifact]
+
+    def save_sparse_matrix(
+        self, name: str, sparse_matrix: SparseMatrixArtifact
+    ) -> None:
+        self.sparse_matrices[name] = sparse_matrix
+
+
+def test_that_adaptive_localization_stores_thresholded_cross_covariance() -> None:
+    responses = np.array(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [3.0, 2.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    param_ensemble = np.array(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [1.0, 1.0, 1.0, 1.0],
+            [3.0, 2.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    obs_context = ObservationContext(
+        responses=responses,
+        observation_values=np.array([1.5, 1.5], dtype=np.float64),
+        observation_errors=np.array([0.1, 0.1], dtype=np.float64),
+        observation_perturbations=np.zeros_like(responses),
+        observation_locations=None,
+    )
+    experiment = _Experiment({})
+    updater = AdaptiveLocalizationUpdate(
+        correlation_threshold=lambda _ensemble_size: 0.5,
+        enkf_truncation=1.0,
+        progress_callback=_noop_callback,
+        experiment=experiment,
+    )
+    updater.prepare(obs_context)
+
+    updater.update(
+        param_ensemble.copy(),
+        GenKwConfig(
+            name="PARAM",
+            group="PARAM",
+            distribution={"name": "uniform", "min": 0, "max": 1},
+            update_strategy=LocalizationType.ADAPTIVE,
+        ),
+        non_zero_variance_mask=np.array([True, False, True]),
+    )
+
+    artifact_name = ADAPTIVE_THRESHOLDED_CROSS_COVARIANCE_ARTIFACT.format(
+        parameter_group="PARAM"
+    )
+    artifact = experiment.sparse_matrices[artifact_name]
+
+    np.testing.assert_allclose(
+        artifact.matrix.toarray(),
+        np.array(
+            [
+                [1.0, -1.0],
+                [0.0, 0.0],
+                [-1.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    assert artifact.matrix.dtype == np.float32
+    assert artifact.metadata["parameter_group"] == "PARAM"
+    assert artifact.metadata["threshold"] == pytest.approx(0.5)
+    assert artifact.metadata["num_parameters"] == 3
+    assert artifact.metadata["num_observations"] == 2
+    np.testing.assert_array_equal(
+        artifact.metadata["updated_parameter_indices"], np.array([0, 2])
+    )

--- a/tests/ert/unit_tests/analysis/test_distance_localization.py
+++ b/tests/ert/unit_tests/analysis/test_distance_localization.py
@@ -108,6 +108,8 @@ def test_that_distance_localization_updates_all_z_layers_at_observation_xy(
         xpos=obs_x,
         ypos=obs_y,
         main_range=main_range,
+        observation_key=np.array(["obs"]),
+        observation_index=np.array(["0"]),
         location_mask=np.ones(responses.shape[0], dtype=bool),
     )
 
@@ -289,6 +291,8 @@ def test_that_distance_localization_matrix_uses_float32() -> None:
             xpos=np.array([0.0]),
             ypos=np.array([0.0]),
             main_range=np.array([1.0]),
+            observation_key=np.array(["obs"]),
+            observation_index=np.array(["0"]),
             location_mask=np.array([True, False]),
         ),
     )
@@ -343,6 +347,8 @@ def test_that_mixed_unlocated_observations_update_distant_field_parameters(
             xpos=np.array([0.5]),
             ypos=np.array([0.5]),
             main_range=np.array([1.0]),
+            observation_key=np.array(["obs"]),
+            observation_index=np.array(["0"]),
             location_mask=np.array([True, False]),
         ),
     )
@@ -404,6 +410,8 @@ def test_that_mixed_unlocated_observations_update_distant_surface_parameters(
             xpos=np.array([0.5]),
             ypos=np.array([0.5]),
             main_range=np.array([1.0]),
+            observation_key=np.array(["obs"]),
+            observation_index=np.array(["0"]),
             location_mask=np.array([True, False]),
         ),
     )
@@ -458,6 +466,8 @@ def test_that_distance_localization_batch_size_does_not_change_result(
             xpos=np.array([0.5, 2.5]),
             ypos=np.array([0.5, 2.5]),
             main_range=np.array([2.0, 2.0]),
+            observation_key=np.array(["obs", "obs"]),
+            observation_index=np.array(["0", "1"]),
             location_mask=np.ones(2, dtype=bool),
         ),
     )
@@ -505,6 +515,8 @@ def test_that_distance_localization_respects_non_zero_variance_mask(
             xpos=np.array([0.5]),
             ypos=np.array([0.5]),
             main_range=np.array([5.0]),
+            observation_key=np.array(["obs"]),
+            observation_index=np.array(["0"]),
             location_mask=np.ones(1, dtype=bool),
         ),
     )

--- a/tests/ert/unit_tests/analysis/test_obs_context_preservation.py
+++ b/tests/ert/unit_tests/analysis/test_obs_context_preservation.py
@@ -32,6 +32,8 @@ def _make_context(
         xpos=np.linspace(0.5, n_obs - 0.5, n_obs),
         ypos=np.full(n_obs, 0.5),
         main_range=np.full(n_obs, 5.0),
+        observation_key=np.array([f"obs_{i}" for i in range(n_obs)]),
+        observation_index=np.array([str(i) for i in range(n_obs)]),
         location_mask=np.ones(n_obs, dtype=bool),
     )
     return ObservationContext(

--- a/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
+++ b/tests/ert/unit_tests/gui/plottery/test_stddev_plot.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.backend_bases import MouseButton, MouseEvent
+from matplotlib.colors import to_rgba
 from matplotlib.figure import Figure
 
 from ert.gui.tools.plot.plot_api import EnsembleObject
@@ -21,6 +23,7 @@ def plot_context():
     ]
     context.history_data = None
     context.layer = 0
+    context.key.return_value = "FIELD"
     context.plotConfig.return_value = PlotConfig(title="StdDev Plot")
     return context
 
@@ -32,6 +35,10 @@ def test_stddev_plot_shows_boxplot(plot_context: PlotContext):
     obs_loc = ObservationPlotLocations(
         x=np.array([1, 3], dtype=np.float32),
         y=np.array([2, 4], dtype=np.float32),
+        radius_x=np.ones(2, dtype=np.float64),
+        radius_y=np.ones(2, dtype=np.float64),
+        observation_key=np.full(2, "", dtype=str),
+        observation_index=np.full(2, "", dtype=str),
     )
     StdDevPlot().plot(
         figure,
@@ -55,6 +62,156 @@ def test_stddev_plot_shows_boxplot(plot_context: PlotContext):
         annotation[0].get_text()
         == f"Min: {min_value:.2f}\nMean: {mean_value:.2f}\nMax: {max_value:.2f}"
     )
+
+    assert len(ax[0].images) == 1
+    assert len(ax[0].collections) == 1
+
+
+def test_stddev_plot_can_show_gaspari_cohn_localization_overlay_on_click(
+    plot_context: PlotContext,
+):
+    figure = plt.figure()
+    std_dev_data = np.ones((5, 5))
+    obs_loc = ObservationPlotLocations(
+        x=np.array([3], dtype=np.float64),
+        y=np.array([3], dtype=np.float64),
+        radius_x=np.array([1.0], dtype=np.float64),
+        radius_y=np.array([1.0], dtype=np.float64),
+        observation_key=np.array(["obs"], dtype=str),
+        observation_index=np.array(["0"], dtype=str),
+    )
+
+    StdDevPlot().plot(
+        figure,
+        plot_context,
+        {},
+        {},
+        {"id": std_dev_data},
+        obs_loc,
+    )
+
+    ax = figure.axes
+    assert len(ax[0].images) == 1
+    assert len(ax[0].collections) == 1
+
+    figure.canvas.draw()
+    display_x, display_y = ax[0].transData.transform((2.5, 2.5))
+    event = MouseEvent(
+        "button_press_event",
+        figure.canvas,
+        display_x,
+        display_y,
+        MouseButton.LEFT,
+    )
+    figure.canvas.callbacks.process("button_press_event", event)
+
+    overlay = ax[0].images[1].get_array()
+    assert overlay.shape == (5, 5, 4)
+    assert overlay.dtype == np.float32
+    alpha = overlay[:, :, 3]
+    max_alpha_index = np.unravel_index(np.argmax(alpha), alpha.shape)
+    assert overlay[*max_alpha_index, :3].tolist() == pytest.approx(
+        to_rgba("#ffb000")[:3]
+    )
+    assert 0.0 < alpha.max() <= 0.35
+    assert alpha[0, 0] == pytest.approx(0.0)
+
+    assert len(ax[0].images) == 2
+    assert len(ax[0].collections) == 1
+    assert ax[0].get_xlim() == pytest.approx((-0.5, 4.5))
+    assert ax[0].get_ylim() == pytest.approx((4.5, -0.5))
+
+
+def test_stddev_plot_maps_observation_overlay_to_rectangular_field_coordinates(
+    plot_context: PlotContext,
+):
+    figure = plt.figure()
+    std_dev_data = np.arange(15, dtype=np.float32).reshape(3, 5)
+    obs_loc = ObservationPlotLocations(
+        x=np.array([2], dtype=np.float64),
+        y=np.array([4], dtype=np.float64),
+        radius_x=np.array([1.0], dtype=np.float64),
+        radius_y=np.array([2.0], dtype=np.float64),
+        observation_key=np.array(["obs"], dtype=str),
+        observation_index=np.array(["0"], dtype=str),
+    )
+
+    StdDevPlot().plot(
+        figure,
+        plot_context,
+        {},
+        {},
+        {"id": std_dev_data},
+        obs_loc,
+    )
+
+    ax = figure.axes[0]
+    assert ax.images[0].get_array().shape == (5, 3)
+
+    figure.canvas.draw()
+    display_x, display_y = ax.transData.transform((1.5, 3.5))
+    event = MouseEvent(
+        "button_press_event",
+        figure.canvas,
+        display_x,
+        display_y,
+        MouseButton.LEFT,
+    )
+    figure.canvas.callbacks.process("button_press_event", event)
+
+    assert ax.images[1].get_array().shape == (5, 3, 4)
+    assert len(ax.images) == 2
+    assert len(ax.collections) == 1
+    assert ax.get_xlim() == pytest.approx((-0.5, 2.5))
+    assert ax.get_ylim() == pytest.approx((4.5, -0.5))
+
+
+def test_stddev_plot_prefers_persisted_rho_overlay(plot_context: PlotContext):
+    figure = plt.figure()
+    std_dev_data = np.ones((3, 3), dtype=np.float32)
+    obs_loc = ObservationPlotLocations(
+        x=np.array([2], dtype=np.float64),
+        y=np.array([2], dtype=np.float64),
+        radius_x=np.array([1.0], dtype=np.float64),
+        radius_y=np.array([1.0], dtype=np.float64),
+        observation_key=np.array(["obs"], dtype=str),
+        observation_index=np.array(["0"], dtype=str),
+    )
+    rho = np.zeros((3, 3), dtype=np.float32)
+    rho[0, 1] = 1.0
+    localization_provider = Mock(return_value=rho)
+
+    StdDevPlot().plot(
+        figure,
+        plot_context,
+        {},
+        {},
+        {"id": std_dev_data},
+        obs_loc,
+        localization_provider,
+    )
+
+    ax = figure.axes[0]
+    figure.canvas.draw()
+    display_x, display_y = ax.transData.transform((1.5, 1.5))
+    event = MouseEvent(
+        "button_press_event",
+        figure.canvas,
+        display_x,
+        display_y,
+        MouseButton.LEFT,
+    )
+    figure.canvas.callbacks.process("button_press_event", event)
+
+    localization_provider.assert_called_once_with("FIELD", "id", "obs", "0")
+    overlay = ax.images[1]
+    assert overlay.get_array().shape == (3, 3)
+    assert overlay.get_array()[1, 0] == pytest.approx(1.0)
+    assert overlay.get_array().sum() == pytest.approx(1.0)
+    assert overlay.cmap(0.0) == pytest.approx((*to_rgba("#ffb000")[:3], 0.0))
+    assert overlay.cmap(1.0) == pytest.approx((*to_rgba("#ffb000")[:3], 0.35))
+    assert len(ax.images) == 2
+    assert len(ax.collections) == 1
 
 
 def test_that_stddev_plot_does_not_crash_and_returns_early_when_no_ensembles():

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_types.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_types.py
@@ -1,0 +1,102 @@
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+
+from ert.field_utils import AxisOrientation, ErtboxParameters
+from ert.gui.tools.plot.plot_types import transform_observation_locations
+
+
+@pytest.mark.parametrize(
+    (
+        "east",
+        "north",
+        "radius",
+        "ertbox_params",
+        "result_loc",
+    ),
+    [
+        pytest.param(
+            [1, 2],
+            [0, 0],
+            [100.0, 200.0],
+            ErtboxParameters(
+                origin=(1000.0, 1000.0),
+                rotation_angle=0.0,
+                nx=10,
+                ny=10,
+                nz=10,
+                axis_orientation=AxisOrientation.LEFT_HANDED,
+                xinc=100.0,
+                yinc=200.0,
+            ),
+            None,
+            id="Observations outside the field (left-handed)",
+        ),
+        pytest.param(
+            [1.0, 101.0],
+            [201.0, 201.0],
+            [100.0, 200.0],
+            ErtboxParameters(
+                origin=(1.0, 1.0),
+                rotation_angle=0.0,
+                nx=10,
+                ny=10,
+                nz=10,
+                axis_orientation=AxisOrientation.LEFT_HANDED,
+                xinc=100.0,
+                yinc=200.0,
+            ),
+            (
+                np.array([0.0, 1.0]),
+                np.array([1.0, 1.0]),
+                np.array([1.0, 2.0]),
+                np.array([0.5, 1.0]),
+                np.array(["", ""]),
+                np.array(["", ""]),
+            ),
+            id="Observations inside the field (left-handed)",
+        ),
+        pytest.param(
+            [1.0, 101.0],
+            [201.0, 201.0],
+            [100.0, 200.0],
+            ErtboxParameters(
+                origin=(1.0, 1.0),
+                rotation_angle=0.0,
+                nx=10,
+                ny=10,
+                nz=10,
+                axis_orientation=AxisOrientation.RIGHT_HANDED,
+                xinc=100.0,
+                yinc=200.0,
+            ),
+            (
+                np.array([0.0, 1.0]),
+                np.array([9.0, 9.0]),
+                np.array([1.0, 2.0]),
+                np.array([0.5, 1.0]),
+                np.array(["", ""]),
+                np.array(["", ""]),
+            ),
+            id="Observations inside the field (right-handed)",
+        ),
+    ],
+)
+def test_that_transform_observation_locations_handles_different_cases(
+    east, north, radius, ertbox_params, result_loc
+):
+    df = pd.DataFrame({"east": east, "north": north, "radius": radius})
+    result = transform_observation_locations(df, ertbox_params)
+    if result is None:
+        assert result_loc is None
+    else:
+        expected_x, expected_y, expected_radius_x, expected_radius_y, keys, indices = (
+            result_loc
+        )
+        assert_allclose(result.x, expected_x)
+        assert_allclose(result.y, expected_y)
+        assert_allclose(result.radius_x, expected_radius_x)
+        assert_allclose(result.radius_y, expected_radius_y)
+        assert np.array_equal(result.observation_key, keys)
+        assert np.array_equal(result.observation_index, indices)

--- a/tests/ert/unit_tests/run_models/test_update_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_update_run_model.py
@@ -1,8 +1,10 @@
 import io
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import polars as pl
+import pytest
 
 from ert.analysis.event import AnalysisCompleteEvent, DataSection
 from ert.run_models.update_run_model import UpdateRunModel
@@ -36,3 +38,49 @@ def test_that_send_smoother_event_persists_observation_report_on_analysis_comple
     assert len(saved_df) == 2
     assert saved_df["observation_key"].to_list() == ["OBS_1", "OBS_2"]
     assert saved_df["status"].to_list() == ["Active", "Deactivated, outlier"]
+
+
+def test_update_ensemble_parameters_uses_posterior_experiment_for_strategy_cache(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    model = MagicMock()
+    model.analysis_settings = SimpleNamespace(
+        enkf_truncation=0.99,
+        distance_localization=True,
+        localization=False,
+        correlation_threshold=None,
+    )
+    model.update_settings = MagicMock()
+    model._rng = MagicMock()
+    model.active_realizations = None
+
+    prior = MagicMock()
+    prior.iteration = 0
+    prior.id = uuid.uuid4()
+    prior.experiment.update_parameters = ["PARAM"]
+    prior.experiment.parameter_configuration = {"PARAM": MagicMock()}
+    prior.experiment.observation_keys = ["OBS"]
+
+    posterior = MagicMock()
+    posterior.experiment = MagicMock()
+
+    captured: dict[str, object] = {}
+
+    def build_strategy_map_spy(**kwargs):
+        captured.update(kwargs)
+        return {"PARAM": MagicMock()}
+
+    monkeypatch.setattr(
+        "ert.run_models.update_run_model.build_strategy_map",
+        build_strategy_map_spy,
+    )
+    smoother_update = MagicMock()
+    monkeypatch.setattr(
+        "ert.run_models.update_run_model.smoother_update",
+        smoother_update,
+    )
+
+    UpdateRunModel.update_ensemble_parameters(model, prior, posterior, weight=1.0)
+
+    assert captured["experiment"] is posterior.experiment
+    smoother_update.assert_called_once()

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -16,6 +16,7 @@ import hypothesis.strategies as st
 import numpy as np
 import polars as pl
 import pytest
+import scipy.sparse as sp
 import xarray as xr
 from hypothesis import assume, given, note
 from hypothesis.extra.numpy import arrays
@@ -52,6 +53,7 @@ from ert.storage import (
     ErtStorageException,
     LocalEnsemble,
     RealizationStorageState,
+    SparseMatrixArtifact,
     open_storage,
 )
 from ert.storage.local_storage import _LOCAL_STORAGE_VERSION, LocalStorage
@@ -74,6 +76,60 @@ def test_create_experiment(tmp_path):
             index = json.load(f)
             assert index["id"] == str(experiment.id)
             assert index["name"] == "test-experiment"
+
+
+def test_localization_matrix_storage_escapes_parameter_group_names(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment(name="test-experiment")
+        artifact = SparseMatrixArtifact(
+            matrix=sp.csr_array(np.eye(2, dtype=np.float32)),
+            metadata={
+                "grid_shape": np.asarray((1, 2), dtype=np.int64),
+                "observation_key": np.array(["obs", "obs"]),
+                "observation_index": np.array(["0", "1"]),
+            },
+        )
+
+        experiment.save_sparse_matrix("localization/GROUP/NAME", artifact)
+
+        assert (
+            experiment.mount_point
+            / "sparse_matrices"
+            / "localization%2FGROUP%2FNAME.npz"
+        ).exists()
+        loaded = experiment.load_sparse_matrix("localization/GROUP/NAME")
+        assert loaded is not None
+        np.testing.assert_array_equal(
+            loaded.matrix.toarray(), artifact.matrix.toarray()
+        )
+        np.testing.assert_array_equal(
+            loaded.metadata["grid_shape"], artifact.metadata["grid_shape"]
+        )
+
+
+def test_sparse_matrix_storage_escapes_artifact_names(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment(name="test-experiment")
+        artifact = SparseMatrixArtifact(
+            matrix=sp.csr_array(np.eye(2, dtype=bool)),
+            metadata={
+                "kind": np.asarray("thresholded_cross_covariance"),
+                "threshold": np.asarray(0.7),
+            },
+        )
+
+        experiment.save_sparse_matrix("GROUP/NAME/artifact", artifact)
+
+        assert (
+            experiment.mount_point / "sparse_matrices" / "GROUP%2FNAME%2Fartifact.npz"
+        ).exists()
+        loaded = experiment.load_sparse_matrix("GROUP/NAME/artifact")
+        assert loaded is not None
+        np.testing.assert_array_equal(
+            loaded.matrix.toarray(), artifact.matrix.toarray()
+        )
+        assert loaded.metadata["kind"] == "thresholded_cross_covariance"
+        assert loaded.metadata["threshold"] == pytest.approx(0.7)
 
 
 def test_that_loading_non_existing_experiment_throws(tmp_path):


### PR DESCRIPTION
https://github.com/user-attachments/assets/f349ec89-d2e7-43d0-986d-280a0da1d202

Running heat equation:

```console
(ert) ➜  eb76609f-986d-4a6b-bced-98519cbe4094 git:(plot-obs-radius) ✗ tree -L 2
.
├── index.json
├── localization
│   ├── COND.metadata.npz
│   └── COND.npz
├── observations
│   └── summary
├── templates
└── templates.json
```

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
