### PR TITLE
Wait for gui simulation threads to finish in tests

### DIFF
--- a/src/ert/gui/experiments/experiment_panel.py
+++ b/src/ert/gui/experiments/experiment_panel.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
 
 EXPERIMENT_IS_MANUAL_UPDATE_MESSAGE = "Execute selected"
 
+GUI_SIMULATION_THREAD_NAME = "ert_gui_simulation_thread"
+
 
 def create_md_table(kv: dict[str, str], output: str) -> str:
     for key, unescaped_value in kv.items():
@@ -72,7 +74,7 @@ def get_simulation_thread(
             rerun_failed_realizations=rerun_failed_realizations,
         )
 
-    return ErtThread(name="ert_gui_simulation_thread", target=run, daemon=True)
+    return ErtThread(name=GUI_SIMULATION_THREAD_NAME, target=run, daemon=True)
 
 
 class ExperimentPanel(QWidget):

--- a/tests/ert/unit_tests/gui/experiments/conftest.py
+++ b/tests/ert/unit_tests/gui/experiments/conftest.py
@@ -1,6 +1,10 @@
+import threading
 from datetime import UTC, datetime
 from uuid import uuid4
 
+import pytest
+
+from ert.gui.experiments.experiment_panel import GUI_SIMULATION_THREAD_NAME
 from ert.storage.local_ensemble import LocalEnsemble
 from ert.storage.local_ensemble import _Index as _EnsembleIndex
 from ert.storage.local_experiment import ExperimentType, LocalExperiment
@@ -81,3 +85,22 @@ class MockStorage(LocalStorage):
         )
         self._ensembles[mock_ensemble2.id] = mock_ensemble2
         self._experiments[mock_experiment.id] = mock_experiment
+
+
+@pytest.fixture(autouse=True)
+def join_simulation_threads():
+    """Wait for GUI simulation threads to finish before a test tears down.
+
+    The GUI runs experiments in a background ``GUI_SIMULATION_THREAD_NAME`` thread
+    which clears the run model's process-global ``_ERT_*`` environment variables
+    when it finishes. Joining the thread before teardown ensures that cleanup has
+    happened, so the variables cannot leak into unrelated tests.
+    """
+    yield
+    for thread in threading.enumerate():
+        if thread.name == GUI_SIMULATION_THREAD_NAME:
+            thread.join(timeout=5)
+            assert not thread.is_alive(), (
+                f"{thread.name} did not finish within the timeout; its "
+                "environment cleanup may leak into other tests"
+            )


### PR DESCRIPTION
Should resolve failing tests such as 
https://github.com/equinor/ert/actions/runs/26239888641/job/77223404795?pr=13617
https://github.com/equinor/ert/actions/runs/26439598491/job/77830775009?pr=13629
https://github.com/equinor/ert/actions/runs/26808441457/job/79034101025


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
