### PR TITLE
Clarify plot widget strategy interface

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import traceback
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 import numpy.typing as npt
@@ -28,30 +28,31 @@ from typing_extensions import override
 from ert.config.distribution import ConstSettings
 from ert.config.gen_kw_config import GenKwConfig
 from ert.gui.icon_utils import load_icon
-from ert.gui.tools.plot.plottery.plots import EverestGradientsPlot
 
 from .plot_api import EnsembleObject, PlotApiKeyDefinition
 
 if TYPE_CHECKING:
     from .plottery import PlotContext
-    from .plottery.plots.cesp import CrossEnsembleStatisticsPlot
-    from .plottery.plots.distribution import DistributionPlot
-    from .plottery.plots.ensemble import EnsemblePlot
-    from .plottery.plots.everest_batch_objective_function_plot import (
-        EverestBatchObjectiveFunctionPlot,
-    )
-    from .plottery.plots.everest_constraints_plot import EverestConstraintsPlot
-    from .plottery.plots.everest_controls_plot import EverestControlsPlot
-    from .plottery.plots.everest_objective_function_plot import (
-        EverestObjectiveFunctionPlot,
-    )
-    from .plottery.plots.gaussian_kde import GaussianKDEPlot
-    from .plottery.plots.histogram import HistogramPlot
-    from .plottery.plots.misfits import MisfitsPlot
-    from .plottery.plots.statistics import StatisticsPlot
-    from .plottery.plots.std_dev import StdDevPlot
 
 logger = logging.getLogger(__name__)
+
+
+class Plotter(Protocol):
+    """Protocol for plot strategies used by PlotWidget."""
+
+    dimensionality: int
+    requires_observations: bool
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: "PlotContext",
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observations: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: npt.NDArray[np.float32] | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None: ...
 
 
 class CustomNavigationToolbar(NavigationToolbar2QT):
@@ -130,21 +131,7 @@ class PlotWidget(QWidget):
     def __init__(
         self,
         name: str,
-        plotter: Union[
-            "EnsemblePlot",
-            "StatisticsPlot",
-            "HistogramPlot",
-            "GaussianKDEPlot",
-            "DistributionPlot",
-            "CrossEnsembleStatisticsPlot",
-            "StdDevPlot",
-            "MisfitsPlot",
-            "EverestBatchObjectiveFunctionPlot",
-            "EverestConstraintsPlot",
-            "EverestControlsPlot",
-            "EverestGradientsPlot",
-            "EverestObjectiveFunctionPlot",
-        ],
+        plotter: Plotter,
         parent: QWidget | None = None,
     ) -> None:
         QWidget.__init__(self, parent)

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,7 @@ from .customize import PlotCustomizer
 from .data_type_keys_widget import DataTypeKeysWidget
 from .plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
 from .plot_ensemble_selection_widget import EnsembleSelectionWidget
-from .plot_widget import PlotWidget
+from .plot_widget import Plotter, PlotWidget
 from .plottery import PlotConfig, PlotContext
 from .plottery.plots import (
     CrossEnsembleStatisticsPlot,
@@ -76,6 +76,12 @@ STD_DEV_DEFAULT = 7
 
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SelectableControlsPlotter(Protocol):
+    def set_selected_controls(self, controls: list[str]) -> None: ...
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -411,7 +417,8 @@ class PlotWindow(QMainWindow):
                 selected_controls = (
                     self._everest_control_selection_widget.get_selected_controls()
                 )
-                plot_widget._plotter.set_selected_controls(selected_controls)  # type: ignore
+                if isinstance(plot_widget._plotter, SelectableControlsPlotter):
+                    plot_widget._plotter.set_selected_controls(selected_controls)
 
             def fetch_data(
                 ensemble: EnsembleObject,
@@ -587,19 +594,7 @@ class PlotWindow(QMainWindow):
     def addPlotWidget(
         self,
         name: str,
-        plotter: EnsemblePlot
-        | StatisticsPlot
-        | HistogramPlot
-        | GaussianKDEPlot
-        | DistributionPlot
-        | CrossEnsembleStatisticsPlot
-        | StdDevPlot
-        | MisfitsPlot
-        | EverestBatchObjectiveFunctionPlot
-        | EverestConstraintsPlot
-        | EverestControlsPlot
-        | EverestGradientsPlot
-        | EverestObjectiveFunctionPlot,
+        plotter: Plotter,
         *,
         enabled: bool = True,
     ) -> None:


### PR DESCRIPTION
Replace the concrete plotter union with a Plotter protocol so PlotWidget depends on the shared plotting interface rather than every implementation. This makes the existing strategy pattern explicit and reduces the places that need updating when new plot types are added.

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
