### PR TITLE
Additional control values plot

### DIFF
--- a/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/tools/plot/plot_ensemble_selection_widget.py
@@ -185,7 +185,11 @@ class EnsembleSelectListWidget(QListWidget):
         for index in range(self._ensemble_count):
             item = self.item(index)
             if item:
-                should_be_checked = index < self._minimum_selected
+                should_be_checked = (
+                    index == self._ensemble_count - 1
+                    if is_everest_application()  # Batch_0
+                    else index <= self._minimum_selected - 1  # Latest ensemble
+                )
                 is_checked = bool(item.data(Qt.ItemDataRole.CheckStateRole))
                 if is_checked and not should_be_checked:
                     self.release_color(

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -11,12 +11,14 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import (
     QApplication,
+    QButtonGroup,
     QDialog,
     QDockWidget,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QRadioButton,
     QStyle,
     QTabWidget,
     QTextEdit,
@@ -304,29 +306,60 @@ class PlotWindow(QMainWindow):
                 self.updatePlot
             )
 
-            group_style = "QGroupBox { font-style: italic; }"
-
-            def create_group_box(title: str, widget: QWidget) -> QGroupBox:
-                group_box = QGroupBox(title)
-                group_box.setStyleSheet(group_style)
+            def create_group_layout(
+                widgets: list[QWidget] | None = None,
+            ) -> QVBoxLayout:
                 layout = QVBoxLayout()
                 layout.setContentsMargins(0, 0, 0, 0)
-                layout.addWidget(widget)
+                for w in widgets or []:
+                    layout.addWidget(w)
+                return layout
+
+            def create_group_box(title: str, layout: QVBoxLayout) -> QGroupBox:
+                group_box = QGroupBox(title)
+                group_box.setStyleSheet("QGroupBox { font-style: italic; }")
                 group_box.setLayout(layout)
                 return group_box
 
             self._everest_controls_group = create_group_box(
-                "Select control(s)", self._everest_control_selection_widget
+                "Select control(s)",
+                create_group_layout([self._everest_control_selection_widget]),
             )
             self._ensemble_group = create_group_box(
-                "Select ensemble(s)", self._ensemble_selection_widget
+                "Select ensemble(s)",
+                create_group_layout([self._ensemble_selection_widget]),
+            )
+
+            self._display_over_batches_radio = QRadioButton("batches")
+            self._display_over_batches_radio.setObjectName("display_over_batches_radio")
+            self._display_over_batches_radio.setChecked(True)
+            self._display_over_controls_radio = QRadioButton("controls")
+            self._display_over_controls_radio.setObjectName(
+                "display_over_controls_radio"
+            )
+            self._display_over_button_group = QButtonGroup(self)
+            self._display_over_button_group.addButton(self._display_over_batches_radio)
+            self._display_over_button_group.addButton(self._display_over_controls_radio)
+            self._display_over_button_group.buttonClicked.connect(self.updatePlot)
+
+            self._display_over_group = create_group_box(
+                "X-axis:",
+                create_group_layout(
+                    [
+                        self._display_over_batches_radio,
+                        self._display_over_controls_radio,
+                    ]
+                ),
             )
 
             right_container = QWidget()
-            right_layout = QVBoxLayout()
-            right_layout.setContentsMargins(0, 0, 0, 0)
-            right_layout.addWidget(self._ensemble_group)
-            right_layout.addWidget(self._everest_controls_group)
+            right_layout = create_group_layout(
+                [
+                    self._ensemble_group,
+                    self._display_over_group,
+                    self._everest_controls_group,
+                ]
+            )
             right_container.setLayout(right_layout)
 
             right_dock = QDockWidget()
@@ -340,6 +373,7 @@ class PlotWindow(QMainWindow):
             self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, right_dock)
 
             self._everest_controls_group.setVisible(False)
+            self._display_over_group.setVisible(False)
             self._data_type_keys_widget.selectDefault()
 
     def get_plot_api_version(self) -> str:
@@ -384,6 +418,7 @@ class PlotWindow(QMainWindow):
         }
         is_everest_ensemble = plot_widget.name == ENSEMBLE and self.is_everest
         self._everest_controls_group.setVisible(is_gradient_plot or is_controls_plot)
+        self._display_over_group.setVisible(is_controls_plot)
 
         self._ensemble_selection_widget.apply_ensemble_filtering(
             require_func_eval=is_objective_plot
@@ -524,6 +559,7 @@ class PlotWindow(QMainWindow):
                 key,
                 layer,
             )
+            plot_context.by_batch = self._display_over_batches_radio.isChecked()
 
             # Check if key is a history key.
             # If it is it already has the data it needs
@@ -635,32 +671,35 @@ class PlotWindow(QMainWindow):
         self._plot_customizer.switch_plot_config_history(key_def)
 
         is_everest_specific_widget = key_def.metadata.get("data_origin") in {
-            "everest_parameters",
             "everest_objectives",
             "everest_constraints",
             "everest_batch_objectives",
         }
-        if (
-            self.is_everest
-            and key_def.response is not None
-            and key_def.response.type in {"summary", "gen_data"}
-        ):
-            if self._prev_key_origin and self._prev_key_origin not in {
+        if self.is_everest:
+            if key_def.response is not None and key_def.response.type in {
                 "summary",
                 "gen_data",
             }:
-                self._ensemble_selection_widget.reset_maximum_ensemble_limit_to_default()
-                self._ensemble_selection_widget.set_minimum_ensemble_limit(0)
-                self._ensemble_selection_widget.clear_ensemble_selection()
-        elif is_everest_specific_widget:
-            if key_def.key != self._prev_key:
-                self._ensemble_selection_widget.set_maximum_ensemble_limit(
-                    EVEREST_UPPER_BATCH_LIMIT
-                )
-                self._ensemble_selection_widget.reset_minimum_ensemble_limit_to_default()
-                self._ensemble_selection_widget.select_all_ensembles()
-        else:
-            self._ensemble_selection_widget.reset_maximum_and_minimum_ensemble_limits_to_default()
+                if self._prev_key_origin and self._prev_key_origin not in {
+                    "summary",
+                    "gen_data",
+                }:
+                    self._ensemble_selection_widget.reset_maximum_ensemble_limit_to_default()
+                    self._ensemble_selection_widget.set_minimum_ensemble_limit(0)
+                    self._ensemble_selection_widget.clear_ensemble_selection()
+            elif is_everest_specific_widget:
+                if key_def.key != self._prev_key:
+                    self._ensemble_selection_widget.set_maximum_ensemble_limit(
+                        EVEREST_UPPER_BATCH_LIMIT
+                    )
+                    self._ensemble_selection_widget.reset_minimum_ensemble_limit_to_default()
+                    self._ensemble_selection_widget.select_all_ensembles()
+            elif key_def.metadata.get("data_origin") == "everest_parameters":
+                if key_def.key != self._prev_key:
+                    self._ensemble_selection_widget.reset_maximum_and_minimum_ensemble_limits_to_default()
+                    self._ensemble_selection_widget.clear_ensemble_selection()
+            else:
+                self._ensemble_selection_widget.reset_maximum_and_minimum_ensemble_limits_to_default()
 
         max_selected = self._ensemble_selection_widget.get_maximum_ensemble_limit()
         str_num_of_ens = f" up to {max_selected}" if self.is_everest else ""

--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -54,6 +54,7 @@ class PlotContext:
         self._y_axis: str | None = None
         self._log_scale = False
         self._extended_plot_information = False
+        self._by_batch: bool = True
 
         self._plot_type: PlotType | None = None
 
@@ -148,3 +149,11 @@ class PlotContext:
     @log_scale.setter
     def log_scale(self, value: bool) -> None:
         self._log_scale = value
+
+    @property
+    def by_batch(self) -> bool:
+        return self._by_batch
+
+    @by_batch.setter
+    def by_batch(self, value: bool) -> None:
+        self._by_batch = value

--- a/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_controls_plot.py
@@ -51,20 +51,77 @@ class EverestControlsPlot:
         obs_loc: ObservationPlotLocations | None,
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
+        plot_context.deactivate_date_support()
+        all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
+
+        if all_dfs:
+            combined = pd.concat(all_dfs, ignore_index=True)
+            if plot_context.by_batch:
+                self.plot_pr_batch(figure, plot_context, combined)
+            else:
+                self.plot_pr_control(figure, plot_context, combined)
+
+    def plot_pr_control(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        combined_data: pd.DataFrame,
+    ) -> None:
+        config = plot_context.plotConfig()
+        axes = figure.add_subplot(111)
+
+        plot_context.y_axis = plot_context.VALUE_AXIS
+        plot_context.x_axis = plot_context.INDEX_AXIS
+        plot_context.plot_type = PlotType.SCATTER
+
+        x_positions = list(range(len(self.selected_controls)))
+        batch_ids = sorted(combined_data["batch_id"].unique().tolist())
+
+        for batch_id in batch_ids:
+            batch_data = combined_data[combined_data["batch_id"] == batch_id]
+            control_name_list = []
+            control_value_list = []
+            for x, control in zip(x_positions, self.selected_controls, strict=True):
+                control_rows = batch_data[batch_data["control_name"] == control]
+                if not control_rows.empty:
+                    for value in control_rows["control_value"]:
+                        control_name_list.append(x)
+                        control_value_list.append(value)
+            if control_name_list:
+                label = "initial batch" if batch_id == 0 else f"batch_{batch_id}"
+                scatter = axes.scatter(
+                    control_name_list,
+                    control_value_list,
+                    color=config.next_color(),
+                    s=20,
+                )
+                if len(batch_ids) <= LEGEND_THRESHOLD:
+                    config.add_legend_item(label, scatter)
+
+        axes.set_xticks(x_positions)
+        axes.set_xticklabels(self.selected_controls, rotation=-30, ha="left")
+
+        config.set_title("Control values by control")
+        PlotTools.finalizePlot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="",
+            default_y_label="Control value",
+        )
+
+    def plot_pr_batch(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        combined_data: pd.DataFrame,
+    ) -> None:
         config = plot_context.plotConfig()
         axes = figure.add_subplot(111)
 
         plot_context.y_axis = plot_context.VALUE_AXIS
         plot_context.x_axis = plot_context.INDEX_AXIS
         plot_context.plot_type = PlotType.LINE
-        plot_context.deactivate_date_support()
-
-        all_dfs = [df for df in ensemble_to_data_map.values() if not df.empty]
-
-        if not all_dfs:
-            return
-
-        combined = pd.concat(all_dfs, ignore_index=True)
 
         tooltip_data = []
         tooltip_labels = []
@@ -72,31 +129,31 @@ class EverestControlsPlot:
         for i, control in (
             enumerate(self.selected_controls) if self.selected_controls else []
         ):
-            data = combined[combined["control_name"] == control].sort_values("batch_id")
-            if data.empty:
-                continue
-
-            color = config.next_color()
-            if i < n_colors:
-                style = "-o"
-            elif i < n_colors * 2:
-                style = "--o"
-            elif i < n_colors * 3:
-                style = ":o"
-            else:
-                style = "-.o"
-            lines = axes.plot(
-                data["batch_id"],
-                data["control_value"],
-                style,
-                color=color,
-                markersize=4,
+            data = combined_data[combined_data["control_name"] == control].sort_values(
+                "batch_id"
             )
-            tooltip_data.append(lines)
-            tooltip_labels.append(control)
-            if len(self.selected_controls) <= LEGEND_THRESHOLD:
-                config.add_legend_item(control, lines[0])
-            if len(control) <= 20:
+            if not data.empty:
+                if i < n_colors:
+                    style = "-o"
+                elif i < n_colors * 2:
+                    style = "--o"
+                elif i < n_colors * 3:
+                    style = ":o"
+                else:
+                    style = "-.o"
+
+                color = config.next_color()
+                lines = axes.plot(
+                    data["batch_id"],
+                    data["control_value"],
+                    style,
+                    color=color,
+                    markersize=4,
+                )
+                tooltip_data.append(lines)
+                tooltip_labels.append(control)
+                if len(self.selected_controls) <= LEGEND_THRESHOLD:
+                    config.add_legend_item(control, lines[0])
                 axes.annotate(
                     control,
                     xy=(data["batch_id"].iloc[-1], data["control_value"].iloc[-1]),
@@ -119,7 +176,7 @@ class EverestControlsPlot:
             disable_values=True,
             hover_color=config.next_color()[0],
         )
-
+        config.set_title("Control values by batch")
         PlotTools.finalizePlot(
             plot_context,
             figure,


### PR DESCRIPTION

**Issue**
Resolves #13641


**Approach**
Added generic "Alternate view"-checkbox to sidebar. Is set to hidden for all but `everest_parameters` as of now. It updates the `PlotContext` (similar to log scale-checkbox)

Alternate control values-plot is a scatter plot with the controls on x axis, values on y axis and where each dot is a batch. Batch_0 is named `initial_batch`. 

Note: In an improved version, this plot should only display best and initial batch, as in Everviz.

Due to legend disappearing when > 5 items, set max ensemble limit to 5. Discovered that `clear_ensemble_selection()` cleared **ALL**, despite lower limit being set to 1. 

<img width="1912" height="1048" alt="image" src="https://github.com/user-attachments/assets/0a5d10e8-6bdc-40a0-8441-0ef2b52aa8af" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
