### PR TITLE
Ensure test_main_everest_entry does not modify env

### DIFF
--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -204,7 +204,7 @@ def test_that_cli_gui_commands_fail_without_visualization_module(monkeypatch):
 
 def setup_main_without_visualization_module(monkeypatch):
     # Remove module from cache to force reimport
-    sys.modules.pop("everest.bin.visualization_script", None)
+    monkeypatch.delitem(sys.modules, "everest.bin.visualization_script", raising=False)
 
     original_import = builtins.__import__
 


### PR DESCRIPTION
Should hopefully resolve flaky rapid tests. Ensures that test setup does not pop from sys.modules without restoring it, potentially affecting state for subsequent tests in the same worker thread.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
