### PR TITLE
Bump CI Python to 3.14 for single python workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
           python-version: '3.12'
         - os: 'ubuntu-latest'
           test-type: 'doc'
-          python-version: '3.14'
+          python-version: '3.13'
     uses: ./.github/workflows/test_everest.yml
     with:
       os: ${{ matrix.os }}
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.12' ]
+        python-version: [ '3.14' ]
         os: [ ubuntu-latest ]
     uses: ./.github/workflows/test_screenshots.yml
     with:
@@ -132,7 +132,7 @@ jobs:
       matrix:
         test-type: [ 'test' ]
         os: [ 'macos-latest' ]
-        python-version: [ '3.12' ]
+        python-version: [ '3.14' ]
 
     uses: ./.github/workflows/test_everest.yml
     with:
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
-        python-version: [ '3.12' ]
+        python-version: [ '3.14' ]
         os: [ 'macos-latest']
 
     uses: ./.github/workflows/test_ert.yml

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,13 +26,13 @@ jobs:
           os: ubuntu-latest
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           prune-cache: false
-          python-version: '3.12'
+          python-version: '3.14'
       - run: |
           uv sync --group dev
           uv pip uninstall pytest-benchmark

--- a/.github/workflows/run_ert_test_data_setups.yml
+++ b/.github/workflows/run_ert_test_data_setups.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.14']
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_pre_commit.yml
+++ b/.github/workflows/run_pre_commit.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test_ert_with_site_config.yml
+++ b/.github/workflows/test_ert_with_site_config.yml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   test-against-lsf:
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        test-type: [ 'gui-tests', 'rapid-tests' ]
-        python-version: ["3.12"]
+        python-version: ["3.14"]
 
     steps:
       - name: Checkout repository
@@ -88,6 +88,5 @@ jobs:
           uv pip install ./dummy_site_config
 
       - name: Rapid tests
-        if: matrix.test-type == 'rapid-tests'
         run: |
           uv run just rapid-tests

--- a/.github/workflows/test_everest_models.yml
+++ b/.github/workflows/test_everest_models.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.12']
+                python-version: ['3.14']
         steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with:

--- a/.github/workflows/test_semeio.yml
+++ b/.github/workflows/test_semeio.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.14']
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Python 3.14 should be somewhat faster than 3.12 as well.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
