### PR TITLE
Harden tests against global-state pollution

### DIFF
--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -354,7 +354,7 @@ def hide_window(request):
     os.environ["QT_QPA_PLATFORM"] = "offscreen"
     yield
     if old_value is None:
-        del os.environ["QT_QPA_PLATFORM"]
+        os.environ.pop("QT_QPA_PLATFORM", None)
     else:
         os.environ["QT_QPA_PLATFORM"] = old_value
 

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -262,7 +262,7 @@ def test_that_es_mda_is_disabled_when_weights_are_invalid(qtbot):
 
 
 @pytest.mark.usefixtures("copy_snake_oil_field")
-def test_that_ert_changes_to_config_directory(qtbot):
+def test_that_ert_changes_to_config_directory(qtbot, monkeypatch):
     """
     This is a regression test that verifies that ert changes directories
     to the config dir (where .ert is).
@@ -280,7 +280,7 @@ def test_that_ert_changes_to_config_directory(qtbot):
     surf.to_file("surface/surf_init_0.irap", fformat="irap_binary")
 
     args = Mock()
-    os.chdir("..")
+    monkeypatch.chdir("..")
     args.config = "test_data/snake_oil_surface.ert"
     with add_gui_log_handler() as log_handler:
         gui, *_ = ert.gui.main._start_initial_gui_window(args, log_handler)

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 import warnings
 from pathlib import Path
@@ -439,9 +438,9 @@ def test_that_ert_warns_if_ascii_surface_is_used(tmp_path, is_ascii_surface, cap
 
 @pytest.mark.parametrize("is_ascii_surface", [True, False])
 async def test_that_ert_writes_surface_in_same_the_format_that_was_read(
-    is_ascii_surface, tmp_path, caplog
+    is_ascii_surface, tmp_path, caplog, monkeypatch
 ):
-    os.chdir(tmp_path)
+    monkeypatch.chdir(tmp_path)
     surf = IrapSurface(
         header=IrapHeader(
             ncol=2,

--- a/tests/ert/unit_tests/config/test_surface_config.py
+++ b/tests/ert/unit_tests/config/test_surface_config.py
@@ -438,9 +438,8 @@ def test_that_ert_warns_if_ascii_surface_is_used(tmp_path, is_ascii_surface, cap
 
 @pytest.mark.parametrize("is_ascii_surface", [True, False])
 async def test_that_ert_writes_surface_in_same_the_format_that_was_read(
-    is_ascii_surface, tmp_path, caplog, monkeypatch
+    is_ascii_surface, use_tmpdir
 ):
-    monkeypatch.chdir(tmp_path)
     surf = IrapSurface(
         header=IrapHeader(
             ncol=2,

--- a/tests/ert/unit_tests/conftest.py
+++ b/tests/ert/unit_tests/conftest.py
@@ -19,7 +19,9 @@ def ensure_bin_in_path():
     """
     path = os.environ["PATH"]
     exec_path = os.path.dirname(sys.executable)
-    os.environ["PATH"] = exec_path + ":" + path
+    os.environ["PATH"] = exec_path + os.pathsep + path
+    yield
+    os.environ["PATH"] = path
 
 
 @pytest.fixture

--- a/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
+++ b/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
@@ -30,6 +30,17 @@ class DarkStorageStateTest(StatefulStorageTest):
         os.environ["ERT_STORAGE_ENS_PATH"] = str(self.storage.path)
         self.client = TestClient(app)
 
+    def _restore_environment(self) -> None:
+        if self.prev_no_token is not None:
+            os.environ["ERT_STORAGE_NO_TOKEN"] = self.prev_no_token
+        else:
+            os.environ.pop("ERT_STORAGE_NO_TOKEN", None)
+
+        if self.prev_ens_path is not None:
+            os.environ["ERT_STORAGE_ENS_PATH"] = self.prev_ens_path
+        else:
+            os.environ.pop("ERT_STORAGE_ENS_PATH", None)
+
     @rule()
     def get_experiments_through_client(self):
         self.client.get("/updates/storage")
@@ -94,19 +105,14 @@ class DarkStorageStateTest(StatefulStorageTest):
         }
 
     def teardown(self):
-        super().teardown()
-        if common._storage is not None:
-            common._storage.close()
-        common._storage = None
-        gc.collect()
-        if self.prev_no_token is not None:
-            os.environ["ERT_STORAGE_NO_TOKEN"] = self.prev_no_token
-        else:
-            del os.environ["ERT_STORAGE_NO_TOKEN"]
-        if self.prev_ens_path is not None:
-            os.environ["ERT_STORAGE_ENS_PATH"] = self.prev_ens_path
-        else:
-            del os.environ["ERT_STORAGE_ENS_PATH"]
+        try:
+            super().teardown()
+            if common._storage is not None:
+                common._storage.close()
+            common._storage = None
+            gc.collect()
+        finally:
+            self._restore_environment()
 
 
 TestDarkStorage = pytest.mark.fuzzing(

--- a/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_forward_model_runner.py
@@ -22,11 +22,6 @@ def create_jobs_json(fm_step_list):
 
 @pytest.fixture(autouse=True)
 def set_up_environ():
-    if "ERT_RUN_ID" in os.environ:
-        del os.environ["ERT_RUN_ID"]
-
-    yield
-
     keys = (
         "KEY_ONE",
         "KEY_TWO",
@@ -35,10 +30,18 @@ def set_up_environ():
         "PATH104",
         "ERT_RUN_ID",
     )
+    original_env = {key: os.environ.get(key) for key in keys}
 
     for key in keys:
-        if key in os.environ:
-            del os.environ[key]
+        os.environ.pop(key, None)
+
+    yield
+
+    for key, value in original_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/resources/_import_from_location.py
+++ b/tests/ert/unit_tests/resources/_import_from_location.py
@@ -7,8 +7,16 @@ def import_from_location(name, location):
     if spec is None:
         raise ImportError(f"Could not find {name}")
     module = importlib.util.module_from_spec(spec)
+    previous_module = sys.modules.get(name)
+    had_previous_module = name in sys.modules
     sys.modules[name] = module
-    if spec.loader is None:
-        raise ImportError(f"No loader for {name}")
-    spec.loader.exec_module(module)
+    try:
+        if spec.loader is None:
+            raise ImportError(f"No loader for {name}")
+        spec.loader.exec_module(module)
+    finally:
+        if had_previous_module:
+            sys.modules[name] = previous_module
+        else:
+            sys.modules.pop(name, None)
     return module

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 from contextlib import suppress
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -37,14 +38,16 @@ careful_copy_file = import_from_location(
     "careful_copy",
     SHELL_SCRIPTS / "careful_copy_file.py",
 ).careful_copy_file
-mkdir = import_from_location(
+make_directory = import_from_location(
     "make_directory",
     SHELL_SCRIPTS / "make_directory.py",
-).mkdir
-copy_directory = import_from_location(
-    "careful_copy",
-    SHELL_SCRIPTS / "copy_directory.py",
-).copy_directory
+)
+mkdir = make_directory.mkdir
+with patch.dict(sys.modules, {"make_directory": make_directory}):
+    copy_directory = import_from_location(
+        "copy_directory",
+        SHELL_SCRIPTS / "copy_directory.py",
+    ).copy_directory
 copy_file = import_from_location(
     "copy_file",
     SHELL_SCRIPTS / "copy_file.py",
@@ -362,9 +365,8 @@ def test_that_delete_directory_can_delete_directories_with_internal_symlinks():
     mkdir("to_be_deleted")
     Path("to_be_deleted/link_target.txt").write_text("hei", encoding="utf-8")
 
-    os.chdir("to_be_deleted")  # symlink() requires this
-    symlink("link_target.txt", "link")
-    os.chdir("..")
+    with pushd("to_be_deleted"):
+        symlink("link_target.txt", "link")
     assert Path("to_be_deleted/link").exists()
 
     delete_directory("to_be_deleted")

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -84,12 +84,14 @@ def create_responses(prior_ensemble, response_times):
     cwd = Path().absolute()
     rng = np.random.default_rng(seed=1234)
     base_path = cwd / "simulations" / "realization-<IENS>" / "iter-0"
-    for i, response_time in enumerate(response_times):
-        sim_path = Path(str(base_path).replace("<IENS>", str(i)))
-        sim_path.mkdir(parents=True, exist_ok=True)
-        os.chdir(sim_path)
-        run_sim(response_time, rng.standard_normal(), fname=f"ECLIPSE_CASE_{i}")
-    os.chdir(cwd)
+    try:
+        for i, response_time in enumerate(response_times):
+            sim_path = Path(str(base_path).replace("<IENS>", str(i)))
+            sim_path.mkdir(parents=True, exist_ok=True)
+            os.chdir(sim_path)
+            run_sim(response_time, rng.standard_normal(), fname=f"ECLIPSE_CASE_{i}")
+    finally:
+        os.chdir(cwd)
     load_parameters_and_responses_from_runpath(
         str(base_path), prior_ensemble, range(len(response_times))
     )

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -16,9 +16,10 @@ from ert.shared import find_available_socket
 
 @pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 @pytest.mark.slow
-def test_create_connection_string():
+def test_create_connection_string(monkeypatch):
     authtoken = "very_secret_token"
     sock = find_available_socket()
+    monkeypatch.setenv("ERT_STORAGE_CONNECTION_STRING", "")
 
     _create_connection_info(sock, authtoken, Path("path/to/cert"))
 
@@ -33,8 +34,6 @@ def test_create_connection_string():
     assert len(connection_string["urls"]) == len(
         set(connection_string["urls"])
     )  # all unique
-
-    del os.environ["ERT_STORAGE_CONNECTION_STRING"]
 
 
 def test_that_service_can_be_started_with_existing_conn_info_json(change_to_tmpdir):
@@ -217,11 +216,11 @@ def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
 
 @pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 @pytest.mark.slow
-def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir):
+def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir, monkeypatch):
     auth_token = "very_secret_token"
     sock = find_available_socket()
-
     cert_path, _, _ = _generate_certificate(Path())
+    monkeypatch.setenv("ERT_STORAGE_CONNECTION_STRING", "")
 
     conn_info = _create_connection_info(sock, auth_token, cert_path)
     # check certificate is readable
@@ -230,9 +229,7 @@ def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir):
 
     # extract hostname from the url strings "https://<hostname>:<port>/..."
     hosts_from_urls = [u.split("https://")[1].split(":")[0] for u in conn_info["urls"]]
-
     assert set(sans) == set(hosts_from_urls)
-    del os.environ["ERT_STORAGE_CONNECTION_STRING"]
 
 
 def test_that_an_exception_is_raised_if_storage_server_file_has_no_permissions(

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -2,7 +2,6 @@ import os
 import queue
 import shutil
 import stat
-import tempfile
 from collections.abc import Callable, Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from copy import deepcopy
@@ -168,10 +167,12 @@ def copy_math_func_test_data_to_tmp(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def cached_example(pytestconfig):
+def cached_example(pytestconfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     cache = pytestconfig.cache
+    copy_index = 0
 
     def run_config(test_data_case: str):
+        nonlocal copy_index
         test_data_name = test_data_case.replace("/", ".")
         if cache.get(f"cached_example:{test_data_case}", None) is None:
             my_tmpdir = cache.mkdir("cached_example_case" + test_data_name)
@@ -189,6 +190,7 @@ def cached_example(pytestconfig):
                 shutil.rmtree(my_tmpdir / "everest")
 
             shutil.copytree(config_path.parent, my_tmpdir / "everest")
+            monkeypatch.chdir(my_tmpdir / "everest")
             config = EverestConfig.load_file(my_tmpdir / "everest" / config_file)
             config.simulator.queue_system = LocalQueueOptions(max_running=2)
             status_queue: queue.SimpleQueue[StatusEvents] = queue.SimpleQueue()
@@ -227,13 +229,13 @@ def cached_example(pytestconfig):
             f"cached_example:{test_data_case}", (None, None, None, None)
         )
 
-        copied_tmpdir = tempfile.mkdtemp()
-        shutil.copytree(result_path, Path(copied_tmpdir) / "everest")
-        copied_path = str(Path(copied_tmpdir) / "everest")
-        os.chdir(copied_path)
+        copied_path = tmp_path / f"everest-{copy_index}"
+        copy_index += 1
+        shutil.copytree(result_path, copied_path)
+        monkeypatch.chdir(copied_path)
 
         return (
-            copied_path,
+            str(copied_path),
             config_file,
             optimal_result_json,
             [status_event_from_json(e) for e in events_list_json],

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -359,7 +359,9 @@ class ServerStatus:
 )
 @pytest.mark.slow
 def test_that_everest_run_warns_on_nonempty_runpath(
-    mock_warn_nonempty, change_to_tmpdir
+    # injected by @patch above; mock params must precede fixtures
+    mock_warn_user_that_runpath_is_nonempty,
+    change_to_tmpdir,
 ):
     existing_runpath = tempfile.TemporaryDirectory()
     (Path(existing_runpath.name) / "somefile").touch()

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -358,7 +358,9 @@ class ServerStatus:
     side_effect=RuntimeError("runpath is nonempty"),
 )
 @pytest.mark.slow
-def test_that_everest_run_warns_on_nonempty_runpath(change_to_tmpdir):
+def test_that_everest_run_warns_on_nonempty_runpath(
+    mock_warn_nonempty, change_to_tmpdir
+):
     existing_runpath = tempfile.TemporaryDirectory()
     (Path(existing_runpath.name) / "somefile").touch()
     assert Path(existing_runpath.name).is_absolute(), (

--- a/tests/everest/test_fm_plugins.py
+++ b/tests/everest/test_fm_plugins.py
@@ -107,8 +107,9 @@ def test_add_logging_handle(plugin_manager):
 
 def test_logging_from_plugin(caplog, plugin_manager):
     handle = logging.StreamHandler()
+    logger = logging.getLogger("my.test")
 
-    logging.getLogger("my.test").addHandler(handle)
+    logger.addHandler(handle)
 
     class Plugin:
         @hookimpl
@@ -123,8 +124,12 @@ def test_logging_from_plugin(caplog, plugin_manager):
 
     caplog.set_level(logging.DEBUG)
 
-    logging.getLogger("my.test").debug("Hello from my test")
-    Plugin().log()
+    try:
+        logger.debug("Hello from my test")
+        Plugin().log()
 
-    assert re.search(r"DEBUG.*my\.test:.*Hello from my test", caplog.text)
-    assert re.search(r"INFO.*my\.plugin:.*Hello from plugin", caplog.text)
+        assert re.search(r"DEBUG.*my\.test:.*Hello from my test", caplog.text)
+        assert re.search(r"INFO.*my\.plugin:.*Hello from plugin", caplog.text)
+    finally:
+        logger.removeHandler(handle)
+        handle.close()


### PR DESCRIPTION
Fixes up some instances of tests potentially changing the global state affecting subsequent tests.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
