### PR TITLE
Move basic customization and plot checkboxes to side panel

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -16,9 +16,7 @@ from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
-    QCheckBox,
     QComboBox,
-    QHBoxLayout,
     QVBoxLayout,
     QWidget,
     QWidgetAction,
@@ -153,29 +151,6 @@ class PlotWidget(QWidget):
         self.resetLayerWidget.connect(self._toolbar.resetLayerWidget)
         self.showLayerWidget.connect(self._toolbar.showLayerWidget)
 
-        self._extended_plot_information_checkbox = QCheckBox(
-            "Extended plot information", self
-        )
-        self._extended_plot_information_checkbox.setObjectName(
-            "extended_plot_information_checkbox"
-        )
-        self._extended_plot_information_checkbox.setCheckable(True)
-        self._extended_plot_information_checkbox.setVisible(False)
-        self._extended_plot_information_checkbox.setToolTip(
-            "Toggle extended plot information"
-        )
-        self._extended_plot_information_checkbox.clicked.connect(
-            self.logExtendedPlotInformationButtonUsage
-        )
-        self._extended_plot_information_checkbox.toggled.connect(
-            self._plotUpdateRequested
-        )
-
-        checkbox_row = QHBoxLayout()
-        checkbox_row.addWidget(self._extended_plot_information_checkbox)
-        checkbox_row.setContentsMargins(16, 8, 16, 8)
-        checkbox_row.addStretch()
-        vbox.addLayout(checkbox_row)
         vbox.addWidget(self._toolbar)
         vbox.addSpacing(8)
         self.setLayout(vbox)
@@ -189,22 +164,9 @@ class PlotWidget(QWidget):
     def resetPlot(self) -> None:
         self._figure.clear()
 
-    def _sync_extended_plot_information_checkbox(self) -> None:
-        if type(self._plotter).__name__ == "EverestBatchObjectiveFunctionPlot":
-            self._extended_plot_information_checkbox.setVisible(True)
-        else:
-            self._extended_plot_information_checkbox.setVisible(False)
-
     @property
     def name(self) -> str:
         return self._name
-
-    def logExtendedPlotInformationButtonUsage(self) -> None:
-        logger.info(
-            "Plotwidget utility used: "
-            f"'Extended plot information button' in tab '{self.name}'"
-        )
-        self._extended_plot_information_checkbox.clicked.disconnect()  # Log only once
 
     def updatePlot(
         self,
@@ -217,10 +179,6 @@ class PlotWidget(QWidget):
     ) -> None:
         self.resetPlot()
         try:
-            plot_context.extended_plot_information = (
-                self._extended_plot_information_checkbox.isVisible()
-                and self._extended_plot_information_checkbox.isChecked()
-            )
             self._plotter.plot(
                 self._figure,
                 plot_context,

--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -25,8 +25,6 @@ from PyQt6.QtWidgets import (
 )
 from typing_extensions import override
 
-from ert.config.distribution import ConstSettings
-from ert.config.gen_kw_config import GenKwConfig
 from ert.gui.icon_utils import load_icon
 
 from .plot_api import EnsembleObject, PlotApiKeyDefinition
@@ -155,15 +153,6 @@ class PlotWidget(QWidget):
         self.resetLayerWidget.connect(self._toolbar.resetLayerWidget)
         self.showLayerWidget.connect(self._toolbar.showLayerWidget)
 
-        self._log_checkbox = QCheckBox("Log scale", self)
-        self._log_checkbox.setObjectName("log_scale_checkbox")
-        self._log_checkbox.setCheckable(True)
-        # only for histogram plot see _sync_log_checkbox
-        self._log_checkbox.setVisible(False)
-        self._log_checkbox.setToolTip("Toggle data domain to log scale and back")
-        self._log_checkbox.clicked.connect(self.logLogScaleButtonUsage)
-        self._log_checkbox.toggled.connect(self._plotUpdateRequested)
-
         self._extended_plot_information_checkbox = QCheckBox(
             "Extended plot information", self
         )
@@ -183,7 +172,6 @@ class PlotWidget(QWidget):
         )
 
         checkbox_row = QHBoxLayout()
-        checkbox_row.addWidget(self._log_checkbox)
         checkbox_row.addWidget(self._extended_plot_information_checkbox)
         checkbox_row.setContentsMargins(16, 8, 16, 8)
         checkbox_row.addStretch()
@@ -192,7 +180,6 @@ class PlotWidget(QWidget):
         vbox.addSpacing(8)
         self.setLayout(vbox)
 
-        self._log_scale_valid_values = True
         self.resetPlot()
 
     @property
@@ -201,27 +188,6 @@ class PlotWidget(QWidget):
 
     def resetPlot(self) -> None:
         self._figure.clear()
-
-    def _sync_log_checkbox(self, key_def: PlotApiKeyDefinition | None = None) -> None:
-        if (
-            type(self._plotter).__name__
-            in {
-                "HistogramPlot",
-                "DistributionPlot",
-                "GaussianKDEPlot",
-            }
-            and self._log_scale_valid_values
-        ):
-            if key_def is not None:
-                a = key_def.parameter
-                if isinstance(a, GenKwConfig) and isinstance(
-                    a.distribution, ConstSettings
-                ):
-                    self._log_checkbox.setVisible(False)
-                    return
-            self._log_checkbox.setVisible(True)
-        else:
-            self._log_checkbox.setVisible(False)
 
     def _sync_extended_plot_information_checkbox(self) -> None:
         if type(self._plotter).__name__ == "EverestBatchObjectiveFunctionPlot":
@@ -232,10 +198,6 @@ class PlotWidget(QWidget):
     @property
     def name(self) -> str:
         return self._name
-
-    def logLogScaleButtonUsage(self) -> None:
-        logger.info(f"Plotwidget utility used: 'Log scale button' in tab '{self.name}'")
-        self._log_checkbox.clicked.disconnect()  # Log only once
 
     def logExtendedPlotInformationButtonUsage(self) -> None:
         logger.info(
@@ -254,14 +216,7 @@ class PlotWidget(QWidget):
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         self.resetPlot()
-        try:  # noqa: PLW0717
-            self._sync_log_checkbox(key_def)
-            self._sync_extended_plot_information_checkbox()
-            plot_context.log_scale = (
-                self._log_checkbox.isVisible()
-                and self._log_checkbox.isChecked()
-                and self._log_scale_valid_values
-            )
+        try:
             plot_context.extended_plot_information = (
                 self._extended_plot_information_checkbox.isVisible()
                 and self._extended_plot_information_checkbox.isChecked()

--- a/src/ert/gui/tools/plot/plot_window.py
+++ b/src/ert/gui/tools/plot/plot_window.py
@@ -12,6 +12,7 @@ from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtWidgets import (
     QApplication,
     QButtonGroup,
+    QCheckBox,
     QDialog,
     QDockWidget,
     QGroupBox,
@@ -352,12 +353,49 @@ class PlotWindow(QMainWindow):
                 ),
             )
 
+            self.log_scale_checkbox = QCheckBox("Log scale")
+            self.log_scale_checkbox.stateChanged.connect(self.updatePlot)
+            self.log_scale_checkbox.setVisible(False)
+
+            plot_config = self._plot_customizer.get_plot_config()
+            self.legend_checkbox = QCheckBox("Legend")
+            self.legend_checkbox.setChecked(plot_config.is_legend_enabled())
+            self.legend_checkbox.stateChanged.connect(self.updatePlot)
+
+            self.grid_checkbox = QCheckBox("Grid")
+            self.grid_checkbox.setChecked(plot_config.is_grid_enabled())
+            self.grid_checkbox.stateChanged.connect(self.updatePlot)
+
+            self.history_checkbox = QCheckBox("History")
+            self.history_checkbox.setChecked(plot_config.is_history_enabled())
+            self.history_checkbox.stateChanged.connect(self.updatePlot)
+            self.history_checkbox.setVisible(False)
+
+            self.observations_checkbox = QCheckBox("Observations")
+            self.observations_checkbox.setChecked(plot_config.is_observations_enabled())
+            self.observations_checkbox.stateChanged.connect(self.updatePlot)
+            self.observations_checkbox.setVisible(False)
+
+            self.customization_group = create_group_box(
+                "Customize",
+                create_group_layout(
+                    [
+                        self.legend_checkbox,
+                        self.grid_checkbox,
+                        self.history_checkbox,
+                        self.observations_checkbox,
+                        self.log_scale_checkbox,
+                        self._display_over_group,
+                    ]
+                ),
+            )
+
             right_container = QWidget()
             right_layout = create_group_layout(
                 [
                     self._ensemble_group,
-                    self._display_over_group,
                     self._everest_controls_group,
+                    self.customization_group,
                 ]
             )
             right_container.setLayout(right_layout)
@@ -502,8 +540,9 @@ class PlotWindow(QMainWindow):
                     elif result is not None:
                         ensemble_to_data_map[ensemble] = result
 
-            log_scale_valid_values = True
+            log_scale_valid_values = False
             if key_def.parameter is not None and key_def.parameter.type == "gen_kw":
+                log_scale_valid_values = True
                 for data in ensemble_to_data_map.values():
                     numeric = data.select_dtypes(include=["number"])
                     # Need non-unique check to disable log scale for
@@ -514,8 +553,12 @@ class PlotWindow(QMainWindow):
                     ):
                         log_scale_valid_values = False
                         break
+            self.log_scale_checkbox.setVisible(log_scale_valid_values)
 
-            plot_widget._log_scale_valid_values = log_scale_valid_values
+            self._plot_customizer.get_plot_config().set_grid_enabled(
+                self.grid_checkbox.isChecked()
+            )
+
             observations = pd.DataFrame()
             if key_def.observations and selected_ensembles:
                 try:
@@ -525,6 +568,10 @@ class PlotWindow(QMainWindow):
                     )
                 except BaseException as e:
                     handle_exception(e)
+            if not observations.empty:
+                self.observations_checkbox.setVisible(True)
+            else:
+                self.observations_checkbox.setVisible(False)
 
             std_dev_images: dict[str, npt.NDArray[np.float32]] = {}
             obs_loc: ObservationPlotLocations | None = None
@@ -576,6 +623,13 @@ class PlotWindow(QMainWindow):
                 except BaseException as e:
                     handle_exception(e)
                     plot_context.history_data = None
+            if plot_context.history_data is None or plot_context.history_data.empty:
+                self.history_checkbox.setVisible(False)
+            else:
+                self.history_checkbox.setVisible(True)
+                self._plot_customizer.get_plot_config().set_history_enabled(
+                    self.history_checkbox.isChecked()
+                )
 
             if key_def.response is not None and key_def.response.type == "rft":
                 plot_context.setXLabel(key.split(":")[-1])
@@ -596,6 +650,13 @@ class PlotWindow(QMainWindow):
                 if not data.empty and data.index.inferred_type == "datetime64":
                     self._preferred_ensemble_x_axis_format = PlotContext.DATE_AXIS
                     break
+
+            plot_config.set_legend_enabled(self.legend_checkbox.isChecked())
+            plot_config.set_grid_enabled(self.grid_checkbox.isChecked())
+            plot_config.set_history_enabled(self.history_checkbox.isChecked())
+            plot_config.set_observations_enabled(self.observations_checkbox.isChecked())
+
+            plot_context.log_scale = self.log_scale_checkbox.isChecked()
 
             self._updateCustomizer(plot_widget, self._preferred_ensemble_x_axis_format)
 

--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -53,7 +53,6 @@ class PlotContext:
         self._x_axis: str | None = None
         self._y_axis: str | None = None
         self._log_scale = False
-        self._extended_plot_information = False
         self._by_batch: bool = True
 
         self._plot_type: PlotType | None = None
@@ -133,14 +132,6 @@ class PlotContext:
 
     def setYLabel(self, value: str) -> None:
         self._plot_config.set_y_label(value)
-
-    @property
-    def extended_plot_information(self) -> bool:
-        return self._extended_plot_information
-
-    @extended_plot_information.setter
-    def extended_plot_information(self, value: bool) -> None:
-        self._extended_plot_information = value
 
     @property
     def log_scale(self) -> bool:

--- a/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
@@ -113,10 +113,9 @@ class EverestBatchObjectiveFunctionPlot:
                         """
                     ).strip("\n")
                 )
+
                 axes.annotate(
-                    f"Batch {batch_id}\nViolation value: {val:.3g}\nType: {val_type}"
-                    if plot_context.extended_plot_information
-                    else f"Batch {batch_id}",
+                    f"Batch {batch_id}",
                     xy=(row["batch_id"], row[value_col]),
                     xytext=(5, -5),
                     textcoords="offset points",
@@ -124,21 +123,12 @@ class EverestBatchObjectiveFunctionPlot:
                     verticalalignment="top",
                     horizontalalignment="left",
                 )
-                if plot_context.extended_plot_information:
-                    axes.margins(y=0.2)
 
         annotation_color = {True: color, False: "red"}
         for _, row in improvement_data.iterrows():
-            improvement_value = (
-                0
-                if row.get("improvement_value", float("nan")) == float("-inf")
-                else row.get("improvement_value", float("nan"))
-            )
             batch_id = int(row["batch_id"])
             axes.annotate(
-                f"Batch {batch_id}\nImprovement value: {improvement_value:.3g}"
-                if plot_context.extended_plot_information
-                else f"Batch {batch_id}",
+                f"Batch {batch_id}",
                 xy=(row["batch_id"], row[value_col]),
                 xytext=(5, -5),
                 textcoords="offset points",
@@ -146,8 +136,6 @@ class EverestBatchObjectiveFunctionPlot:
                 verticalalignment="top",
                 horizontalalignment="left",
             )
-            if plot_context.extended_plot_information:
-                axes.margins(y=0.2)
 
         config.add_legend_item("Accepted", lines[0])
         config.add_legend_item(

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -147,7 +147,7 @@ def test_that_plotting_gen_kw_parameter_with_negative_values_hides_log_scale_che
     plot_widget = plot_window._central_tab.currentWidget()
     assert plot_widget is not None
 
-    log_checkbox = plot_widget.findChild(QCheckBox, name="log_scale_checkbox")
+    log_checkbox = plot_window.log_scale_checkbox
     assert log_checkbox.isVisible()
     assert not log_checkbox.isChecked()
 


### PR DESCRIPTION
**Issue**
Resolves #13569


**Approach**
Removed `log_scale` and its sync methods from the `PlotWidget`

Copied the grid, legend, history and observations from the customization widget. Side panel now overwrites them, so nothing happens if attempting to toggle them in the customization widget. Setting title, colors, style etc still work 

(Screenshot of new behavior in GUI if applicable)
<img width="1509" height="830" alt="Screenshot 2026-06-01 at 13 06 38" src="https://github.com/user-attachments/assets/e718e2ae-77aa-457a-8ac4-e634caebb5a9" />
<img width="1503" height="827" alt="Screenshot 2026-06-01 at 13 06 30" src="https://github.com/user-attachments/assets/b73a05b7-a8c6-44e1-9bb9-14e3acbeeecb" />
<img width="1494" height="828" alt="Screenshot 2026-06-01 at 13 06 19" src="https://github.com/user-attachments/assets/72aef317-9025-41c2-846c-22a1869878df" />
<img width="1908" height="1039" alt="Screenshot 2026-06-01 at 13 05 54" src="https://github.com/user-attachments/assets/17960483-fc3b-45e3-bb62-5693854e7000" />
<img width="1905" height="1032" alt="Screenshot 2026-06-01 at 13 05 16" src="https://github.com/user-attachments/assets/56f5b892-b6d3-4e6e-a6aa-f7bdf77d19f4" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
