### PR TITLE
Handle fastexcel errors when reading design matrices

### DIFF
--- a/src/ert/config/design_matrix.py
+++ b/src/ert/config/design_matrix.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import polars as pl
-from fastexcel import CalamineError
+from fastexcel import CalamineCellError, CalamineError
 from polars.exceptions import InvalidOperationError
 
 from ert.config.parsing.config_errors import ConfigWarning
@@ -252,31 +253,33 @@ class DesignMatrix:
 
         try:
             param_names = (
-                pl.read_excel(
-                    self.xls_filename,
-                    sheet_name=self.design_sheet,
-                    has_header=False,
-                    read_options={"n_rows": 1, "dtypes": "string"},
+                _read_excel(
+                    lambda: pl.read_excel(
+                        self.xls_filename,
+                        sheet_name=self.design_sheet,
+                        has_header=False,
+                        read_options={"n_rows": 1, "dtypes": "string"},
+                    ),
+                    f"Design sheet '{self.design_sheet}' header row",
                 )
                 .select(pl.all().str.strip_chars())
                 .row(0)
             )
         except pl.exceptions.NoDataError as err:
             raise ValueError("Design sheet headers are empty.") from err
-        except CalamineError as err:
-            raise ValueError(
-                "File could not be loaded. It seems to be either invalid or corrupted."
-            ) from err
         design_matrix_df = (
-            pl.read_excel(
-                self.xls_filename,
-                sheet_name=self.design_sheet,
-                has_header=False,
-                drop_empty_cols=False,
-                drop_empty_rows=True,
-                raise_if_empty=False,
-                infer_schema_length=None,
-                read_options={"skip_rows": 1},
+            _read_excel(
+                lambda: pl.read_excel(
+                    self.xls_filename,
+                    sheet_name=self.design_sheet,
+                    has_header=False,
+                    drop_empty_cols=False,
+                    drop_empty_rows=True,
+                    raise_if_empty=False,
+                    infer_schema_length=None,
+                    read_options={"skip_rows": 1},
+                ),
+                f"Design sheet '{self.design_sheet}'",
             )
             .with_columns(pl.col(pl.Float32, pl.Float64).fill_nan(None))
             .with_columns(pl.col(pl.String).str.strip_chars())
@@ -443,14 +446,17 @@ class DesignMatrix:
 
         :raises: ValueError if defaults sheet is non-empty but non-parsable
         """
-        default_df = pl.read_excel(
-            xls_filename,
-            sheet_name=defaults_sheetname,
-            has_header=False,
-            drop_empty_cols=True,
-            drop_empty_rows=True,
-            raise_if_empty=False,
-            read_options={"dtypes": "string"},
+        default_df = _read_excel(
+            lambda: pl.read_excel(
+                xls_filename,
+                sheet_name=defaults_sheetname,
+                has_header=False,
+                drop_empty_cols=True,
+                drop_empty_rows=True,
+                raise_if_empty=False,
+                read_options={"dtypes": "string"},
+            ),
+            f"Default sheet '{defaults_sheetname}'",
         )
         if default_df.is_empty():
             return {}
@@ -486,6 +492,21 @@ class DesignMatrix:
             for row in default_df.iter_rows()
             if row[0] not in existing_parameters
         }
+
+
+def _read_excel(
+    read_excel: Callable[[], pl.DataFrame], sheet_description: str
+) -> pl.DataFrame:
+    try:
+        return read_excel()
+    except CalamineCellError as err:
+        raise ValueError(
+            f"{sheet_description} contains invalid Excel cell values: {err}"
+        ) from err
+    except CalamineError as err:
+        raise ValueError(
+            "File could not be loaded. It seems to be either invalid or corrupted."
+        ) from err
 
 
 def convert_numeric_string_columns(df: pl.DataFrame) -> pl.DataFrame:

--- a/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
+++ b/tests/ert/unit_tests/sensitivity_analysis/test_design_matrix.py
@@ -5,7 +5,12 @@ import polars as pl
 import pytest
 from xlsxwriter import Workbook
 
-from ert.config import DataSource, DesignMatrix, GenKwConfig
+from ert.config import (
+    ConfigValidationError,
+    DataSource,
+    DesignMatrix,
+    GenKwConfig,
+)
 from ert.config.design_matrix import DESIGN_MATRIX_GROUP
 from ert.config.parsing.config_errors import ConfigWarning
 from tests.ert.conftest import _create_design_matrix
@@ -609,3 +614,50 @@ def test_that_excel_datetime_columns_are_converted_to_strings_with_warning(tmp_p
     assert df.schema["date_col"] == pl.String
     assert "2026-03-01" in df["date_col"][0]
     assert "2026-03-02" in df["date_col"][1]
+
+
+def test_that_design_sheet_excel_error_cells_raise_config_validation_error(tmp_path):
+    design_path = tmp_path / "design_matrix.xlsx"
+    with Workbook(design_path) as wb:
+        ws = wb.add_worksheet("DesignSheet")
+
+        ws.write(0, 0, "REAL")
+        ws.write(0, 1, "a")
+        ws.write(0, 11, "")
+
+        ws.write(1, 0, 0)
+        ws.write(1, 1, 1)
+        ws.write_formula(1, 11, "=DOES_NOT_EXIST()", None, "#NAME?")
+
+    with pytest.raises(
+        ConfigValidationError,
+        match=(
+            r"Design sheet 'DesignSheet' contains invalid Excel cell values: "
+            r".*#NAME\?"
+        ),
+    ):
+        DesignMatrix(design_path, "DesignSheet", None)
+
+
+def test_that_default_sheet_excel_error_cells_raise_config_validation_error(tmp_path):
+    design_path = tmp_path / "design_matrix.xlsx"
+    with Workbook(design_path) as wb:
+        design_sheet = wb.add_worksheet("DesignSheet")
+        design_sheet.write(0, 0, "REAL")
+        design_sheet.write(0, 1, "a")
+        design_sheet.write(1, 0, 0)
+        design_sheet.write(1, 1, 1)
+        design_sheet.write(2, 0, 1)
+        design_sheet.write(2, 1, 2)
+
+        default_sheet = wb.add_worksheet("DefaultSheet")
+        default_sheet.write(0, 0, "b")
+        default_sheet.write(0, 1, "2")
+        default_sheet.write(1, 0, "c")
+        default_sheet.write_formula(1, 1, "=DOES_NOT_EXIST()", None, "#NAME?")
+
+    with pytest.raises(
+        ConfigValidationError,
+        match=r"Default sheet contains empty cells",
+    ):
+        DesignMatrix(design_path, "DesignSheet", "DefaultSheet")


### PR DESCRIPTION
**Issue**
Resolves #13628 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
