### PR TITLE
Disallow os.chdir imports in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ select = [
     "SIM",   # flake-8-simplify
     "SLOT",
     "TD",
+    "TID251", # banned-api (bare os.chdir in tests)
     "TID",
     "TRY203",
     "TRY300",
@@ -287,6 +288,7 @@ allowed-confusables = ["–"]
 "src/ert/dark_storage/json_schema/__init__.py" = ["F401"]
 "src/ert/dark_storage/*" = ["RUF029"] # unused-async
 "*.ipynb" = ["E402"]
+"!tests/**" = ["TID251"]
 
 
 [tool.ruff.lint.pylint]
@@ -299,6 +301,9 @@ allow-dunder-method-names = [
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.chdir".msg = "Use monkeypatch.chdir or the use_tmpdir fixture so the working directory is restored on teardown."
 
 [tool.pyright]
 include = ["src"]

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -376,9 +376,9 @@ def _qt_excepthook(monkeypatch):
     monkeypatch.setattr(sys, "excepthook", excepthook)
 
 
-def _run_snake_oil(source_root: Path):
+def _run_snake_oil(source_root: Path, monkeypatch: pytest.MonkeyPatch):
     shutil.copytree(source_root / "test-data" / "ert" / "snake_oil", "test_data")
-    os.chdir("test_data")
+    monkeypatch.chdir("test_data")
     with fileinput.input("snake_oil.ert", inplace=True) as fin:
         for line in fin:
             if "NUM_REALIZATIONS 25" in line:
@@ -401,9 +401,9 @@ def _run_snake_oil(source_root: Path):
     run_cli(parsed)
 
 
-def _run_heat_equation(source_root: Path, run_mode):
+def _run_heat_equation(source_root: Path, run_mode, monkeypatch: pytest.MonkeyPatch):
     shutil.copytree(source_root / "test-data" / "ert" / "heat_equation", "test_data")
-    os.chdir("test_data")
+    monkeypatch.chdir("test_data")
     with Path("config.ert").open("a", encoding="utf-8") as fh:
         fh.write("QUEUE_OPTION LOCAL MAX_RUNNING 2\n")
     parser = ArgumentParser(prog="test_main")
@@ -430,7 +430,7 @@ def _shared_snake_oil_case(request, monkeypatch, source_root: Path):
     )
     monkeypatch.chdir(cache_path)
     if not (cache_path / "test_data").exists():
-        _run_snake_oil(source_root)
+        _run_snake_oil(source_root, monkeypatch)
     else:
         monkeypatch.chdir("test_data")
 
@@ -448,7 +448,7 @@ def _shared_heat_equation_es(request, monkeypatch, source_root: Path):
     )
     monkeypatch.chdir(cache_path)
     if not os.listdir(cache_path):
-        _run_heat_equation(source_root, ENSEMBLE_SMOOTHER_MODE)
+        _run_heat_equation(source_root, ENSEMBLE_SMOOTHER_MODE, monkeypatch)
     else:
         monkeypatch.chdir("test_data")
 
@@ -466,7 +466,7 @@ def _shared_heat_equation_esmda(request, monkeypatch, source_root: Path):
     )
     monkeypatch.chdir(cache_path)
     if not os.listdir(cache_path):
-        _run_heat_equation(source_root, ES_MDA_MODE)
+        _run_heat_equation(source_root, ES_MDA_MODE, monkeypatch)
     else:
         monkeypatch.chdir("test_data")
 
@@ -484,7 +484,7 @@ def _shared_heat_equation_enif(request, monkeypatch, source_root: Path):
     )
     monkeypatch.chdir(cache_path)
     if not os.listdir(cache_path):
-        _run_heat_equation(source_root, ENIF_MODE)
+        _run_heat_equation(source_root, ENIF_MODE, monkeypatch)
     else:
         monkeypatch.chdir("test_data")
 

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -748,8 +748,9 @@ def test_that_plugin_forward_model_validation_failure_propagates(tmp_path):
 
 @pytest.mark.slow
 def test_that_validate_pre_realization_run_is_called_when_runmodel_is_evaluated(
-    tmp_path,
+    tmp_path, monkeypatch
 ):
+    monkeypatch.chdir(tmp_path)
     (tmp_path / "test.ert").write_text(
         dedent(
             """
@@ -779,12 +780,8 @@ def test_that_validate_pre_realization_run_is_called_when_runmodel_is_evaluated(
     runtime_plugins = ErtRuntimePlugins(
         installed_forward_model_steps={"WILL_FAIL_VALIDATION": FM()}
     )
-    original_cwd = Path.cwd()
-    try:
-        with pytest.raises(ErtCliError) as exc_info:
-            run_cli(args, runtime_plugins)
-    finally:
-        os.chdir(original_cwd)
+    with pytest.raises(ErtCliError) as exc_info:
+        run_cli(args, runtime_plugins)
     assert (
         "Validation failed for forward model step WILL_FAIL_VALIDATION: No go"
         in str(exc_info.value)
@@ -793,11 +790,12 @@ def test_that_validate_pre_realization_run_is_called_when_runmodel_is_evaluated(
 
 @pytest.mark.slow
 def test_that_validate_pre_realization_run_is_not_called_when_user_defined_step_overwrites(  # noqa: E501
-    tmp_path,
+    tmp_path, monkeypatch
 ):
     """If a site plugin defines a forward model step that will fail validation, but
     the user has defined her own step that does not have any validation,
     the site-installed step validation should not run"""
+    monkeypatch.chdir(tmp_path)
     (tmp_path / "A_POPULAR_STEP_NAME").write_text("EXECUTABLE echo", encoding="utf-8")
     (tmp_path / "test.ert").write_text(
         dedent(
@@ -829,11 +827,7 @@ def test_that_validate_pre_realization_run_is_not_called_when_user_defined_step_
     runtime_plugins = ErtRuntimePlugins(
         installed_forward_model_steps={"A_POPULAR_STEP_NAME": FM()}
     )
-    original_cwd = Path.cwd()
-    try:
-        run_cli(args, runtime_plugins)
-    finally:
-        os.chdir(original_cwd)
+    run_cli(args, runtime_plugins)
 
 
 def test_that_plugin_forward_model_validation_accepts_valid_args(tmp_path):

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -41,7 +41,7 @@ def api(tmpdir, source_root, monkeypatch):
         test_data_root = source_root / "test-data" / "ert"
         test_data_dir = test_data_root / "snake_oil"
         shutil.copytree(test_data_dir, "test_data")
-        os.chdir("test_data")
+        os.chdir("test_data")  # noqa: TID251  inside tmpdir.as_cwd() which restores
         yield PlotApi(test_data_dir)
 
 

--- a/tests/ert/unit_tests/resources/test_shell.py
+++ b/tests/ert/unit_tests/resources/test_shell.py
@@ -16,17 +16,6 @@ from tests.ert.utils import SOURCE_DIR
 
 from ._import_from_location import import_from_location
 
-
-@contextlib.contextmanager
-def pushd(path):
-    cwd0 = Path.cwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(cwd0)
-
-
 SHELL_SCRIPTS = SOURCE_DIR / "src" / "ert" / "resources" / "shell_scripts"
 
 symlink = import_from_location(
@@ -365,7 +354,7 @@ def test_that_delete_directory_can_delete_directories_with_internal_symlinks():
     mkdir("to_be_deleted")
     Path("to_be_deleted/link_target.txt").write_text("hei", encoding="utf-8")
 
-    with pushd("to_be_deleted"):
+    with contextlib.chdir("to_be_deleted"):
         symlink("link_target.txt", "link")
     assert Path("to_be_deleted/link").exists()
 
@@ -470,7 +459,7 @@ def test_copy_file2():
 
     Path("file2").write_text("Hei ...", encoding="utf-8")
 
-    with pushd("root/sub/path"):
+    with contextlib.chdir("root/sub/path"):
         copy_file("../../../file2")
         assert os.path.isfile("file2")
 

--- a/tests/ert/unit_tests/scenarios/test_summary_response.py
+++ b/tests/ert/unit_tests/scenarios/test_summary_response.py
@@ -1,4 +1,4 @@
-import os
+import contextlib
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -84,14 +84,11 @@ def create_responses(prior_ensemble, response_times):
     cwd = Path().absolute()
     rng = np.random.default_rng(seed=1234)
     base_path = cwd / "simulations" / "realization-<IENS>" / "iter-0"
-    try:
-        for i, response_time in enumerate(response_times):
-            sim_path = Path(str(base_path).replace("<IENS>", str(i)))
-            sim_path.mkdir(parents=True, exist_ok=True)
-            os.chdir(sim_path)
+    for i, response_time in enumerate(response_times):
+        sim_path = Path(str(base_path).replace("<IENS>", str(i)))
+        sim_path.mkdir(parents=True, exist_ok=True)
+        with contextlib.chdir(sim_path):
             run_sim(response_time, rng.standard_normal(), fname=f"ECLIPSE_CASE_{i}")
-    finally:
-        os.chdir(cwd)
     load_parameters_and_responses_from_runpath(
         str(base_path), prior_ensemble, range(len(response_times))
     )

--- a/tests/ert/unit_tests/storage/test_parameter_sample_types.py
+++ b/tests/ert/unit_tests/storage/test_parameter_sample_types.py
@@ -182,7 +182,7 @@ async def test_initialize_random_seed(
         # Make a clean directory for the second case, which is identical
         # to the first, except that it uses the random seed from the first
         os.makedirs("second")
-        os.chdir("second")
+        os.chdir("second")  # noqa: TID251  inside tmpdir.as_cwd() which restores
         random_seed = (
             next(
                 message

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -1,8 +1,7 @@
-import os
 import queue
 import shutil
 import stat
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -39,17 +38,15 @@ def testdata() -> Path:
 
 @pytest.fixture
 def copy_testdata_tmpdir(
-    testdata: Path, tmp_path: Path
-) -> Iterator[Callable[[str | None], Path]]:
+    testdata: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Callable[[str | None], Path]:
     def _copy_tree(path: str | None = None):
         path_ = testdata if path is None else testdata / path
         shutil.copytree(path_, tmp_path, dirs_exist_ok=True)
         return path_
 
-    cwd = Path.cwd()
-    os.chdir(tmp_path)
-    yield _copy_tree
-    os.chdir(cwd)
+    monkeypatch.chdir(tmp_path)
+    return _copy_tree
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
See https://docs.astral.sh/ruff/rules/banned-api/ 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
