### PR TITLE
Make config a required argument for the `ert api` cli command

### DIFF
--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -338,6 +338,7 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         description="Expose ERT data through an HTTP server",
     )
     ert_api_parser.set_defaults(func=run_ert_storage)
+    ert_api_parser.add_argument("config", type=valid_file, help=config_help)
     ert_api_add_parser_options(ert_api_parser)
 
     # test_run_parser

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -73,6 +73,12 @@ def write_to_pipe(connection_info: str | dict[str, Any]) -> None:
 
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "config",
+        type=str,
+        help=("ERT config file to start the server from "),
+        nargs="?",  # optional
+    )
     add_parser_options(ap)
     return ap.parse_args()
 
@@ -320,12 +326,6 @@ def main() -> None:
 
 
 def add_parser_options(ap: ArgumentParser) -> None:
-    ap.add_argument(
-        "config",
-        type=str,
-        help=("ERT config file to start the server from "),
-        nargs="?",  # optional
-    )
     ap.add_argument(
         "--project",
         "-p",

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -73,12 +73,6 @@ def write_to_pipe(connection_info: str | dict[str, Any]) -> None:
 
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser()
-    ap.add_argument(
-        "config",
-        type=str,
-        help=("ERT config file to start the server from "),
-        nargs="?",  # optional
-    )
     add_parser_options(ap)
     return ap.parse_args()
 

--- a/tests/ert/ui_tests/cli/test_cli.py
+++ b/tests/ert/ui_tests/cli/test_cli.py
@@ -75,6 +75,14 @@ def test_that_the_cli_raises_exceptions_when_parameters_are_missing(mode):
         )
 
 
+def test_that_the_cli_raises_exceptions_when_config_is_missing_for_api(
+    capsys: pytest.CaptureFixture[str],
+):
+    with pytest.raises(SystemExit, match="2"):
+        run_cli("api")
+    assert "the following arguments are required: config" in capsys.readouterr().err
+
+
 @pytest.mark.usefixtures("copy_poly_case")
 def test_that_the_cli_raises_exceptions_when_no_weight_provided_for_es_mda():
     with pytest.raises(


### PR DESCRIPTION
The ert api subparser was being passed to an `add_parser_options` function that added `config` as an optional argument when it should be required.

**Issue**
Resolves #13602 

**Approach**
- Dropped `config` from `add_parser_options`
- Moved the optional config arg addition where it was needed
- Added required config to `ert_api_parser` the way it's done for other subparsers


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] ~~**When there are user facing changes**: Updated documentation~~
- [ ] ~~**New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).~~
- [ ] ~~**Large PR**: Prepare changes in small commits for more convenient review~~
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
