### PR TITLE
Randomize test ordering on Python 3.14 CI

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -52,6 +52,14 @@ jobs:
       run: |
         uv sync --group dev
 
+    # Randomizes test ordering (and reseeds RNGs) to detect order-dependent
+    # flaky tests. The chosen seed is printed in
+    # the test output so failures can be reproduced with --randomly-seed=N.
+    - name: Enable randomized test ordering (Python 3.14)
+      if: inputs.python-version == '3.14'
+      run: |
+        uv pip install pytest-randomly
+
     - name: GUI Test
       if: inputs.test-type == 'gui-tests'
       run: |

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -63,6 +63,14 @@ jobs:
       run: |
         uv sync --group dev
 
+    # Randomizes test ordering (and reseeds RNGs) to detect order-dependent
+    # flaky tests. The chosen seed is printed in
+    # the test output so failures can be reproduced with --randomly-seed=N.
+    - name: Enable randomized test ordering (Python 3.14)
+      if: inputs.python-version == '3.14' && inputs.test-type == 'test'
+      run: |
+        uv pip install pytest-randomly
+
     - name: Run Tests Linux
       if: ${{ inputs.test-type == 'test' && runner.os != 'macOS'}}
       run: |


### PR DESCRIPTION
Resolves #13689

Use https://github.com/pytest-dev/pytest-randomly to try and catch order dependant tests

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
