### PR TITLE
Use codecov-action instead of codecov/test-results-action

### DIFF
--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -124,6 +124,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results
+        files: junit.xml,junit-doc.xml,junit-mem.xml
 
     - name: Test CLI
       run: |

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -120,9 +120,10 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
 
     - name: Test CLI
       run: |

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -108,6 +108,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results
+        files: junit.xml
 
     - name: Test for a clean repository
       if: ${{ inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc' }}

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -104,9 +104,10 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() && inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc' }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
 
     - name: Test for a clean repository
       if: ${{ inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc' }}

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
-        files: cov1.xml,cov2.xml
+        files: cov1.xml
         flags: ${{ inputs.test-type }}
     - name: codecov retry sleep
       if: steps.codecov1.outcome == 'failure' && inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc'
@@ -98,7 +98,7 @@ jobs:
       if: steps.codecov1.outcome == 'failure' && inputs.test-type != 'everest-docs-entry-test' && inputs.test-type != 'doc'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: cov1.xml,cov2.xml
+        files: cov1.xml
         flags: ${{ inputs.test-type }}
         fail_ci_if_error: ${{ github.ref == 'refs/heads/main' }}
 
@@ -116,7 +116,7 @@ jobs:
         # Remove things we have generated on purpose:
         ls -la
         rm -rf .coverage
-        rm -f coverage.xml cov1.xml cov2.xml junit.xml
+        rm -f coverage.xml cov1.xml junit.xml
         rm -f ert.*.whl
         rm -f codecov.SHA*
         rm -f codecov


### PR DESCRIPTION
**Issue**
Resolves #13686 

Updated to use codecov-action instead of test-results.
Removed `cov2` file from everest workflow.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
