### PR TITLE
Warn and skip constant parameter groups in all update strategies

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -244,6 +244,18 @@ def perform_ensemble_update(
         param_variance = np.var(param_ensemble_array, axis=1)
         non_zero_variance_mask = ~np.isclose(param_variance, 0.0)
 
+        if not non_zero_variance_mask.any():
+            log_msg = (
+                f"All {non_zero_variance_mask.size} parameters in '{param_group}' "
+                f"have 0 variance across realizations and will not be updated."
+            )
+            logger.warning(log_msg)
+            progress_callback(AnalysisStatusEvent(msg=log_msg))
+            target_ensemble.save_parameters_numpy(
+                param_ensemble_array, param_group, iens_active_index
+            )
+            continue
+
         if (param_count := (~non_zero_variance_mask).sum()) > 0:
             log_msg = (
                 f"There are {param_count} parameters with 0 variance "

--- a/src/ert/analysis/_update_strategies/_adaptive.py
+++ b/src/ert/analysis/_update_strategies/_adaptive.py
@@ -156,6 +156,8 @@ class AdaptiveLocalizationUpdate:
         start_time = time.perf_counter()
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
+            if update_idx.size == 0:
+                continue
             X_local = param_ensemble[update_idx, :]
 
             param_ensemble[update_idx, :] = self._smoother.assimilate_batch(

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import ExitStack as does_not_raise
 from typing import Any
 from unittest.mock import patch
@@ -29,6 +30,7 @@ from ert.config import (
     Field,
     GenDataConfig,
     GenKwConfig,
+    LocalizationType,
     ObservationSettings,
     OutlierSettings,
 )
@@ -508,6 +510,102 @@ def test_that_alpha_can_be_used_for_outlier_detection(
         assert (
             posterior_update.observations_and_responses["status"].to_list() == expected
         )
+
+
+@pytest.mark.parametrize(
+    "update_strategy",
+    [LocalizationType.ADAPTIVE, LocalizationType.GLOBAL],
+)
+def test_that_constant_parameter_is_skipped_with_warning_and_carried_over(
+    storage, obs, caplog, update_strategy
+):
+    """A parameter that is constant across all realizations has zero variance, so
+    no parameters are selected for update. Regardless of the
+    update strategy, the group should now be skipped with a warning and carried
+    over to the posterior unchanged.
+    """
+    constant_parameter = GenKwConfig(
+        name="KEY_1",
+        group="PARAMETER",
+        distribution={"name": "uniform", "min": 0, "max": 1},
+        update_strategy=update_strategy,
+    ).model_dump(mode="json")
+    response_config = GenDataConfig(keys=["RESPONSE"]).model_dump(mode="json")
+    experiment = storage.create_experiment(
+        name="constant_param",
+        experiment_config={
+            "parameter_configuration": [constant_parameter],
+            "response_configuration": [response_config],
+            "observations": obs,
+        },
+    )
+    prior_storage = storage.create_ensemble(
+        experiment,
+        ensemble_size=10,
+        iteration=0,
+        name="prior",
+    )
+    rng = np.random.default_rng(1234)
+
+    prior_storage.save_parameters(
+        dataset=pl.concat(
+            [
+                pl.DataFrame({"KEY_1": [0.5], "realization": iens})
+                for iens in range(prior_storage.ensemble_size)
+            ],
+            how="vertical",
+        )
+    )
+
+    for iens in range(prior_storage.ensemble_size):
+        values = rng.uniform(0.8, 1, 3)
+        prior_storage.save_response(
+            "gen_data",
+            pl.DataFrame(
+                {
+                    "response_key": "RESPONSE",
+                    "report_step": pl.Series(np.full(len(values), 0), dtype=pl.UInt16),
+                    "index": pl.Series(range(len(values)), dtype=pl.UInt16),
+                    "values": values,
+                }
+            ),
+            iens,
+        )
+
+    posterior_storage = storage.create_ensemble(
+        prior_storage.experiment_id,
+        ensemble_size=prior_storage.ensemble_size,
+        iteration=1,
+        name="posterior",
+        prior_ensemble=prior_storage,
+    )
+
+    es_settings = ESSettings()
+    strategy_map = build_strategy_map(
+        parameters=["KEY_1"],
+        param_configs=prior_storage.experiment.parameter_configuration,
+        enkf_truncation=es_settings.enkf_truncation,
+        correlation_threshold=es_settings.correlation_threshold,
+    )
+    with caplog.at_level(logging.WARNING):
+        smoother_update(
+            prior_storage,
+            posterior_storage,
+            observations=["OBSERVATION"],
+            update_settings=ObservationSettings(),
+            rng=rng,
+            strategy_map=strategy_map,
+        )
+
+    assert "have 0 variance across realizations and will not be updated" in caplog.text
+
+    prior_values = prior_storage.load_parameters_numpy(
+        "KEY_1", np.arange(prior_storage.ensemble_size)
+    )
+    posterior_values = posterior_storage.load_parameters_numpy(
+        "KEY_1", np.arange(prior_storage.ensemble_size)
+    )
+    assert np.array_equal(prior_values, posterior_values)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
**Issue**
Resolves #13695



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
