### PR TITLE
Fix tests leaking update_log into working directory

### DIFF
--- a/tests/ert/ui_tests/gui/test_update_runs.py
+++ b/tests/ert/ui_tests/gui/test_update_runs.py
@@ -168,7 +168,10 @@ def test_that_report_table_is_displayed_on_no_active_observations(
 
 
 @pytest.fixture
-def poly_case_with_autoscale_observations_config(source_root, tmp_path, run_experiment):
+def poly_case_with_autoscale_observations_config(
+    source_root, tmp_path, monkeypatch, run_experiment
+):
+    monkeypatch.chdir(tmp_path)
     _new_poly_example(source_root, tmp_path, 2)
 
     config_path = tmp_path / "poly.ert"
@@ -209,11 +212,14 @@ def test_that_autoscale_tab_is_displayed_in_es_update(
 
 
 @pytest.fixture
-def poly_case_with_one_missing_response(source_root, tmp_path, run_experiment):
+def poly_case_with_one_missing_response(
+    source_root, tmp_path, monkeypatch, run_experiment
+):
     """
     Sets up a poly case with missing response in realization 0 at indices
     corresponding to observations 2 and 4.
     """
+    monkeypatch.chdir(tmp_path)
     _new_poly_example(source_root, tmp_path, 2)
     config_path = tmp_path / "poly.ert"
     # ensures observations are not disabled due to unlucky responses
@@ -273,11 +279,12 @@ def test_that_report_table_is_displayed_on_missing_responses(
     ],
 )
 def poly_case_with_changed_response_on_match_key(
-    source_root, tmp_path, run_experiment, request
+    source_root, tmp_path, monkeypatch, run_experiment, request
 ):
     """
     Sets up a poly case with all responses changed on match key in realization 0.
     """
+    monkeypatch.chdir(tmp_path)
     _new_poly_example(source_root, tmp_path, 2)
     config_path = tmp_path / "poly.ert"
     # ensures observations are not disabled due to unlucky responses


### PR DESCRIPTION
See https://github.com/equinor/ert/actions/runs/26887998196/job/79306079031


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
