### PR TITLE
Add on-hover-functionality and unit testing to Everest batch obj. func.-plot

### DIFF
--- a/src/ert/gui/tools/plot/plot_widget.py
+++ b/src/ert/gui/tools/plot/plot_widget.py
@@ -164,27 +164,8 @@ class PlotWidget(QWidget):
         self._log_checkbox.clicked.connect(self.logLogScaleButtonUsage)
         self._log_checkbox.toggled.connect(self._plotUpdateRequested)
 
-        self._extended_plot_information_checkbox = QCheckBox(
-            "Extended plot information", self
-        )
-        self._extended_plot_information_checkbox.setObjectName(
-            "extended_plot_information_checkbox"
-        )
-        self._extended_plot_information_checkbox.setCheckable(True)
-        self._extended_plot_information_checkbox.setVisible(False)
-        self._extended_plot_information_checkbox.setToolTip(
-            "Toggle extended plot information"
-        )
-        self._extended_plot_information_checkbox.clicked.connect(
-            self.logExtendedPlotInformationButtonUsage
-        )
-        self._extended_plot_information_checkbox.toggled.connect(
-            self._plotUpdateRequested
-        )
-
         checkbox_row = QHBoxLayout()
         checkbox_row.addWidget(self._log_checkbox)
-        checkbox_row.addWidget(self._extended_plot_information_checkbox)
         checkbox_row.setContentsMargins(16, 8, 16, 8)
         checkbox_row.addStretch()
         vbox.addLayout(checkbox_row)
@@ -223,12 +204,6 @@ class PlotWidget(QWidget):
         else:
             self._log_checkbox.setVisible(False)
 
-    def _sync_extended_plot_information_checkbox(self) -> None:
-        if type(self._plotter).__name__ == "EverestBatchObjectiveFunctionPlot":
-            self._extended_plot_information_checkbox.setVisible(True)
-        else:
-            self._extended_plot_information_checkbox.setVisible(False)
-
     @property
     def name(self) -> str:
         return self._name
@@ -236,13 +211,6 @@ class PlotWidget(QWidget):
     def logLogScaleButtonUsage(self) -> None:
         logger.info(f"Plotwidget utility used: 'Log scale button' in tab '{self.name}'")
         self._log_checkbox.clicked.disconnect()  # Log only once
-
-    def logExtendedPlotInformationButtonUsage(self) -> None:
-        logger.info(
-            "Plotwidget utility used: "
-            f"'Extended plot information button' in tab '{self.name}'"
-        )
-        self._extended_plot_information_checkbox.clicked.disconnect()  # Log only once
 
     def updatePlot(
         self,
@@ -254,17 +222,12 @@ class PlotWidget(QWidget):
         key_def: PlotApiKeyDefinition | None = None,
     ) -> None:
         self.resetPlot()
-        try:  # noqa: PLW0717
+        try:
             self._sync_log_checkbox(key_def)
-            self._sync_extended_plot_information_checkbox()
             plot_context.log_scale = (
                 self._log_checkbox.isVisible()
                 and self._log_checkbox.isChecked()
                 and self._log_scale_valid_values
-            )
-            plot_context.extended_plot_information = (
-                self._extended_plot_information_checkbox.isVisible()
-                and self._extended_plot_information_checkbox.isChecked()
             )
             self._plotter.plot(
                 self._figure,

--- a/src/ert/gui/tools/plot/plottery/plot_context.py
+++ b/src/ert/gui/tools/plot/plottery/plot_context.py
@@ -53,7 +53,6 @@ class PlotContext:
         self._x_axis: str | None = None
         self._y_axis: str | None = None
         self._log_scale = False
-        self._extended_plot_information = False
         self._by_batch: bool = True
 
         self._plot_type: PlotType | None = None
@@ -133,14 +132,6 @@ class PlotContext:
 
     def setYLabel(self, value: str) -> None:
         self._plot_config.set_y_label(value)
-
-    @property
-    def extended_plot_information(self) -> bool:
-        return self._extended_plot_information
-
-    @extended_plot_information.setter
-    def extended_plot_information(self, value: bool) -> None:
-        self._extended_plot_information = value
 
     @property
     def log_scale(self) -> bool:

--- a/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/tools/plot/plottery/plots/everest_batch_objective_function_plot.py
@@ -60,7 +60,6 @@ class EverestBatchObjectiveFunctionPlot:
 
         if not all_dfs:
             return
-
         combined = pd.concat(all_dfs, ignore_index=True)
 
         value_col = next(
@@ -86,6 +85,20 @@ class EverestBatchObjectiveFunctionPlot:
             "-o",
             color=color,
         )
+
+        improvement_scatter_labels = []
+        improvement_scatter_data = None
+        if not improvement_data.empty:
+            improvement_scatter_data = axes.scatter(
+                improvement_data["batch_id"],
+                improvement_data[value_col],
+                c=color,
+                s=20,
+                zorder=5,
+            )
+            for _, row in improvement_data.iterrows():
+                batch_id = int(row["batch_id"])
+                improvement_scatter_labels.append(f"Batch {batch_id}")
 
         rejected_scatter_labels = []
         rejected_scatter_data = None
@@ -113,41 +126,6 @@ class EverestBatchObjectiveFunctionPlot:
                         """
                     ).strip("\n")
                 )
-                axes.annotate(
-                    f"Batch {batch_id}\nViolation value: {val:.3g}\nType: {val_type}"
-                    if plot_context.extended_plot_information
-                    else f"Batch {batch_id}",
-                    xy=(row["batch_id"], row[value_col]),
-                    xytext=(5, -5),
-                    textcoords="offset points",
-                    color="red",
-                    verticalalignment="top",
-                    horizontalalignment="left",
-                )
-                if plot_context.extended_plot_information:
-                    axes.margins(y=0.2)
-
-        annotation_color = {True: color, False: "red"}
-        for _, row in improvement_data.iterrows():
-            improvement_value = (
-                0
-                if row.get("improvement_value", float("nan")) == float("-inf")
-                else row.get("improvement_value", float("nan"))
-            )
-            batch_id = int(row["batch_id"])
-            axes.annotate(
-                f"Batch {batch_id}\nImprovement value: {improvement_value:.3g}"
-                if plot_context.extended_plot_information
-                else f"Batch {batch_id}",
-                xy=(row["batch_id"], row[value_col]),
-                xytext=(5, -5),
-                textcoords="offset points",
-                color=annotation_color[row["is_improvement"]],
-                verticalalignment="top",
-                horizontalalignment="left",
-            )
-            if plot_context.extended_plot_information:
-                axes.margins(y=0.2)
 
         config.add_legend_item("Accepted", lines[0])
         config.add_legend_item(
@@ -159,14 +137,19 @@ class EverestBatchObjectiveFunctionPlot:
 
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
 
-        if rejected_scatter_data and rejected_scatter_labels:
-            PlotTools.labels_on_hover(
-                PlotType.SCATTER,
-                axes,
-                figure,
-                data=rejected_scatter_data,
-                labels=rejected_scatter_labels,
-            )
+        hover_label_and_data_tuples = [
+            (rejected_scatter_labels, rejected_scatter_data),
+            (improvement_scatter_labels, improvement_scatter_data),
+        ]
+        for labels, scatter_data in hover_label_and_data_tuples:
+            if labels and scatter_data:
+                PlotTools.labels_on_hover(
+                    PlotType.SCATTER,
+                    axes,
+                    figure,
+                    data=scatter_data,
+                    labels=labels,
+                )
 
         PlotTools.finalizePlot(
             plot_context,
@@ -175,4 +158,3 @@ class EverestBatchObjectiveFunctionPlot:
             default_x_label="Batch iteration",
             default_y_label="Aggregated objective value",
         )
-        return

--- a/tests/everest/unit_tests/plots/test_everest_batch_objective_function_plot.py
+++ b/tests/everest/unit_tests/plots/test_everest_batch_objective_function_plot.py
@@ -1,0 +1,101 @@
+import pandas as pd
+import pytest
+from matplotlib.figure import Figure
+from tests.everest.unit_tests.plots.utils import move_cursor
+
+from ert.gui.tools.plot.plot_api import EnsembleObject
+from ert.gui.tools.plot.plottery.plots import EverestBatchObjectiveFunctionPlot
+
+
+@pytest.fixture
+def ensemble():
+    return EnsembleObject(
+        "batch_0", "id", False, "experiment_1", started_at="2012-12-10T00:00:00"
+    )
+
+
+@pytest.fixture
+def batch_objective_data():
+    return pd.DataFrame(
+        {
+            "batch_id": [0, 1, 2, 3],
+            "objective_function_value": [8.0, 9.0, 10.0, 7.0],
+            "is_improvement": [True, True, False, True],
+            "improvement_value": [float("-inf"), 2.0, float("nan"), 2.0],
+            "constraint_violation_type": [
+                None,
+                None,
+                "bound constraint violation",
+                "non-improvement",
+            ],
+            "constraint_violation_value": [
+                None,
+                None,
+                0.3,
+                None,
+            ],
+        }
+    )
+
+
+def test_that_date_support_is_disabled(generic_plot_context):
+    generic_plot_context.deactivate_date_support()
+    assert not generic_plot_context.is_date_support_active()
+
+
+def test_that_accepted_and_rejected_is_plotted_correctly(
+    ensemble, batch_objective_data, generic_plot_context
+):
+    plot, figure = EverestBatchObjectiveFunctionPlot(), Figure()
+    plot.plot(
+        figure,
+        generic_plot_context,
+        {ensemble: batch_objective_data},
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    axes = figure.get_axes()[0]
+    lines = axes.get_lines()
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.get_color() == generic_plot_context.plotConfig().current_color()
+    assert line.get_linestyle() == "-"
+    assert line.get_marker() == "o"
+
+    collections = axes.collections
+    assert len(collections) == 2
+
+
+def test_that_hovering_over_points_shows_correct_tooltip(
+    ensemble, batch_objective_data, generic_plot_context
+):
+    plot, figure = EverestBatchObjectiveFunctionPlot(), Figure()
+    plot.plot(
+        figure,
+        generic_plot_context,
+        {ensemble: batch_objective_data},
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    axes = figure.get_axes()[0]
+
+    move_cursor(axes=axes, x=0, y=8.0)
+
+    annotations = list(axes.texts)
+    assert len(annotations) == 2
+    rejected_batches = annotations[0]
+    accepted_batches = annotations[1]
+
+    accepted_batches_text = accepted_batches.get_text()
+    assert "Batch 0" in accepted_batches_text
+    assert accepted_batches.get_visible()
+    assert not rejected_batches.get_visible()
+
+    move_cursor(axes=axes, x=2, y=10.0)
+    assert rejected_batches.get_visible()
+    assert "Batch 2" in rejected_batches.get_text()
+    assert not accepted_batches.get_visible()


### PR DESCRIPTION
**Issue**
Resolves #13596 
Partly #13702

**Approach**
- Added on-hover to batch obj. plot by adding scatter points for batches (no line hover as discussed)
- Removed extended plot information, no longer needed, covered by on-hover
- Added payback unit test for batch obj

<img width="1510" height="948" alt="image" src="https://github.com/user-attachments/assets/4d662879-f4c8-4403-9010-5beb4e90213b" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
