### PR TITLE
Warn when ENIF ignores configured update strategies

### DIFF
--- a/src/ert/cli/main.py
+++ b/src/ert/cli/main.py
@@ -70,6 +70,24 @@ def run_cli(args: Namespace, runtime_plugins: ErtRuntimePlugins | None = None) -
             f"'OBS_CONFIG observation_file.txt'."
         )
 
+    if (
+        args.mode == ENIF_MODE
+        and ert_config.analysis_config.parameter_type_update_strategies
+    ):
+        strategies = "".join(
+            f"  {param_type}: {strategy.name}\n"
+            for param_type, strategy in (
+                ert_config.analysis_config.parameter_type_update_strategies.items()
+            )
+        )
+        print(
+            "Warning: Any given update strategy will be ignored "
+            "when running Ensemble Information Filter.\n"
+            "The following parameter update strategies were found "
+            "in the configuration:\n"
+            f"{strategies}"
+        )
+
     if args.mode in {
         ENSEMBLE_SMOOTHER_MODE,
         ENIF_MODE,

--- a/src/ert/gui/experiments/ensemble_information_filter_panel.py
+++ b/src/ert/gui/experiments/ensemble_information_filter_panel.py
@@ -58,6 +58,34 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
         layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         self.setObjectName("enif_panel")
 
+        if analysis_config.parameter_type_update_strategies:
+            strategies_html = "".join(
+                f"<li><b>{param_type}</b>: {strategy.name}</li>"
+                for param_type, strategy in (
+                    analysis_config.parameter_type_update_strategies.items()
+                )
+            )
+            warning_label = QLabel(
+                "<b>Warning:</b> Any given update strategy will be ignored "
+                "when running Ensemble Information Filter."
+                "<p>The following parameter update strategies were found "
+                "in the configuration:"
+                f"<ul>{strategies_html}</ul>"
+            )
+            warning_label.setObjectName("enif_warning_panel")
+            warning_label.setWordWrap(True)
+            warning_label.setTextFormat(Qt.TextFormat.RichText)
+            warning_label.setStyleSheet(
+                "QLabel#enif_warning_panel {"
+                " background-color: #fff3cd;"
+                " color: #664d03;"
+                " border: 1px solid #ffe69c;"
+                " border-radius: 4px;"
+                " padding: 8px;"
+                "}"
+            )
+            layout.addRow(warning_label)
+
         self._experiment_name_field = StringBox(
             TextModel(""),
             placeholder_text=self.notifier.storage.get_unique_experiment_name(


### PR DESCRIPTION
Show a warning in both the CLI and the GUI experiment panel listing the parameter types and their configured update strategies whenever Ensemble Information Filter is run with a configuration that defines per-parameter-type update strategies, so users are aware those strategies will not be applied.

**Issue**
Resolves #13674

<img width="1417" height="760" alt="image" src="https://github.com/user-attachments/assets/357f2d2b-d1e5-4e1a-91ed-d981384500ed" />