### PR TITLE
More deprecation removals

### DIFF
--- a/docs/ert/getting_started/howto/plugin_system.rst
+++ b/docs/ert/getting_started/howto/plugin_system.rst
@@ -181,7 +181,7 @@ Implement the hook specification as follows to register the workflow job ``CSV_E
             "CSV_EXPORT": "/path/to/csv_export"
         }
 
-.. _legacy_ert_workflow_jobs:
+.. _ert_workflow_jobs:
 
 2. **Using the ertscript_workflow hook**
 

--- a/docs/ert/reference/workflows/workflows.rst
+++ b/docs/ert/reference/workflows/workflows.rst
@@ -76,4 +76,4 @@ state of the experiment that is running:
         ):
             print(f"Provided user arguments: {workflow_args}")
 
-For how to load internal workflow jobs into ERT, see: :ref:`installing workflows <legacy_ert_workflow_jobs>`
+For how to load internal workflow jobs into ERT, see: :ref:`installing workflows <ert_workflow_jobs>`

--- a/src/ert/__main__.py
+++ b/src/ert/__main__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import locale
 import logging
 import logging.config
@@ -15,7 +14,6 @@ from argparse import ArgumentParser, ArgumentTypeError
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 from uuid import UUID
 
 import yaml
@@ -247,29 +245,6 @@ def run_lint_wrapper(args: Namespace, _: ErtRuntimePlugins) -> None:
     lint_file(args.config)
 
 
-class DeprecatedAction(argparse.Action):
-    def __init__(self, alternative_option: str | None = None, **kwargs: Any) -> None:
-        self.alternative_option: str | None = alternative_option
-        super().__init__(**kwargs)
-
-    def __call__(
-        self,
-        parser: ArgumentParser,
-        namespace: argparse.Namespace,
-        values: Any,
-        option_string: str | None = None,
-    ) -> None:
-        alternative_msg: str = (
-            f"Use {self.alternative_option} instead." if self.alternative_option else ""
-        )
-        warnings.warn(
-            f"{option_string} is deprecated and will be removed in "
-            f"future versions. {alternative_msg}",
-            stacklevel=1,
-        )
-        setattr(namespace, self.dest, values)
-
-
 def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
     if parser is None:
         parser = ArgumentParser(description="ERT - Ensemble Reservoir Tool")
@@ -346,15 +321,6 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         TEST_RUN_MODE, help=test_run_description, description=test_run_description
     )
     test_run_parser.add_argument(
-        "--current-case",
-        type=valid_name,
-        default="default",
-        action=DeprecatedAction,
-        dest="current_ensemble",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --current-ensemble instead.",
-    )
-    test_run_parser.add_argument(
         "--current-ensemble",
         type=valid_name,
         default="default",
@@ -378,15 +344,6 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         "For example, if 'Number of realizations:50 and Active realizations is 0-9', "
         "then only realizations 0,1,2,3,...,9 will be used to perform experiments "
         "while realizations 10,11, 12,...,49 will be excluded.",
-    )
-    ensemble_experiment_parser.add_argument(
-        "--current-case",
-        type=valid_ensemble,
-        default="default",
-        action=DeprecatedAction,
-        dest="current_ensemble",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --current-ensemble instead.",
     )
     ensemble_experiment_parser.add_argument(
         "--current-ensemble",
@@ -413,29 +370,10 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         help=ensemble_smoother_description,
     )
     ensemble_smoother_parser.add_argument(
-        "--current-case",
-        type=valid_name,
-        action=DeprecatedAction,
-        alternative_option="--current-ensemble",
-        dest="current_ensemble",
-        default="default",
-        help="Deprecated: This argument is deprecated and has no effect.",
-    )
-    ensemble_smoother_parser.add_argument(
         "--current-ensemble",
         type=valid_name,
         default="default",
         help="This argument is deprecated and has no effect.",
-    )
-    ensemble_smoother_parser.add_argument(
-        "--target-case",
-        type=valid_name_format,
-        default="iter-%d",
-        action=DeprecatedAction,
-        alternative_option="--target-ensemble",
-        dest="target_ensemble",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --target-ensemble instead.",
     )
     ensemble_smoother_parser.add_argument(
         "--target-ensemble",
@@ -499,15 +437,6 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         ES_MDA_MODE, description=es_mda_description, help=es_mda_description
     )
     es_mda_parser.add_argument(
-        "--target-case",
-        type=valid_name_format,
-        action=DeprecatedAction,
-        alternative_option="--target-ensemble",
-        dest="target_ensemble",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --target-ensemble instead.",
-    )
-    es_mda_parser.add_argument(
         "--target-ensemble",
         type=valid_name_format,
         help="The es_mda creates multiple ensembles for the different "
@@ -530,15 +459,6 @@ def get_ert_parser(parser: ArgumentParser | None = None) -> ArgumentParser:
         help="Example custom relative weights: '8,4,2,1'. This means multiple data "
         "assimilation ensemble smoother will half the weight applied to the "
         "observation errors from one iteration to the next across 4 iterations.",
-    )
-    es_mda_parser.add_argument(
-        "--restart-case",
-        type=valid_name,
-        default=None,
-        action=DeprecatedAction,
-        dest="restart_ensemble_id",
-        help="Deprecated: This argument is deprecated and will be "
-        "removed in future versions. Use --restart-ensemble instead.",
     )
     es_mda_parser.add_argument(
         "--restart-ensemble",

--- a/src/ert/config/__init__.py
+++ b/src/ert/config/__init__.py
@@ -56,7 +56,7 @@ from .rft_config import RFTConfig
 from .summary_config import SummaryConfig
 from .surface_config import SurfaceConfig
 from .workflow import Workflow
-from .workflow_config import LegacyWorkflowConfigs, WorkflowConfigs
+from .workflow_config import WorkflowConfigs
 from .workflow_fixtures import (
     HookedWorkflowFixtures,
     PostExperimentFixtures,
@@ -118,7 +118,6 @@ __all__ = [
     "KnownQueueOptions",
     "KnownQueueOptionsAdapter",
     "KnownResponseTypes",
-    "LegacyWorkflowConfigs",
     "LocalQueueOptions",
     "LocalizationType",
     "ModelConfig",

--- a/src/ert/config/workflow_config.py
+++ b/src/ert/config/workflow_config.py
@@ -1,105 +1,13 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from argparse import ArgumentParser
 from collections.abc import Callable
 
 from .ert_script import ErtScript
-from .parsing import SchemaItemType
 from .workflow_job import ErtScriptWorkflow
 
 logger = logging.getLogger(__name__)
-
-
-class LegacyErtScriptWorkflow:
-    """This is a wrapper around ErtScriptWorkflow to keep backwards compatibility"""
-
-    def __init__(
-        self, actual_workflow: ErtScriptWorkflow, workflow_configs: WorkflowConfigs
-    ) -> None:
-        self._actual_workflow = actual_workflow
-        self._workflow_configs = workflow_configs
-
-    @property
-    def name(self) -> str:
-        return self._actual_workflow.name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        self._actual_workflow.name = value
-
-    @property
-    def min_args(self) -> int | None:
-        return self._actual_workflow.min_args
-
-    @min_args.setter
-    def min_args(self, value: int | None) -> None:
-        self._actual_workflow.min_args = value
-
-    @property
-    def max_args(self) -> int | None:
-        return self._actual_workflow.max_args
-
-    @max_args.setter
-    def max_args(self, value: int | None) -> None:
-        self._actual_workflow.max_args = value
-
-    @property
-    def arg_types(self) -> list[SchemaItemType]:
-        return self._actual_workflow.arg_types
-
-    @arg_types.setter
-    def arg_types(self, value: list[SchemaItemType]) -> None:
-        self._actual_workflow.arg_types = value
-
-    @property
-    def stop_on_fail(self) -> bool:
-        return self._actual_workflow.stop_on_fail
-
-    @stop_on_fail.setter
-    def stop_on_fail(self, value: bool) -> None:
-        self._actual_workflow.stop_on_fail = value
-
-    @property
-    def ert_script(self) -> type[ErtScript]:
-        return self._actual_workflow.ert_script
-
-    @ert_script.setter
-    def ert_script(self, value: type[ErtScript]) -> None:
-        self._actual_workflow.ert_script = value
-
-    @property
-    def description(self) -> str:
-        return self._actual_workflow.description
-
-    @description.setter
-    def description(self, value: str) -> None:
-        self._actual_workflow.description = value
-
-    @property
-    def category(self) -> str:
-        return self._actual_workflow.category
-
-    @category.setter
-    def category(self, value: str) -> None:
-        self._actual_workflow.category = value
-
-    @property
-    def examples(self) -> str | None:
-        return self._actual_workflow.examples
-
-    @examples.setter
-    def examples(self, value: str | None) -> None:
-        self._actual_workflow.examples = value
-
-    @property
-    def parser(self) -> Callable[[], ArgumentParser] | None:
-        return self._workflow_configs.parsers[self.name]
-
-    @parser.setter
-    def parser(self, value: Callable[[], ArgumentParser] | None) -> None:
-        self._workflow_configs.parsers[self.name] = value
 
 
 class WorkflowConfigs:
@@ -149,40 +57,3 @@ class WorkflowConfigs:
             else:
                 configs[workflow.name] = workflow
         return configs
-
-
-class LegacyWorkflowConfigs(WorkflowConfigs):
-    def add_workflow(  # type: ignore
-        self,
-        ert_script: type[ErtScript],
-        name: str = "",
-        description: str = "",
-        examples: str | None = None,
-        parser: Callable[[], ArgumentParser] | None = None,
-        category: str = "other",
-    ) -> ErtScriptWorkflow:
-        """
-        :param category: dot separated string
-        :param parser: will extract information to use in documentation
-        :param examples: must be valid rst, will be added to documentation
-        :param description: must be valid rst, defaults to __doc__
-        :param ert_script: class which inherits from ErtScript
-        :param name: Optional name for workflow (default is name of class)
-        :return: Instantiated workflow config.
-        """
-        warnings.warn(
-            "Use of legacy_ertscript_workflow is deprecated. "
-            "Please see documentation for how to use ertscript_workflow instead",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        workflow = ErtScriptWorkflow(
-            name=name or ert_script.__name__,
-            ert_script=ert_script,
-            description=description,
-            examples=examples,
-            category=category,
-        )
-        self._workflows.append(workflow)
-        self.parsers[workflow.name] = parser
-        return LegacyErtScriptWorkflow(workflow, self)  # type: ignore

--- a/src/ert/plugins/hook_specifications/__init__.py
+++ b/src/ert/plugins/hook_specifications/__init__.py
@@ -7,7 +7,6 @@ from .jobs import (
     ertscript_workflow,
     installable_workflow_jobs,
     job_documentation,
-    legacy_ertscript_workflow,
 )
 from .logging import add_log_handle_to_root, add_span_processor
 from .net_utils import get_ip_address
@@ -23,6 +22,5 @@ __all__ = [
     "installable_forward_model_steps",
     "installable_workflow_jobs",
     "job_documentation",
-    "legacy_ertscript_workflow",
     "site_configurations",
 ]

--- a/src/ert/plugins/hook_specifications/jobs.py
+++ b/src/ert/plugins/hook_specifications/jobs.py
@@ -44,9 +44,3 @@ def ertscript_workflow(config: WorkflowConfigs) -> None:
 
     :param config: A handle to the main workflow config.
     """
-
-
-@no_type_check
-@hook_specification
-def legacy_ertscript_workflow(config: WorkflowConfigs) -> None:
-    """Deprecated Variant of the hook ertscript_workflow"""

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -15,7 +15,6 @@ from ert.config import (
     ForwardModelStepDocumentation,
     ForwardModelStepPlugin,
     KnownQueueOptions,
-    LegacyWorkflowConfigs,
     LocalQueueOptions,
     SiteInstalledForwardModelStep,
     WorkflowConfigs,
@@ -270,7 +269,6 @@ class ErtPluginManager(pluggy.PluginManager):
 
     def get_documentation_for_workflows(self) -> dict[str, JobDoc]:
         workflow_config = self.get_ertscript_workflows()
-        legacy_workflow_config = self.get_legacy_ertscript_workflows()
 
         job_docs: dict[str, JobDoc] = {  # type: ignore
             workflow.name: {
@@ -282,16 +280,6 @@ class ErtPluginManager(pluggy.PluginManager):
                 "category": workflow.category,
             }
             for workflow in workflow_config._workflows
-        } | {
-            workflow.name: {
-                "description": workflow.description,
-                "examples": workflow.examples,
-                "parser": legacy_workflow_config.parsers[workflow.name],
-                "config_file": None,
-                "source_package": workflow.source_package,
-                "category": workflow.category,
-            }
-            for workflow in legacy_workflow_config._workflows
         }
 
         fm_step_doc = self.get_documentation_for_forward_model_steps()
@@ -312,11 +300,6 @@ class ErtPluginManager(pluggy.PluginManager):
     def get_ertscript_workflows(self) -> WorkflowConfigs:
         config = WorkflowConfigs()
         self.hook.ertscript_workflow(config=config)
-        return config
-
-    def get_legacy_ertscript_workflows(self) -> WorkflowConfigs:
-        config = LegacyWorkflowConfigs()
-        self.hook.legacy_ertscript_workflow(config=config)
         return config
 
     def add_logging_handle_to_root(self, logger: logging.Logger) -> None:
@@ -371,8 +354,6 @@ def get_site_plugins(
 
     all_workflow_jobs: dict[str, WorkflowJob] = dict[str, WorkflowJob](
         plugin_manager.get_ertscript_workflows().get_workflows()
-    ) | dict[str, WorkflowJob](
-        plugin_manager.get_legacy_ertscript_workflows().get_workflows()
     )
 
     for job_path in installable_workflow_jobs.values():

--- a/tests/ert/unit_tests/plugins/test_workflow_config.py
+++ b/tests/ert/unit_tests/plugins/test_workflow_config.py
@@ -1,12 +1,7 @@
-import argparse
 import logging
 from unittest.mock import Mock
 
-import pytest
-
-from ert import ErtScript
 from ert.config import workflow_config
-from ert.config.workflow_config import LegacyWorkflowConfigs
 
 
 def test_workflow_config_duplicate_log_message(caplog, monkeypatch):
@@ -24,99 +19,3 @@ def test_workflow_config_duplicate_log_message(caplog, monkeypatch):
     with caplog.at_level(logging.INFO):
         config.get_workflows()
     assert "Duplicate workflow name: same_name, skipping" in caplog.text
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_name_through_dunder_field():
-    class MockedErtScript(ErtScript):
-        pass
-
-    configs = LegacyWorkflowConfigs()
-    _ = configs.add_workflow(ert_script=MockedErtScript)
-
-    assert configs.get_workflows()["MockedErtScript"].ert_script is MockedErtScript
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_name_through_parameter():
-    class MockedErtScript(ErtScript):
-        pass
-
-    configs = LegacyWorkflowConfigs()
-    _ = configs.add_workflow(ert_script=MockedErtScript, name="parameter_name")
-
-    assert configs.get_workflows()["parameter_name"].ert_script is MockedErtScript
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_name_through_add_workflow_return_value():
-    configs = LegacyWorkflowConfigs()
-
-    class MockedErtScript(ErtScript):
-        pass
-
-    workflow = configs.add_workflow(ert_script=MockedErtScript)
-    workflow.name = "name"
-
-    assert configs.get_workflows()["name"].ert_script is MockedErtScript
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_description_defaults_to_its_docstring():
-    class MockedErtScript(ErtScript):
-        """description"""
-
-    configs = LegacyWorkflowConfigs()
-    _ = configs.add_workflow(ert_script=MockedErtScript)
-
-    assert configs.get_workflows()["MockedErtScript"].description == "description"
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_description_through_parameter():
-    class MockedErtScript(ErtScript):
-        pass
-
-    configs = LegacyWorkflowConfigs()
-    _ = configs.add_workflow(ert_script=MockedErtScript, description="description")
-
-    assert configs.get_workflows()["MockedErtScript"].description == "description"
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_description_through_add_workflow_return_value():
-    configs = LegacyWorkflowConfigs()
-    workflow = configs.add_workflow(ert_script=ErtScript)
-    workflow.description = "description"
-
-    assert configs.get_workflows()["ErtScript"].description == "description"
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_examples_through_parameter():
-    configs = LegacyWorkflowConfigs()
-    workflow = configs.add_workflow(ert_script=ErtScript, examples="examples")
-    workflow.name = "name"
-
-    assert configs.get_workflows()["name"].examples == "examples"
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_config_can_set_examples_through_add_workflow_return_value():
-    configs = LegacyWorkflowConfigs()
-    workflow = configs.add_workflow(ert_script=ErtScript)
-    workflow.examples = "examples"
-
-    assert configs.get_workflows()["ErtScript"].examples == "examples"
-
-
-@pytest.mark.filterwarnings("ignore:Use of legacy_ertscript_workflow is deprecated")
-def test_legacy_workflow_configs_sets_parser_through_add_workflow_return_value():
-    configs = LegacyWorkflowConfigs()
-    workflow = configs.add_workflow(ert_script=ErtScript, name="name")
-
-    def create_parser():
-        return argparse.ArgumentParser()
-
-    workflow.parser = create_parser
-    assert configs.parsers[workflow.name] is create_parser

--- a/tests/ert/unit_tests/test_main.py
+++ b/tests/ert/unit_tests/test_main.py
@@ -52,16 +52,15 @@ def test_argparse_exec_ensemble_experiment_valid_case():
 
 
 def test_argparse_exec_ensemble_experiment_current_case():
-    with pytest.warns(UserWarning, match="current-case is deprecated"):
-        parsed = ert_parser(
-            None,
-            [
-                ENSEMBLE_EXPERIMENT_MODE,
-                "--current-case",
-                "test_case",
-                "path/to/config.ert",
-            ],
-        )
+    parsed = ert_parser(
+        None,
+        [
+            ENSEMBLE_EXPERIMENT_MODE,
+            "--current-ensemble",
+            "test_case",
+            "path/to/config.ert",
+        ],
+    )
     assert parsed.mode == ENSEMBLE_EXPERIMENT_MODE
     assert parsed.current_ensemble == "test_case"
     assert parsed.func.__name__ == "run_cli"


### PR DESCRIPTION
* The legacy_workflow_config has had a deprecation warning for 10 months.
* The deprecated actions have given warnings since 2024.


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
