### PR TITLE
Add Everest check for on-hover in ensemble-plot

### DIFF
--- a/src/ert/gui/tools/plot/plottery/plots/ensemble.py
+++ b/src/ert/gui/tools/plot/plottery/plots/ensemble.py
@@ -93,14 +93,14 @@ class EnsemblePlot:
         plotHistory(plot_context, axes)
 
         default_x_label = "Date" if plot_context.is_date_support_active() else "Index"
-
-        PlotTools.labels_on_hover(
-            PlotType.LINE,
-            axes,
-            figure,
-            data=tooltip_data,
-            labels=tooltip_labels,
-        )
+        if is_everest:
+            PlotTools.labels_on_hover(
+                PlotType.LINE,
+                axes,
+                figure,
+                data=tooltip_data,
+                labels=tooltip_labels,
+            )
 
         PlotTools.finalizePlot(
             plot_context,


### PR DESCRIPTION
**Issue**
Resolves #13727


**Approach**
Unsure if the functionality is wanted for Ert. Currently two bugs connected to the on-hover(more info in issue). If wanted functionality in Ert, should be introduced at a later stage. 

*Ensemble-plot in Everest(hover-box):*
<img width="1511" height="947" alt="image" src="https://github.com/user-attachments/assets/2fb24f8f-2fd2-4ff3-8f58-40ee078927fd" />
*Ensemble-plot in Ert(no hover-box):*
<img width="1496" height="830" alt="image" src="https://github.com/user-attachments/assets/c19f0992-e05f-4ad3-b9ef-64452df1da6d" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
