### PR TITLE
Decrease runtime of dark storage performance test

### DIFF
--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -329,7 +329,7 @@ def test_that_load_scalars_handles_many_genkw_keys(benchmark, tmp_path):
     storage_path = tmp_path / "storage"
 
     reals = 100
-    num_keys = 10000
+    num_keys = 500
     parameter_configs = [
         GenKwConfig(
             name=f"P{i}",


### PR DESCRIPTION
**Issue**
Fixing this performance test caused codespeed to timeout at 40min. 


**Approach**
Decreasing number of keys to limit runtime

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
