### PR TITLE
Improve the tooltip manager api

### DIFF
--- a/src/ert/gui/plotting/everest_plots/everest_batch_objective_function_plot.py
+++ b/src/ert/gui/plotting/everest_plots/everest_batch_objective_function_plot.py
@@ -86,37 +86,39 @@ class EverestBatchObjectiveFunctionPlot:
             color=color,
         )
 
-        improvement_scatter_labels = []
-        improvement_scatter_data = None
+        scatter_labels = []
+        scatter_data = []
         if not improvement_data.empty:
-            improvement_scatter_data = axes.scatter(
-                improvement_data["batch_id"],
-                improvement_data[value_col],
-                c=color,
-                s=20,
-                zorder=5,
+            scatter_data.append(
+                axes.scatter(
+                    improvement_data["batch_id"],
+                    improvement_data[value_col],
+                    c=color,
+                    s=20,
+                    zorder=5,
+                )
             )
             for _, row in improvement_data.iterrows():
                 batch_id = int(row["batch_id"])
-                improvement_scatter_labels.append(f"Batch {batch_id}")
+                scatter_labels.append(f"Batch {batch_id}")
 
-        rejected_scatter_labels = []
-        rejected_scatter_data = None
         rejected_data = data[~data["is_improvement"]]
         if not rejected_data.empty:
-            rejected_scatter_data = axes.scatter(
-                rejected_data["batch_id"],
-                rejected_data[value_col],
-                c="red",
-                s=20,
-                zorder=5,
+            scatter_data.append(
+                axes.scatter(
+                    rejected_data["batch_id"],
+                    rejected_data[value_col],
+                    c="red",
+                    s=20,
+                    zorder=5,
+                )
             )
             for _, row in rejected_data.iterrows():
                 batch_id = int(row["batch_id"])
                 val_type = row.get("constraint_violation_type", "N/A")
                 val = row.get("constraint_violation_value", float("nan"))
 
-                rejected_scatter_labels.append(
+                scatter_labels.append(
                     dedent(
                         f"""
                         Batch {batch_id}
@@ -137,19 +139,14 @@ class EverestBatchObjectiveFunctionPlot:
 
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
 
-        hover_label_and_data_tuples = [
-            (rejected_scatter_labels, rejected_scatter_data),
-            (improvement_scatter_labels, improvement_scatter_data),
-        ]
-        for labels, scatter_data in hover_label_and_data_tuples:
-            if labels and scatter_data:
-                PlotTools.labels_on_hover(
-                    PlotType.SCATTER,
-                    axes,
-                    figure,
-                    data=scatter_data,
-                    labels=labels,
-                )
+        if scatter_labels and scatter_data:
+            PlotTools.labels_on_hover(
+                PlotType.SCATTER,
+                axes,
+                figure,
+                data=scatter_data,
+                labels=scatter_labels,
+            )
 
         PlotTools.finalizePlot(
             plot_context,

--- a/src/ert/gui/plotting/everest_plots/everest_gradients_plot.py
+++ b/src/ert/gui/plotting/everest_plots/everest_gradients_plot.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+from matplotlib.container import BarContainer
 
 from ert.gui.plotting.utils.plot_context import PlotType
 from ert.gui.plotting.utils.plot_tools import ConditionalAxisFormatter, PlotTools
@@ -84,7 +85,7 @@ class EverestGradientsPlot:
         n_controls = len(self.selected_controls)
         bar_width = 0.8 / n_controls
 
-        bar_containers = []
+        bar_containers: list[BarContainer] = []
         n_colors = config.get_number_of_colors()
         for i, control in enumerate(self.selected_controls):
             values = []

--- a/src/ert/gui/plotting/utils/plot_tools.py
+++ b/src/ert/gui/plotting/utils/plot_tools.py
@@ -5,12 +5,14 @@ import math
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.ticker as mticker
+from matplotlib.backend_bases import Event, MouseEvent
 from matplotlib.collections import PathCollection
 from matplotlib.container import BarContainer
 from matplotlib.lines import Line2D
 
 from ert.gui.plotting.utils.plot_context import PlotType
 from ert.gui.plotting.utils.tooltip_manager import (
+    ValidatedMouseEvent,
     create_tooltip_manager,
 )
 
@@ -182,7 +184,10 @@ class PlotTools:
         plot_type: PlotType,
         axes: Axes,
         figure: Figure,
-        data: list[list[Line2D]] | PathCollection | list[BarContainer],
+        data: list[list[Line2D]]
+        | PathCollection
+        | list[PathCollection]
+        | list[BarContainer],
         labels: list[str],
         **options: Any,
     ) -> None:
@@ -197,16 +202,39 @@ class PlotTools:
 
         hover_color = options.get("hover_color")
         disable_values = options.get("disable_values", False)
-        tooltip_manager = create_tooltip_manager(
-            plot_type,
-            hover_box,
-            figure,
-            axes,
-            hover_color=hover_color,
-            disable_values=disable_values,
-        )
+
+        try:
+            tooltip_manager = create_tooltip_manager(
+                data,
+                labels,
+                plot_type,
+                hover_box,
+                figure,
+                axes,
+                hover_color=hover_color,
+                disable_values=disable_values,
+            )
+        except (TypeError, ValueError) as e:
+            logger.warning(f"Failed to create tooltip manager: {e}")
+            return
+
+        wrong_event_type_flagged = False
+
+        def _handle_event(event: Event) -> None:
+            if not isinstance(event, MouseEvent):
+                nonlocal wrong_event_type_flagged
+                if not wrong_event_type_flagged:
+                    logger.warning(f"Expected a MouseEvent, got {type(event).__name__}")
+                    wrong_event_type_flagged = True
+                return
+            if event.inaxes != axes:
+                hover_box.set_visible(False)
+                figure.canvas.draw_idle()
+                return
+            custom_event = ValidatedMouseEvent(event, axes)
+            tooltip_manager.on_hover(custom_event)
 
         figure.canvas.mpl_connect(
             "motion_notify_event",
-            lambda event: tooltip_manager.on_hover(event, data, labels),  # type: ignore
+            _handle_event,
         )

--- a/src/ert/gui/plotting/utils/tooltip_manager.py
+++ b/src/ert/gui/plotting/utils/tooltip_manager.py
@@ -1,17 +1,20 @@
 import math
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from collections.abc import Iterator
+from typing import Generic, TypeVar, cast
 
 import numpy as np
 from matplotlib.axes import Axes
-from matplotlib.backend_bases import Event
+from matplotlib.backend_bases import MouseEvent
 from matplotlib.collections import PathCollection
 from matplotlib.container import BarContainer
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
 from matplotlib.text import Annotation
+from matplotlib.transforms import Bbox
 from matplotlib.typing import ColorType
+from numpy.typing import ArrayLike
 
 from ert.gui.plotting.utils.plot_context import PlotType
 from ert.gui.utils import SIGNIFICANT_DIGITS
@@ -19,27 +22,76 @@ from ert.gui.utils import SIGNIFICANT_DIGITS
 PlotDataType = TypeVar("PlotDataType")
 ShapeType = TypeVar("ShapeType")
 
+# A fallback bounding box with a width and height of 200px
+# in case the hover box has not been rendered yet and returns a degenerate bbox.
+FALL_BACK_BBOX = Bbox.from_bounds(0, 0, 200, 200)
+
+
+class Point:
+    """
+    A simple class to represent a point in both coordinate and pixel space.
+
+    Attributes:
+        x_coord (float): The x coordinate in data space.
+        y_coord (float): The y coordinate in data space.
+        x (float): The x coordinate in pixel space.
+        y (float): The y coordinate in pixel space.
+    """
+
+    def __init__(self, array: ArrayLike, axes: Axes) -> None:
+        array = np.asarray(array)
+        if array.shape != (2,):
+            raise ValueError(f"Expected array of shape (2,), got {array.shape}")
+        self.x_coord = array[0]
+        self.y_coord = array[1]
+        self.x = axes.transData.transform((self.x_coord, self.y_coord))[0]
+        self.y = axes.transData.transform((self.x_coord, self.y_coord))[1]
+
+    def pixels(self) -> tuple[float, float]:
+        return self.x, self.y
+
+
+class ValidatedMouseEvent:
+    def __init__(self, event: MouseEvent, axes: Axes) -> None:
+        if event.xdata is None or event.ydata is None:
+            raise ValueError("MouseEvent must have valid xy coordinates")
+
+        self._event = event
+        self.inaxes = event.inaxes
+        self.position = Point((event.xdata, event.ydata), axes)
+
+    def as_mpl(self) -> MouseEvent:
+        return self._event
+
 
 class ToolTipManager(ABC, Generic[PlotDataType, ShapeType]):
+    PADDING = 10
+
     def __init__(
         self,
+        data: PlotDataType,
+        labels: list[str],
         hover_box: Annotation,
         figure: Figure,
         axes: Axes,
         hover_color: str | None = None,
     ) -> None:
+        self.data = data
+        self.labels = labels
         self.hover_box = hover_box
         self.figure = figure
         self.axes = axes
         self.hover_color = hover_color
 
     @abstractmethod
-    def on_hover(self, event: Event, data: PlotDataType, labels: list[str]) -> None:
+    def on_hover(self, event: ValidatedMouseEvent) -> None:
         """Method to attach to the plot's `motion_notify_event`."""
         ...
 
     @abstractmethod
-    def on_enter(self, shape: ShapeType, label: str, event: Event) -> None:
+    def on_enter(
+        self, shape: ShapeType, label: str, event: ValidatedMouseEvent
+    ) -> None:
         """Method to call whenever the cursor intersects with a shape."""
         ...
 
@@ -48,37 +100,76 @@ class ToolTipManager(ABC, Generic[PlotDataType, ShapeType]):
         """Method to call whenever the cursor leaves a shape."""
         ...
 
-    def euclidean_distance(
-        self, p: tuple[float, float], q: tuple[float, float]
-    ) -> float:
+    def euclidean_distance(self, p: Point, q: Point) -> float:
         """Calculate the Euclidean distance between two points."""
-        return math.hypot(p[0] - q[0], p[1] - q[1])
+        return math.hypot(p.x - q.x, p.y - q.y)
+
+    def set_hover_box_position(self, event: ValidatedMouseEvent) -> None:
+        """Sets position of the hover box, ensuring it stays within the axes bounds."""
+        axes_bbox = self.axes.bbox
+        width, height = self.hover_box.get_window_extent().size
+
+        if width <= 1.0 or height <= 1.0:
+            width, height = FALL_BACK_BBOX.size
+
+        x, y = event.position.pixels()
+        min_x = axes_bbox.x0 + self.PADDING
+        max_x = axes_bbox.x1 - width - self.PADDING
+        min_y = axes_bbox.y0 + self.PADDING
+        max_y = axes_bbox.y1 - height - self.PADDING
+
+        x = min(max(x, min_x), max_x)
+        y = min(max(y, min_y), max_y)
+
+        x_data, y_data = self.axes.transData.inverted().transform((x, y))
+        self.hover_box.xy = (x_data, y_data)
 
 
 class BarTooltipManager(ToolTipManager[list[BarContainer], Rectangle]):
-    def on_hover(
-        self, event: Event, data: list[BarContainer], labels: list[str]
+    def __init__(
+        self,
+        data: list[BarContainer],
+        labels: list[str],
+        hover_box: Annotation,
+        figure: Figure,
+        axes: Axes,
     ) -> None:
-        if event.inaxes != self.axes:  # type: ignore
-            self.on_exit()
-            return
-        for bar_container_idx, bars in enumerate(data):
+        bars = sum(len(b.patches) for b in data)
+        if bars != len(labels):
+            raise ValueError(
+                f"Number of labels must equal number of bars.\n"
+                f"Found {len(labels)} labels and {bars} bars."
+            )
+
+        super().__init__(
+            data,
+            labels,
+            hover_box,
+            figure,
+            axes,
+        )
+
+    def on_hover(self, event: ValidatedMouseEvent) -> None:
+        for bar_container_idx, bars in enumerate(self.data):
             for bar_idx, bar in enumerate(bars.patches):
-                if bar.contains(event)[0]:  # type: ignore
+                contains, _ = bar.contains(event.as_mpl())
+                if contains:
                     value = bar.get_height()
-                    idx = bar_idx * len(data) + bar_container_idx
+                    idx = bar_idx * len(self.data) + bar_container_idx
                     self.on_enter(
                         bar,
-                        f"{labels[idx]}\nValue: {value:.{SIGNIFICANT_DIGITS}g}",
+                        f"{self.labels[idx]}\nValue: {value:.{SIGNIFICANT_DIGITS}g}",
                         event,
                     )
                     return
 
         self.on_exit()
 
-    def on_enter(self, shape: Rectangle, label: str, event: Event) -> None:
-        self.hover_box.xy = (event.xdata, event.ydata)  # type: ignore
+    def on_enter(
+        self, shape: Rectangle, label: str, event: ValidatedMouseEvent
+    ) -> None:
         self.hover_box.set_text(label)
+        self.set_hover_box_position(event)
         self.hover_box.set_visible(True)
         self.figure.canvas.draw_idle()
 
@@ -91,6 +182,8 @@ class BarTooltipManager(ToolTipManager[list[BarContainer], Rectangle]):
 class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
     def __init__(
         self,
+        data: list[list[Line2D]],
+        labels: list[str],
         hover_box: Annotation,
         figure: Figure,
         axes: Axes,
@@ -98,7 +191,14 @@ class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
         *,
         disable_values: bool = False,
     ) -> None:
+        if len(labels) != len(data):
+            raise ValueError(
+                f"Number of labels must equal number of line groups.\n"
+                f"Found {len(labels)} labels and {len(data)} lines."
+            )
         super().__init__(
+            data,
+            labels,
             hover_box,
             figure,
             axes,
@@ -112,30 +212,24 @@ class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
 
     def on_hover(
         self,
-        event: Event,
-        data: list[list[Line2D]],
-        labels: list[str],
+        event: ValidatedMouseEvent,
     ) -> None:
-        if event.inaxes != self.axes:  # type: ignore
-            self.on_exit()
-            return
-
-        for lines, label in zip(data, labels, strict=True):
+        for lines, label in zip(self.data, self.labels, strict=True):
             for line in lines:
-                contains, idx = line.contains(event)  # type: ignore
+                contains, idx = line.contains(event.as_mpl())
                 if contains:
                     hover_text = label
                     if not self.disable_values:
-                        value = line.get_ydata()[idx["ind"][0]]  # type: ignore
-                        hover_text += f"\nValue: {value:.{SIGNIFICANT_DIGITS}g}"  # type: ignore
+                        value = np.asarray(line.get_ydata())[idx["ind"][0]]
+                        hover_text += f"\nValue: {value:.{SIGNIFICANT_DIGITS}g}"
                     self.on_enter(line, hover_text, event)
                     return
 
         self.on_exit()
 
-    def on_enter(self, shape: Line2D, label: str, event: Event) -> None:
-        self.hover_box.xy = (event.xdata, event.ydata)  # type: ignore
+    def on_enter(self, shape: Line2D, label: str, event: ValidatedMouseEvent) -> None:
         self.hover_box.set_text(label)
+        self.set_hover_box_position(event)
 
         # Only need to update tooltip text and position if its the same line.
         if self.current_line == shape:
@@ -143,7 +237,6 @@ class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
             return
 
         self.on_exit(redraw=False)
-
         self.current_line = shape
 
         if self.hover_color is not None:
@@ -157,7 +250,6 @@ class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
         self.current_line.set_linewidth(self.line_width * 1.5)
 
         self.hover_box.set_visible(True)
-
         self.figure.canvas.draw_idle()
 
     def on_exit(self, *, redraw: bool = True) -> None:
@@ -187,42 +279,54 @@ class LineTooltipManager(ToolTipManager[list[list[Line2D]], Line2D]):
 
 
 class ScatterTooltipManager(
-    ToolTipManager[PathCollection, np.ndarray[tuple[int], np.dtype[np.float64]]]
+    ToolTipManager[list[PathCollection] | PathCollection, Point]
 ):
+    def __init__(
+        self,
+        data: PathCollection | list[PathCollection],
+        labels: list[str],
+        hover_box: Annotation,
+        figure: Figure,
+        axes: Axes,
+    ) -> None:
+        points = data if isinstance(data, list) else [data]
+        num_points = sum(len(np.asarray(d.get_offsets())) for d in points)
+        if num_points != len(labels):
+            raise ValueError(
+                f"Number of labels must equal number of points.\n"
+                f"Found {len(labels)} labels and {num_points} points."
+            )
+
+        super().__init__(
+            data,
+            labels,
+            hover_box,
+            figure,
+            axes,
+        )
+
     def on_hover(
         self,
-        event: Event,
-        data: PathCollection,
-        labels: list[str],
+        event: ValidatedMouseEvent,
     ) -> None:
-        if event.inaxes != self.axes:  # type: ignore
-            self.on_exit()
-            return
-
-        scatter_points: np.ndarray[tuple[int, int], np.dtype[np.float64]] = np.asarray(
-            data.get_offsets()
-        )
-        for scatter, label in zip(scatter_points, labels, strict=True):
-            pp = self.axes.transData.transform(scatter)
-            ep = self.axes.transData.transform((event.xdata, event.ydata))  # type: ignore
-
+        for point, label in zip(self._get_points(self.data), self.labels, strict=True):
             # This is from Matplotlib's source code for converting plot coordinates
             # to pixels and adjust according to the figure's DPI.
             threshold = self.figure.dpi / 72.0 * 5.0
-            if self.euclidean_distance((pp[0], pp[1]), (ep[0], ep[1])) <= threshold:
-                self.on_enter(scatter, label, event)
+            if self.euclidean_distance(point, event.position) <= threshold:
+                self.on_enter(point, label, event)
                 return
 
         self.on_exit()
 
     def on_enter(
         self,
-        shape: np.ndarray[tuple[int], np.dtype[np.float64]],
+        shape: Point,
         label: str,
-        event: Event,
+        event: ValidatedMouseEvent,
     ) -> None:
-        self.hover_box.xy = (event.xdata, event.ydata)  # type: ignore
         self.hover_box.set_text(label)
+        self.set_hover_box_position(event)
         self.hover_box.set_visible(True)
         self.figure.canvas.draw_idle()
 
@@ -231,8 +335,22 @@ class ScatterTooltipManager(
         if redraw:
             self.figure.canvas.draw_idle()
 
+    def _get_points(
+        self, data: PathCollection | list[PathCollection]
+    ) -> Iterator[Point]:
+        scatters = data if isinstance(data, list) else [data]
+        for scatter in scatters:
+            yield from (
+                Point(offset, self.axes) for offset in np.asarray(scatter.get_offsets())
+            )
+
 
 def create_tooltip_manager(
+    data: list[BarContainer]
+    | list[list[Line2D]]
+    | PathCollection
+    | list[PathCollection],
+    labels: list[str],
     plot_type: PlotType,
     hover_box: Annotation,
     figure: Figure,
@@ -243,10 +361,37 @@ def create_tooltip_manager(
 ) -> BarTooltipManager | LineTooltipManager | ScatterTooltipManager:
     match plot_type:
         case PlotType.BAR:
-            return BarTooltipManager(hover_box, figure, axes)
+            if isinstance(data, list) and all(
+                isinstance(d, BarContainer) for d in data
+            ):
+                return BarTooltipManager(
+                    cast(list[BarContainer], data), labels, hover_box, figure, axes
+                )
         case PlotType.LINE:
-            return LineTooltipManager(
-                hover_box, figure, axes, hover_color, disable_values=disable_values
-            )
+            if isinstance(data, list) and all(
+                isinstance(d, list) and all(isinstance(line, Line2D) for line in d)
+                for d in data
+            ):
+                return LineTooltipManager(
+                    cast(list[list[Line2D]], data),
+                    labels,
+                    hover_box,
+                    figure,
+                    axes,
+                    hover_color,
+                    disable_values=disable_values,
+                )
         case PlotType.SCATTER:
-            return ScatterTooltipManager(hover_box, figure, axes)
+            if isinstance(data, PathCollection) or (
+                isinstance(data, list)
+                and all(isinstance(d, PathCollection) for d in data)
+            ):
+                return ScatterTooltipManager(
+                    cast(PathCollection | list[PathCollection], data),
+                    labels,
+                    hover_box,
+                    figure,
+                    axes,
+                )
+
+    raise TypeError(f"Invalid data type {type(data).__name__} for {plot_type} plot")

--- a/tests/everest/unit_tests/plots/test_everest_batch_objective_function_plot.py
+++ b/tests/everest/unit_tests/plots/test_everest_batch_objective_function_plot.py
@@ -84,16 +84,17 @@ def test_that_hovering_over_points_shows_correct_tooltip(
     move_cursor(axes=axes, x=0, y=8.0)
 
     annotations = list(axes.texts)
-    assert len(annotations) == 2
-    rejected_batches = annotations[0]
-    accepted_batches = annotations[1]
+    assert len(annotations) == 1
 
-    accepted_batches_text = accepted_batches.get_text()
+    tooltip = annotations[0]
+
+    accepted_batches_text = tooltip.get_text()
     assert "Batch 0" in accepted_batches_text
-    assert accepted_batches.get_visible()
-    assert not rejected_batches.get_visible()
+    assert tooltip.get_visible()
 
-    move_cursor(axes=axes, x=2, y=10.0)
-    assert rejected_batches.get_visible()
-    assert "Batch 2" in rejected_batches.get_text()
-    assert not accepted_batches.get_visible()
+    move_cursor(axes=axes, x=2.0, y=10.0)
+    assert tooltip.get_visible()
+    assert "Batch 2" in tooltip.get_text()
+
+    move_cursor(axes=axes, x=0.0, y=0.0)
+    assert not tooltip.get_visible()

--- a/tests/everest/unit_tests/tooltip_manager/conftest.py
+++ b/tests/everest/unit_tests/tooltip_manager/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def plot_data_1D() -> tuple[list[int], list[str]]:
+    return list(range(10)), [str(i) for i in range(10)]
+
+
+@pytest.fixture
+def plot_data_2D() -> tuple[list[list[int]], list[str]]:
+    return [list(range(10)) for _ in range(10)], [f"Point {i}" for i in range(10)]

--- a/tests/everest/unit_tests/tooltip_manager/test_tooltip_manager.py
+++ b/tests/everest/unit_tests/tooltip_manager/test_tooltip_manager.py
@@ -1,0 +1,150 @@
+from matplotlib import pyplot as plt
+from matplotlib.backend_bases import KeyEvent, MouseEvent
+
+from ert.gui.plotting.utils.plot_context import PlotType
+from ert.gui.plotting.utils.plot_tools import PlotTools
+
+
+def test_that_tooltip_manager_catches_wrong_data_type_for_the_plot_type_selected(
+    plot_data_1D, caplog
+):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_1D
+
+    fig, ax = plt.subplots()
+    scatter = ax.scatter(x_data, x_data)
+
+    PlotTools.labels_on_hover(
+        PlotType.LINE,
+        ax,
+        fig,
+        data=scatter,
+        labels=labels,
+    )
+
+    assert len(caplog.records) == 1
+    assert "Invalid data type PathCollection for line plot" in caplog.records[0].message
+
+
+def test_that_scatter_plot_tooltip_manager_catches_different_num_labels_vs_datapoints(
+    plot_data_1D, caplog
+):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_1D
+
+    fig, ax = plt.subplots()
+    scatter = ax.scatter(x_data, x_data)
+
+    labels.append("Extra label")
+
+    PlotTools.labels_on_hover(
+        PlotType.SCATTER,
+        ax,
+        fig,
+        data=scatter,
+        labels=labels,
+    )
+
+    assert len(caplog.records) == 1
+    assert "Found 11 labels and 10 points." in caplog.records[0].message
+
+
+def test_that_bar_plot_tooltip_manager_catches_different_num_labels_vs_datapoints(
+    plot_data_1D, caplog
+):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_1D
+
+    fig, ax = plt.subplots()
+    bars = ax.bar(x_data, x_data)
+
+    labels.append("Extra label")
+
+    PlotTools.labels_on_hover(
+        PlotType.BAR,
+        ax,
+        fig,
+        data=[bars],
+        labels=labels,
+    )
+
+    assert len(caplog.records) == 1
+    assert "Found 11 labels and 10 bars." in caplog.records[0].message
+
+
+def test_that_line_plot_tooltip_manager_catches_different_num_labels_vs_datapoints(
+    plot_data_2D, caplog
+):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_2D
+
+    fig, ax = plt.subplots()
+
+    lines = [ax.plot(x) for x in x_data]
+
+    labels.append("Extra label")
+
+    PlotTools.labels_on_hover(
+        PlotType.LINE,
+        ax,
+        fig,
+        data=lines,
+        labels=labels,
+    )
+
+    assert len(caplog.records) == 1
+    assert "Found 11 labels and 10 lines." in caplog.records[0].message
+
+
+def test_that_tooltip_manager_catches_incorrect_event_type(plot_data_1D, caplog):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_1D
+
+    fig, ax = plt.subplots()
+    scatter = ax.scatter(x_data, x_data)
+
+    PlotTools.labels_on_hover(
+        PlotType.SCATTER,
+        ax,
+        fig,
+        data=scatter,
+        labels=labels,
+    )
+
+    event = KeyEvent("test", ax.figure.canvas, key="a")
+    ax.figure.canvas.callbacks.process("motion_notify_event", event)
+    assert len(caplog.records) == 1
+    assert (
+        f"Expected a MouseEvent, got {type(event).__name__}"
+        in caplog.records[0].message
+    )
+
+    ax.figure.canvas.callbacks.process("motion_notify_event", event)
+    assert len(caplog.records) == 1, (
+        "No new warning should be logged for repeated errors"
+    )
+
+
+def test_that_tooltip_manager_catches_invalid_axes(plot_data_1D, caplog):
+    caplog.set_level("WARNING")
+    x_data, labels = plot_data_1D
+
+    fig, ax = plt.subplots()
+    scatter = ax.scatter(x_data, x_data)
+
+    PlotTools.labels_on_hover(
+        PlotType.SCATTER,
+        ax,
+        fig,
+        data=scatter,
+        labels=labels,
+    )
+
+    event = MouseEvent("test", ax.figure.canvas, 0, 0)
+
+    event.inaxes = None
+    ax.figure.canvas.callbacks.process("motion_notify_event", event)
+
+    assert len(caplog.records) == 0, (
+        "No warning should be logged for events outside of axes"
+    )


### PR DESCRIPTION
**Issue**
Resolves #13713 
Resolves #13697 

**Approach**
🧪 🧠 🙏 

TLDR;

- [x] Fix matplotlib typing issues
- [x] Improve error handling
- [x] Expand accessibility for `ScatterTooltipManager`. It can now also accept `list[PathCollection]`
- [x] Add Padding for the hover bbox so that it does not overflow the figure dimensions

## Why
Since its inception the `ScatterTooltipManager` has been plagued with the infamous `# type: ignore`. The `CustomEvent` and `Point` class attempts to upfront all of the typing headaches and also abstract away some of the inner details of the different types of `coordinates` used in matplotlib. 

Code that can and should fail is now being raised, but the caught exceptions are just being ignored and the plotter simply removes the tooltip. This is because the `mpl_connect` callback runs everytime your mouse moves, with a refresh rate of 60 times a seconds depending on the backend system used. Logging every time an error is raised, causes spam and should be handled in a smarter way if we even want to handle it in the first place.