### PR TITLE
Move EGRID test helper into rft_generator

### DIFF
--- a/tests/ert/rft_generator.py
+++ b/tests/ert/rft_generator.py
@@ -44,3 +44,49 @@ def cell_start(date=(1, 1, 2000), ijks=((1, 1, 1), (2, 1, 2)), *args, **kwargs):
         ("CONJPOS ", int_arr([j for _, j, _ in ijks])),
         ("CONKPOS ", int_arr([k for _, _, k in ijks])),
     ]
+
+
+def pad_to(lst: list[int], target_len: int):
+    return np.pad(
+        np.array(lst, dtype=np.int32), (0, target_len - len(lst)), mode="constant"
+    )
+
+
+def create_egrid(nx, ny, nz, x_width, y_width, layer_height):
+    """EGrid file contents with nz layers, nx cells in the i direction and ny cells in
+    the j direction.
+
+    Each cell has width x_width in the i direction and y_width in the j direction and
+    height layer_height in the z direction.
+    """
+
+    height = nz * layer_height
+    cells_per_layer = nx * ny
+
+    coord = np.array(
+        [
+            [i * x_width, j * y_width, 0, i * x_width, j * y_width, height]
+            for j in range(ny + 1)
+            for i in range(nx + 1)
+        ],
+        dtype=">f4",
+    )
+
+    zcoord = np.array(
+        [
+            [z * layer_height] * (cells_per_layer * 4)
+            + [(z + 1) * layer_height] * (cells_per_layer * 4)
+            for z in range(nz)
+        ],
+        dtype=">f4",
+    )
+    return [
+        ("FILEHEAD", pad_to([3, 2007, 0, 0, 0, 0, 1], 100)),
+        ("MAPAXES ", np.array([0.0, 1.0, 0.0, 0.0, 1.0, 0.0], dtype=">f4")),
+        ("GRIDUNIT", np.array([b"METRES  ", b"        "], dtype="|S8")),
+        ("GRIDHEAD", pad_to([1, nx, ny, nz], 100)),
+        ("COORD   ", coord.ravel()),
+        ("ZCORN   ", zcoord.ravel()),
+        ("ACTNUM  ", np.ones(nx * ny * nz, dtype=">i4")),
+        ("ENDGRID ", np.array([], dtype=">i4")),
+    ]

--- a/tests/ert/ui_tests/gui/test_rft_visualizations.py
+++ b/tests/ert/ui_tests/gui/test_rft_visualizations.py
@@ -22,7 +22,7 @@ from ert.gui.tools.plot.plot_window import (
 )
 from ert.services import ErtServerController
 from ert.storage import open_storage
-from tests.ert.rft_generator import cell_start
+from tests.ert.rft_generator import cell_start, create_egrid
 
 from .conftest import (
     add_experiment_manually,
@@ -37,35 +37,7 @@ def pad_to(lst: list[int], target_len: int):
 
 
 def write_egrid(path: Path):
-    nz = 50
-    resfo.write(
-        path,
-        [
-            ("FILEHEAD", pad_to([3, 2007, 0, 0, 0, 0, 1], 100)),
-            ("MAPAXES ", np.array([0.0, 1.0, 0.0, 0.0, 1.0, 0.0], dtype=">f4")),
-            ("GRIDUNIT", np.array([b"METRES  ", b"        "], dtype="|S8")),
-            ("GRIDHEAD", pad_to([1, 1, 1, nz], 100)),
-            (
-                "COORD   ",
-                np.array(
-                    [
-                        [[[0, 0, 0], [0, 0, nz]], [[0, 1, 0], [0, 1, nz]]],
-                        [[[1, 0, 0], [1, 0, nz]], [[1, 1, 0], [1, 1, nz]]],
-                    ],
-                    dtype=">f4",
-                ).ravel(),
-            ),
-            (
-                "ZCORN   ",
-                np.array(
-                    [v for k in range(nz) for v in [k] * 4 + [k + 1] * 4],
-                    dtype=">f4",
-                ),
-            ),
-            ("ACTNUM  ", np.ones((nz,), dtype=">i4")),
-            ("ENDGRID ", np.array([], dtype=">i4")),
-        ],
-    )
+    resfo.write(path, create_egrid(1, 1, 50, 1, 1, 1))
 
 
 @pytest.fixture
@@ -77,7 +49,7 @@ def rft_config(tmp_path: Path):
         rft_file = runpath / "BASE.RFT"
         offset = i / 2
         depth = np.linspace(0, 2 * np.pi, dtype=np.float32)
-        write_egrid(runpath / "BASE.EGRID")
+        resfo.write(runpath / "BASE.EGRID", create_egrid(1, 1, 50, 1, 1, 1))
         resfo.write(
             rft_file,
             [

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -19,7 +19,7 @@ from ert.config._create_observation_dataframes import _handle_rft_observation
 from ert.config._observations import RFTObservation
 from ert.config.parsing import ConfigValidationError, ObservationType
 from ert.config.rft_config import _get_zonemap, _read_egrid
-from tests.ert.rft_generator import cell_start, float_arr
+from tests.ert.rft_generator import cell_start, create_egrid, float_arr
 
 
 @pytest.fixture(autouse=True)
@@ -355,52 +355,6 @@ def test_that_number_of_connections_can_be_different_per_well(mock_resfo_file, e
     ]
 
 
-def pad_to(lst: list[int], target_len: int):
-    return np.pad(
-        np.array(lst, dtype=np.int32), (0, target_len - len(lst)), mode="constant"
-    )
-
-
-def _egrid(nx, ny, nz, x_width, y_width, layer_height):
-    """EGrid file contents with nz layers, nx cells in the i direction and ny cells in
-    the j direction.
-
-    Each cell has width x_width in the i direction and y_width in the j direction and
-    height layer_height in the z direction.
-    """
-
-    height = nz * layer_height
-    cells_per_layer = nx * ny
-
-    coord = np.array(
-        [
-            [i * x_width, j * y_width, 0, i * x_width, j * y_width, height]
-            for j in range(ny + 1)
-            for i in range(nx + 1)
-        ],
-        dtype=">f4",
-    )
-
-    zcoord = np.array(
-        [
-            [z * layer_height] * (cells_per_layer * 4)
-            + [(z + 1) * layer_height] * (cells_per_layer * 4)
-            for z in range(nz)
-        ],
-        dtype=">f4",
-    )
-    return [
-        ("FILEHEAD", pad_to([3, 2007, 0, 0, 0, 0, 1], 100)),
-        ("MAPAXES ", np.array([0.0, 1.0, 0.0, 0.0, 1.0, 0.0], dtype=">f4")),
-        ("GRIDUNIT", np.array([b"METRES  ", b"        "], dtype="|S8")),
-        ("GRIDHEAD", pad_to([1, nx, ny, nz], 100)),
-        ("COORD   ", coord.ravel()),
-        ("ZCORN   ", zcoord.ravel()),
-        ("ACTNUM  ", np.ones(nx * ny * nz, dtype=">i4")),
-        ("ENDGRID ", np.array([], dtype=">i4")),
-    ]
-
-
 @pytest.fixture
 def egrid():
     """EGrid file contents with three layers.
@@ -413,7 +367,7 @@ def egrid():
     Third layer depth is from 2.0 to 3.0
 
     """
-    return _egrid(2, 2, 3, 50.0, 50.0, 1.0)
+    return create_egrid(2, 2, 3, 50.0, 50.0, 1.0)
 
 
 def test_that_locations_are_found_in_corresponding_grid(mock_resfo_file, egrid):
@@ -550,7 +504,7 @@ def test_that_connection_cells_are_processed_independently(mock_resfo_file):
 
     mock_resfo_file(
         "/tmp/does_not_exist/ECLBASE1.EGRID",
-        _egrid(5, 2, 3, 50.0, 50.0, 1.0),
+        create_egrid(5, 2, 3, 50.0, 50.0, 1.0),
     )
     mock_resfo_file(
         "/tmp/does_not_exist/ECLBASE1.RFT",


### PR DESCRIPTION
Lift the egrid content builder into `tests/ert/rft_generator`, removing duplication and giving future RFT tests a common function for creating synthetic EGRIDs.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
