### PR TITLE
Add --dist loadgroup to pytest addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,9 @@ everest = ["data/**/*", "*.tmpl", "detached/jobs/everserver"]
 
 
 [tool.pytest.ini_options]
-addopts = "-ra --strict-markers"
+# --dist loadgroup ensures @pytest.mark.xdist_group markers are honored
+# whenever parallelism (-n) is enabled. It is a no-op for serial runs.
+addopts = "-ra --strict-markers --dist loadgroup"
 norecursedirs = [
     "*.egg",
     ".*",


### PR DESCRIPTION
Avoids test failing if one runs `pytest -n ` but forgets to add the `--dist loadgroup`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
