### PR TITLE
Add tests for EverestControlSelectionWidget

### DIFF
--- a/src/ert/gui/tools/plot/widgets/everest_control_selection_widget.py
+++ b/src/ert/gui/tools/plot/widgets/everest_control_selection_widget.py
@@ -43,9 +43,10 @@ class EverestControlSelectionWidget(QWidget):
         self._pinned_control = control
         self._controls_list.blockSignals(True)
         self._controls_list.clearSelection()
-        matches = self._controls_list.findItems(control, Qt.MatchFlag.MatchExactly)
-        for item in matches:
-            item.setSelected(True)
+        if control is not None:
+            matches = self._controls_list.findItems(control, Qt.MatchFlag.MatchExactly)
+            for item in matches:
+                item.setSelected(True)
         self._controls_list.blockSignals(False)
 
     def get_selected_controls(self) -> list[str]:

--- a/tests/ert/unit_tests/gui/ertwidgets/test_everest_control_selection_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_everest_control_selection_widget.py
@@ -47,7 +47,7 @@ def test_that_setting_pinned_to_already_pinned_control_does_not_emit_signal(
         widget.set_pinned_control("control_b")
 
 
-def test_that_setting_pinned_to_none_allows_unselecting_all_controls(
+def test_that_setting_pinned_to_none_does_not_emit_signal_and_clears_selection(
     qtbot, controls_list
 ):
     widget = EverestControlSelectionWidget(controls=controls_list)
@@ -55,27 +55,53 @@ def test_that_setting_pinned_to_none_allows_unselecting_all_controls(
 
     widget.set_pinned_control("control_b")
 
-    control_a = widget._controls_list.item(0)
-    control_b = widget._controls_list.item(1)
-    control_c = widget._controls_list.item(2)
-    assert control_a is not None
-    assert control_b is not None
-    assert control_c is not None
+    for i in range(widget._controls_list.count()):
+        item = widget._controls_list.item(i)
+        assert item is not None
+        item.setSelected(True)
 
-    control_a.setSelected(True)
-    control_b.setSelected(True)
-    control_c.setSelected(True)
+    assert widget.get_selected_controls() == controls_list
+    with qtbot.assertNotEmitted(widget.controlSelectionChanged):
+        widget.set_pinned_control(None)
+        assert widget.get_selected_controls() == []
+
+
+def test_that_setting_pinned_control_to_non_existent_control_does_not_emit_signal_and_clears_selection(  # noqa: E501
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    widget.set_pinned_control("control_b")
+
+    for i in range(widget._controls_list.count()):
+        item = widget._controls_list.item(i)
+        assert item is not None
+        item.setSelected(True)
+
+    assert widget.get_selected_controls() == controls_list
+    with qtbot.assertNotEmitted(widget.controlSelectionChanged):
+        widget.set_pinned_control("non_existent_control")
+        assert widget.get_selected_controls() == []
+
+
+def test_that_setting_pinned_control_clears_selection_of_other_controls(
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    for i in range(widget._controls_list.count()):
+        item = widget._controls_list.item(i)
+        assert item is not None
+        item.setSelected(True)
 
     assert widget.get_selected_controls() == controls_list
 
-    control_a.setSelected(False)
-    control_b.setSelected(False)
-    control_c.setSelected(False)
+    widget.set_pinned_control("control_b")
 
-    assert widget.get_selected_controls() == ["control_b"]
-    widget.set_pinned_control(None)
-    control_b.setSelected(False)
-    assert widget.get_selected_controls() == []
+    selected = widget.get_selected_controls()
+    assert selected == ["control_b"]
 
 
 def test_that_setting_pinned_control_selects_it_and_makes_it_unselectable(

--- a/tests/ert/unit_tests/gui/ertwidgets/test_everest_control_selection_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_everest_control_selection_widget.py
@@ -1,0 +1,120 @@
+import pytest
+from PyQt6.QtCore import Qt
+
+from ert.gui.tools.plot.widgets.everest_control_selection_widget import (
+    EverestControlSelectionWidget,
+)
+
+
+@pytest.fixture
+def controls_list():
+    return ["control_a", "control_b", "control_c"]
+
+
+def test_that_setting_controls_populates_list(qtbot, controls_list):
+    widget = EverestControlSelectionWidget(controls=[])
+    qtbot.addWidget(widget)
+
+    widget.set_controls(controls_list)
+
+    assert widget._controls_list.count() == len(controls_list)
+    assert [
+        widget._controls_list.item(i).text()
+        for i in range(widget._controls_list.count())
+    ] == controls_list
+    assert widget.get_selected_controls() == []
+
+
+def test_that_selecting_controls_emits_signal(qtbot, controls_list):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    with qtbot.waitSignal(widget.controlSelectionChanged, timeout=1000):
+        item = widget._controls_list.item(0)
+        assert item is not None
+        item.setSelected(True)
+
+
+def test_that_setting_pinned_to_already_pinned_control_does_not_emit_signal(
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    widget.set_pinned_control("control_b")
+
+    with qtbot.assertNotEmitted(widget.controlSelectionChanged):
+        widget.set_pinned_control("control_b")
+
+
+def test_that_setting_pinned_to_none_allows_unselecting_all_controls(
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    widget.set_pinned_control("control_b")
+
+    control_a = widget._controls_list.item(0)
+    control_b = widget._controls_list.item(1)
+    control_c = widget._controls_list.item(2)
+    assert control_a is not None
+    assert control_b is not None
+    assert control_c is not None
+
+    control_a.setSelected(True)
+    control_b.setSelected(True)
+    control_c.setSelected(True)
+
+    assert widget.get_selected_controls() == controls_list
+
+    control_a.setSelected(False)
+    control_b.setSelected(False)
+    control_c.setSelected(False)
+
+    assert widget.get_selected_controls() == ["control_b"]
+    widget.set_pinned_control(None)
+    control_b.setSelected(False)
+    assert widget.get_selected_controls() == []
+
+
+def test_that_setting_pinned_control_selects_it_and_makes_it_unselectable(
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    widget.set_pinned_control("control_b")
+
+    selected = widget.get_selected_controls()
+    assert selected == ["control_b"]
+
+    matching_items = widget._controls_list.findItems(
+        "control_b", Qt.MatchFlag.MatchExactly
+    )
+    assert len(matching_items) == 1
+    control_b = matching_items[0]
+    assert control_b is not None
+    assert control_b.isSelected()
+    control_b.setSelected(False)
+    selected_after = widget.get_selected_controls()
+    assert selected_after == ["control_b"]
+
+
+def test_that_changing_selection_of_multiple_controls_emit_signal_and_updates_selection(
+    qtbot, controls_list
+):
+    widget = EverestControlSelectionWidget(controls=controls_list)
+    qtbot.addWidget(widget)
+
+    with qtbot.waitSignals([widget.controlSelectionChanged] * 3, timeout=1000):
+        control_a = widget._controls_list.item(0)
+        control_b = widget._controls_list.item(1)
+        assert control_a is not None
+        assert control_b is not None
+        control_a.setSelected(True)
+        assert widget.get_selected_controls() == ["control_a"]
+        control_b.setSelected(True)
+        assert widget.get_selected_controls() == ["control_a", "control_b"]
+        control_a.setSelected(False)
+        assert widget.get_selected_controls() == ["control_b"]


### PR DESCRIPTION
**Issue**
Resolves #13751


**Approach**
Added test for selection, unselection, signal and pinned control


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
