### PR TITLE
Create migration for stripping extra keys from ExperimentConfig

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 29
+_LOCAL_STORAGE_VERSION = 30
 
 
 class _Migrations(BaseModel, extra="forbid"):
@@ -520,6 +520,7 @@ class LocalStorage(BaseMode):
             to27,
             to28,
             to29,
+            to30,
         )
 
         try:  # noqa: PLW0717
@@ -578,6 +579,7 @@ class LocalStorage(BaseMode):
                     26: to27,
                     27: to28,
                     28: to29,
+                    29: to30,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to30.py
+++ b/src/ert/storage/migration/to30.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+info = "Strip fields not in ExperimentConfig from experiment index"
+
+_ALLOWED_EXPERIMENT_KEYS = frozenset(
+    {
+        "experiment_type",
+        "ert_templates",
+        "observations",
+        "design_matrix",
+        "parameter_configuration",
+        "response_configuration",
+        "derived_response_configuration",
+        "target_ensemble",
+        "shape_registry",
+        "analysis_settings",
+        "update_settings",
+        "ensemble_id",
+        "restart_run",
+        "prior_ensemble_id",
+        "weights",
+        "optimization_output_dir",
+        "simulation_dir",
+        "input_constraints",
+        "optimization",
+        "model",
+        "keep_run_path",
+        "experiment_name",
+    }
+)
+
+
+def _strip_unknown_fields(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
+        return
+
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
+            continue
+
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
+            continue
+
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+
+        unknown_keys = [
+            key for key in experiment_data if key not in _ALLOWED_EXPERIMENT_KEYS
+        ]
+        if unknown_keys:
+            for key in unknown_keys:
+                experiment_data.pop(key)
+            logger.info(
+                "Stripped fields not in ExperimentConfig from %s: %s",
+                index_file,
+                ", ".join(sorted(unknown_keys)),
+            )
+            index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+
+
+def migrate(path: Path) -> None:
+    _strip_unknown_fields(path)

--- a/tests/ert/unit_tests/storage/migration/test_to30.py
+++ b/tests/ert/unit_tests/storage/migration/test_to30.py
@@ -1,0 +1,120 @@
+import json
+import logging
+
+from ert.storage.migration.to30 import migrate
+
+
+def test_that_migration_removes_fields_not_in_experiment_config(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+            "storage_path": "/project/storage",
+            "runpath_file": "/project/runpath_file",
+            "user_config_file": "/project/model.ert",
+            "env_vars": {"OMP_NUM_THREADS": "1"},
+            "env_pr_fm_step": {"ECLIPSE100": {"ECLPATH": "/usr"}},
+            "runpath_config": {"num_realizations": 200},
+            "queue_config": {"max_submit": 1},
+            "forward_model_steps": [{"type": "site_installed"}],
+            "substitutions": {"<CONFIG_PATH>": "/project"},
+            "hooked_workflows": {"PRE_SIMULATION": []},
+            "active_realizations": [True, False],
+            "log_path": "/project/update_log",
+            "random_seed": 123456,
+            "start_iteration": 0,
+            "minimum_required_realizations": 1,
+            "some_future_unknown_field": {"foo": "bar"},
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    experiment = updated["experiment"]
+
+    stripped_fields = {
+        "some_future_unknown_field",
+        "storage_path",
+        "runpath_file",
+        "user_config_file",
+        "env_vars",
+        "env_pr_fm_step",
+        "runpath_config",
+        "queue_config",
+        "forward_model_steps",
+        "substitutions",
+        "hooked_workflows",
+        "active_realizations",
+        "log_path",
+        "random_seed",
+        "start_iteration",
+        "minimum_required_realizations",
+    }
+    assert stripped_fields.isdisjoint(experiment)
+
+    assert experiment["experiment_type"] == "Ensemble Experiment"
+    assert experiment["parameter_configuration"] == [
+        {"type": "gen_kw", "name": "PARAM1"}
+    ]
+
+
+def test_that_migration_leaves_experiment_with_only_known_fields_untouched(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "queue_config": {"max_submit": 1},
+            "random_seed": 123456,
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        migrate(root)
+
+    assert "queue_config" in caplog.text
+    assert "random_seed" in caplog.text
+    assert str(exp_path / "index.json") in caplog.text


### PR DESCRIPTION
**Issue**
Migration needed to clean up fields after extra=forbid is enforced on models


**Approach**
Pop all keys not on model, log removed keys, write back to storage with only allowed

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
