### PR TITLE
Replace underscore with dash for Everest realization folders

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -311,7 +311,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
             runpath_format_string=str(
                 Path(everest_config.simulation_dir)
                 / "batch_<ITER>"
-                / "realization_<REALIZATION_ID>"
+                / "realization-<REALIZATION_ID>"
                 / "<SIM_DIR>"
             ),
             eclbase_format_string=eclbase

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -771,7 +771,7 @@ def test_that_install_data_with_inline_data_generates_a_file(
     run_model.run_experiment(EvaluatorServerConfig())
     for expected_dir in ("evaluation_0", "perturbation_0"):
         expected_file = Path(
-            f"everest_output/sim_output/batch_0/realization_0/{expected_dir}/output.json"
+            f"everest_output/sim_output/batch_0/realization-0/{expected_dir}/output.json"
         )
         assert expected_file.exists()
         with expected_file.open(encoding="utf-8") as fp:

--- a/tests/everest/test_environment.py
+++ b/tests/everest/test_environment.py
@@ -39,6 +39,6 @@ def test_that_runpath_strings_are_generated_correctly(
         str(Path(run_arg.runpath).relative_to(Path().absolute()))
         for run_arg in run_args
     ] == [
-        f"everest_output/simulation_folder/batch_{iteration}/realization_0/evaluation_0",
-        f"everest_output/simulation_folder/batch_{iteration}/realization_2/evaluation_0",
+        f"everest_output/simulation_folder/batch_{iteration}/realization-0/evaluation_0",
+        f"everest_output/simulation_folder/batch_{iteration}/realization-2/evaluation_0",
     ]

--- a/tests/everest/test_everest_run_model.py
+++ b/tests/everest/test_everest_run_model.py
@@ -173,7 +173,7 @@ def test_substitutions_from_everest_config(
             f"{config_dir}"
             "/custom_output_folder"
             "/the_simulations_dir/"
-            "batch_<ITER>/realization_<REALIZATION_ID>/<SIM_DIR>"
+            "batch_<ITER>/realization-<REALIZATION_ID>/<SIM_DIR>"
         ),
         "<ECL_BASE>": "ECLBASE<IENS>",
         "<ECLBASE>": "ECLBASE<IENS>",

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -168,7 +168,7 @@ async def test_status_too_few_realizations_succeeded(copy_math_func_test_data_to
     config_dict["install_jobs"].append(
         {"name": "fail_simulation", "executable": "jobs/fail_simulation.py"}
     )
-    config_dict["forward_model"].append("fail_simulation --fail realization_0")
+    config_dict["forward_model"].append("fail_simulation --fail realization-0")
     with pytest.warns(ConfigWarning, match="The `controls.type` field is deprecated"):
         config = EverestConfig.model_validate(config_dict)
 

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -91,16 +91,16 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the failed simulation folder still exists
-    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_1").exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization-0/perturbation_1").exists(), (
         "Simulation folder should be there, something went wrong and was removed!"
     )
 
     # Check the successful simulation folders do not exist
-    assert not (Path(simulation_dir) / "batch_0/realization_0/evaluation_0").exists(), (
+    assert not (Path(simulation_dir) / "batch_0/realization-0/evaluation_0").exists(), (
         "Simulation folder should not be there, something went wrong!"
     )
 
-    assert not (Path(simulation_dir) / "batch_0/realization_0/simulation_1").exists(), (
+    assert not (Path(simulation_dir) / "batch_0/realization-0/simulation_1").exists(), (
         "Simulation folder should not be there, something went wrong!"
     )
 
@@ -116,15 +116,15 @@ def test_remove_run_path(copy_math_func_test_data_to_tmp):
     run_model.run_experiment(evaluator_server_config)
 
     # Check the all simulation folder exist when delete_run_path is set to False
-    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_1").exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization-0/perturbation_1").exists(), (
         "Simulation folder should be there, something went wrong and was removed!"
     )
 
-    assert (Path(simulation_dir) / "batch_0/realization_0/evaluation_0").exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization-0/evaluation_0").exists(), (
         "Simulation folder should be there, something went wrong and was removed"
     )
 
-    assert (Path(simulation_dir) / "batch_0/realization_0/perturbation_0").exists(), (
+    assert (Path(simulation_dir) / "batch_0/realization-0/perturbation_0").exists(), (
         "Simulation folder should be there, something went wrong and was removed"
     )
 

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -263,7 +263,7 @@ def test_user_specified_data_n_template(copy_math_func_test_data_to_tmp, test):
         Path("everest_output")
         / "sim_output"
         / "batch_0"
-        / "realization_0"
+        / "realization-0"
         / "perturbation_0"
         / "well_drill_constants.json"
     )


### PR DESCRIPTION
**Issue**
Resolves #13760 


Replace underscore with dash.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
