### PR TITLE
Show loading indicator in SearchBox

### DIFF
--- a/src/ert/gui/ertwidgets/searchbox.py
+++ b/src/ert/gui/ertwidgets/searchbox.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import QSize, Qt, QTimer
 from PyQt6.QtCore import pyqtSignal as Signal
-from PyQt6.QtGui import QColor, QFocusEvent, QKeyEvent
-from PyQt6.QtWidgets import QLineEdit
+from PyQt6.QtGui import QColor, QFocusEvent, QKeyEvent, QMovie, QResizeEvent
+from PyQt6.QtWidgets import QLabel, QLineEdit, QStyle
 from typing_extensions import override
 
 
@@ -12,26 +12,71 @@ class SearchBox(QLineEdit):
 
     filterChanged = Signal(object)
 
-    def __init__(self, debounce_timeout: int = 1000) -> None:
+    def __init__(
+        self,
+        debounce_timeout: int = 1000,
+        *,
+        show_pending_indicator: bool = False,
+    ) -> None:
         QLineEdit.__init__(self)
 
         self.setToolTip("Type to search!")
         self.active_color = self.palette().color(self.foregroundRole())
         self.disable_search = True
-        self.presentSearch()
+        self._use_pending_indicator = show_pending_indicator
+        self._pending_movie = QMovie("img:loading.gif")
+        self._pending_movie.setScaledSize(QSize(16, 16))
+
+        self._pending_indicator = QLabel(self)
+        self._pending_indicator.setFixedSize(QSize(16, 16))
+        self._pending_indicator.setMovie(self._pending_movie)
+        self._pending_indicator.hide()
+
         self.textChanged.connect(self._start_debounce_timer)
-        self._debounce_timout = debounce_timeout
+
+        self._debounce_timeout = debounce_timeout
         self._debounce_timer = QTimer(self)
         self._debounce_timer.setSingleShot(True)
         self._debounce_timer.timeout.connect(self._emit_filter_changed)
+        self._search_pending = False
+
+        if self._use_pending_indicator:
+            self.setTextMargins(0, 0, self._pending_indicator.width() + 4, 0)
+        self.presentSearch()
+
+    def _show_pending_indicator(self) -> None:
+        if not self._use_pending_indicator:
+            return
+
+        self._pending_indicator.show()
+        self._pending_movie.start()
+
+    def _hide_pending_indicator(self) -> None:
+        if not self._use_pending_indicator:
+            return
+
+        self._pending_movie.stop()
+        self._pending_indicator.hide()
 
     def _start_debounce_timer(self, _filter: Any) -> None:
+        if self.disable_search:
+            return
+
+        if not self._search_pending:
+            self._show_pending_indicator()
+            self._search_pending = True
+
         if not self._debounce_timer.isActive():
-            self._debounce_timer.start(self._debounce_timout)
-        self._debounce_timer.setInterval(self._debounce_timout)
+            self._debounce_timer.start(self._debounce_timeout)
+        self._debounce_timer.setInterval(self._debounce_timeout)
 
     def _emit_filter_changed(self) -> None:
-        self.filterChanged.emit(self.filter())
+        try:
+            self.filterChanged.emit(self.filter())
+        finally:
+            if self._search_pending:
+                self._hide_pending_indicator()
+                self._search_pending = False
 
     def filter(self) -> str:
         if self.disable_search:
@@ -48,8 +93,8 @@ class SearchBox(QLineEdit):
 
     def activateSearch(self) -> None:
         """Is called to remove the greyed out search"""
-        self.disable_search = False
         self.setText("")
+        self.disable_search = False
         palette = self.palette()
         palette.setColor(self.foregroundRole(), self.active_color)
         self.setPalette(palette)
@@ -60,7 +105,7 @@ class SearchBox(QLineEdit):
             self.activateSearch()
 
     def exitSearch(self) -> None:
-        """Called when the line edit looses focus"""
+        """Called when the line edit loses focus"""
         if not self.text():
             self.presentSearch()
 
@@ -73,6 +118,18 @@ class SearchBox(QLineEdit):
     def focusOutEvent(self, a0: QFocusEvent | None) -> None:
         QLineEdit.focusOutEvent(self, a0)
         self.exitSearch()
+
+    @override
+    def resizeEvent(self, a0: QResizeEvent | None) -> None:
+        style = self.style()
+        assert style is not None
+        frame_width = style.pixelMetric(QStyle.PixelMetric.PM_DefaultFrameWidth)
+        self._pending_indicator.move(
+            self.rect().right() - frame_width - self._pending_indicator.width(),
+            int((self.height() - self._pending_indicator.height()) / 2),
+        )
+
+        QLineEdit.resizeEvent(self, a0)
 
     @override
     def keyPressEvent(self, a0: QKeyEvent | None) -> None:

--- a/src/ert/gui/ertwidgets/searchbox.py
+++ b/src/ert/gui/ertwidgets/searchbox.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from PyQt6.QtCore import QSize, Qt, QTimer
 from PyQt6.QtCore import pyqtSignal as Signal
-from PyQt6.QtGui import QColor, QFocusEvent, QKeyEvent, QMovie, QResizeEvent
-from PyQt6.QtWidgets import QLabel, QLineEdit, QStyle
+from PyQt6.QtGui import QColor, QCursor, QFocusEvent, QKeyEvent, QMovie, QResizeEvent
+from PyQt6.QtWidgets import QApplication, QLabel, QLineEdit, QStyle
 from typing_extensions import override
 
 
@@ -12,18 +12,12 @@ class SearchBox(QLineEdit):
 
     filterChanged = Signal(object)
 
-    def __init__(
-        self,
-        debounce_timeout: int = 1000,
-        *,
-        show_pending_indicator: bool = False,
-    ) -> None:
+    def __init__(self, debounce_timeout: int = 1000) -> None:
         QLineEdit.__init__(self)
 
         self.setToolTip("Type to search!")
         self.active_color = self.palette().color(self.foregroundRole())
         self.disable_search = True
-        self._use_pending_indicator = show_pending_indicator
         self._pending_movie = QMovie("img:loading.gif")
         self._pending_movie.setScaledSize(QSize(16, 16))
 
@@ -40,30 +34,25 @@ class SearchBox(QLineEdit):
         self._debounce_timer.timeout.connect(self._emit_filter_changed)
         self._search_pending = False
 
-        if self._use_pending_indicator:
-            self.setTextMargins(0, 0, self._pending_indicator.width() + 4, 0)
+        self.setTextMargins(0, 0, self._pending_indicator.width() + 4, 0)
         self.presentSearch()
 
-    def _show_pending_indicator(self) -> None:
-        if not self._use_pending_indicator:
-            return
-
+    def _show_pending_state(self) -> None:
         self._pending_indicator.show()
         self._pending_movie.start()
+        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
-    def _hide_pending_indicator(self) -> None:
-        if not self._use_pending_indicator:
-            return
-
+    def _hide_pending_state(self) -> None:
         self._pending_movie.stop()
         self._pending_indicator.hide()
+        QApplication.restoreOverrideCursor()
 
     def _start_debounce_timer(self, _filter: Any) -> None:
         if self.disable_search:
             return
 
         if not self._search_pending:
-            self._show_pending_indicator()
+            self._show_pending_state()
             self._search_pending = True
 
         if not self._debounce_timer.isActive():
@@ -71,12 +60,10 @@ class SearchBox(QLineEdit):
         self._debounce_timer.setInterval(self._debounce_timeout)
 
     def _emit_filter_changed(self) -> None:
-        try:
-            self.filterChanged.emit(self.filter())
-        finally:
-            if self._search_pending:
-                self._hide_pending_indicator()
-                self._search_pending = False
+        self.filterChanged.emit(self.filter())
+        if self._search_pending:
+            self._hide_pending_state()
+            self._search_pending = False
 
     def filter(self) -> str:
         if self.disable_search:
@@ -86,6 +73,9 @@ class SearchBox(QLineEdit):
     def presentSearch(self) -> None:
         """Is called to present the greyed out search"""
         self.disable_search = True
+        if self._search_pending:
+            self._hide_pending_state()
+            self._search_pending = False
         self.setText("Search")
         palette = self.palette()
         palette.setColor(self.foregroundRole(), self.passive_color)
@@ -122,7 +112,8 @@ class SearchBox(QLineEdit):
     @override
     def resizeEvent(self, a0: QResizeEvent | None) -> None:
         style = self.style()
-        assert style is not None
+        if style is None:
+            raise RuntimeError("SearchBox style is unexpectedly None")
         frame_width = style.pixelMetric(QStyle.PixelMetric.PM_DefaultFrameWidth)
         self._pending_indicator.move(
             self.rect().right() - frame_width - self._pending_indicator.width(),

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -131,7 +131,7 @@ class DataTypeKeysWidget(QWidget):
 
         filter_layout = QHBoxLayout()
 
-        self.search_box = SearchBox(show_pending_indicator=True)
+        self.search_box = SearchBox()
         self.search_box.filterChanged.connect(self.setSearchString)
         filter_layout.addWidget(self.search_box)
 

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -131,7 +131,7 @@ class DataTypeKeysWidget(QWidget):
 
         filter_layout = QHBoxLayout()
 
-        self.search_box = SearchBox()
+        self.search_box = SearchBox(show_pending_indicator=True)
         self.search_box.filterChanged.connect(self.setSearchString)
         filter_layout.addWidget(self.search_box)
 

--- a/tests/ert/unit_tests/gui/ertwidgets/test_searchbox.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_searchbox.py
@@ -4,7 +4,7 @@ from ert.gui.ertwidgets.searchbox import SearchBox
 
 
 def test_search_box_does_not_emit_filter_changed_when_focused(qtbot):
-    search_box = SearchBox(debounce_timeout=10, show_pending_indicator=True)
+    search_box = SearchBox(debounce_timeout=10)
     qtbot.addWidget(search_box)
 
     signal_spy = QSignalSpy(search_box.filterChanged)
@@ -18,7 +18,7 @@ def test_search_box_does_not_emit_filter_changed_when_focused(qtbot):
 
 
 def test_search_box_shows_pending_indicator_while_debounce_is_active(qtbot):
-    search_box = SearchBox(debounce_timeout=100, show_pending_indicator=True)
+    search_box = SearchBox(debounce_timeout=100)
     qtbot.addWidget(search_box)
     search_box.show()
 

--- a/tests/ert/unit_tests/gui/ertwidgets/test_searchbox.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_searchbox.py
@@ -1,0 +1,37 @@
+from PyQt6.QtTest import QSignalSpy
+
+from ert.gui.ertwidgets.searchbox import SearchBox
+
+
+def test_search_box_does_not_emit_filter_changed_when_focused(qtbot):
+    search_box = SearchBox(debounce_timeout=10, show_pending_indicator=True)
+    qtbot.addWidget(search_box)
+
+    signal_spy = QSignalSpy(search_box.filterChanged)
+
+    search_box.setFocus()
+    qtbot.wait(20)
+
+    assert len(signal_spy) == 0
+    assert not search_box._search_pending
+    assert not search_box._pending_indicator.isVisible()
+
+
+def test_search_box_shows_pending_indicator_while_debounce_is_active(qtbot):
+    search_box = SearchBox(debounce_timeout=100, show_pending_indicator=True)
+    qtbot.addWidget(search_box)
+    search_box.show()
+
+    search_box.activateSearch()
+    qtbot.keyClicks(search_box, "abc")
+
+    assert search_box.filter() == "abc"
+    assert search_box._search_pending
+    assert search_box._pending_indicator.isVisible()
+
+    with qtbot.waitSignal(search_box.filterChanged, timeout=200) as blocker:
+        pass
+
+    assert blocker.args == ["abc"]
+    assert not search_box._search_pending
+    assert not search_box._pending_indicator.isVisible()


### PR DESCRIPTION
Add an optional pending indicator to SearchBox while a search is waiting to be applied.

This gives users immediate feedback after typing in search fields where the resulting filter operation may trigger slower downstream updates. The indicator is opt-in so other existing SearchBox usages keep their current behavior.

**Issue**
Resolves #13745 


**Approach**
I went with a small pending indicator in the search box itself rather than changing the global cursor. If it is preferred to use the existing wait-cursor pattern instead, I am happy to change it.

The indicator is shown when a typed search starts waiting to be applied, and is hidden after the debounced filter signal has been emitted and handled. 

The indicator is intended to cover the search/filter pending state only. Downstream plot updates may still happen after filtering changes the selected item, but those are already covered by existing loading feedback.

<img width="600" height="343" alt="Loading" src="https://github.com/user-attachments/assets/a65ffe9b-9472-496f-93d1-17729dbc70b9" />

Observation: search input can trigger graph updates through selection changes. Avoiding unnecessary graph updates might make it possible to lower the debounce time, which could make the interface feel more responsive.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
