### PR TITLE
Replace obs_scaling_factors with blobs

### DIFF
--- a/src/ert/analysis/_update_commons.py
+++ b/src/ert/analysis/_update_commons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import logging
 from collections.abc import Callable, Iterable
 from enum import StrEnum
@@ -16,6 +17,7 @@ from . import misfit_preprocessor
 from .event import (
     AnalysisDataEvent,
     AnalysisEvent,
+    AnalysisScalingEvent,
     DataSection,
 )
 from .snapshots import (
@@ -232,7 +234,22 @@ def _preprocess_observations_and_responses(
         )
 
         if updated_std_scales is not None and scaling_factors_df is not None:
-            posterior_ensemble.save_observation_scaling_factors(scaling_factors_df)
+            buf = io.BytesIO()
+            scaling_factors_df.write_parquet(buf)
+            scaling_bytes = buf.getvalue()
+            num_groups = (
+                scaling_factors_df["input_group"].n_unique()
+                if "input_group" in scaling_factors_df.columns
+                else 1
+            )
+            progress_callback(
+                AnalysisScalingEvent(
+                    update_algorithm="ensemble_smoother",
+                    scaling_bytes=scaling_bytes,
+                    num_observations=len(scaling_factors_df),
+                    num_groups=num_groups,
+                )
+            )
 
             # Recompute with updated scales
             observations_and_responses = observations_and_responses.with_columns(

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -93,3 +93,11 @@ class AnalysisMatrixEvent(AnalysisEvent):
     data_type: str
     update_algorithm: str
     matrix_bytes: bytes = Field(exclude=True)
+
+
+class AnalysisScalingEvent(AnalysisEvent):
+    event_type: Literal["AnalysisScalingEvent"] = "AnalysisScalingEvent"
+    update_algorithm: str
+    scaling_bytes: bytes = Field(exclude=True)
+    num_observations: int
+    num_groups: int

--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import json
 from enum import IntEnum
 from typing import cast
@@ -32,6 +33,7 @@ from PyQt6.QtWidgets import (
 from ert.config.response_config import BaseResponseConfig
 from ert.config.rft_config import RFTConfig
 from ert.storage import Ensemble, Experiment, RealizationStorageState
+from ert.storage.blob_data import BlobType
 from ert.warnings import capture_specific_warning
 
 from .export_dialog import ExportDialog
@@ -313,7 +315,15 @@ class _EnsembleWidget(QWidget):
         ax.set_title(selected.observation_key)
         ax.grid(True)
         obs = selected.observation_data
-        scaling_df = self._ensemble.load_observation_scaling_factors()
+        scaling_blobs = self._ensemble.load_blobs(BlobType.SCALING_FACTORS)
+        if scaling_blobs:
+            try:
+                raw = self._ensemble.load_blob(scaling_blobs[0].uri)
+                scaling_df = pl.read_parquet(io.BytesIO(raw))
+            except FileNotFoundError:
+                scaling_df = None
+        else:
+            scaling_df = None
 
         def _try_render_scaled_obs() -> None:
             if scaling_df is None:

--- a/src/ert/run_models/update_run_model.py
+++ b/src/ert/run_models/update_run_model.py
@@ -10,6 +10,7 @@ from ert.analysis.event import (
     AnalysisErrorEvent,
     AnalysisEvent,
     AnalysisMatrixEvent,
+    AnalysisScalingEvent,
     AnalysisStatusEvent,
     AnalysisTimeEvent,
 )
@@ -191,6 +192,8 @@ class UpdateRunModel(RunModel, UpdateRunModelConfig):
                     )
                 )
             case AnalysisMatrixEvent():
+                ensemble.save_blob(event)
+            case AnalysisScalingEvent():
                 ensemble.save_blob(event)
             case AnalysisCompleteEvent():
                 ensemble.save_blob(event)

--- a/src/ert/storage/blob_data.py
+++ b/src/ert/storage/blob_data.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Discriminator
 class BlobType(StrEnum):
     OBSERVATION_REPORT = "observation_report"
     MATRIX = "matrix"
+    SCALING_FACTORS = "scaling_factors"
 
 
 class ObservationReportData(BaseModel):
@@ -24,6 +25,13 @@ class MatrixStorageData(BaseModel):
     data_type: str
 
 
+class ScalingFactorsData(BaseModel):
+    blob_type: Literal[BlobType.SCALING_FACTORS] = BlobType.SCALING_FACTORS
+    update_algorithm: str
+    num_observations: int
+    num_groups: int
+
+
 class BlobStorageData(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -32,6 +40,6 @@ class BlobStorageData(BaseModel):
     file_type: str
     name: str
     blob_info: Annotated[
-        MatrixStorageData | ObservationReportData,
+        MatrixStorageData | ObservationReportData | ScalingFactorsData,
         Discriminator("blob_type"),
     ]

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -47,6 +47,7 @@ from .blob_data import (
     BlobType,
     MatrixStorageData,
     ObservationReportData,
+    ScalingFactorsData,
 )
 from .load_status import LoadResult
 from .mode import BaseMode, Mode, require_write
@@ -55,7 +56,11 @@ from .realization_storage_state import RealizationStorageState
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from ert.analysis.event import AnalysisCompleteEvent, AnalysisMatrixEvent
+    from ert.analysis.event import (
+        AnalysisCompleteEvent,
+        AnalysisMatrixEvent,
+        AnalysisScalingEvent,
+    )
 
     from .local_experiment import LocalExperiment
     from .local_storage import LocalStorage
@@ -701,21 +706,6 @@ class LocalEnsemble(BaseMode):
         return df.rename(
             {config.name: f"{config.group_name}:{config.name}" for config in gen_kws}
         )
-
-    @require_write
-    def save_observation_scaling_factors(self, dataset: pl.DataFrame) -> None:
-        self._storage._to_parquet_transaction(
-            self.mount_point / "observation_scaling_factors.parquet", dataset
-        )
-
-    def load_observation_scaling_factors(
-        self,
-    ) -> pl.DataFrame | None:
-        ds_path = self.mount_point / "observation_scaling_factors.parquet"
-        if ds_path.exists():
-            return pl.read_parquet(ds_path)
-
-        return None
 
     @staticmethod
     def sample_parameter(
@@ -1376,13 +1366,17 @@ class LocalEnsemble(BaseMode):
         try:
             blob_path.relative_to(blob_dir)
         except ValueError:
+            logger.warning("Blob URI %s resolves outside of blob directory", uri)
             raise FileNotFoundError(uri) from None
+        if not blob_path.exists():
+            logger.warning("Blob file %s not found", uri)
+            raise FileNotFoundError(uri)
         return blob_path.read_bytes()
 
     @require_write
     def save_blob(
         self,
-        blob_event: AnalysisCompleteEvent | AnalysisMatrixEvent,
+        blob_event: AnalysisCompleteEvent | AnalysisMatrixEvent | AnalysisScalingEvent,
     ) -> None:
         blob_dir = self._path / BLOB_DATA_DIR
         blob_dir.mkdir(parents=True, exist_ok=True)
@@ -1406,6 +1400,19 @@ class LocalEnsemble(BaseMode):
                 ),
             )
             data = blob_event.matrix_bytes
+        elif blob_event.event_type == "AnalysisScalingEvent":
+            blob_data = BlobStorageData(
+                uri=uri,
+                file_size=len(blob_event.scaling_bytes),
+                file_type="application/parquet",
+                name="scaling_factors",
+                blob_info=ScalingFactorsData(
+                    update_algorithm=blob_event.update_algorithm,
+                    num_observations=blob_event.num_observations,
+                    num_groups=blob_event.num_groups,
+                ),
+            )
+            data = blob_event.scaling_bytes
         else:
             buf = io.BytesIO()
             pl.DataFrame(

--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 30
+_LOCAL_STORAGE_VERSION = 31
 
 
 def open_storage(
@@ -539,6 +539,7 @@ class LocalStorage(BaseMode):
             to28,
             to29,
             to30,
+            to31,
         )
 
         try:  # noqa: PLW0717
@@ -598,6 +599,7 @@ class LocalStorage(BaseMode):
                     27: to28,
                     28: to29,
                     29: to30,
+                    30: to31,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to31.py
+++ b/src/ert/storage/migration/to31.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import io
+import json
+import uuid
+from pathlib import Path
+
+import polars as pl
+
+info = "Migrate observation_scaling_factors.parquet to blob storage"
+
+
+def _migrate_scaling_factors(path: Path) -> None:
+    ensembles_dir = path / "ensembles"
+    if not ensembles_dir.exists():
+        return
+
+    for ens_dir in ensembles_dir.iterdir():
+        if not ens_dir.is_dir():
+            continue
+
+        old_file = ens_dir / "observation_scaling_factors.parquet"
+        if not old_file.exists():
+            continue
+
+        try:
+            df = pl.read_parquet(old_file)
+        except Exception:
+            continue
+
+        blob_dir = ens_dir / "blobs"
+        blob_dir.mkdir(parents=True, exist_ok=True)
+
+        blob_id = uuid.uuid4().hex[:8]
+        blob_file = blob_dir / f"{blob_id}.blob"
+        blob_meta_file = blob_dir / f"{blob_id}.blob.json"
+
+        buf = io.BytesIO()
+        df.write_parquet(buf)
+        blob_bytes = buf.getvalue()
+
+        num_groups = df["input_group"].n_unique() if "input_group" in df.columns else 1
+
+        blob_meta = {
+            "uri": f"{blob_id}.blob",
+            "file_size": len(blob_bytes),
+            "file_type": "application/parquet",
+            "name": "scaling_factors",
+            "blob_info": {
+                "blob_type": "scaling_factors",
+                "update_algorithm": "ensemble_smoother",
+                "num_observations": len(df),
+                "num_groups": num_groups,
+            },
+        }
+
+        blob_file.write_bytes(blob_bytes)
+        blob_meta_file.write_text(json.dumps(blob_meta, indent=2), encoding="utf-8")
+        old_file.unlink()
+
+
+def migrate(path: Path) -> None:
+    _migrate_scaling_factors(path)

--- a/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
+++ b/tests/ert/ui_tests/cli/analysis/test_adaptive_localization.py
@@ -1,13 +1,16 @@
+import io
 import shutil
 from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
+import polars as pl
 import pytest
 
 from ert.config import ErtConfig
 from ert.mode_definitions import ENSEMBLE_SMOOTHER_MODE
 from ert.storage import open_storage
+from ert.storage.blob_data import BlobType
 from tests.ert.ui_tests.cli.run_cli import run_cli
 
 random_seed_line = "RANDOM_SEED 1234\n\n"
@@ -216,8 +219,10 @@ ANALYSIS_SET_VAR OBSERVATIONS AUTO_SCALE POLY_OBS1_*
         "poly_localization_0.ert", "test_experiment"
     )
     with open_storage(storage_path) as storage:
-        sf = storage.get_ensemble(posterior_ens_id).load_observation_scaling_factors()
-        assert sf is not None
+        ensemble = storage.get_ensemble(posterior_ens_id)
+        scaling_blobs = ensemble.load_blobs(BlobType.SCALING_FACTORS)
+        assert len(scaling_blobs) == 1
+        sf = pl.read_parquet(io.BytesIO(ensemble.load_blob(scaling_blobs[0].uri)))
         records_from_pl = (
             sf.select(["input_group", "obs_key", "index"]).to_numpy().tolist()
         )

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from contextlib import ExitStack as does_not_raise
 from typing import Any
@@ -26,7 +27,7 @@ from ert.analysis._update_commons import (
 )
 from ert.analysis._update_strategies._adaptive import AdaptiveLocalizationUpdate
 from ert.analysis._update_strategies._protocol import ObservationContext
-from ert.analysis.event import AnalysisCompleteEvent
+from ert.analysis.event import AnalysisCompleteEvent, AnalysisScalingEvent
 from ert.config import (
     ESSettings,
     Field,
@@ -38,6 +39,7 @@ from ert.config import (
 )
 from ert.field_utils import AxisOrientation, ErtboxParameters, FieldFileFormat
 from ert.storage import Ensemble, open_storage
+from ert.storage.blob_data import BlobType
 
 
 @pytest.fixture
@@ -840,6 +842,10 @@ def test_that_autoscaling_saves_scaling_factors_to_posterior_ensemble(storage):
             name="dummy_posterior", ensemble_size=10
         )
 
+        def progress_callback(event):
+            if isinstance(event, AnalysisScalingEvent):
+                posterior_ensemble.save_blob(event)
+
         _mock_preprocess_observations_and_responses(
             observations_and_responses,
             observation_settings=ObservationSettings(
@@ -847,13 +853,15 @@ def test_that_autoscaling_saves_scaling_factors_to_posterior_ensemble(storage):
                 auto_scale_observations=[["obs1*"]],
             ),
             global_std_scaling=1,
-            progress_callback=lambda _: None,
+            progress_callback=progress_callback,
             prior_ensemble=prior_ensemble,
             posterior_ensemble=posterior_ensemble,
         )
 
-        scaling_factors = posterior_ensemble.load_observation_scaling_factors()
-        assert scaling_factors is not None
+        scaling_blobs = posterior_ensemble.load_blobs(BlobType.SCALING_FACTORS)
+        assert len(scaling_blobs) == 1
+        raw = posterior_ensemble.load_blob(scaling_blobs[0].uri)
+        scaling_factors = pl.read_parquet(io.BytesIO(raw))
         assert "input_group" in scaling_factors.columns
         assert "obs_key" in scaling_factors.columns
         assert "scaling_factor" in scaling_factors.columns
@@ -861,7 +869,7 @@ def test_that_autoscaling_saves_scaling_factors_to_posterior_ensemble(storage):
         assert scaling_factors["scaling_factor"].to_list() == [2.0, 3.0]
 
         # Verify nothing was saved to the prior ensemble
-        assert prior_ensemble.load_observation_scaling_factors() is None
+        assert prior_ensemble.load_blobs(BlobType.SCALING_FACTORS) == []
 
 
 @pytest.mark.parametrize(

--- a/tests/ert/unit_tests/storage/migration/test_to31.py
+++ b/tests/ert/unit_tests/storage/migration/test_to31.py
@@ -1,0 +1,82 @@
+import io
+from pathlib import Path
+
+import polars as pl
+
+from ert.storage.blob_data import BlobStorageData, ScalingFactorsData
+from ert.storage.migration.to31 import migrate
+
+
+def _read_blob_metadata(blob_meta_path: Path) -> BlobStorageData:
+    return BlobStorageData.model_validate_json(
+        blob_meta_path.read_text(encoding="utf-8")
+    )
+
+
+def test_that_migration_moves_scaling_factor_parquet_to_blob_storage(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    ensemble_dir = root / "ensembles" / "ens-1"
+    ensemble_dir.mkdir(parents=True)
+
+    old_path = ensemble_dir / "observation_scaling_factors.parquet"
+    old_df = pl.DataFrame(
+        {
+            "input_group": ["obs1*", "obs2*"],
+            "index": ["r0", "r1"],
+            "obs_key": ["OBS_1", "OBS_2"],
+            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
+        }
+    )
+    old_df.write_parquet(old_path)
+
+    migrate(root)
+
+    assert not old_path.exists()
+
+    blob_dir = ensemble_dir / "blobs"
+    blob_data_files = list(blob_dir.glob("*.blob"))
+    blob_meta_files = list(blob_dir.glob("*.blob.json"))
+    assert len(blob_data_files) == 1
+    assert len(blob_meta_files) == 1
+
+    meta = _read_blob_metadata(blob_meta_files[0])
+    assert meta.name == "scaling_factors"
+    assert meta.file_type == "application/parquet"
+    assert isinstance(meta.blob_info, ScalingFactorsData)
+    assert meta.blob_info.update_algorithm == "ensemble_smoother"
+    assert meta.blob_info.num_observations == 2
+    assert meta.blob_info.num_groups == 2
+
+    migrated_df = pl.read_parquet(io.BytesIO((blob_dir / meta.uri).read_bytes()))
+    assert migrated_df.to_dict(as_series=False) == old_df.to_dict(as_series=False)
+
+
+def test_that_migration_defaults_num_groups_to_one_when_input_group_is_missing(
+    tmp_path,
+):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    ensemble_dir = root / "ensembles" / "ens-1"
+    ensemble_dir.mkdir(parents=True)
+
+    old_path = ensemble_dir / "observation_scaling_factors.parquet"
+    pl.DataFrame(
+        {
+            "index": ["r0", "r1"],
+            "obs_key": ["OBS_1", "OBS_2"],
+            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
+        }
+    ).write_parquet(old_path)
+
+    migrate(root)
+
+    blob_meta_files = list((ensemble_dir / "blobs").glob("*.blob.json"))
+    assert len(blob_meta_files) == 1
+
+    meta = _read_blob_metadata(blob_meta_files[0])
+    assert isinstance(meta.blob_info, ScalingFactorsData)
+    assert meta.blob_info.num_observations == 2
+    assert meta.blob_info.num_groups == 1


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/13668


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
