### PR TITLE
Fix docstring and typehints for killed_by_oom

### DIFF
--- a/src/_ert/forward_model_runner/forward_model_step.py
+++ b/src/_ert/forward_model_runner/forward_model_step.py
@@ -10,7 +10,7 @@ import socket
 import sys
 import time
 import uuid
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from dataclasses import dataclass, field
 from os import path
 from pathlib import Path
@@ -33,13 +33,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def killed_by_oom(pids: set[int]) -> bool:
-    """Will try to detect if a process (or any of its descendants) was killed
-    by the Linux OOM-killer.
+def killed_by_oom(pids: Iterable[int]) -> bool:
+    """Detects whether any of the processes were killed due to OOM.
 
     Debug information will be logged through the system logger.
-
     Since pids can be reused, this can in theory give false positives.
+    Always just returns False on mac.
     """
 
     if sys.platform == "darwin":


### PR DESCRIPTION
While reading the docstring I realised the interface was not quite right.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
