### PR TITLE
Bump to ruff 0.15.17

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: actionlint
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.17
     hooks:
     - id: ruff-check
       args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,7 @@ ignore = [
     "PLR0904", # too-many-public-methods
     "PLR1702", # too-many-nested-blocks
     "RUF067",  # code in __init__ files
+    "RUF076",  # pytest-autouse-fixture
 ]
 
 # Allow EN DASH (U+2013)

--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -444,7 +444,7 @@ class EnsembleEvaluator:
             self._server_started.set_exception(e)
             zmq_context.destroy(linger=0)
             return
-        try:  # noqa: PLW0717
+        try:
             await self._server_done.wait()
             try:
                 await asyncio.wait_for(self._dispatchers_empty.wait(), timeout=5)

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -64,7 +64,7 @@ def setup_logging(options: argparse.Namespace) -> Generator[None, None, None]:
         log_dir.mkdir(exist_ok=True)
     except PermissionError as err:
         sys.exit(str(err))
-    try:  # noqa: PLW0717
+    try:
         os.environ["ERT_LOG_DIR"] = str(log_dir)
 
         config_dict = yaml.safe_load(LOGGING_CONFIG.read_text(encoding="utf-8"))

--- a/tests/ert/ui_tests/gui/test_missing_runpath.py
+++ b/tests/ert/ui_tests/gui/test_missing_runpath.py
@@ -70,7 +70,7 @@ def test_missing_runpath_has_isolated_failures(
 
         return inner
 
-    try:  # noqa: PLW0717
+    try:
         with open_gui_with_config(tmp_path / "config.ert") as gui:
             qtbot.addWidget(gui)
             run_experiment(
@@ -128,7 +128,7 @@ def test_missing_runpath_does_not_show_waiting_bar(
 
         return inner
 
-    try:  # noqa: PLW0717
+    try:
         with open_gui_with_config(tmp_path / "config.ert") as gui:
             qtbot.addWidget(gui)
             run_experiment(

--- a/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ert/unit_tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -128,7 +128,7 @@ async def test_evaluator_raises_on_start_with_address_in_use(make_ee_config):
     ee_config = make_ee_config(use_ipc_protocol=False)
     ctx = zmq.asyncio.Context()
     socket = ctx.socket(zmq.ROUTER)
-    try:  # noqa: PLW0717
+    try:
         ee_config.router_port = socket.bind_to_random_port(
             "tcp://*",
             min_port=ee_config.min_port,

--- a/tests/ert/utils.py
+++ b/tests/ert/utils.py
@@ -216,7 +216,7 @@ async def poll(
 
     poll_task = asyncio.create_task(driver.poll())
     completed = set()
-    try:  # noqa: PLW0717
+    try:
         while True:
             event = await driver.event_queue.get()
             if isinstance(event, StartedEvent):

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -318,7 +318,7 @@ def test_that_multiple_started_experiments_each_receive_distinct_run_ids(
     monkeypatch.setenv("ERT_STORAGE_TOKEN", "password")
     original = dict(_runs)
     _runs.clear()
-    try:  # noqa: PLW0717
+    try:
         credentials = b64encode(b"username:password").decode()
         auth_headers = {"Authorization": f"Basic {credentials}"}
         client = TestClient(app)


### PR DESCRIPTION
Ignore the new rule prohibiting pytest-autouse-fixtures, which we use heavily.

Also includes changes removing ignore statements, as ruff has become better at detecting situations that are false positives.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
