### PR TITLE
Add on-hover tooltip for constraints and controls plot

### DIFF
--- a/src/ert/gui/plotting/everest_plots/everest_constraints_plot.py
+++ b/src/ert/gui/plotting/everest_plots/everest_constraints_plot.py
@@ -71,6 +71,8 @@ class EverestConstraintsPlot:
 
         realizations = sorted(combined["realization"].unique())
 
+        line_data = []
+        line_labels = []
         for realization in realizations:
             data = combined[combined["realization"] == realization].sort_values(
                 "batch_id"
@@ -86,6 +88,8 @@ class EverestConstraintsPlot:
                 color=color,
                 markersize=4,
             )
+            line_data.append(lines)
+            line_labels.append(f"Realization {int(realization)}")
             if len(realizations) <= LEGEND_THRESHOLD:
                 config.add_legend_item(f"Realization {int(realization)}", lines[0])
 
@@ -120,6 +124,16 @@ class EverestConstraintsPlot:
             axes.set_ylim(ylim)
 
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
+
+        PlotTools.labels_on_hover(
+            PlotType.LINE,
+            axes,
+            figure,
+            data=line_data,
+            labels=line_labels,
+            disable_values=True,
+            hover_color=config.next_color()[0],
+        )
 
         PlotTools.finalizePlot(
             plot_context,

--- a/src/ert/gui/plotting/everest_plots/everest_controls_plot.py
+++ b/src/ert/gui/plotting/everest_plots/everest_controls_plot.py
@@ -80,6 +80,8 @@ class EverestControlsPlot:
         data = combined_data[combined_data["control_name"].isin(self.selected_controls)]
         batch_ids = sorted(data["batch_id"].unique().tolist())
 
+        scatter_data = []
+        scatter_labels = []
         for batch_id in batch_ids:
             batch_data = data[data["batch_id"] == batch_id]
             if not batch_data.empty:
@@ -90,11 +92,22 @@ class EverestControlsPlot:
                     color=config.next_color(),
                     s=20,
                 )
+                scatter_data.append(scatter)
+                scatter_labels.extend([label] * len(batch_data))
                 if len(batch_ids) <= LEGEND_THRESHOLD:
                     config.add_legend_item(label, scatter)
         axes.tick_params(axis="x", rotation=-30)
 
         config.set_title("Control values by control")
+
+        PlotTools.labels_on_hover(
+            PlotType.SCATTER,
+            axes,
+            figure,
+            data=scatter_data,
+            labels=scatter_labels,
+        )
+
         PlotTools.finalizePlot(
             plot_context,
             figure,

--- a/tests/everest/unit_tests/plots/test_everest_constraints_plot.py
+++ b/tests/everest/unit_tests/plots/test_everest_constraints_plot.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from tests.everest.unit_tests.plots.utils import create_everest_figure
+from tests.everest.unit_tests.plots.utils import create_everest_figure, move_cursor
 
 from ert.gui.plotting.everest_plots import EverestConstraintsPlot
 from ert.gui.plotting.utils.plot_context import PlotType
@@ -93,3 +93,38 @@ def test_that_bounds_have_correct_style(
 
     spans = axes.patches
     assert len(spans) == 2
+
+
+def test_that_tooltip_shows_on_hover(
+    everest_ensemble, generic_plot_context, constraints_data
+):
+    figure = create_everest_figure(
+        EverestConstraintsPlot(),
+        constraints_data,
+        generic_plot_context,
+        everest_ensemble,
+    )
+
+    axes = figure.get_axes()[0]
+
+    move_cursor(
+        axes,
+        x=0.0,
+        y=0.1,
+    )
+
+    annotations = axes.texts
+    assert len(annotations) == 1
+
+    hover_annotation = annotations[0]
+
+    assert hover_annotation.get_text() == "Realization 0"
+    assert hover_annotation.get_visible()
+
+    move_cursor(
+        axes,
+        x=0.0,
+        y=1.0,
+    )
+
+    assert not hover_annotation.get_visible()

--- a/tests/everest/unit_tests/plots/test_everest_controls_plot.py
+++ b/tests/everest/unit_tests/plots/test_everest_controls_plot.py
@@ -303,3 +303,47 @@ def test_that_hover_annotation_displays_control_name_for_by_batch_plot(
     )
 
     assert not hover_annotation.get_visible()
+
+
+def test_that_hover_annotation_displays_batch_id_for_by_control_plot(
+    generic_plot_context, everest_ensemble, controls_data
+):
+    generic_plot_context.by_batch = False
+    plot = EverestControlsPlot()
+    plot.set_selected_controls(["ctrl_a", "ctrl_b"])
+    figure = create_everest_figure(
+        plot, controls_data, generic_plot_context, everest_ensemble
+    )
+
+    axes = figure.get_axes()[0]
+
+    move_cursor(
+        axes=axes,
+        x=0.0,
+        y=1.0,
+    )
+
+    annotations = [text for text in axes.texts if "batch" in text.get_text()]
+
+    assert len(annotations) == 1
+
+    hover_annotation = annotations[0]
+    assert hover_annotation.get_text() == "initial batch"
+    assert hover_annotation.get_visible()
+
+    move_cursor(
+        axes=axes,
+        x=0,
+        y=1.5,
+    )
+
+    assert hover_annotation.get_text() == "batch_1"
+    assert hover_annotation.get_visible()
+
+    move_cursor(
+        axes=axes,
+        x=0,
+        y=0,
+    )
+
+    assert not hover_annotation.get_visible()


### PR DESCRIPTION
**Issue**
Resolves #13702 


**Approach**
Added on-hover tooltip to controls `plot_per_control` plot and constrains plot.

<img width="1148" height="671" alt="image" src="https://github.com/user-attachments/assets/c47f44c9-bb67-4d5f-bb9c-520b8c28ba97" />

<img width="1144" height="672" alt="image" src="https://github.com/user-attachments/assets/6d0c3b99-4c57-492a-85cd-51954af7048d" />

