### PR TITLE
Truncate long experiment names

### DIFF
--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import QComboBox
 
 from ert.config import ErrorInfo
 from ert.gui.ertnotifier import ErtNotifier
+from ert.gui.utils import truncate_dropdown_item
 from ert.storage import RealizationStorageState
 
 from .suggestor import Suggestor
@@ -90,7 +91,8 @@ class EnsembleSelector(QComboBox):
         try:
             for ensemble in ensemble_list:
                 self.addItem(
-                    f"{ensemble.experiment.name} : {ensemble.name}",
+                    f"{truncate_dropdown_item(ensemble.experiment.name)}"
+                    f" : {ensemble.name}",
                     userData=str(ensemble.id),
                 )
             if ensemble_list:

--- a/src/ert/gui/plotting/ert_plots/cesp.py
+++ b/src/ert/gui/plotting/ert_plots/cesp.py
@@ -10,6 +10,7 @@ from typing_extensions import TypedDict
 
 from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
 from ert.gui.plotting.utils import ConditionalAxisFormatter, PlotTools
+from ert.gui.utils import truncate_experiment_name
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -120,7 +121,7 @@ def plot_cross_ensemble_statistics(
     axes.set_xticklabels(
         [""]
         + [
-            f"{ensemble.experiment_name} : {ensemble.name}"
+            f"{truncate_experiment_name(ensemble.experiment_name)} : {ensemble.name}"
             for ensemble in ensemble_list
         ]
         + [""],

--- a/src/ert/gui/plotting/ert_plots/distribution.py
+++ b/src/ert/gui/plotting/ert_plots/distribution.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
 from ert.gui.plotting.utils.plot_tools import ConditionalAxisFormatter, PlotTools
+from ert.gui.utils import truncate_experiment_name
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -75,7 +76,7 @@ def plotDistribution(
     axes.set_xticklabels(
         [""]
         + [
-            f"{ensemble.experiment_name} : {ensemble.name}"
+            f"{truncate_experiment_name(ensemble.experiment_name)} : {ensemble.name}"
             for ensemble in ensemble_list
         ]
         + [""],

--- a/src/ert/gui/plotting/ert_plots/gaussian_kde.py
+++ b/src/ert/gui/plotting/ert_plots/gaussian_kde.py
@@ -8,6 +8,7 @@ from scipy.stats import gaussian_kde
 
 from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
 from ert.gui.plotting.utils.plot_tools import ConditionalAxisFormatter, PlotTools
+from ert.gui.utils import truncate_experiment_name
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -64,7 +65,11 @@ def plotGaussianKDE(
             continue
         if not _array_is_constant(data[0]):
             _plotGaussianKDE(
-                axes, config, data[0], f"{ensemble.experiment_name} : {ensemble.name}"
+                axes,
+                config,
+                data[0],
+                f"{truncate_experiment_name(ensemble.experiment_name)}"
+                f" : {ensemble.name}",
             )
 
     if plot_context.log_scale:

--- a/src/ert/gui/plotting/ert_plots/histogram.py
+++ b/src/ert/gui/plotting/ert_plots/histogram.py
@@ -10,6 +10,7 @@ from matplotlib.patches import Rectangle
 
 from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
 from ert.gui.plotting.utils.plot_tools import ConditionalAxisFormatter, PlotTools
+from ert.gui.utils import truncate_experiment_name
 from ert.shared.status.utils import convert_to_numeric
 
 if TYPE_CHECKING:
@@ -103,7 +104,8 @@ def plotHistogram(
         axes[ensemble.name] = figure.add_subplot(ensemble_count, 1, index + 1)
 
         axes[ensemble.name].set_title(
-            f"{config.title()} ({ensemble.experiment_name} : {ensemble.name})"
+            f"{config.title()} ({truncate_experiment_name(ensemble.experiment_name)}"
+            f" : {ensemble.name})"
         )
         axes[ensemble.name].set_xlabel(x_label)
         axes[ensemble.name].set_ylabel(y_label)
@@ -136,7 +138,12 @@ def plotHistogram(
                 )
                 axes[ensemble.name].legend(
                     [legend_patch],
-                    [f"{ensemble.experiment_name} : {ensemble.name}"],
+                    [
+                        (
+                            f"{truncate_experiment_name(ensemble.experiment_name)}"
+                            f" : {ensemble.name}"
+                        )
+                    ],
                     numpoints=1,
                 )
                 if index != 0:

--- a/src/ert/gui/plotting/ert_plots/statistics.py
+++ b/src/ert/gui/plotting/ert_plots/statistics.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 
 from ert.gui.plotting.utils import PlotConfig, PlotContext, PlotStyle
 from ert.gui.plotting.utils.plot_tools import PlotTools
+from ert.gui.utils import truncate_experiment_name
 
 from .history import plot_history
 from .observations import plotObservations
@@ -55,7 +56,10 @@ class StatisticsPlot:
                     plot_context.deactivate_date_support()
                     plot_context.x_axis = plot_context.INDEX_AXIS
 
-                label = f"{ensemble.experiment_name} : {ensemble.name}"
+                label = (
+                    f"{truncate_experiment_name(ensemble.experiment_name)}"
+                    f" : {ensemble.name}"
+                )
                 style = config.get_statistics_style("mean")
                 rectangle = Rectangle(
                     (0, 0), 1, 1, color=style.color, alpha=0.8

--- a/src/ert/gui/plotting/ert_plots/std_dev.py
+++ b/src/ert/gui/plotting/ert_plots/std_dev.py
@@ -10,6 +10,7 @@ from matplotlib.figure import Figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ert.gui.plotting.utils.plot_types import ObservationPlotLocations
+from ert.gui.utils import truncate_experiment_name
 
 if TYPE_CHECKING:
     from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
@@ -55,7 +56,9 @@ class StdDevPlot:
                     ax_heat.text(
                         0.5,
                         0.5,
-                        f"No data for {ensemble.experiment_name} : {ensemble.name}",
+                        f"No data for "
+                        f"{truncate_experiment_name(ensemble.experiment_name)}"
+                        f" : {ensemble.name}",
                         ha="center",
                         va="center",
                     )
@@ -122,7 +125,8 @@ class StdDevPlot:
                     self._colorbar(im)
 
                 ax_heat.set_title(
-                    f"{ensemble.experiment_name} : {ensemble.name} layer={layer}",
+                    f"{truncate_experiment_name(ensemble.experiment_name)}"
+                    f" : {ensemble.name} layer={layer}",
                     wrap=True,
                     fontsize=10,  # Reduced font size
                 )

--- a/src/ert/gui/plotting/shared_plots/ensemble.py
+++ b/src/ert/gui/plotting/shared_plots/ensemble.py
@@ -11,7 +11,7 @@ from ert.gui.plotting.ert_plots.history import plot_history
 from ert.gui.plotting.ert_plots.observations import plotObservations
 from ert.gui.plotting.utils.plot_context import PlotType
 from ert.gui.plotting.utils.plot_tools import PlotTools
-from ert.gui.utils import is_everest_application
+from ert.gui.utils import is_everest_application, truncate_experiment_name
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -74,7 +74,8 @@ class EnsemblePlot:
                 label = (
                     f"{ensemble.name}"
                     if is_everest
-                    else f"{ensemble.experiment_name} : {ensemble.name}"
+                    else f"{truncate_experiment_name(ensemble.experiment_name)}"
+                    f" : {ensemble.name}"
                 )
                 lines = self._plotLines(
                     axes,

--- a/src/ert/gui/plotting/widgets/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_ensemble_selection_widget.py
@@ -31,7 +31,7 @@ from typing_extensions import override
 
 from ert.gui.icon_utils import load_icon
 from ert.gui.plotting.plot_api import EnsembleObject
-from ert.gui.utils import is_everest_application
+from ert.gui.utils import is_everest_application, truncate_experiment_name
 
 
 class EnsembleSelectionWidget(QWidget):
@@ -127,7 +127,8 @@ class EnsembleSelectListWidget(QListWidget):
         cutoff = self._maximum_selected if is_everest else self._minimum_selected
         for i, ensemble in enumerate(sorted_ensembles):
             item_text = (
-                f"{ensemble.experiment_name} : {ensemble.name}"
+                f"{truncate_experiment_name(ensemble.experiment_name)}"
+                f" : {ensemble.name}"
                 if not is_everest
                 else ensemble.name
             )

--- a/src/ert/gui/utils.py
+++ b/src/ert/gui/utils.py
@@ -5,6 +5,27 @@ LEGEND_THRESHOLD = 5
 # Number of significant digits to show in plots
 SIGNIFICANT_DIGITS = 4
 
+LONGEST_DEFAULT_EXPERIMENT_NAME = len("ensemble_information_filter")
+
 
 def is_everest_application() -> bool:
     return QApplication.applicationName().lower() == "everest"
+
+
+def truncate_string(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+
+    truncation_indicator = "..."
+    visible_length = max_length - len(truncation_indicator)
+    front_len = visible_length // 2
+    back_len = visible_length - front_len
+    return f"{text[:front_len]}{truncation_indicator}{text[-back_len:]}"
+
+
+def truncate_dropdown_item(text: str) -> str:
+    return truncate_string(text, 100)
+
+
+def truncate_experiment_name(name: str) -> str:
+    return truncate_string(name, LONGEST_DEFAULT_EXPERIMENT_NAME)

--- a/tests/ert/unit_tests/gui/test_gui_utils.py
+++ b/tests/ert/unit_tests/gui/test_gui_utils.py
@@ -1,0 +1,71 @@
+import pytest
+
+from ert.gui.utils import (
+    LONGEST_DEFAULT_EXPERIMENT_NAME,
+    truncate_dropdown_item,
+    truncate_experiment_name,
+    truncate_string,
+)
+
+
+@pytest.mark.parametrize(
+    ("input_string", "max_length", "expected_output"),
+    [
+        ("short", 10, "short"),
+        ("exactlyten", 10, "exactlyten"),
+        (
+            "exactlyis11",
+            10,
+            "exa...is11",
+        ),
+    ],
+)
+def test_that_truncate_string_truncates_when_appropriate(
+    input_string, max_length, expected_output
+):
+    truncatedString = truncate_string(input_string, max_length)
+    assert truncatedString == expected_output
+    if input_string != expected_output:
+        assert len(truncatedString) == max_length
+    else:
+        assert len(truncatedString) == len(input_string)
+
+
+@pytest.mark.parametrize(
+    ("experiment_name", "expected_output"),
+    [
+        ("ensemble_information_filter", "ensemble_information_filter"),
+        ("ensemble_information_filter_11", "ensemble_inf...on_filter_11"),
+    ],
+)
+def test_that_truncate_experiment_name_to_longest_default_length(
+    experiment_name, expected_output
+):
+    truncatedName = truncate_experiment_name(experiment_name)
+    assert truncatedName == expected_output
+    if experiment_name != expected_output:
+        assert len(truncatedName) == LONGEST_DEFAULT_EXPERIMENT_NAME
+    else:
+        assert len(truncatedName) == len(experiment_name)
+
+
+@pytest.mark.parametrize(
+    ("dropdown_item", "expected_output"),
+    [
+        ("short item", "short item"),
+        ("a" * 100, "a" * 100),
+        (
+            "a" * 101,
+            "a" * 48 + "..." + "a" * 49,
+        ),
+    ],
+)
+def test_that_truncate_dropdown_item_truncates_to_100_characters(
+    dropdown_item, expected_output
+):
+    truncatedItem = truncate_dropdown_item(dropdown_item)
+    assert truncatedItem == expected_output
+    if dropdown_item != expected_output:
+        assert len(truncatedItem) == 100
+    else:
+        assert len(truncatedItem) == len(dropdown_item)


### PR DESCRIPTION
**Issue**
Resolves #13707


**Approach**
Based collected data (default names filtered out):
- Unique name count: 702
- Longest name: 78
- Average name length: 10.2

_Note: Data is collected through the grafana dashboards_ 

Truncate middle, such that `iter-%` becomes visible and its possible to distinguish across experiments, but also between iterations. Using the longest default experiment name + 2 (allows experiment iterations up to 10) as truncation threshold. 

https://github.com/user-attachments/assets/309e0573-e88f-4c08-81d8-3ee439fcf332




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)