### PR TITLE
Prevent filters from changing the active plot

### DIFF
--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -163,7 +163,7 @@ class DataTypeKeysWidget(QWidget):
 
         self.setLayout(layout)
 
-    def _clear_current_index_if_filtered_out(
+    def _clear_current_index_if_source_item_is_hidden(
         self, previous_source_index: QModelIndex
     ) -> None:
         previous_proxy_index = self.filter_model.mapFromSource(previous_source_index)
@@ -182,7 +182,7 @@ class DataTypeKeysWidget(QWidget):
             for value, visible in item.items():
                 self.filter_model.setFilterOnMetadata("data_origin", value, visible)
 
-            self._clear_current_index_if_filtered_out(previous_source_index)
+            self._clear_current_index_if_source_item_is_hidden(previous_source_index)
         finally:
             self._updating_filter = False
 
@@ -214,7 +214,7 @@ class DataTypeKeysWidget(QWidget):
         self._updating_filter = True
         try:
             self.filter_model.setFilterFixedString(filter_ or "")
-            self._clear_current_index_if_filtered_out(previous_source_index)
+            self._clear_current_index_if_source_item_is_hidden(previous_source_index)
         finally:
             self._updating_filter = False
 

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -169,7 +169,6 @@ class DataTypeKeysWidget(QWidget):
         previous_proxy_index = self.filter_model.mapFromSource(previous_source_index)
 
         if not previous_proxy_index.isValid():
-            self.data_type_keys_widget.clearSelection()
             self.data_type_keys_widget.setCurrentIndex(QModelIndex())
 
     def _current_source_index(self) -> QModelIndex:

--- a/src/ert/gui/tools/plot/data_type_keys_widget.py
+++ b/src/ert/gui/tools/plot/data_type_keys_widget.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import QSize
+from PyQt6.QtCore import QModelIndex, QSize
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtGui import QColor, QPainter, QPaintEvent
 from PyQt6.QtWidgets import (
@@ -117,6 +117,8 @@ class DataTypeKeysWidget(QWidget):
     def __init__(self, key_defs: list[PlotApiKeyDefinition]) -> None:
         QWidget.__init__(self)
 
+        self._updating_filter = False
+
         self.__filter_popup = FilterPopup(self, key_defs)
         self.__filter_popup.filterSettingsChanged.connect(self.onItemChanged)
 
@@ -144,8 +146,9 @@ class DataTypeKeysWidget(QWidget):
         self.data_type_keys_widget = QListView()
         self.data_type_keys_widget.setModel(self.filter_model)
         self._sel_model = self.data_type_keys_widget.selectionModel()
-        assert self._sel_model is not None
-        self._sel_model.selectionChanged.connect(self.itemSelected)
+        if not self._sel_model:
+            raise RuntimeError("Selection model was not defined")
+        self._sel_model.currentChanged.connect(self.itemSelected)
 
         layout.addSpacing(15)
         layout.addWidget(self.data_type_keys_widget, 2)
@@ -160,11 +163,34 @@ class DataTypeKeysWidget(QWidget):
 
         self.setLayout(layout)
 
-    def onItemChanged(self, item: dict[str, bool]) -> None:
-        for value, visible in item.items():
-            self.filter_model.setFilterOnMetadata("data_origin", value, visible)
+    def _clear_current_index_if_filtered_out(
+        self, previous_source_index: QModelIndex
+    ) -> None:
+        previous_proxy_index = self.filter_model.mapFromSource(previous_source_index)
 
-    def itemSelected(self) -> None:
+        if not previous_proxy_index.isValid():
+            self.data_type_keys_widget.clearSelection()
+            self.data_type_keys_widget.setCurrentIndex(QModelIndex())
+
+    def _current_source_index(self) -> QModelIndex:
+        return self.filter_model.mapToSource(self.data_type_keys_widget.currentIndex())
+
+    def onItemChanged(self, item: dict[str, bool]) -> None:
+        previous_source_index = self._current_source_index()
+
+        self._updating_filter = True
+        try:
+            for value, visible in item.items():
+                self.filter_model.setFilterOnMetadata("data_origin", value, visible)
+
+            self._clear_current_index_if_filtered_out(previous_source_index)
+        finally:
+            self._updating_filter = False
+
+    def itemSelected(self, current: QModelIndex, previous: QModelIndex) -> None:
+        if self._updating_filter:
+            return
+
         selected_item = self.getSelectedItem()
         if selected_item is not None:
             self.dataTypeKeySelected.emit()
@@ -184,7 +210,14 @@ class DataTypeKeysWidget(QWidget):
                 return
 
     def setSearchString(self, filter_: str | None) -> None:
-        self.filter_model.setFilterFixedString(filter_ or "")
+        previous_source_index = self._current_source_index()
+
+        self._updating_filter = True
+        try:
+            self.filter_model.setFilterFixedString(filter_ or "")
+            self._clear_current_index_if_filtered_out(previous_source_index)
+        finally:
+            self._updating_filter = False
 
     def showFilterPopup(self) -> None:
         self.__filter_popup.show()

--- a/tests/ert/unit_tests/gui/tools/plot/test_data_type_keys_widget.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_data_type_keys_widget.py
@@ -5,13 +5,13 @@ from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
 from ert.gui.tools.plot.plot_api import PlotApiKeyDefinition
 
 
-def create_key_def(key: str) -> PlotApiKeyDefinition:
+def create_key_def(key: str, data_origin: str = "summary") -> PlotApiKeyDefinition:
     return PlotApiKeyDefinition(
         key=key,
         index_type=None,
         observations=False,
         dimensionality=1,
-        metadata={"data_origin": "summary"},
+        metadata={"data_origin": data_origin},
     )
 
 
@@ -19,7 +19,7 @@ def create_key_def(key: str) -> PlotApiKeyDefinition:
 def key_defs() -> list[PlotApiKeyDefinition]:
     return [
         create_key_def("A"),
-        create_key_def("B"),
+        create_key_def("B", data_origin="gen_data"),
     ]
 
 
@@ -27,7 +27,6 @@ def test_that_filtering_out_current_key_does_not_emit_data_type_key_selected(
     qtbot: QtBot,
     key_defs: list[PlotApiKeyDefinition],
 ) -> None:
-    """Filtering out the current key should clear selection without emitting."""
     widget = DataTypeKeysWidget(key_defs)
     qtbot.addWidget(widget)
 
@@ -44,7 +43,6 @@ def test_that_filtering_keeps_current_key_when_still_visible(
     qtbot: QtBot,
     key_defs: list[PlotApiKeyDefinition],
 ) -> None:
-    """Filtering should keep the current key selected when it remains visible."""
     widget = DataTypeKeysWidget(key_defs)
     qtbot.addWidget(widget)
 
@@ -56,3 +54,22 @@ def test_that_filtering_keeps_current_key_when_still_visible(
 
     assert widget.data_type_keys_widget.currentIndex().isValid()
     assert widget.getSelectedItem() == key_defs[0]
+
+
+def test_that_metadata_filtering_current_key_does_not_emit_data_type_key_selected(
+    qtbot: QtBot,
+    key_defs: list[PlotApiKeyDefinition],
+) -> None:
+    widget = DataTypeKeysWidget(key_defs)
+    qtbot.addWidget(widget)
+
+    # Select a non-default key before applying the metadata filter.
+    selected_index = widget.filter_model.index(1, 0)
+    widget.data_type_keys_widget.setCurrentIndex(selected_index)
+    assert widget.getSelectedItem() == key_defs[1]
+
+    # Hide the metadata group containing the current key.
+    with qtbot.assertNotEmitted(widget.dataTypeKeySelected):
+        widget.onItemChanged({"gen_data": False})
+
+    assert widget.getSelectedItem() is None

--- a/tests/ert/unit_tests/gui/tools/plot/test_data_type_keys_widget.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_data_type_keys_widget.py
@@ -1,0 +1,58 @@
+import pytest
+from pytestqt.qtbot import QtBot
+
+from ert.gui.tools.plot.data_type_keys_widget import DataTypeKeysWidget
+from ert.gui.tools.plot.plot_api import PlotApiKeyDefinition
+
+
+def create_key_def(key: str) -> PlotApiKeyDefinition:
+    return PlotApiKeyDefinition(
+        key=key,
+        index_type=None,
+        observations=False,
+        dimensionality=1,
+        metadata={"data_origin": "summary"},
+    )
+
+
+@pytest.fixture
+def key_defs() -> list[PlotApiKeyDefinition]:
+    return [
+        create_key_def("A"),
+        create_key_def("B"),
+    ]
+
+
+def test_that_filtering_out_current_key_does_not_emit_data_type_key_selected(
+    qtbot: QtBot,
+    key_defs: list[PlotApiKeyDefinition],
+) -> None:
+    """Filtering out the current key should clear selection without emitting."""
+    widget = DataTypeKeysWidget(key_defs)
+    qtbot.addWidget(widget)
+
+    widget.selectDefault()
+    assert widget.getSelectedItem() == key_defs[0]
+
+    with qtbot.assertNotEmitted(widget.dataTypeKeySelected):
+        widget.setSearchString("B")
+
+    assert widget.getSelectedItem() is None
+
+
+def test_that_filtering_keeps_current_key_when_still_visible(
+    qtbot: QtBot,
+    key_defs: list[PlotApiKeyDefinition],
+) -> None:
+    """Filtering should keep the current key selected when it remains visible."""
+    widget = DataTypeKeysWidget(key_defs)
+    qtbot.addWidget(widget)
+
+    widget.selectDefault()
+    assert widget.getSelectedItem() == key_defs[0]
+
+    with qtbot.assertNotEmitted(widget.dataTypeKeySelected):
+        widget.setSearchString("A")
+
+    assert widget.data_type_keys_widget.currentIndex().isValid()
+    assert widget.getSelectedItem() == key_defs[0]


### PR DESCRIPTION
Filtering the data type key list can currently change the active plot if the selected key is filtered out. This happens because changing the proxy filter can update the QListView current index, which then emits dataTypeKeySelected even though the user only changed the filter text.

This change stores the current source index before applying the filter. After filtering, the current index is cleared if the previously selected key is no longer visible. Filter-induced current index changes are ignored while the filter update is running, so they do not trigger a plot change.

**Issue**
Resolves #13787


**Approach**
Use currentChanged instead of selectionChanged, since the selected plot key is derived from QListView.currentIndex().
Store the current source index before applying search or metadata filters.
After filtering, map the previous source index back through the proxy model.
If `mapFromSource(...)` returns an invalid index, the key has been filtered out, so the list selection and current index are cleared.
Guard current-index changes while filters are being applied so filter-induced changes do not emit dataTypeKeySelected.
<img width="938" height="487" alt="filter-test" src="https://github.com/user-attachments/assets/bbb22b7b-0872-47af-af2d-4fb8cf6b3936" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
