### PR TITLE
Fix ExperimentConfig missing keys

### DIFF
--- a/src/ert/run_models/ensemble_experiment.py
+++ b/src/ert/run_models/ensemble_experiment.py
@@ -15,6 +15,7 @@ from ert.run_models.initial_ensemble_run_model import (
 )
 from ert.run_models.run_model_configs import EnsembleExperimentConfig
 from ert.storage import Ensemble
+from ert.storage.local_experiment import LocalExperiment
 from ert.trace import tracer
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,12 @@ class EnsembleExperiment(InitialEnsembleRunModel, EnsembleExperimentConfig):
         assert self._ensemble_id is not None
         return self._storage.get_ensemble(self._ensemble_id)
 
+    def _create_experiment_storage(self) -> LocalExperiment:
+        return self._storage.create_experiment(
+            experiment_config=self.to_experiment_config(),
+            name=self.experiment_name,
+        )
+
     @tracer.start_as_current_span(f"{__name__}.run_experiment")
     def run_experiment(
         self,
@@ -46,10 +53,7 @@ class EnsembleExperiment(InitialEnsembleRunModel, EnsembleExperimentConfig):
 
         self.run_workflows(fixtures=PreExperimentFixtures(random_seed=self.random_seed))
 
-        experiment_storage = self._storage.create_experiment(
-            experiment_config=self.to_experiment_config(),
-            name=self.experiment_name,
-        )
+        experiment_storage = self._create_experiment_storage()
 
         ensemble_storage = self._storage.create_ensemble(
             experiment_storage,

--- a/src/ert/run_models/ensemble_smoother.py
+++ b/src/ert/run_models/ensemble_smoother.py
@@ -16,6 +16,7 @@ from ert.run_models.initial_ensemble_run_model import (
 )
 from ert.run_models.run_model_configs import EnsembleSmootherConfig
 from ert.run_models.update_run_model import UpdateRunModel
+from ert.storage.local_experiment import LocalExperiment
 from ert.trace import tracer
 
 from .run_model import ErtRunError
@@ -25,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 class EnsembleSmoother(InitialEnsembleRunModel, UpdateRunModel, EnsembleSmootherConfig):
     _total_iterations: int = PrivateAttr(default=2)
+
+    def _create_experiment_storage(self) -> LocalExperiment:
+        return self._storage.create_experiment(
+            experiment_config=self.to_experiment_config(),
+            name=self.experiment_name,
+        )
 
     @tracer.start_as_current_span(f"{__name__}.run_experiment")
     def run_experiment(
@@ -39,10 +46,7 @@ class EnsembleSmoother(InitialEnsembleRunModel, UpdateRunModel, EnsembleSmoother
 
         self.run_workflows(fixtures=PreExperimentFixtures(random_seed=self.random_seed))
 
-        experiment_storage = self._storage.create_experiment(
-            experiment_config=self.to_experiment_config(),
-            name=self.experiment_name,
-        )
+        experiment_storage = self._create_experiment_storage()
 
         prior = self._storage.create_ensemble(
             experiment_storage,

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -55,7 +55,7 @@ from ert.run_models.run_model_configs import EverestRunModelConfig
 from ert.runpaths import Runpaths
 from ert.storage import ExperimentState, ExperimentStatus
 from ert.storage.local_ensemble import EverestRealizationInfo
-from ert.storage.local_experiment import ExperimentType
+from ert.storage.local_experiment import ExperimentType, LocalExperiment
 from ert.substitutions import Substitutions
 from everest.config import (
     ControlConfig,
@@ -806,6 +806,11 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                 ensemble.update_improvement_flag(is_improvement=True)
                 max_total_objective = total_objective
 
+    def _create_experiment_storage(self) -> LocalExperiment:
+        return self._storage.create_experiment(
+            name=self.experiment_name, experiment_config=self.to_experiment_config()
+        )
+
     def run_experiment(
         self,
         evaluator_server_config: EvaluatorServerConfig,
@@ -815,9 +820,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
         self.log_at_startup()
         self._eval_server_cfg = evaluator_server_config
 
-        self._experiment = self._experiment or self._storage.create_experiment(
-            name=self.experiment_name, experiment_config=self.to_experiment_config()
-        )
+        self._experiment = self._experiment or self._create_experiment_storage()
 
         self._experiment.status = ExperimentStatus(
             message="Experiment started", status=ExperimentState.running

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -10,7 +10,7 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.run_model_configs import ManualUpdateConfig
 from ert.run_models.update_run_model import UpdateRunModel
 from ert.storage import Ensemble
-from ert.storage.local_experiment import ExperimentType
+from ert.storage.local_experiment import ExperimentType, LocalExperiment
 
 from .run_model import ErtRunError
 
@@ -42,14 +42,7 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
         self.set_env_key("_ERT_EXPERIMENT_ID", str(prior_experiment.id))
         self.set_env_key("_ERT_ENSEMBLE_ID", str(self._prior.id))
 
-        experiment_config = self.to_experiment_config(
-            prior_experiment_config=prior_experiment.experiment_config
-        )
-
-        target_experiment = self._storage.create_experiment(
-            experiment_config=experiment_config,
-            name=f"Manual update of {self._prior.name}",
-        )
+        target_experiment = self._create_experiment_storage()
         self.update(
             self._prior,
             self.target_ensemble % (self._prior.iteration + 1),
@@ -67,6 +60,16 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
     @classmethod
     def _experiment_type(cls) -> ExperimentType:
         return ExperimentType.MANUAL_UPDATE
+
+    def _create_experiment_storage(self) -> LocalExperiment:
+        experiment_config = self.to_experiment_config(
+            prior_experiment_config=self._prior.experiment.experiment_config
+        )
+
+        return self._storage.create_experiment(
+            experiment_config=experiment_config,
+            name=f"Manual update of {self._prior.name}",
+        )
 
     def check_if_runpath_exists(self) -> bool:
         # Will not run a forward model, so does not create files on runpath

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -18,7 +18,11 @@ from ert.run_models.initial_ensemble_run_model import (
 from ert.run_models.run_model_configs import MultipleDataAssimilationConfig
 from ert.run_models.update_run_model import UpdateRunModel
 from ert.storage import Ensemble
-from ert.storage.local_experiment import ExperimentConfig, ExperimentType
+from ert.storage.local_experiment import (
+    ExperimentConfig,
+    ExperimentType,
+    LocalExperiment,
+)
 from ert.trace import tracer
 
 from .run_model import ErtRunError
@@ -54,6 +58,12 @@ class MultipleDataAssimilation(
 
         self._start_iteration = start_iteration
         self._total_iterations = total_iterations
+
+    def _create_experiment_storage(self) -> LocalExperiment:
+        return self._storage.create_experiment(
+            experiment_config=self.to_experiment_config(),
+            name=self.experiment_name,
+        )
 
     def _create_experiment_for_restart(
         self, original_experiment: ExperimentConfig
@@ -108,10 +118,7 @@ class MultipleDataAssimilation(
             self.run_workflows(
                 fixtures=PreExperimentFixtures(random_seed=self.random_seed),
             )
-            experiment_storage = self._storage.create_experiment(
-                experiment_config=self.to_experiment_config(),
-                name=self.experiment_name,
-            )
+            experiment_storage = self._create_experiment_storage()
 
             prior = self._storage.create_ensemble(
                 experiment_storage,

--- a/src/ert/run_models/run_model_configs.py
+++ b/src/ert/run_models/run_model_configs.py
@@ -89,6 +89,30 @@ class RunModelConfig(BaseModelWithContextSupport):
     minimum_required_realizations: int = 0
     supports_rerunning_failed_realizations: ClassVar[bool] = False
 
+    def _common_fields(self) -> ExperimentConfig:
+        return {
+            "storage_path": self.storage_path,
+            "runpath_file": str(self.runpath_file),
+            "user_config_file": str(self.user_config_file),
+            "env_vars": self.env_vars,
+            "env_pr_fm_step": self.env_pr_fm_step,
+            "runpath_config": self.runpath_config.model_dump(mode="json"),
+            "queue_config": self.queue_config.model_dump(mode="json"),
+            "forward_model_steps": [
+                fm_step.model_dump(mode="json") for fm_step in self.forward_model_steps
+            ],
+            "substitutions": self.substitutions,
+            "hooked_workflows": {
+                hook: [workflow.model_dump(mode="json") for workflow in workflows]
+                for hook, workflows in self.hooked_workflows.items()
+            },
+            "active_realizations": self.active_realizations,
+            "log_path": str(self.log_path),
+            "random_seed": self.random_seed,
+            "start_iteration": self.start_iteration,
+            "minimum_required_realizations": self.minimum_required_realizations,
+        }
+
     @model_validator(mode="after")
     def _restore_plugin_forward_model_step_subclasses(self) -> Self:
         runtime_plugins = init_context_var.get()
@@ -151,6 +175,7 @@ class InitialEnsembleRunModelConfig(RunModelConfig):
                 resp.model_dump(mode="json")
                 for resp in self.derived_response_configuration
             ],
+            "experiment_name": self.experiment_name,
         }
 
         if self.observations is not None:
@@ -187,9 +212,10 @@ class EnsembleSmootherConfig(InitialEnsembleRunModelConfig, UpdateRunModelConfig
 
     def to_experiment_config(self) -> ExperimentConfig:
         return {
-            "experiment_type": ExperimentType.ENSEMBLE_SMOOTHER,
             **self._initial_ensemble_experiment_config(),
             **self._update_experiment_config(),
+            **self._common_fields(),
+            "experiment_type": ExperimentType.ENSEMBLE_SMOOTHER,
         }
 
 
@@ -200,9 +226,10 @@ class EnsembleInformationFilterConfig(
 
     def to_experiment_config(self) -> ExperimentConfig:
         return {
-            "experiment_type": ExperimentType.ENSEMBLE_INFORMATION_FILTER,
             **self._initial_ensemble_experiment_config(),
             **self._update_experiment_config(),
+            **self._common_fields(),
+            "experiment_type": ExperimentType.ENSEMBLE_INFORMATION_FILTER,
         }
 
 
@@ -213,9 +240,10 @@ class EnsembleExperimentConfig(InitialEnsembleRunModelConfig):
 
     def to_experiment_config(self) -> ExperimentConfig:
         return {
-            "experiment_type": self.experiment_type,
             **self._initial_ensemble_experiment_config(),
             "target_ensemble": self.target_ensemble,
+            **self._common_fields(),
+            "experiment_type": self.experiment_type,
         }
 
 
@@ -253,7 +281,6 @@ class EverestRunModelConfig(RunModelConfig):
 
     def to_experiment_config(self) -> ExperimentConfig:
         return {
-            "experiment_type": ExperimentType.EVEREST,
             "optimization_output_dir": self.optimization_output_dir,
             "simulation_dir": self.simulation_dir,
             "parameter_configuration": [
@@ -270,6 +297,8 @@ class EverestRunModelConfig(RunModelConfig):
             "keep_run_path": self.keep_run_path,
             "experiment_name": self.experiment_name,
             "target_ensemble": self.target_ensemble,
+            **self._common_fields(),
+            "experiment_type": ExperimentType.EVEREST,
         }
 
 
@@ -282,18 +311,21 @@ class ManualUpdateConfig(UpdateRunModelConfig):
         self, *, prior_experiment_config: ExperimentConfig
     ) -> ExperimentConfig:
         return {
-            "experiment_type": ExperimentType.MANUAL_UPDATE,
             "ensemble_id": self.ensemble_id,
             "ert_templates": self.ert_templates,
             **self._update_experiment_config(),
-            "parameter_configuration": prior_experiment_config[
-                "parameter_configuration"
-            ],
-            "response_configuration": prior_experiment_config["response_configuration"],
+            "parameter_configuration": prior_experiment_config.get(
+                "parameter_configuration", []
+            ),
+            "response_configuration": prior_experiment_config.get(
+                "response_configuration", []
+            ),
             "derived_response_configuration": prior_experiment_config.get(
                 "derived_response_configuration", []
             ),
             "observations": prior_experiment_config.get("observations", []),
+            **self._common_fields(),
+            "experiment_type": ExperimentType.MANUAL_UPDATE,
         }
 
 
@@ -308,12 +340,13 @@ class MultipleDataAssimilationConfig(
 
     def to_experiment_config(self) -> ExperimentConfig:
         return {
-            "experiment_type": ExperimentType.ES_MDA,
             **self._initial_ensemble_experiment_config(),
             **self._update_experiment_config(),
+            **self._common_fields(),
             "restart_run": self.restart_run,
             "prior_ensemble_id": self.prior_ensemble_id,
             "weights": self.weights,
+            "experiment_type": ExperimentType.ES_MDA,
         }
 
 

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -32,6 +32,7 @@ from ert.config import (
 from ert.config import Field as FieldConfig
 from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config._observations import Observation
+from ert.config.parsing.hook_runtime import HookRuntime
 from ert.config.response_config import DerivedResponseConfig
 
 from .mode import BaseMode, Mode, require_write
@@ -72,6 +73,23 @@ class ExperimentConfig(TypedDict, total=False):
     """
 
     experiment_type: ExperimentType
+
+    # Common fields
+    minimum_required_realizations: int
+    random_seed: int
+    storage_path: str
+    user_config_file: str
+    runpath_file: str
+    log_path: str
+    start_iteration: int
+    active_realizations: list[bool]
+    hooked_workflows: dict[HookRuntime, list[dict[str, Any]]]
+    substitutions: dict[str, str]
+    queue_config: dict[str, Any]
+    env_vars: dict[str, Any]
+    env_pr_fm_step: dict[str, Any]
+    runpath_config: dict[str, Any]
+    forward_model_steps: list[dict[str, Any]]
 
     # Initial-ensemble fields
     ert_templates: list[tuple[str, str]]

--- a/src/ert/storage/migration/to30.py
+++ b/src/ert/storage/migration/to30.py
@@ -32,6 +32,21 @@ _ALLOWED_EXPERIMENT_KEYS = frozenset(
         "model",
         "keep_run_path",
         "experiment_name",
+        "minimum_required_realizations",
+        "random_seed",
+        "storage_path",
+        "user_config_file",
+        "runpath_file",
+        "log_path",
+        "start_iteration",
+        "active_realizations",
+        "hooked_workflows",
+        "substitutions",
+        "queue_config",
+        "env_vars",
+        "env_pr_fm_step",
+        "runpath_config",
+        "forward_model_steps",
     }
 )
 

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -1,3 +1,4 @@
+import json
 import queue
 import string
 import unittest
@@ -680,6 +681,31 @@ def _create_and_verify_runmodel_snapshot(config, snapshot, cli_args, case):
         serialized,
         f"{Path(config.user_config_file).stem}.json",
     )
+
+    # Also verify what actually lands in storage for models that create experiments
+    if cli_args.mode != EVALUATE_ENSEMBLE_MODE:
+        runmodel._create_experiment_storage()
+        experiments_dir = Path(config.ens_path) / "experiments"
+        experiment_dir = next(experiments_dir.iterdir())
+        index_json_path = experiment_dir / "index.json"
+        index_text = index_json_path.read_text(encoding="utf-8")
+        index_serialized = index_text.replace(cwd, f"test-data/ert/{case}")
+        index_data = json.loads(index_serialized)
+        saved_experiment = index_data["experiment"]
+        for key, val in json.loads(serialized).items():
+            if val is None:
+                assert key not in saved_experiment, (
+                    "None values should be excluded from saved experiment"
+                )
+                continue
+            assert key in saved_experiment, (
+                f"Key '{key}' not found in saved experiment. Expected value: '{val}'"
+            )
+
+            assert saved_experiment[key] == val, (
+                f"Mismatch in key '{key}'. Found "
+                f"'{index_data['experiment'][key]}', expected '{val}'"
+            )
 
 
 cases_to_test = [

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -62,6 +62,7 @@ from ert.run_models import (
 )
 from ert.run_models.run_model_configs import MultipleDataAssimilationConfig
 from ert.storage import open_storage
+from ert.storage.local_experiment import LocalExperiment
 
 
 def realistic_text(min_size=1, max_size=4):
@@ -684,28 +685,27 @@ def _create_and_verify_runmodel_snapshot(config, snapshot, cli_args, case):
 
     # Also verify what actually lands in storage for models that create experiments
     if cli_args.mode != EVALUATE_ENSEMBLE_MODE:
-        runmodel._create_experiment_storage()
-        experiments_dir = Path(config.ens_path) / "experiments"
-        experiment_dir = next(experiments_dir.iterdir())
-        index_json_path = experiment_dir / "index.json"
-        index_text = index_json_path.read_text(encoding="utf-8")
-        index_serialized = index_text.replace(cwd, f"test-data/ert/{case}")
-        index_data = json.loads(index_serialized)
-        saved_experiment = index_data["experiment"]
-        for key, val in json.loads(serialized).items():
-            if val is None:
-                assert key not in saved_experiment, (
-                    "None values should be excluded from saved experiment"
+        with runmodel._storage:
+            experiment: LocalExperiment = runmodel._create_experiment_storage()
+            index_json_path = experiment._path / "index.json"
+            index_text = index_json_path.read_text(encoding="utf-8")
+            index_serialized = index_text.replace(cwd, f"test-data/ert/{case}")
+            index_data = json.loads(index_serialized)
+            saved_experiment = index_data["experiment"]
+            for key, val in json.loads(serialized).items():
+                if val is None:
+                    assert key not in saved_experiment, (
+                        "None values should be excluded from saved experiment"
+                    )
+                    continue
+                assert key in saved_experiment, (
+                    f"Key {key} not found in saved experiment. Expected value: {val}"
                 )
-                continue
-            assert key in saved_experiment, (
-                f"Key '{key}' not found in saved experiment. Expected value: '{val}'"
-            )
 
-            assert saved_experiment[key] == val, (
-                f"Mismatch in key '{key}'. Found "
-                f"'{index_data['experiment'][key]}', expected '{val}'"
-            )
+                assert saved_experiment[key] == val, (
+                    f"Mismatch in key '{key}'. Found "
+                    f"'{index_data['experiment'][key]}', expected '{val}'"
+                )
 
 
 cases_to_test = [

--- a/tests/ert/unit_tests/storage/migration/test_to30.py
+++ b/tests/ert/unit_tests/storage/migration/test_to30.py
@@ -34,6 +34,7 @@ def test_that_migration_removes_fields_not_in_experiment_config(tmp_path):
             "start_iteration": 0,
             "minimum_required_realizations": 1,
             "some_future_unknown_field": {"foo": "bar"},
+            "some_future_unknown_field2": "value",
         },
     }
     (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
@@ -45,21 +46,7 @@ def test_that_migration_removes_fields_not_in_experiment_config(tmp_path):
 
     stripped_fields = {
         "some_future_unknown_field",
-        "storage_path",
-        "runpath_file",
-        "user_config_file",
-        "env_vars",
-        "env_pr_fm_step",
-        "runpath_config",
-        "queue_config",
-        "forward_model_steps",
-        "substitutions",
-        "hooked_workflows",
-        "active_realizations",
-        "log_path",
-        "random_seed",
-        "start_iteration",
-        "minimum_required_realizations",
+        "some_future_unknown_field2",
     }
     assert stripped_fields.isdisjoint(experiment)
 
@@ -83,6 +70,22 @@ def test_that_migration_leaves_experiment_with_only_known_fields_untouched(tmp_p
         "experiment": {
             "experiment_type": "Ensemble Experiment",
             "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+            "minimum_required_realizations": 1,
+            "random_seed": 123456,
+            "storage_path": "/some/path",
+            "runpath_file": "/some/runpath",
+            "user_config_file": "/some/config",
+            "env_vars": {"VAR": "value"},
+            "env_pr_fm_step": {"MODEL": {"VAR2": "value2"}},
+            "runpath_config": {"num_realizations": 100},
+            "queue_config": {"max_submit": 10},
+            "forward_model_steps": [{"type": "site_installed"}],
+            "substitutions": {"<KEY>": "value"},
+            "hooked_workflows": {"PRE_SIMULATION": [{"name": "workflow1"}]},
+            "active_realizations": [True, True, False],
+            "log_path": "/some/log",
+            "start_iteration": 0,
+            "experiment_name": "Experiment 1",
         },
     }
     (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
@@ -108,6 +111,8 @@ def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
             "experiment_type": "Ensemble Experiment",
             "queue_config": {"max_submit": 1},
             "random_seed": 123456,
+            "unknown_field": "foo",
+            "old_legacy_field": "bar",
         },
     }
     (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
@@ -115,6 +120,6 @@ def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         migrate(root)
 
-    assert "queue_config" in caplog.text
-    assert "random_seed" in caplog.text
+    assert "unknown_field" in caplog.text
+    assert "old_legacy_field" in caplog.text
     assert str(exp_path / "index.json") in caplog.text


### PR DESCRIPTION

**Issue**
Resolves #13800


**Approach**
This commit fixes the issue where ExperimentConfig contains less keys than before, therefore we were missing a lot of data in the storage.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
