### PR TITLE
Validate populated rft response

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -299,7 +299,10 @@ class RFTConfig(ResponseConfig):
         rft_data = self._scan_rft(rft_filepath)
 
         if not rft_data:
-            return pl.DataFrame(schema=self.response_schema())
+            raise ConfigValidationError(
+                f"Did not find any responses matching the observation well(s): "
+                f"'{list(self.data_to_read.keys())}'",
+            )
 
         egrid_filepath = self._ergrid_filepath(rft_filepath)
         grid = _read_egrid(egrid_filepath)

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -90,27 +90,20 @@ def test_that_match_key_dict_expr_fits_match_key():
     assert response2["response_dict"].to_list() == ["well_connection_cell=None"]
 
 
-def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo_file):
+def test_that_rft_with_no_matching_well_and_dates_raise_error(mock_resfo_file):
     mock_resfo_file("/tmp/does_not_exist/BASE.RFT", [])
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={"No such well": {"2000-01-01": ["PRESSURE", "SWAT"]}},
     )
-    df = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-    assert df.is_empty()
-    assert set(df.columns) == {
-        "response_key",
-        "date",
-        "well",
-        "property",
-        "time",
-        "depth",
-        "values",
-        "well_connection_cell",
-        "cell_center",
-        "cell_zones",
-    }
+    with pytest.raises(
+        ConfigValidationError,
+        match=(
+            "Did not find any responses matching the "
+            r"observation well\(s\): '\['No such well'\]'"
+        ),
+    ):
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
 
 def test_that_rft_with_empty_data_to_read_returns_empty_df(mock_resfo_file):


### PR DESCRIPTION
Resolves #13801 

Should no RFT responses be loaded from the results (if any are defined in ert config or observation config) there should be raised an error.

This behaviour mimicks the behaviour of summary observations (SummaryConfig.read_from_file).

There is an issue where empty response dataframes passed to LocalEnsemble.save_response raises unhandled exceptions.
