### PR TITLE
Warn about summary and rft keys missing responses

### DIFF
--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -1,10 +1,37 @@
+import warnings
 from abc import abstractmethod
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import polars as pl
 from pydantic import BaseModel, Field
 
+from ert.warnings import PostExperimentWarning
+
 from .parsing import ConfigDict
+
+_RESPONSE_WARNING_LIMIT = 5
+
+
+def _warn_about_missing_responses(
+    missing_items: list[str],
+    item_label: Literal["key(s)", "well(s) at time(s)"],
+    filename: str,
+) -> None:
+    if not missing_items:
+        return
+
+    num_excess = len(missing_items) - _RESPONSE_WARNING_LIMIT
+
+    warning = (
+        f"Could not find responses for {item_label} in '{filename}':\n"
+        + "\n".join(missing_items[:_RESPONSE_WARNING_LIMIT])
+        + (f"\n... and {num_excess} other missing responses" if num_excess > 0 else "")
+    )
+    warnings.warn(
+        warning,
+        PostExperimentWarning,
+        stacklevel=1,
+    )
 
 
 class InvalidResponseFile(Exception):

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -31,7 +31,11 @@ from .parsing import (
     ConfigWarning,
     parse_zonemap,
 )
-from .response_config import InvalidResponseFile, ResponseConfig
+from .response_config import (
+    InvalidResponseFile,
+    ResponseConfig,
+    _warn_about_missing_responses,
+)
 from .responses_index import responses_index
 
 logger = logging.getLogger(__name__)
@@ -288,6 +292,28 @@ class RFTConfig(ResponseConfig):
             "cell_zones": pl.List(pl.String),
         }
 
+    def _warn_about_missing_rft_responses(
+        self,
+        rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry],
+        rft_filename: str,
+    ) -> None:
+        well_time_keys = {
+            (well, time)
+            for well, time_dict in self.data_to_read.items()
+            for time in time_dict
+        }
+        well_time_keys_rft_data = {(well, time.isoformat()) for well, time in rft_data}
+        well_time_without_response: set[tuple[str, str]] = (
+            well_time_keys - well_time_keys_rft_data
+        )
+
+        formatted_items = [
+            f"{well}: {time}" for well, time in sorted(well_time_without_response)
+        ]
+        _warn_about_missing_responses(
+            formatted_items, "well(s) at time(s)", rft_filename
+        )
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         """Reads the RFT values from <RUNPATH>/<ECLBASE>.RFT"""
         if not self.data_to_read:
@@ -296,6 +322,8 @@ class RFTConfig(ResponseConfig):
         rft_filepath = self._rft_filepath(self.input_files[0], run_path, iens, iter_)
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry]
         rft_data = self._scan_rft(rft_filepath)
+
+        self._warn_about_missing_rft_responses(rft_data, Path(rft_filepath).name)
 
         if not rft_data:
             return pl.DataFrame(schema=self.response_schema())

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -11,7 +11,7 @@ from ert.substitutions import substitute_runpath_name
 from ._read_summary import read_summary
 from .parsing import ConfigDict, ConfigKeys
 from .parsing.config_errors import ConfigValidationError, ConfigWarning
-from .response_config import InvalidResponseFile, ResponseConfig
+from .response_config import ResponseConfig
 from .responses_index import responses_index
 
 logger = logging.getLogger(__name__)
@@ -29,21 +29,11 @@ class SummaryConfig(ResponseConfig):
     @field_validator("keys", mode="before")
     @classmethod
     def dedupe_and_sort_keys(cls, keys: list[str]) -> list[str]:
-        if len(keys) < 1:
-            raise ValueError("SummaryConfig must be given at least one key")
-
         return sorted(set(keys))
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         filename = substitute_runpath_name(self.input_files[0], iens, iter_)
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
-        if len(data) == 0 or len(keys) == 0:
-            # https://github.com/equinor/ert/issues/6974
-            # There is a bug with storing empty responses so we have
-            # to raise an error in that case
-            raise InvalidResponseFile(
-                f"Did not find any summary values matching {self.keys} in {filename}"
-            )
 
         # Important: Pick lowest unit resolution to allow for using
         # datetimes many years into the future

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -11,7 +11,7 @@ from ert.substitutions import substitute_runpath_name
 from ._read_summary import read_summary
 from .parsing import ConfigDict, ConfigKeys
 from .parsing.config_errors import ConfigValidationError, ConfigWarning
-from .response_config import ResponseConfig
+from .response_config import ResponseConfig, _warn_about_missing_responses
 from .responses_index import responses_index
 
 logger = logging.getLogger(__name__)
@@ -31,10 +31,17 @@ class SummaryConfig(ResponseConfig):
     def dedupe_and_sort_keys(cls, keys: list[str]) -> list[str]:
         return sorted(set(keys))
 
+    def _warn_about_missing_summary_responses(
+        self, response_keys: list[str], filename: str
+    ) -> None:
+        keys_missing_responses = sorted(set(self.keys) - set(response_keys) - {"*"})
+        _warn_about_missing_responses(keys_missing_responses, "key(s)", filename)
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         filename = substitute_runpath_name(self.input_files[0], iens, iter_)
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
 
+        self._warn_about_missing_summary_responses(keys, filename)
         # Important: Pick lowest unit resolution to allow for using
         # datetimes many years into the future
         time_map_series = pl.Series(time_map).dt.cast_time_unit("ms")

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -874,12 +874,6 @@ class LocalEnsemble(BaseMode):
                 f"must contain a 'values' variable"
             )
 
-        if len(data) == 0:
-            raise ValueError(
-                f"Responses {response_type} are empty. "
-                "Cannot proceed with saving to storage."
-            )
-
         if "realization" not in data.columns:
             data.insert_column(
                 0,

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -18,7 +19,9 @@ from ert.config import (
 from ert.config._create_observation_dataframes import _handle_rft_observation
 from ert.config._observations import RFTObservation
 from ert.config.parsing import ConfigValidationError, ObservationType
+from ert.config.response_config import _RESPONSE_WARNING_LIMIT
 from ert.config.rft_config import _get_zonemap, _read_egrid
+from ert.warnings import PostExperimentWarning
 from tests.ert.rft_generator import cell_start, create_egrid, float_arr
 
 
@@ -90,6 +93,9 @@ def test_that_match_key_dict_expr_fits_match_key():
     assert response2["response_dict"].to_list() == ["well_connection_cell=None"]
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Could not find responses for well\(s\) at time\(s\)"
+)
 def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo_file):
     mock_resfo_file("/tmp/does_not_exist/BASE.RFT", [])
     rft_config = RFTConfig(
@@ -797,6 +803,9 @@ def test_that_missing_egrid_with_locations_raises_invalid_response_file(
         rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Could not find responses for well\(s\) at time\(s\)"
+)
 def test_that_missing_egrid_without_locations_raises_invalid_response_file(
     mock_resfo_file,
 ):
@@ -904,6 +913,9 @@ def test_that_non_matching_wells_are_ignored_silently(mock_resfo_file, egrid):
     ]
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:Could not find responses for well\(s\) at time\(s\)"
+)
 def test_that_wildcard_well_with_specific_date_matches_all_wells(
     mock_resfo_file, egrid
 ):
@@ -1325,3 +1337,117 @@ def test_that_approximate_missing_rft_values_keyword_sets_interpolation_to_true_
     config = ErtConfig.from_dict(config_dict)
     rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
     assert rft_config.approximate_missing_values is expected_setting
+
+
+def test_that_missing_response_for_rft_well_raises_warning(mock_resfo_file, egrid):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(date=(1, 1, 2000), well_name="WELL"),
+            ("PRESSURE", float_arr([100.0, 200.0])),
+            ("SWAT    ", float_arr([0.1, 0.2])),
+            ("SGAS    ", float_arr([0.3, 0.4])),
+            ("DEPTH   ", float_arr([20.0, 30.0])),
+            *cell_start(date=(1, 2, 2000), well_name="WELL"),
+            ("PRESSURE", float_arr([101.0, 201.0])),
+            ("SWAT    ", float_arr([0.01, 0.01])),
+            ("SGAS    ", float_arr([0.01, 0.01])),
+            ("DEPTH   ", float_arr([21.0, 31.0])),
+        ],
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        egrid,
+    )
+
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "NOT_A_WELL": {"2000-01-01": ["PRESSURE", "SWAT"]},
+            "WELL": {"2000-01-01": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    expected_warnings = [
+        "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
+        "NOT_A_WELL: 2000-01-01",
+    ]
+    assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
+
+
+def test_that_one_existing_and_one_missing_rft_response_warns_about_the_one_missing(
+    mock_resfo_file, egrid
+):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(date=(1, 1, 2000), well_name="WELL"),
+            ("PRESSURE", float_arr([100.0, 200.0])),
+            ("SWAT    ", float_arr([0.1, 0.2])),
+            ("SGAS    ", float_arr([0.3, 0.4])),
+            ("DEPTH   ", float_arr([20.0, 30.0])),
+        ],
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        egrid,
+    )
+
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "WELL": {
+                "4000-01-01": ["PRESSURE", "SWAT"],
+                "2000-01-01": ["PRESSURE", "SWAT"],
+            },
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+    expected_warnings = [
+        "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
+        "WELL: 4000-01-01",
+    ]
+    assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
+
+
+def test_that_many_missing_response_warnings_are_truncated(mock_resfo_file, egrid):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(date=(1, 1, 2000), well_name="WELL"),
+            ("PRESSURE", float_arr([100.0, 200.0])),
+            ("SWAT    ", float_arr([0.1, 0.2])),
+            ("SGAS    ", float_arr([0.3, 0.4])),
+            ("DEPTH   ", float_arr([20.0, 30.0])),
+        ],
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        egrid,
+    )
+    num_missing_responses = 9
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "WELL": {
+                f"400{n}-01-01": ["PRESSURE", "SWAT"]
+                for n in range(num_missing_responses)
+            }
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+    warning_msg = next(
+        str(w.message) for w in warnings if "Could not find responses" in str(w.message)
+    )
+    warning_lines = warning_msg.splitlines()
+    warning_lines = warning_lines[1:]  # Discard first line
+    last_line = warning_lines.pop(-1)
+
+    assert len(warning_lines) == _RESPONSE_WARNING_LIMIT
+    match = re.search(r"and (\d+) other missing responses", last_line)
+    excess_warnings = int(match.group(1))
+    assert excess_warnings == num_missing_responses - _RESPONSE_WARNING_LIMIT

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -23,12 +23,15 @@ from ert.config._observations import DEFAULT_LOCALIZATION_RADIUS
 @given(summaries(summary_keys=st.just(["WOPR:OP1"])))
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.slow
-def test_reading_empty_summaries_raises(wopr_summary):
+def test_that_reading_empty_summaries_returns_empty_df_with_column_schema(wopr_summary):
     smspec, unsmry = wopr_summary
     smspec.to_file("CASE.SMSPEC")
     unsmry.to_file("CASE.UNSMRY")
-    with pytest.raises(InvalidResponseFile, match="Did not find any summary values"):
-        SummaryConfig(input_files=["CASE"], keys=["WWCT:OP1"]).read_from_file(".", 0, 0)
+    responses_df = SummaryConfig(
+        input_files=["CASE"], keys=["WWCT:OP1"]
+    ).read_from_file(".", 0, 0)
+    assert responses_df.is_empty()
+    assert responses_df.columns == ["response_key", "time", "values"]
 
 
 def test_summary_config_normalizes_list_of_keys():

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -1,5 +1,6 @@
 import re
 from contextlib import suppress
+from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 
@@ -14,15 +15,18 @@ from ert.config import (
     ErtConfig,
     InvalidResponseFile,
     SummaryConfig,
+    summary_config,
 )
 from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config._observations import DEFAULT_LOCALIZATION_RADIUS
+from ert.warnings import PostExperimentWarning
 
 
 @settings(max_examples=10)
 @given(summaries(summary_keys=st.just(["WOPR:OP1"])))
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.slow
+@pytest.mark.filterwarnings(r"ignore:Could not find responses for key\(s\)")
 def test_that_reading_empty_summaries_returns_empty_df_with_column_schema(wopr_summary):
     smspec, unsmry = wopr_summary
     smspec.to_file("CASE.SMSPEC")
@@ -234,3 +238,34 @@ def test_that_defaulted_summary_obs_values_have_type_float32(tmpdir):
     assert summary_observations["east"].dtype == pl.Float32
     assert summary_observations["north"].dtype == pl.Float32
     assert summary_observations["radius"].dtype == pl.Float32
+
+
+def test_that_when_not_finding_response_obs_keys_raises_warning(monkeypatch):
+    response_keys = ["WOPR:OP1", "FOPR"]
+    obs_keys = ["WOPR:OP1", "WWCT:OP1", "WOPR:OP2"]
+
+    def mock_read_summary(*args):
+        return (
+            None,
+            response_keys,
+            [datetime.fromisoformat("2012-10-10")] * 2,
+            [[None] * 2] * 2,
+        )
+
+    monkeypatch.setattr(summary_config, "read_summary", mock_read_summary)
+
+    with pytest.warns(PostExperimentWarning) as warnings:
+        SummaryConfig(input_files=["CASE"], keys=list(obs_keys)).read_from_file(
+            ".", 0, 0
+        )
+
+    warning = next(
+        str(w.message) for w in warnings if "Could not find response" in str(w.message)
+    )
+    expected_warning = dedent(
+        """\
+        Could not find responses for key(s) in 'CASE':
+        WOPR:OP2
+        WWCT:OP1"""
+    )
+    assert warning == expected_warning

--- a/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
+++ b/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
@@ -80,15 +80,15 @@ class DarkStorageStateTest(StatefulStorageTest):
     @rule(model_ensemble=StatefulStorageTest.ensembles, data=st.data())
     def get_response_csv_through_client(self, model_ensemble, data):
         assume(model_ensemble.response_values)
-        response_name, response_key = data.draw(
-            st.sampled_from(
-                [
-                    (response_name, response_key)
-                    for response_name, r in model_ensemble.response_values.items()
-                    for response_key in r["response_key"]
-                ]
-            )
-        )
+
+        response_sample_space = [
+            (response_name, response_key)
+            for response_name, r in model_ensemble.response_values.items()
+            for response_key in r["response_key"]
+        ]
+        if not response_sample_space:
+            return
+        response_name, response_key = data.draw(st.sampled_from(response_sample_space))
         df = pd.read_parquet(
             io.BytesIO(
                 self.client.get(

--- a/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
+++ b/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
@@ -21,6 +21,7 @@ def escape(s):
     return quote(quote(quote(s, safe="")))
 
 
+@pytest.mark.filterwarnings(r"ignore:Could not find responses for key\(s\)")
 class DarkStorageStateTest(StatefulStorageTest):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -1105,31 +1105,28 @@ async def test_that_writing_and_reading_empty_response_in_storage_results_in_emp
         LocalExperiment, "response_configuration", {"summary": SummaryConfig()}
     )
 
-    storage = open_storage(tmp_path, mode="w")
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        ensemble = storage.create_ensemble(experiment.id, ensemble_size=1, name="test")
+        await _write_responses_to_storage(str(tmp_path), 0, ensemble)
 
-    experiment = storage.create_experiment()
-    ensemble = storage.create_ensemble(experiment.id, ensemble_size=1, name="test")
-    await _write_responses_to_storage(str(tmp_path), 0, ensemble)
+        summary_response_path = ensemble._realization_dir(0) / "summary.parquet"
+        assert Path(summary_response_path).is_file()
+        responses = pl.read_parquet(summary_response_path)
+        assert responses.is_empty()
+        assert responses.columns == response_column_scheme
 
-    summary_response_path = ensemble._realization_dir(0) / "summary.parquet"
-    assert Path(summary_response_path).is_file()
-    responses = pl.read_parquet(summary_response_path)
-    assert responses.is_empty()
-    assert responses.columns == response_column_scheme
+        # Mock response config to contain a response key, else the parquet file
+        # will never be read as the code exits earlier.
+        monkeypatch.setattr(
+            LocalExperiment,
+            "response_configuration",
+            {"summary": SummaryConfig(keys=["FOPR"])},
+        )
+        monkeypatch.setattr(
+            LocalExperiment, "response_key_to_response_type", {"FOPR": "summary"}
+        )
 
-    # Mock response config to contain a response key, else the parquet file will never
-    # be read as the code exits earlier.
-    monkeypatch.setattr(
-        LocalExperiment,
-        "response_configuration",
-        {"summary": SummaryConfig(keys=["FOPR"])},
-    )
-    monkeypatch.setattr(
-        LocalExperiment, "response_key_to_response_type", {"FOPR": "summary"}
-    )
-
-    responses = ensemble.load_responses("FOPR", (0,))
-    assert responses.is_empty()
-    assert responses.columns == response_column_scheme
-
-    storage.close()
+        responses = ensemble.load_responses("FOPR", (0,))
+        assert responses.is_empty()
+        assert responses.columns == response_column_scheme

--- a/tests/ert/unit_tests/storage/test_local_ensemble.py
+++ b/tests/ert/unit_tests/storage/test_local_ensemble.py
@@ -20,14 +20,16 @@ from ert.config import GenKwConfig, RFTConfig, SummaryConfig
 from ert.config._observations import RFTObservation
 from ert.config.response_config import InvalidResponseFile
 from ert.exceptions import StorageError
-from ert.storage import open_storage
+from ert.storage import LocalExperiment, open_storage
 from ert.storage.blob_data import (
     BlobStorageData,
     BlobType,
     MatrixStorageData,
     ObservationReportData,
 )
-from ert.storage.local_ensemble import _write_responses_to_storage
+from ert.storage.local_ensemble import (
+    _write_responses_to_storage,
+)
 from ert.storage.mode import ModeError
 
 
@@ -1086,3 +1088,48 @@ def test_that_parameter_group_sizes_is_stored_in_matrix_blob_metadata(tmp_path):
         assert len(blobs) == 1
         assert isinstance(blobs[0].blob_info, MatrixStorageData)
         assert blobs[0].blob_info.parameter_group_sizes == {"PORO": 8, "PERM": 3}
+
+
+async def test_that_writing_and_reading_empty_response_in_storage_results_in_empty_df_with_schema_columns(  # noqa: E501
+    tmp_path, monkeypatch
+):
+    """This test writes an empty set of responses to storage and asserts that the
+    parquet file contains the correct columns.
+    Then the test also checks that loading said file through ensemble results in an
+    empty dataframe.
+    """
+    response_column_scheme = ["realization", "response_key", "time", "values"]
+    empty_response = pl.DataFrame({"response_key": [], "time": [], "values": []})
+    monkeypatch.setattr(SummaryConfig, "read_from_file", lambda *args: empty_response)
+    monkeypatch.setattr(
+        LocalExperiment, "response_configuration", {"summary": SummaryConfig()}
+    )
+
+    storage = open_storage(tmp_path, mode="w")
+
+    experiment = storage.create_experiment()
+    ensemble = storage.create_ensemble(experiment.id, ensemble_size=1, name="test")
+    await _write_responses_to_storage(str(tmp_path), 0, ensemble)
+
+    summary_response_path = ensemble._realization_dir(0) / "summary.parquet"
+    assert Path(summary_response_path).is_file()
+    responses = pl.read_parquet(summary_response_path)
+    assert responses.is_empty()
+    assert responses.columns == response_column_scheme
+
+    # Mock response config to contain a response key, else the parquet file will never
+    # be read as the code exits earlier.
+    monkeypatch.setattr(
+        LocalExperiment,
+        "response_configuration",
+        {"summary": SummaryConfig(keys=["FOPR"])},
+    )
+    monkeypatch.setattr(
+        LocalExperiment, "response_key_to_response_type", {"FOPR": "summary"}
+    )
+
+    responses = ensemble.load_responses("FOPR", (0,))
+    assert responses.is_empty()
+    assert responses.columns == response_column_scheme
+
+    storage.close()

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -95,42 +95,6 @@ def test_that_loading_non_existing_ensemble_throws(tmp_path):
             experiment.get_ensemble_by_name("non-existing-ensemble")
 
 
-def test_that_saving_empty_responses_fails_nicely(tmp_path):
-    with open_storage(tmp_path, mode="w") as storage:
-        experiment = storage.create_experiment()
-        ensemble = storage.create_ensemble(
-            experiment, ensemble_size=1, iteration=0, name="prior"
-        )
-
-        # Test for entirely empty dataset
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Dataset for response group 'RESPONSE' must contain a 'values' variable"
-            ),
-        ):
-            ensemble.save_response("RESPONSE", pl.DataFrame(), 0)
-
-        # Test for dataset with 'values' but no actual data
-        empty_data = pl.DataFrame(
-            {
-                "response_key": [],
-                "report_step": [],
-                "index": [],
-                "values": [],
-            }
-        )
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Responses RESPONSE are empty\\. "
-                "Cannot proceed with saving to storage\\."
-            ),
-        ):
-            ensemble.save_response("RESPONSE", empty_data, 0)
-
-
 def test_that_local_ensemble_save_parameter_raises_value_error_given_xr_array_dataset(
     tmp_path,
 ):
@@ -1812,7 +1776,7 @@ response_configs = st.lists(
                 min_size=1,
                 max_size=1,
             ),
-            keys=st.lists(summary_selectors, min_size=1),
+            keys=st.lists(summary_selectors),
         ),
     ),
     unique_by=lambda x: x.type,
@@ -2185,8 +2149,8 @@ class StatefulStorageTest(RuleBasedStateMachine):
         expected_summary_keys = (
             st.just(smry_config.keys)
             if smry_config.has_finalized_keys
-            else st.lists(summary_variables(), min_size=1)
-        )
+            else st.lists(summary_variables())
+        ).map(lambda xs: [x for x in xs if x != "TIME"])
 
         summaries_strategy = summaries(
             summary_keys=expected_summary_keys,
@@ -2216,11 +2180,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         smspec.to_file(self.tmpdir + f"/{summary.input_files[0]}.SMSPEC")
         unsmry.to_file(self.tmpdir + f"/{summary.input_files[0]}.UNSMRY")
 
-        try:
-            ds = summary.read_from_file(self.tmpdir, self.iens_to_edit, 0)
-        except Exception as e:  # no match in keys
-            assume(False)
-            raise AssertionError from e
+        ds = summary.read_from_file(self.tmpdir, self.iens_to_edit, 0)
         storage_ensemble.save_response(summary.type, ds, self.iens_to_edit)
 
         model_ensemble.response_values[summary.type] = ds


### PR DESCRIPTION
By just removing this, it seems like esmda works even with empty response files. 

Will investigate a bit more before this can be merged.