### PR TITLE
Change migration order to31, to32 -> to32, to31

### DIFF
--- a/src/ert/storage/migration/to31.py
+++ b/src/ert/storage/migration/to31.py
@@ -1,63 +1,112 @@
 from __future__ import annotations
 
-import io
 import json
-import uuid
+import logging
 from pathlib import Path
 
-import polars as pl
+logger = logging.getLogger(__name__)
 
-info = "Migrate observation_scaling_factors.parquet to blob storage"
+info = "Strip fields not in the observation models from experiment observations"
+
+_ALLOWED_OBSERVATION_KEYS: dict[str, frozenset[str]] = {
+    "summary_observation": frozenset(
+        {
+            "type",
+            "name",
+            "value",
+            "error",
+            "key",
+            "date",
+            "shape_id",
+            "error_mode",
+            "error_min",
+        }
+    ),
+    "general_observation": frozenset(
+        {
+            "type",
+            "name",
+            "data",
+            "value",
+            "error",
+            "restart",
+            "index",
+            "shape_id",
+        }
+    ),
+    "rft_observation": frozenset(
+        {
+            "type",
+            "name",
+            "well",
+            "date",
+            "property",
+            "value",
+            "error",
+            "east",
+            "north",
+            "tvd",
+            "md",
+            "shape_id",
+            "zone",
+        }
+    ),
+    "breakthrough": frozenset(
+        {
+            "type",
+            "name",
+            "key",
+            "date",
+            "error",
+            "threshold",
+            "shape_id",
+        }
+    ),
+}
 
 
-def _migrate_scaling_factors(path: Path) -> None:
-    ensembles_dir = path / "ensembles"
-    if not ensembles_dir.exists():
+def _strip_unknown_fields(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
         return
 
-    for ens_dir in ensembles_dir.iterdir():
-        if not ens_dir.is_dir():
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
             continue
 
-        old_file = ens_dir / "observation_scaling_factors.parquet"
-        if not old_file.exists():
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
             continue
 
-        try:
-            df = pl.read_parquet(old_file)
-        except Exception:
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+        observations = experiment_data.get("observations")
+        if not observations:
             continue
 
-        blob_dir = ens_dir / "blobs"
-        blob_dir.mkdir(parents=True, exist_ok=True)
+        stripped_keys: set[str] = set()
+        for observation in observations:
+            allowed_keys = _ALLOWED_OBSERVATION_KEYS.get(observation.get("type"))
+            if allowed_keys is None:
+                logger.warning(
+                    "Cannot migrate observation with unknown type "
+                    f"{observation.get('type')} in {index_file}"
+                )
+                continue
 
-        blob_id = uuid.uuid4().hex[:8]
-        blob_file = blob_dir / f"{blob_id}.blob"
-        blob_meta_file = blob_dir / f"{blob_id}.blob.json"
+            unknown_keys = [key for key in observation if key not in allowed_keys]
+            for key in unknown_keys:
+                observation.pop(key)
+            stripped_keys.update(unknown_keys)
 
-        buf = io.BytesIO()
-        df.write_parquet(buf)
-        blob_bytes = buf.getvalue()
-
-        num_groups = df["input_group"].n_unique() if "input_group" in df.columns else 1
-
-        blob_meta = {
-            "uri": f"{blob_id}.blob",
-            "file_size": len(blob_bytes),
-            "file_type": "application/parquet",
-            "name": "scaling_factors",
-            "blob_info": {
-                "blob_type": "scaling_factors",
-                "update_algorithm": "ensemble_smoother",
-                "num_observations": len(df),
-                "num_groups": num_groups,
-            },
-        }
-
-        blob_file.write_bytes(blob_bytes)
-        blob_meta_file.write_text(json.dumps(blob_meta, indent=2), encoding="utf-8")
-        old_file.unlink()
+        if stripped_keys:
+            logger.info(
+                "Stripped fields not in the observation models from %s: %s",
+                index_file,
+                ", ".join(sorted(stripped_keys)),
+            )
+            index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
 
 
 def migrate(path: Path) -> None:
-    _migrate_scaling_factors(path)
+    _strip_unknown_fields(path)

--- a/src/ert/storage/migration/to32.py
+++ b/src/ert/storage/migration/to32.py
@@ -1,112 +1,63 @@
 from __future__ import annotations
 
+import io
 import json
-import logging
+import uuid
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import polars as pl
 
-info = "Strip fields not in the observation models from experiment observations"
-
-_ALLOWED_OBSERVATION_KEYS: dict[str, frozenset[str]] = {
-    "summary_observation": frozenset(
-        {
-            "type",
-            "name",
-            "value",
-            "error",
-            "key",
-            "date",
-            "shape_id",
-            "error_mode",
-            "error_min",
-        }
-    ),
-    "general_observation": frozenset(
-        {
-            "type",
-            "name",
-            "data",
-            "value",
-            "error",
-            "restart",
-            "index",
-            "shape_id",
-        }
-    ),
-    "rft_observation": frozenset(
-        {
-            "type",
-            "name",
-            "well",
-            "date",
-            "property",
-            "value",
-            "error",
-            "east",
-            "north",
-            "tvd",
-            "md",
-            "shape_id",
-            "zone",
-        }
-    ),
-    "breakthrough": frozenset(
-        {
-            "type",
-            "name",
-            "key",
-            "date",
-            "error",
-            "threshold",
-            "shape_id",
-        }
-    ),
-}
+info = "Migrate observation_scaling_factors.parquet to blob storage"
 
 
-def _strip_unknown_fields(path: Path) -> None:
-    experiments_dir = path / "experiments"
-    if not experiments_dir.exists():
+def _migrate_scaling_factors(path: Path) -> None:
+    ensembles_dir = path / "ensembles"
+    if not ensembles_dir.exists():
         return
 
-    for exp_dir in experiments_dir.iterdir():
-        if not exp_dir.is_dir():
+    for ens_dir in ensembles_dir.iterdir():
+        if not ens_dir.is_dir():
             continue
 
-        index_file = exp_dir / "index.json"
-        if not index_file.exists():
+        old_file = ens_dir / "observation_scaling_factors.parquet"
+        if not old_file.exists():
             continue
 
-        index_data = json.loads(index_file.read_text(encoding="utf-8"))
-        experiment_data = index_data.get("experiment", {})
-        observations = experiment_data.get("observations")
-        if not observations:
+        try:
+            df = pl.read_parquet(old_file)
+        except Exception:
             continue
 
-        stripped_keys: set[str] = set()
-        for observation in observations:
-            allowed_keys = _ALLOWED_OBSERVATION_KEYS.get(observation.get("type"))
-            if allowed_keys is None:
-                logger.warning(
-                    "Cannot migrate observation with unknown type "
-                    f"{observation.get('type')} in {index_file}"
-                )
-                continue
+        blob_dir = ens_dir / "blobs"
+        blob_dir.mkdir(parents=True, exist_ok=True)
 
-            unknown_keys = [key for key in observation if key not in allowed_keys]
-            for key in unknown_keys:
-                observation.pop(key)
-            stripped_keys.update(unknown_keys)
+        blob_id = uuid.uuid4().hex[:8]
+        blob_file = blob_dir / f"{blob_id}.blob"
+        blob_meta_file = blob_dir / f"{blob_id}.blob.json"
 
-        if stripped_keys:
-            logger.info(
-                "Stripped fields not in the observation models from %s: %s",
-                index_file,
-                ", ".join(sorted(stripped_keys)),
-            )
-            index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+        buf = io.BytesIO()
+        df.write_parquet(buf)
+        blob_bytes = buf.getvalue()
+
+        num_groups = df["input_group"].n_unique() if "input_group" in df.columns else 1
+
+        blob_meta = {
+            "uri": f"{blob_id}.blob",
+            "file_size": len(blob_bytes),
+            "file_type": "application/parquet",
+            "name": "scaling_factors",
+            "blob_info": {
+                "blob_type": "scaling_factors",
+                "update_algorithm": "ensemble_smoother",
+                "num_observations": len(df),
+                "num_groups": num_groups,
+            },
+        }
+
+        blob_file.write_bytes(blob_bytes)
+        blob_meta_file.write_text(json.dumps(blob_meta, indent=2), encoding="utf-8")
+        old_file.unlink()
 
 
 def migrate(path: Path) -> None:
-    _strip_unknown_fields(path)
+    _migrate_scaling_factors(path)

--- a/tests/ert/unit_tests/storage/migration/test_to31.py
+++ b/tests/ert/unit_tests/storage/migration/test_to31.py
@@ -1,82 +1,194 @@
-import io
-from pathlib import Path
+import json
+import logging
 
-import polars as pl
+import numpy as np
 
-from ert.storage.blob_data import BlobStorageData, ScalingFactorsData
 from ert.storage.migration.to31 import migrate
 
 
-def _read_blob_metadata(blob_meta_path: Path) -> BlobStorageData:
-    return BlobStorageData.model_validate_json(
-        blob_meta_path.read_text(encoding="utf-8")
-    )
-
-
-def test_that_migration_moves_scaling_factor_parquet_to_blob_storage(tmp_path):
+def test_that_migration_removes_fields_not_in_observation_models(tmp_path):
     root = tmp_path / "project"
     root.mkdir()
 
-    ensemble_dir = root / "ensembles" / "ens-1"
-    ensemble_dir.mkdir(parents=True)
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
 
-    old_path = ensemble_dir / "observation_scaling_factors.parquet"
-    old_df = pl.DataFrame(
-        {
-            "input_group": ["obs1*", "obs2*"],
-            "index": ["r0", "r1"],
-            "obs_key": ["OBS_1", "OBS_2"],
-            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
-        }
-    )
-    old_df.write_parquet(old_path)
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "shape_id": None,
+                    "some_future_unknown_field": {"foo": "bar"},
+                    "std": 0.5,
+                },
+                {
+                    "type": "general_observation",
+                    "name": "GEN_1",
+                    "data": "POLY_RES",
+                    "value": 2.0,
+                    "error": 0.2,
+                    "restart": 0,
+                    "index": 3,
+                    "shape_id": None,
+                    "response_key": "POLY_RES",
+                    "report_step": 0,
+                },
+                {
+                    "type": "rft_observation",
+                    "name": "RFT_1",
+                    "well": "OP_1",
+                    "date": "2024-01-15",
+                    "property": "PRESSURE",
+                    "value": 250.0,
+                    "error": 5.0,
+                    "east": 123.5,
+                    "north": 456.7,
+                    "tvd": 2500.0,
+                    "md": None,
+                    "shape_id": None,
+                    "zone": None,
+                    "radius": 3000.0,
+                },
+                {
+                    "type": "breakthrough",
+                    "name": "BT_1",
+                    "key": "FWPR",
+                    "date": "2024-01-15T00:00:00",
+                    "error": 0.1,
+                    "threshold": 0.5,
+                    "shape_id": None,
+                    "obsolete_key": "remove me",
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
 
     migrate(root)
 
-    assert not old_path.exists()
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    observations = updated["experiment"]["observations"]
 
-    blob_dir = ensemble_dir / "blobs"
-    blob_data_files = list(blob_dir.glob("*.blob"))
-    blob_meta_files = list(blob_dir.glob("*.blob.json"))
-    assert len(blob_data_files) == 1
-    assert len(blob_meta_files) == 1
+    summary, general, rft, breakthrough = observations
 
-    meta = _read_blob_metadata(blob_meta_files[0])
-    assert meta.name == "scaling_factors"
-    assert meta.file_type == "application/parquet"
-    assert isinstance(meta.blob_info, ScalingFactorsData)
-    assert meta.blob_info.update_algorithm == "ensemble_smoother"
-    assert meta.blob_info.num_observations == 2
-    assert meta.blob_info.num_groups == 2
+    assert "some_future_unknown_field" not in summary
+    assert "std" not in summary
+    assert summary["key"] == "FOPR"
+    assert np.isclose(summary["value"], 1.0)
 
-    migrated_df = pl.read_parquet(io.BytesIO((blob_dir / meta.uri).read_bytes()))
-    assert migrated_df.to_dict(as_series=False) == old_df.to_dict(as_series=False)
+    assert "response_key" not in general
+    assert "report_step" not in general
+    assert general["data"] == "POLY_RES"
+    assert general["index"] == 3
+
+    assert "radius" not in rft
+    assert rft["well"] == "OP_1"
+    assert np.isclose(rft["east"], 123.5)
+
+    assert "obsolete_key" not in breakthrough
+    assert np.isclose(breakthrough["threshold"], 0.5)
 
 
-def test_that_migration_defaults_num_groups_to_one_when_input_group_is_missing(
-    tmp_path,
-):
+def test_that_migration_leaves_observations_with_only_known_fields_untouched(tmp_path):
     root = tmp_path / "project"
     root.mkdir()
 
-    ensemble_dir = root / "ensembles" / "ens-1"
-    ensemble_dir.mkdir(parents=True)
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
 
-    old_path = ensemble_dir / "observation_scaling_factors.parquet"
-    pl.DataFrame(
-        {
-            "index": ["r0", "r1"],
-            "obs_key": ["OBS_1", "OBS_2"],
-            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
-        }
-    ).write_parquet(old_path)
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "shape_id": None,
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
 
     migrate(root)
 
-    blob_meta_files = list((ensemble_dir / "blobs").glob("*.blob.json"))
-    assert len(blob_meta_files) == 1
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
 
-    meta = _read_blob_metadata(blob_meta_files[0])
-    assert isinstance(meta.blob_info, ScalingFactorsData)
-    assert meta.blob_info.num_observations == 2
-    assert meta.blob_info.num_groups == 1
+
+def test_that_migration_handles_experiments_without_observations(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "std": 0.5,
+                    "response_key": "FOPR",
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        migrate(root)
+
+    assert "std" in caplog.text
+    assert "response_key" in caplog.text
+    assert str(exp_path / "index.json") in caplog.text

--- a/tests/ert/unit_tests/storage/migration/test_to32.py
+++ b/tests/ert/unit_tests/storage/migration/test_to32.py
@@ -1,194 +1,82 @@
-import json
-import logging
+import io
+from pathlib import Path
 
-import numpy as np
+import polars as pl
 
+from ert.storage.blob_data import BlobStorageData, ScalingFactorsData
 from ert.storage.migration.to32 import migrate
 
 
-def test_that_migration_removes_fields_not_in_observation_models(tmp_path):
+def _read_blob_metadata(blob_meta_path: Path) -> BlobStorageData:
+    return BlobStorageData.model_validate_json(
+        blob_meta_path.read_text(encoding="utf-8")
+    )
+
+
+def test_that_migration_moves_scaling_factor_parquet_to_blob_storage(tmp_path):
     root = tmp_path / "project"
     root.mkdir()
 
-    exp_path = root / "experiments" / "exp1"
-    exp_path.mkdir(parents=True)
+    ensemble_dir = root / "ensembles" / "ens-1"
+    ensemble_dir.mkdir(parents=True)
 
-    index_data = {
-        "id": "exp-id",
-        "name": "exp1",
-        "ensembles": [],
-        "experiment": {
-            "experiment_type": "Ensemble Experiment",
-            "observations": [
-                {
-                    "type": "summary_observation",
-                    "name": "FOPR_1",
-                    "value": 1.0,
-                    "error": 0.1,
-                    "key": "FOPR",
-                    "date": "2024-01-15",
-                    "shape_id": None,
-                    "some_future_unknown_field": {"foo": "bar"},
-                    "std": 0.5,
-                },
-                {
-                    "type": "general_observation",
-                    "name": "GEN_1",
-                    "data": "POLY_RES",
-                    "value": 2.0,
-                    "error": 0.2,
-                    "restart": 0,
-                    "index": 3,
-                    "shape_id": None,
-                    "response_key": "POLY_RES",
-                    "report_step": 0,
-                },
-                {
-                    "type": "rft_observation",
-                    "name": "RFT_1",
-                    "well": "OP_1",
-                    "date": "2024-01-15",
-                    "property": "PRESSURE",
-                    "value": 250.0,
-                    "error": 5.0,
-                    "east": 123.5,
-                    "north": 456.7,
-                    "tvd": 2500.0,
-                    "md": None,
-                    "shape_id": None,
-                    "zone": None,
-                    "radius": 3000.0,
-                },
-                {
-                    "type": "breakthrough",
-                    "name": "BT_1",
-                    "key": "FWPR",
-                    "date": "2024-01-15T00:00:00",
-                    "error": 0.1,
-                    "threshold": 0.5,
-                    "shape_id": None,
-                    "obsolete_key": "remove me",
-                },
-            ],
-        },
-    }
-    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+    old_path = ensemble_dir / "observation_scaling_factors.parquet"
+    old_df = pl.DataFrame(
+        {
+            "input_group": ["obs1*", "obs2*"],
+            "index": ["r0", "r1"],
+            "obs_key": ["OBS_1", "OBS_2"],
+            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
+        }
+    )
+    old_df.write_parquet(old_path)
 
     migrate(root)
 
-    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
-    observations = updated["experiment"]["observations"]
+    assert not old_path.exists()
 
-    summary, general, rft, breakthrough = observations
+    blob_dir = ensemble_dir / "blobs"
+    blob_data_files = list(blob_dir.glob("*.blob"))
+    blob_meta_files = list(blob_dir.glob("*.blob.json"))
+    assert len(blob_data_files) == 1
+    assert len(blob_meta_files) == 1
 
-    assert "some_future_unknown_field" not in summary
-    assert "std" not in summary
-    assert summary["key"] == "FOPR"
-    assert np.isclose(summary["value"], 1.0)
+    meta = _read_blob_metadata(blob_meta_files[0])
+    assert meta.name == "scaling_factors"
+    assert meta.file_type == "application/parquet"
+    assert isinstance(meta.blob_info, ScalingFactorsData)
+    assert meta.blob_info.update_algorithm == "ensemble_smoother"
+    assert meta.blob_info.num_observations == 2
+    assert meta.blob_info.num_groups == 2
 
-    assert "response_key" not in general
-    assert "report_step" not in general
-    assert general["data"] == "POLY_RES"
-    assert general["index"] == 3
-
-    assert "radius" not in rft
-    assert rft["well"] == "OP_1"
-    assert np.isclose(rft["east"], 123.5)
-
-    assert "obsolete_key" not in breakthrough
-    assert np.isclose(breakthrough["threshold"], 0.5)
+    migrated_df = pl.read_parquet(io.BytesIO((blob_dir / meta.uri).read_bytes()))
+    assert migrated_df.to_dict(as_series=False) == old_df.to_dict(as_series=False)
 
 
-def test_that_migration_leaves_observations_with_only_known_fields_untouched(tmp_path):
+def test_that_migration_defaults_num_groups_to_one_when_input_group_is_missing(
+    tmp_path,
+):
     root = tmp_path / "project"
     root.mkdir()
 
-    exp_path = root / "experiments" / "exp1"
-    exp_path.mkdir(parents=True)
+    ensemble_dir = root / "ensembles" / "ens-1"
+    ensemble_dir.mkdir(parents=True)
 
-    index_data = {
-        "id": "exp-id",
-        "name": "exp1",
-        "ensembles": [],
-        "experiment": {
-            "experiment_type": "Ensemble Experiment",
-            "observations": [
-                {
-                    "type": "summary_observation",
-                    "name": "FOPR_1",
-                    "value": 1.0,
-                    "error": 0.1,
-                    "key": "FOPR",
-                    "date": "2024-01-15",
-                    "shape_id": None,
-                },
-            ],
-        },
-    }
-    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+    old_path = ensemble_dir / "observation_scaling_factors.parquet"
+    pl.DataFrame(
+        {
+            "index": ["r0", "r1"],
+            "obs_key": ["OBS_1", "OBS_2"],
+            "scaling_factor": pl.Series([2.0, 3.0], dtype=pl.Float32),
+        }
+    ).write_parquet(old_path)
 
     migrate(root)
 
-    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
-    assert updated == index_data
+    blob_meta_files = list((ensemble_dir / "blobs").glob("*.blob.json"))
+    assert len(blob_meta_files) == 1
 
-
-def test_that_migration_handles_experiments_without_observations(tmp_path):
-    root = tmp_path / "project"
-    root.mkdir()
-
-    exp_path = root / "experiments" / "exp1"
-    exp_path.mkdir(parents=True)
-
-    index_data = {
-        "id": "exp-id",
-        "name": "exp1",
-        "ensembles": [],
-        "experiment": {
-            "experiment_type": "Ensemble Experiment",
-            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
-        },
-    }
-    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
-
-    migrate(root)
-
-    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
-    assert updated == index_data
-
-
-def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
-    root = tmp_path / "project"
-    root.mkdir()
-
-    exp_path = root / "experiments" / "exp1"
-    exp_path.mkdir(parents=True)
-
-    index_data = {
-        "id": "exp-id",
-        "name": "exp1",
-        "ensembles": [],
-        "experiment": {
-            "experiment_type": "Ensemble Experiment",
-            "observations": [
-                {
-                    "type": "summary_observation",
-                    "name": "FOPR_1",
-                    "value": 1.0,
-                    "error": 0.1,
-                    "key": "FOPR",
-                    "date": "2024-01-15",
-                    "std": 0.5,
-                    "response_key": "FOPR",
-                },
-            ],
-        },
-    }
-    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
-
-    with caplog.at_level(logging.INFO):
-        migrate(root)
-
-    assert "std" in caplog.text
-    assert "response_key" in caplog.text
-    assert str(exp_path / "index.json") in caplog.text
+    meta = _read_blob_metadata(blob_meta_files[0])
+    assert isinstance(meta.blob_info, ScalingFactorsData)
+    assert meta.blob_info.num_observations == 2
+    assert meta.blob_info.num_groups == 1


### PR DESCRIPTION
**Issue**
Resolves backport issue due to migration order https://github.com/equinor/ert/pull/13799


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
