### PR TITLE
backport: Create migration for stripping extra keys from observations

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 30
+_LOCAL_STORAGE_VERSION = 31
 
 
 class _Migrations(BaseModel, extra="forbid"):
@@ -521,6 +521,7 @@ class LocalStorage(BaseMode):
             to28,
             to29,
             to30,
+            to31,
         )
 
         try:  # noqa: PLW0717
@@ -580,6 +581,7 @@ class LocalStorage(BaseMode):
                     27: to28,
                     28: to29,
                     29: to30,
+                    30: to31,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to31.py
+++ b/src/ert/storage/migration/to31.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+info = "Strip fields not in the observation models from experiment observations"
+
+_ALLOWED_OBSERVATION_KEYS: dict[str, frozenset[str]] = {
+    "summary_observation": frozenset(
+        {
+            "type",
+            "name",
+            "value",
+            "error",
+            "key",
+            "date",
+            "shape_id",
+            "error_mode",
+            "error_min",
+        }
+    ),
+    "general_observation": frozenset(
+        {
+            "type",
+            "name",
+            "data",
+            "value",
+            "error",
+            "restart",
+            "index",
+            "shape_id",
+        }
+    ),
+    "rft_observation": frozenset(
+        {
+            "type",
+            "name",
+            "well",
+            "date",
+            "property",
+            "value",
+            "error",
+            "east",
+            "north",
+            "tvd",
+            "md",
+            "shape_id",
+            "zone",
+        }
+    ),
+    "breakthrough": frozenset(
+        {
+            "type",
+            "name",
+            "key",
+            "date",
+            "error",
+            "threshold",
+            "shape_id",
+        }
+    ),
+}
+
+
+def _strip_unknown_fields(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
+        return
+
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
+            continue
+
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
+            continue
+
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+        observations = experiment_data.get("observations")
+        if not observations:
+            continue
+
+        stripped_keys: set[str] = set()
+        for observation in observations:
+            allowed_keys = _ALLOWED_OBSERVATION_KEYS.get(observation.get("type"))
+            if allowed_keys is None:
+                logger.warning(
+                    "Cannot migrate observation with unknown type "
+                    f"{observation.get('type')} in {index_file}"
+                )
+                continue
+
+            unknown_keys = [key for key in observation if key not in allowed_keys]
+            for key in unknown_keys:
+                observation.pop(key)
+            stripped_keys.update(unknown_keys)
+
+        if stripped_keys:
+            logger.info(
+                "Stripped fields not in the observation models from %s: %s",
+                index_file,
+                ", ".join(sorted(stripped_keys)),
+            )
+            index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+
+
+def migrate(path: Path) -> None:
+    _strip_unknown_fields(path)

--- a/tests/ert/unit_tests/storage/migration/test_to31.py
+++ b/tests/ert/unit_tests/storage/migration/test_to31.py
@@ -1,0 +1,194 @@
+import json
+import logging
+
+import numpy as np
+
+from ert.storage.migration.to31 import migrate
+
+
+def test_that_migration_removes_fields_not_in_observation_models(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "shape_id": None,
+                    "some_future_unknown_field": {"foo": "bar"},
+                    "std": 0.5,
+                },
+                {
+                    "type": "general_observation",
+                    "name": "GEN_1",
+                    "data": "POLY_RES",
+                    "value": 2.0,
+                    "error": 0.2,
+                    "restart": 0,
+                    "index": 3,
+                    "shape_id": None,
+                    "response_key": "POLY_RES",
+                    "report_step": 0,
+                },
+                {
+                    "type": "rft_observation",
+                    "name": "RFT_1",
+                    "well": "OP_1",
+                    "date": "2024-01-15",
+                    "property": "PRESSURE",
+                    "value": 250.0,
+                    "error": 5.0,
+                    "east": 123.5,
+                    "north": 456.7,
+                    "tvd": 2500.0,
+                    "md": None,
+                    "shape_id": None,
+                    "zone": None,
+                    "radius": 3000.0,
+                },
+                {
+                    "type": "breakthrough",
+                    "name": "BT_1",
+                    "key": "FWPR",
+                    "date": "2024-01-15T00:00:00",
+                    "error": 0.1,
+                    "threshold": 0.5,
+                    "shape_id": None,
+                    "obsolete_key": "remove me",
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    observations = updated["experiment"]["observations"]
+
+    summary, general, rft, breakthrough = observations
+
+    assert "some_future_unknown_field" not in summary
+    assert "std" not in summary
+    assert summary["key"] == "FOPR"
+    assert np.isclose(summary["value"], 1.0)
+
+    assert "response_key" not in general
+    assert "report_step" not in general
+    assert general["data"] == "POLY_RES"
+    assert general["index"] == 3
+
+    assert "radius" not in rft
+    assert rft["well"] == "OP_1"
+    assert np.isclose(rft["east"], 123.5)
+
+    assert "obsolete_key" not in breakthrough
+    assert np.isclose(breakthrough["threshold"], 0.5)
+
+
+def test_that_migration_leaves_observations_with_only_known_fields_untouched(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "shape_id": None,
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_handles_experiments_without_observations(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "observations": [
+                {
+                    "type": "summary_observation",
+                    "name": "FOPR_1",
+                    "value": 1.0,
+                    "error": 0.1,
+                    "key": "FOPR",
+                    "date": "2024-01-15",
+                    "std": 0.5,
+                    "response_key": "FOPR",
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        migrate(root)
+
+    assert "std" in caplog.text
+    assert "response_key" in caplog.text
+    assert str(exp_path / "index.json") in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
Backport of https://github.com/equinor/ert/pull/13799

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
