### PR TITLE
Remove RuntimeError for data type widgets

### DIFF
--- a/src/ert/gui/ertwidgets/searchbox.py
+++ b/src/ert/gui/ertwidgets/searchbox.py
@@ -112,13 +112,12 @@ class SearchBox(QLineEdit):
     @override
     def resizeEvent(self, a0: QResizeEvent | None) -> None:
         style = self.style()
-        if style is None:
-            raise RuntimeError("SearchBox style is unexpectedly None")
-        frame_width = style.pixelMetric(QStyle.PixelMetric.PM_DefaultFrameWidth)
-        self._pending_indicator.move(
-            self.rect().right() - frame_width - self._pending_indicator.width(),
-            int((self.height() - self._pending_indicator.height()) / 2),
-        )
+        if style:
+            frame_width = style.pixelMetric(QStyle.PixelMetric.PM_DefaultFrameWidth)
+            self._pending_indicator.move(
+                self.rect().right() - frame_width - self._pending_indicator.width(),
+                int((self.height() - self._pending_indicator.height()) / 2),
+            )
 
         QLineEdit.resizeEvent(self, a0)
 

--- a/src/ert/gui/plotting/widgets/data_type_keys_widget.py
+++ b/src/ert/gui/plotting/widgets/data_type_keys_widget.py
@@ -149,9 +149,8 @@ class DataTypeKeysWidget(QWidget):
         self.data_type_keys_widget = QListView()
         self.data_type_keys_widget.setModel(self.filter_model)
         self._sel_model = self.data_type_keys_widget.selectionModel()
-        if not self._sel_model:
-            raise RuntimeError("Selection model was not defined")
-        self._sel_model.currentChanged.connect(self.itemSelected)
+        if self._sel_model:
+            self._sel_model.currentChanged.connect(self.itemSelected)
 
         layout.addSpacing(15)
         layout.addWidget(self.data_type_keys_widget, 2)


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
Removed `if not, raise RuntimeError`-pattern




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

