### PR TITLE
Drop raising when responses are empty

### DIFF
--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -11,7 +11,7 @@ from ert.substitutions import substitute_runpath_name
 from ._read_summary import read_summary
 from .parsing import ConfigDict, ConfigKeys
 from .parsing.config_errors import ConfigValidationError, ConfigWarning
-from .response_config import InvalidResponseFile, ResponseConfig
+from .response_config import ResponseConfig
 from .responses_index import responses_index
 
 logger = logging.getLogger(__name__)
@@ -29,21 +29,11 @@ class SummaryConfig(ResponseConfig):
     @field_validator("keys", mode="before")
     @classmethod
     def dedupe_and_sort_keys(cls, keys: list[str]) -> list[str]:
-        if len(keys) < 1:
-            raise ValueError("SummaryConfig must be given at least one key")
-
         return sorted(set(keys))
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         filename = substitute_runpath_name(self.input_files[0], iens, iter_)
         _, keys, time_map, data = read_summary(f"{run_path}/{filename}", self.keys)
-        if len(data) == 0 or len(keys) == 0:
-            # https://github.com/equinor/ert/issues/6974
-            # There is a bug with storing empty responses so we have
-            # to raise an error in that case
-            raise InvalidResponseFile(
-                f"Did not find any summary values matching {self.keys} in {filename}"
-            )
 
         # Important: Pick lowest unit resolution to allow for using
         # datetimes many years into the future

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -874,12 +874,6 @@ class LocalEnsemble(BaseMode):
                 f"must contain a 'values' variable"
             )
 
-        if len(data) == 0:
-            raise ValueError(
-                f"Responses {response_type} are empty. "
-                "Cannot proceed with saving to storage."
-            )
-
         if "realization" not in data.columns:
             data.insert_column(
                 0,

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -95,42 +95,6 @@ def test_that_loading_non_existing_ensemble_throws(tmp_path):
             experiment.get_ensemble_by_name("non-existing-ensemble")
 
 
-def test_that_saving_empty_responses_fails_nicely(tmp_path):
-    with open_storage(tmp_path, mode="w") as storage:
-        experiment = storage.create_experiment()
-        ensemble = storage.create_ensemble(
-            experiment, ensemble_size=1, iteration=0, name="prior"
-        )
-
-        # Test for entirely empty dataset
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Dataset for response group 'RESPONSE' must contain a 'values' variable"
-            ),
-        ):
-            ensemble.save_response("RESPONSE", pl.DataFrame(), 0)
-
-        # Test for dataset with 'values' but no actual data
-        empty_data = pl.DataFrame(
-            {
-                "response_key": [],
-                "report_step": [],
-                "index": [],
-                "values": [],
-            }
-        )
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Responses RESPONSE are empty\\. "
-                "Cannot proceed with saving to storage\\."
-            ),
-        ):
-            ensemble.save_response("RESPONSE", empty_data, 0)
-
-
 def test_that_local_ensemble_save_parameter_raises_value_error_given_xr_array_dataset(
     tmp_path,
 ):
@@ -1812,7 +1776,7 @@ response_configs = st.lists(
                 min_size=1,
                 max_size=1,
             ),
-            keys=st.lists(summary_selectors, min_size=1),
+            keys=st.lists(summary_selectors, min_size=0),
         ),
     ),
     unique_by=lambda x: x.type,
@@ -2183,7 +2147,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
             raise AssertionError
 
         expected_summary_keys = (
-            st.just(smry_config.keys)
+            st.just(["TIME", *smry_config.keys])
             if smry_config.has_finalized_keys
             else st.lists(summary_variables(), min_size=1)
         )
@@ -2216,11 +2180,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         smspec.to_file(self.tmpdir + f"/{summary.input_files[0]}.SMSPEC")
         unsmry.to_file(self.tmpdir + f"/{summary.input_files[0]}.UNSMRY")
 
-        try:
-            ds = summary.read_from_file(self.tmpdir, self.iens_to_edit, 0)
-        except Exception as e:  # no match in keys
-            assume(False)
-            raise AssertionError from e
+        ds = summary.read_from_file(self.tmpdir, self.iens_to_edit, 0)
         storage_ensemble.save_response(summary.type, ds, self.iens_to_edit)
 
         model_ensemble.response_values[summary.type] = ds


### PR DESCRIPTION

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
