### PR TITLE
Filter out empty locations for suggestor message

### DIFF
--- a/src/ert/gui/ertwidgets/suggestor/_suggestor_message.py
+++ b/src/ert/gui/ertwidgets/suggestor/_suggestor_message.py
@@ -72,7 +72,7 @@ class SuggestorMessage(QWidget):
 
         self._icon = icon
         self._message = message.replace("<", "&lt;").replace(">", "&gt;")
-        self._locations = locations
+        self._locations = [loc for loc in locations if loc]
 
         if self._locations and not self._locations[0]:
             self._locations.pop(0)

--- a/tests/ert/unit_tests/gui/test_suggestor.py
+++ b/tests/ert/unit_tests/gui/test_suggestor.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import QApplication, QPushButton, QWidget
 
 from ert.config import ErrorInfo, WarningInfo
 from ert.gui.ertwidgets import Suggestor
+from ert.gui.ertwidgets.suggestor._suggestor_message import SuggestorMessage
 from ert.gui.ertwidgets.suggestor.suggestor import _CopyAllButton
 
 
@@ -55,3 +56,8 @@ def test_that_copy_all_button_concatenates_errors_warnings_and_deprecations(qtbo
     assert remove_whitespaces(QApplication.clipboard().text()) == remove_whitespaces(
         expected_clipboard
     )
+
+
+def test_that_empty_locations_are_filtered_out_of_the_suggestor_message(qtbot):
+    suggestor_message = SuggestorMessage("", "", "", QWidget(), "", [""] * 20)
+    assert suggestor_message._locations == []


### PR DESCRIPTION
Quick fixup as I found that the suggestor message sometimes contain lots of locations, but when inspecting these, they are just empty strings repeated many times.

Trying to drop down the `show more` button in this window does nothing, as the locations are empty strings:
`["", "", "", "", "", "", ...]`

<img width="600" height="200" alt="image" src="https://github.com/user-attachments/assets/ad84c590-8601-49bd-84be-8359f8907b09" />
