### PR TITLE
Create migration for stripping extra keys from ResponseConfigs

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 32
+_LOCAL_STORAGE_VERSION = 33
 
 
 def open_storage(
@@ -541,6 +541,7 @@ class LocalStorage(BaseMode):
             to30,
             to31,
             to32,
+            to33,
         )
 
         try:  # noqa: PLW0717
@@ -602,6 +603,7 @@ class LocalStorage(BaseMode):
                     29: to30,
                     30: to31,
                     31: to32,
+                    32: to33,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to33.py
+++ b/src/ert/storage/migration/to33.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+info = "Strip fields not in the response config models from experiment responses"
+
+_ALLOWED_RESPONSE_CONFIG_KEYS: dict[str, frozenset[str]] = {
+    "summary": frozenset(
+        {
+            "type",
+            "input_files",
+            "keys",
+            "has_finalized_keys",
+        }
+    ),
+    "gen_data": frozenset(
+        {
+            "type",
+            "input_files",
+            "keys",
+            "report_steps_list",
+            "has_finalized_keys",
+        }
+    ),
+    "rft": frozenset(
+        {
+            "type",
+            "name",
+            "has_finalized_keys",
+            "input_files",
+            "keys",
+            "data_to_read",
+            "zonemap",
+            "approximate_missing_values",
+        }
+    ),
+    "everest_constraints": frozenset(
+        {
+            "type",
+            "has_finalized_keys",
+            "input_files",
+            "keys",
+            "scales",
+            "targets",
+            "upper_bounds",
+            "lower_bounds",
+        }
+    ),
+    "everest_objectives": frozenset(
+        {
+            "type",
+            "has_finalized_keys",
+            "input_files",
+            "keys",
+            "scales",
+            "weights",
+            "objective_types",
+        }
+    ),
+    "breakthrough": frozenset(
+        {
+            "type",
+            "keys",
+            "summary_keys",
+            "thresholds",
+            "observed_dates",
+            "has_finalized_keys",
+        }
+    ),
+}
+
+
+def _strip_unknown_fields(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
+        return
+
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
+            continue
+
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
+            continue
+
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+
+        response_lists = [
+            experiment_data.get("response_configuration"),
+            experiment_data.get("derived_response_configuration"),
+        ]
+
+        stripped_keys: set[str] = set()
+        for response_list in response_lists:
+            if not response_list:
+                continue
+
+            for response_config in response_list:
+                allowed_keys = _ALLOWED_RESPONSE_CONFIG_KEYS.get(
+                    response_config.get("type")
+                )
+                if allowed_keys is None:
+                    logger.warning(
+                        "Cannot migrate response config with unknown type "
+                        f"{response_config.get('type')} in {index_file}"
+                    )
+                    continue
+
+                unknown_keys = [
+                    key for key in response_config if key not in allowed_keys
+                ]
+                for key in unknown_keys:
+                    response_config.pop(key)
+                stripped_keys.update(unknown_keys)
+
+        if stripped_keys:
+            logger.info(
+                "Stripped fields not in the response config models from %s: %s",
+                index_file,
+                ", ".join(sorted(stripped_keys)),
+            )
+            index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+
+
+def migrate(path: Path) -> None:
+    _strip_unknown_fields(path)

--- a/tests/ert/unit_tests/storage/migration/test_to33.py
+++ b/tests/ert/unit_tests/storage/migration/test_to33.py
@@ -1,0 +1,228 @@
+import json
+import logging
+
+from ert.storage.migration.to33 import migrate
+
+
+def test_that_migration_removes_fields_not_in_response_config_models(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "response_configuration": [
+                {
+                    "type": "summary",
+                    "input_files": ["CASE"],
+                    "keys": ["FOPR"],
+                    "has_finalized_keys": True,
+                    "legacy_summary_key": "remove me",
+                },
+                {
+                    "type": "gen_data",
+                    "input_files": ["gen_%d.out"],
+                    "keys": ["GEN_1"],
+                    "report_steps_list": [[0, 1]],
+                    "has_finalized_keys": True,
+                    "report_step": 0,
+                },
+                {
+                    "type": "rft",
+                    "name": "rft",
+                    "input_files": ["CASE.DATA"],
+                    "keys": ["RFT_KEY"],
+                    "has_finalized_keys": False,
+                    "data_to_read": {"OP_1": {"*": ["PRESSURE"]}},
+                    "zonemap": None,
+                    "approximate_missing_values": True,
+                    "response_key": "RFT_KEY",
+                    "locations": [12, 12, 12],
+                },
+            ],
+            "derived_response_configuration": [
+                {
+                    "type": "breakthrough",
+                    "keys": ["BT_1"],
+                    "summary_keys": ["FWPR"],
+                    "thresholds": [0.5],
+                    "observed_dates": ["2024-01-15T00:00:00"],
+                    "has_finalized_keys": True,
+                    "deprecated": True,
+                },
+                {
+                    "type": "everest_constraints",
+                    "input_files": ["constraints.txt"],
+                    "keys": ["CONS_1"],
+                    "scales": [1.0],
+                    "targets": [0.0],
+                    "upper_bounds": [1.0],
+                    "lower_bounds": [None],
+                    "has_finalized_keys": True,
+                    "max_submit": 1,
+                },
+                {
+                    "type": "everest_objectives",
+                    "input_files": ["objectives.txt"],
+                    "keys": ["OBJ_1"],
+                    "scales": [1.0],
+                    "weights": [1.0],
+                    "objective_types": ["mean"],
+                    "has_finalized_keys": True,
+                    "random_seed": 123,
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    responses = updated["experiment"]["response_configuration"]
+    derived_responses = updated["experiment"]["derived_response_configuration"]
+
+    summary, gen_data, rft = responses
+    breakthrough, everest_constraints, everest_objectives = derived_responses
+
+    assert "legacy_summary_key" not in summary
+    assert summary["keys"] == ["FOPR"]
+
+    assert "report_step" not in gen_data
+    assert gen_data["report_steps_list"] == [[0, 1]]
+
+    assert "response_key" not in rft
+    assert rft["approximate_missing_values"] is True
+
+    assert "deprecated" not in breakthrough
+    assert breakthrough["summary_keys"] == ["FWPR"]
+
+    assert "max_submit" not in everest_constraints
+    assert everest_constraints["upper_bounds"] == [1.0]
+
+    assert "random_seed" not in everest_objectives
+    assert everest_objectives["objective_types"] == ["mean"]
+
+
+def test_that_migration_leaves_response_configs_with_only_known_fields_untouched(
+    tmp_path,
+):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "response_configuration": [
+                {
+                    "type": "summary",
+                    "input_files": ["CASE"],
+                    "keys": ["FOPR"],
+                    "has_finalized_keys": True,
+                },
+            ],
+            "derived_response_configuration": [
+                {
+                    "type": "breakthrough",
+                    "keys": ["BT_1"],
+                    "summary_keys": ["FWPR"],
+                    "thresholds": [0.5],
+                    "observed_dates": ["2024-01-15T00:00:00"],
+                    "has_finalized_keys": True,
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_handles_experiments_without_response_configs(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "parameter_configuration": [{"type": "gen_kw", "name": "PARAM1"}],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    assert updated == index_data
+
+
+def test_that_migration_logs_the_stripped_keys(tmp_path, caplog):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            "experiment_type": "Ensemble Experiment",
+            "response_configuration": [
+                {
+                    "type": "rft",
+                    "name": "rft",
+                    "input_files": ["CASE.DATA"],
+                    "keys": ["RFT_KEY"],
+                    "has_finalized_keys": False,
+                    "data_to_read": {"OP_1": {"*": ["PRESSURE"]}},
+                    "zonemap": None,
+                    "approximate_missing_values": True,
+                    "response_key": "RFT_KEY",
+                    "report_step": 0,
+                },
+            ],
+            "derived_response_configuration": [
+                {
+                    "type": "breakthrough",
+                    "keys": ["BT_1"],
+                    "summary_keys": ["FWPR"],
+                    "thresholds": [0.5],
+                    "observed_dates": ["2024-01-15T00:00:00"],
+                    "has_finalized_keys": True,
+                    "deprecated": True,
+                },
+            ],
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        migrate(root)
+
+    assert "response_key" in caplog.text
+    assert "report_step" in caplog.text
+    assert "deprecated" in caplog.text
+    assert str(exp_path / "index.json") in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
