### PR TITLE
Fix rft obs deactivated by other obs in grid gap

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -50,8 +50,8 @@ RFTProperty: TypeAlias = str
 
 @dataclass(frozen=True)
 class WellConnectionCell:
-    grid_index: GridIndex
-    cell_center: Point
+    grid_index: GridIndex | None
+    cell_center: Point | None
 
 
 # The egrid and zonemap are needed in both ``read_from_file`` and
@@ -162,15 +162,15 @@ class RFTConfig(ResponseConfig):
             strict=True,
         ):
             if cell is None:
-                raise InvalidResponseFile(
-                    f"Did not find grid coordinate for location(s) {location}"
+                location_cell_map[location] = WellConnectionCell(
+                    None,
+                    None,
                 )
-            # cells returned by grid are 0-based, while zonemap
-            # and RFTEntry.connections are 1-based, so unifying
-            location_cell_map[location] = WellConnectionCell(
-                (cell[0] + 1, cell[1] + 1, cell[2] + 1),
-                grid.cell_corners(*cell).mean(axis=0),
-            )
+            else:
+                location_cell_map[location] = WellConnectionCell(
+                    (cell[0] + 1, cell[1] + 1, cell[2] + 1),
+                    tuple(grid.cell_corners(*cell).mean(axis=0)),
+                )
         return location_cell_map
 
     @staticmethod
@@ -415,15 +415,18 @@ class RFTConfig(ResponseConfig):
 
         location_cell_map = self._map_locations_to_cells(grid_filepath, locations)
 
+        def _get_zone_list(loc: Point) -> list[str]:
+            grid_index = location_cell_map[loc].grid_index
+            if grid_index is None:
+                return []
+            return zonemap.get(grid_index[-1], [])
+
         return pl.DataFrame(
             {
                 "east": [loc[0] for loc in locations],
                 "north": [loc[1] for loc in locations],
                 "tvd": [loc[2] for loc in locations],
-                "actual_zones": [
-                    zonemap.get(location_cell_map[loc].grid_index[-1], [])
-                    for loc in locations
-                ],
+                "actual_zones": [_get_zone_list(loc) for loc in locations],
                 "well_connection_cell": [
                     location_cell_map[loc].grid_index for loc in locations
                 ],

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -537,9 +537,7 @@ def test_that_connection_cells_are_processed_independently(mock_resfo_file):
     assert observation_metadata["actual_zones"].to_list() == [[]]
 
 
-def test_that_location_outside_of_the_grid_raises_invalid_response_file(
-    mock_resfo_file, egrid
-):
+def test_that_location_outside_of_the_grid_maps_to_none(mock_resfo_file, egrid):
     config = ErtConfig.from_dict(
         {
             "ECLBASE": "ECLBASE<IENS>",
@@ -548,7 +546,7 @@ def test_that_location_outside_of_the_grid_raises_invalid_response_file(
                 [
                     {
                         "type": ObservationType.RFT,
-                        "name": "NAME",
+                        "name": "Outside_grid",
                         "WELL": "WELL",
                         "VALUE": "700",
                         "ERROR": "0.1",
@@ -557,6 +555,18 @@ def test_that_location_outside_of_the_grid_raises_invalid_response_file(
                         "NORTH": 1000.0,
                         "EAST": 1000.0,
                         "TVD": 1500.0,
+                    },
+                    {
+                        "type": ObservationType.RFT,
+                        "name": "Inside_grid",
+                        "WELL": "WELL",
+                        "VALUE": "700",
+                        "ERROR": "0.1",
+                        "DATE": "2000-01-01",
+                        "PROPERTY": "PRESSURE",
+                        "NORTH": 1.0,
+                        "EAST": 1.0,
+                        "TVD": 1.5,
                     },
                 ],
             ),
@@ -570,8 +580,17 @@ def test_that_location_outside_of_the_grid_raises_invalid_response_file(
 
     rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])
     observations = pl.DataFrame(config.observation_declarations)
-    with pytest.raises(InvalidResponseFile, match="Did not find grid coordinate"):
-        rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
+    observation_metadata = rft_config.obtain_location_metadata(
+        "/tmp/does_not_exist", 1, 1, observations
+    )
+    assert observation_metadata.row(0, named=True) == {
+        "east": 1000.0,
+        "north": 1000.0,
+        "tvd": 1500.0,
+        "actual_zones": [],
+        "well_connection_cell": None,
+        "well_connection_cell_center": None,
+    }
 
 
 def test_that_handle_rft_observations_prioritize_provided_radius_over_default():


### PR DESCRIPTION
Due to the mathematical representation of grid cells, there can be gaps between cells. If an RFT observation was located in such a gap, it would disable all other RFT observations as well due to the error raised in _map_locations_to_cells. This commit changes the behavior so that only the affected RFT observation is deactivated, while the other RFT observations remain active.

**Issue**
Resolves #13834 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
