### PR TITLE
Increase ORPHAN_KILL_DELAY in scheduler to five minutes

### DIFF
--- a/src/ert/scheduler/scheduler.py
+++ b/src/ert/scheduler/scheduler.py
@@ -63,7 +63,7 @@ class Scheduler:
     BATCH_KILLING_INTERVAL = 1.5
 
     # Seconds for driver to report job as finished after checksum arrival
-    ORPHAN_KILL_DELAY = 60
+    ORPHAN_KILL_DELAY = 300
 
     def __init__(
         self,


### PR DESCRIPTION
**Issue**
60s might not be enough, maybe there are some delays on the cluster. 

**Approach**
⏫ 

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
