### PR TITLE
Reduce logging of private args overwriting global args in create_forward_model_json

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -205,13 +205,22 @@ def create_forward_model_json(
     def handle_default(fm_step: ForwardModelStep, arg: str) -> str:
         return fm_step.default_mapping.get(arg, arg)
 
+    fm_steps_with_overwritten_globals: list[dict[str, Any]] = []
     for fm_step in forward_model_steps:
-        for key, val in fm_step.private_args.items():
-            if key in context and key != val and context[key] != val:
-                logger.info(
-                    f"Private arg '{key}':'{val}' chosen over"
-                    f" global '{context[key]}' in forward model step {fm_step.name}"
-                )
+        overwritten_keys = {
+            key: {"private_arg": val, "global_arg": context[key]}
+            for key, val in fm_step.private_args.items()
+            if key in context and key != val and context[key] != val
+        }
+        if overwritten_keys:
+            fm_steps_with_overwritten_globals.append(
+                {"forward_model_step_name": fm_step.name, "key": overwritten_keys}
+            )
+    if fm_steps_with_overwritten_globals:
+        logger.info(
+            "Private args chosen over global args for the following "
+            f"forward model steps and variables: {fm_steps_with_overwritten_globals}"
+        )
     config_file_path = Path(user_config_file) if user_config_file is not None else None
     config_path = str(config_file_path.parent) if config_file_path else ""
     config_file = str(config_file_path.name) if config_file_path else ""

--- a/tests/ert/unit_tests/config/test_create_forward_model_json.py
+++ b/tests/ert/unit_tests/config/test_create_forward_model_json.py
@@ -606,13 +606,27 @@ def test_that_private_over_global_args_gives_logging_message(caplog):
         ),
         encoding="utf-8",
     )
-
+    Path("step_file").write_text(
+        "EXECUTABLE echo\nARGLIST <VAR1> <VAR2> <VAR3>\n", encoding="utf-8"
+    )
+    Path("step_file2").write_text(
+        "EXECUTABLE echo\nARGLIST <VAR1> <VAR2> <VAR3> <VAR4>\n", encoding="utf-8"
+    )
     # Write a minimal config file
     Path("config_file.ert").write_text(
         "NUM_REALIZATIONS 1\n"
         "DEFINE <ARG> A\n"
         "INSTALL_JOB job_name job_file\n"
-        "FORWARD_MODEL job_name(<ARG>=B)",
+        "FORWARD_MODEL job_name(<ARG>=B)\n"
+        "DEFINE <VAR1> 10\n"
+        "DEFINE <VAR2> 20\n"
+        "DEFINE <VAR3> 55\n"
+        "DEFINE <VAR4> 105\n"
+        "INSTALL_JOB step_name step_file\n"
+        "INSTALL_JOB step_name2 step_file2\n"
+        "FORWARD_MODEL step_name(<VAR1>=10, <VAR2>=<VAR2>, <VAR3>=5)\n"
+        "FORWARD_MODEL step_name2(<VAR1>=10, <VAR2>=<VAR2>, <VAR3>=7, <VAR4>=100)\n"
+        "FORWARD_MODEL step_name(<VAR1>=10, <VAR2>=<VAR2>, <VAR3>=6)\n",
         encoding="utf-8",
     )
 
@@ -627,9 +641,28 @@ def test_that_private_over_global_args_gives_logging_message(caplog):
 
     fm_data = data["jobList"][0]
 
-    assert len(ert_config.forward_model_steps) == 1
+    assert len(ert_config.forward_model_steps) == 4
     assert fm_data["argList"] == ["B"]
-    assert "Private arg '<ARG>':'B' chosen over global 'A'" in caplog.text
+    private_args_messages = [
+        msg for msg in caplog.messages if "Private args chosen over global args" in msg
+    ]
+    assert len(private_args_messages) == 1
+    message = private_args_messages[0]
+    assert (
+        "Private args chosen over global args for the following forward model "
+        "steps and variables: ["
+        "{'forward_model_step_name': 'job_name', "
+        "'key': {'<ARG>': {'private_arg': 'B', 'global_arg': 'A'}}}, "
+        "{'forward_model_step_name': 'step_name', "
+        "'key': {'<VAR3>': {'private_arg': '5', 'global_arg': '55'}}}, "
+        "{'forward_model_step_name': 'step_name2', "
+        "'key': {'<VAR3>': {'private_arg': '7', 'global_arg': '55'}, "
+        "'<VAR4>': {'private_arg': '100', 'global_arg': '105'}}}, "
+        "{'forward_model_step_name': 'step_name', "
+        "'key': {'<VAR3>': {'private_arg': '6', 'global_arg': '55'}}}]"
+    ) in message
+    assert "'<VAR1>'" not in message
+    assert "'<VAR2>'" not in message
 
 
 @pytest.mark.usefixtures("use_tmpdir")
@@ -669,7 +702,7 @@ def test_that_private_over_global_args_does_not_give_logging_message_for_argpass
     fm_data = data["jobList"][0]
     assert len(ert_config.forward_model_steps) == 1
     assert fm_data["argList"] == ["A"]
-    assert "Private arg '<ARG>':'<ARG>' chosen over global 'A'" not in caplog.text
+    assert "Private args chosen over global args" not in caplog.text
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -1508,17 +1508,11 @@ def test_validate_no_logs_when_overwriting_with_same_value(caplog):
         )
 
     assert (
-        "Private arg '<VAR3>':'5' chosen over global '55' "
-        "in forward model step step_name"
+        "{'forward_model_step_name': 'step_name', 'key': {'<VAR3>': "
+        "{'private_arg': '5', 'global_arg': '55'}}}"
     ) in caplog.text
-    assert (
-        "Private arg '<VAR1>':'10' chosen over global '10' "
-        "in forward model step step_name"
-    ) not in caplog.text
-    assert (
-        "Private arg '<VAR2>':'20' chosen over global '20' "
-        "in forward model step step_name"
-    ) not in caplog.text
+    assert ("'<VAR1>': {'private_arg':") not in caplog.text
+    assert ("'<VAR2>': {'private_arg':") not in caplog.text
 
 
 def test_that_unresolved_forward_model_placeholders_are_logged_at_startup(caplog):


### PR DESCRIPTION
**Issue**
Resolves [#154](https://github.com/equinor/scout/issues/1549)


**Approach**
This commit reduces the logging by creating a list of all forward_model_steps with their overwrites and logging that list once, instead of logging every overwrite separately.


(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
