### PR TITLE
Stop fuzzing during unit test

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ ert-memory-tests:
     _RJEM_MALLOC_CONF="dirty_decay_ms:100,muzzy_decay_ms:100" pytest -n 2 {{pytest_args}} tests/ert -m "limit_memory" --memray
 
 ert-unit-tests:
-    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not (memory_test or limit_memory)"
+    pytest {{pytest_args}} -n 4 --dist loadgroup --benchmark-disable tests/ert/unit_tests tests/ert/performance_tests -m "not (memory_test or limit_memory or fuzzing)"
 
 ert-doc-tests:
     pytest {{pytest_args}} --doctest-modules src/ --ignore src/ert/dark_storage


### PR DESCRIPTION
I've noticed in other PRs that you find for example fuzzing test `TestStorage` and `TestDarkStorage` being run under both unit tests and fuzzing tests.

I thought we should keep these separated, but please sanity check that no tests are left untested by this change.