### PR TITLE
Remove INTERNAL FALSE from documentation

### DIFF
--- a/docs/ert/reference/workflows/configuring_jobs.rst
+++ b/docs/ert/reference/workflows/configuring_jobs.rst
@@ -39,7 +39,6 @@ executable:
 
 ::
 
-    INTERNAL   FALSE                    -- Optional - Set to FALSE by default.
     EXECUTABLE path/to/program          -- Path to a program/script which will be invoked by the job.
 
 


### PR DESCRIPTION
The example in the documentation will otherwise give a deprecation warning.

Note that the opposite 'INTERNAL TRUE' is not deprecated..

**Issue**
Resolves outdated doc


**Approach**
👓 📖 🔪 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
