### PR TITLE
Expose blobs through dark storage ensemble API

### DIFF
--- a/src/ert/dark_storage/endpoints/ensembles.py
+++ b/src/ert/dark_storage/endpoints/ensembles.py
@@ -2,11 +2,12 @@ import logging
 from collections import Counter
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Response
 
 from ert.dark_storage import json_schema as js
 from ert.dark_storage.common import get_storage, reraise_as_http_errors
 from ert.storage import Storage
+from ert.storage.blob_data import BlobStorageData
 
 router = APIRouter(tags=["ensemble"])
 logger = logging.getLogger(__name__)
@@ -38,4 +39,32 @@ def get_ensemble(
         realization_storage_states=Counter(
             state for states in ensemble.get_ensemble_state() for state in states
         ),
+    )
+
+
+@router.get("/ensembles/{ensemble_id}/blobs")
+def get_blobs(
+    *,
+    storage: Storage = DEFAULT_STORAGE,
+    ensemble_id: UUID,
+) -> list[BlobStorageData]:
+    with reraise_as_http_errors(logger):
+        ensemble = storage.get_ensemble(ensemble_id)
+        return ensemble.load_blobs()
+
+
+@router.get("/ensembles/{ensemble_id}/blobs/{uri}")
+def get_blob(
+    *,
+    storage: Storage = DEFAULT_STORAGE,
+    ensemble_id: UUID,
+    uri: str,
+) -> Response:
+    with reraise_as_http_errors(logger):
+        ensemble = storage.get_ensemble(ensemble_id)
+        blob = ensemble.load_blob(uri)
+
+    return Response(
+        content=blob,
+        media_type="application/octet-stream",
     )

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -7,6 +7,7 @@ import pytest
 from requests import Response
 from starlette.testclient import TestClient
 
+from ert.analysis.event import AnalysisCompleteEvent, AnalysisMatrixEvent, DataSection
 from ert.config._observations import SummaryObservation
 from ert.config._shapes import CircleShapeConfig, ShapeRegistry
 from ert.dark_storage.common import get_storage_api_version
@@ -299,6 +300,73 @@ def test_that_experiment_observations_endpoint_returns_localization(
     assert observations_by_name["OBSERVATION_2"]["east"] == [9.5]
     assert observations_by_name["OBSERVATION_2"]["north"] == [3.5]
     assert observations_by_name["OBSERVATION_2"]["radius"] == [20.0]
+
+
+def test_blob_endpoint_includes_matrix_parameter_group_sizes(
+    tmp_path, monkeypatch, dark_storage_app
+):
+    storage_path = tmp_path / "storage"
+
+    with open_storage(storage_path, mode="w") as storage:
+        experiment = storage.create_experiment(name="test-experiment")
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=1, iteration=0, name="test-ensemble"
+        )
+        ensemble.save_blob(
+            AnalysisMatrixEvent(
+                name="K",
+                sparse=False,
+                shape=(2, 2),
+                data_type="float64",
+                update_algorithm="enif",
+                parameter_group_sizes={"PORO": 8, "PERM": 3},
+                matrix_bytes=b"matrix",
+            )
+        )
+        ensemble_id = ensemble.id
+
+    monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage_path))
+
+    with TestClient(dark_storage_app) as client:
+        resp = client.get(f"/ensembles/{ensemble_id}/blobs")
+
+    assert resp.status_code == 200
+
+    [blob] = resp.json()
+    assert blob["name"] == "K"
+    assert blob["blob_info"]["parameter_group_sizes"] == {
+        "PORO": 8,
+        "PERM": 3,
+    }
+
+
+def test_that_blob_endpoint_returns_blob_bytes(tmp_path, monkeypatch, dark_storage_app):
+    storage_path = tmp_path / "storage"
+    with open_storage(storage_path, mode="w") as storage:
+        experiment = storage.create_experiment(name="test-experiment")
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=1, iteration=0, name="test-ensemble"
+        )
+        ensemble.save_blob(
+            AnalysisCompleteEvent(
+                data=DataSection(
+                    header=["observation_key", "status", "value"],
+                    data=[("OBS", "Active", 1.5)],
+                ),
+                update_algorithm="ensemble_smoother",
+            )
+        )
+        blob = ensemble.load_blobs()[0]
+        blob_bytes = ensemble.load_blob(blob.uri)
+        ensemble_id = ensemble.id
+
+    monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage_path))
+    with TestClient(dark_storage_app) as client:
+        resp: Response = client.get(f"/ensembles/{ensemble_id}/blobs/{blob.uri}")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.content == blob_bytes
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Include blob metadata in ensemble responses and add support for downloading stored blob contents by URI.

This lets clients discover blobs associated with an ensemble and retrieve their binary payloads through the dark storage API.

**Issue**
Resolves #13755 


**Approach**
To send blob metadata alongside the ensemble data, the dark storage ensemble response schema was extended with the blob metadata loaded from ensemble storage. The added tests follow similar patterns as other endpoint tests. 

- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
