### PR TITLE
Have fm_dispatch print success to stdout on exit

### DIFF
--- a/src/_ert/forward_model_runner/fm_dispatch.py
+++ b/src/_ert/forward_model_runner/fm_dispatch.py
@@ -225,6 +225,7 @@ def fm_dispatch(args: list[str]) -> None:
 
     signal.signal(signal.SIGTERM, sigterm_handler)
     _report_all_messages(fm_runner.run(parsed_args.steps), reporters)
+    print("fm dispatch completed successfully")
 
 
 def main() -> None:

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -483,3 +483,12 @@ async def test_fm_dispatch_main_signals_sigterm_on_exception(
     assert "forward model critical error" in capsys.readouterr().out
 
     mock_killpg.assert_called_with(17, signal.SIGTERM)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_fm_dispatch_logs_success_before_exiting(
+    capsys: pytest.CaptureFixture[str],
+):
+    write_forward_model_description({"ens_id": "_id_", "jobList": []})
+    fm_dispatch(args=[])
+    assert "fm dispatch completed successfully" in capsys.readouterr().out


### PR DESCRIPTION
This should make it easier to see if it is fm_dispatch or the cluster hanging on orphan processes

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
