### PR TITLE
Use blobs in experiment storage for rho matrices

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 
     from ert.config import ParameterConfig
     from ert.storage import Ensemble
+    from ert.storage.local_experiment import LocalExperiment
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +216,9 @@ def perform_ensemble_update(
             ypos=filtered_data["north"].to_numpy()[has_location],
             main_range=filtered_data["radius"].to_numpy()[has_location],
             location_mask=has_location,
+            observation_keys=filtered_data["observation_key"]
+            .to_numpy()[has_location]
+            .tolist(),
         )
 
     obs_context = ObservationContext(
@@ -298,6 +302,7 @@ def build_strategy_map(
     correlation_threshold: Callable[[int], float],
     *,
     progress_callback: Callable[[AnalysisEvent], None] | None = None,
+    experiment: LocalExperiment | None = None,
 ) -> dict[str, UpdateStrategy]:
     """Build a mapping from parameter group names to update strategies.
 
@@ -318,6 +323,8 @@ def build_strategy_map(
         threshold.
     progress_callback : Callable[[AnalysisEvent], None] | None
         Callback for reporting progress.
+    experiment : LocalExperiment | None
+        Optional experiment for loading cached rho matrices.
 
     Returns
     -------
@@ -330,11 +337,11 @@ def build_strategy_map(
     strategy_map: dict[str, UpdateStrategy] = {}
 
     field_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, Field, progress_callback
+        enkf_truncation, Field, progress_callback, experiment
     )
 
     surface_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, SurfaceConfig, progress_callback
+        enkf_truncation, SurfaceConfig, progress_callback, experiment
     )
 
     global_strategy = GlobalESUpdate(

--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import time
 from collections.abc import Callable
 from datetime import timedelta
@@ -9,9 +10,14 @@ from typing import TYPE_CHECKING
 
 import humanize
 import numpy as np
+import scipy as sp
 from iterative_ensemble_smoother import LocalizedESMDA
 
-from ert.analysis.event import AnalysisEvent, AnalysisStatusEvent
+from ert.analysis.event import (
+    AnalysisEvent,
+    AnalysisRhoMatrixEvent,
+    AnalysisStatusEvent,
+)
 from ert.config import Field, SurfaceConfig
 from ert.field_utils import (
     AxisOrientation,
@@ -27,6 +33,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ert.config import ParameterConfig
+    from ert.storage.local_experiment import LocalExperiment
 
     from ._protocol import ObservationContext
 
@@ -39,10 +46,12 @@ class DistanceLocalizationUpdate:
         enkf_truncation: float,
         param_type: type[Field | SurfaceConfig],
         progress_callback: Callable[[AnalysisEvent], None],
+        experiment: LocalExperiment | None = None,
     ) -> None:
         self._enkf_truncation = enkf_truncation
         self._param_type = param_type
         self._progress_callback = progress_callback
+        self._experiment = experiment
         self._obs_loc: ObservationLocations | None = None
         self._smoother: LocalizedESMDA | None = None
         self._ensemble_size: int = 0
@@ -125,6 +134,19 @@ class DistanceLocalizationUpdate:
 
         return result
 
+    def _load_rho_from_storage(
+        self, param_name: str
+    ) -> npt.NDArray[np.floating] | None:
+        """Try to load a cached rho matrix from experiment blob storage."""
+        if self._experiment is None:
+            return None
+        obs_keys = (
+            self._obs_loc.observation_keys
+            if self._obs_loc is not None and self._obs_loc.observation_keys
+            else None
+        )
+        return self._experiment.load_rho_matrix(param_name, obs_keys)
+
     def _full_localization_matrix(
         self,
         num_params: int,
@@ -170,32 +192,50 @@ class DistanceLocalizationUpdate:
         if ertbox.axis_orientation is None:
             raise ValueError("Field grid axis orientation must be defined")
 
-        xpos, ypos = transform_positions_to_local_field_coordinates(
-            ertbox.origin,
-            ertbox.rotation_angle,
-            self._obs_loc.xpos,
-            self._obs_loc.ypos,
-        )
+        cached_rho = self._load_rho_from_storage(param_config.name)
+        if cached_rho is not None:
+            rho_2d = cached_rho
+        else:
+            xpos, ypos = transform_positions_to_local_field_coordinates(
+                ertbox.origin,
+                ertbox.rotation_angle,
+                self._obs_loc.xpos,
+                self._obs_loc.ypos,
+            )
 
-        ellipse_rotation = transform_local_ellipse_angle_to_local_coords(
-            ertbox.rotation_angle,
-            np.zeros_like(self._obs_loc.main_range),
-        )
+            ellipse_rotation = transform_local_ellipse_angle_to_local_coords(
+                ertbox.rotation_angle,
+                np.zeros_like(self._obs_loc.main_range),
+            )
 
-        rho_matrix = calc_rho_for_2d_grid_layer(
-            nx=ertbox.nx,
-            ny=ertbox.ny,
-            xinc=ertbox.xinc,
-            yinc=ertbox.yinc,
-            obs_xpos=xpos,
-            obs_ypos=ypos,
-            obs_main_range=self._obs_loc.main_range,
-            obs_perp_range=self._obs_loc.main_range,
-            obs_anisotropy_angle=ellipse_rotation,
-            axis_orientation=ertbox.axis_orientation,
-        )
+            rho_matrix = calc_rho_for_2d_grid_layer(
+                nx=ertbox.nx,
+                ny=ertbox.ny,
+                xinc=ertbox.xinc,
+                yinc=ertbox.yinc,
+                obs_xpos=xpos,
+                obs_ypos=ypos,
+                obs_main_range=self._obs_loc.main_range,
+                obs_perp_range=self._obs_loc.main_range,
+                obs_anisotropy_angle=ellipse_rotation,
+                axis_orientation=ertbox.axis_orientation,
+            )
 
-        rho_2d = rho_matrix.reshape(ertbox.nx * ertbox.ny, -1)
+            rho_2d = rho_matrix.reshape(ertbox.nx * ertbox.ny, -1)
+
+            if self._obs_loc.observation_keys:
+                rho_sparse = sp.sparse.csc_matrix(rho_2d)
+                buf = io.BytesIO()
+                sp.sparse.save_npz(buf, rho_sparse)
+                self._progress_callback(
+                    AnalysisRhoMatrixEvent(
+                        param_name=param_config.name,
+                        observation_keys=self._obs_loc.observation_keys,
+                        shape=rho_2d.shape,
+                        data_type=str(rho_2d.dtype),
+                        matrix_bytes=buf.getvalue(),
+                    )
+                )
 
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
@@ -242,37 +282,56 @@ class DistanceLocalizationUpdate:
 
         assert self._obs_loc is not None
 
-        xpos, ypos = transform_positions_to_local_field_coordinates(
-            (param_config.xori, param_config.yori),
-            param_config.rotation,
-            self._obs_loc.xpos,
-            self._obs_loc.ypos,
-        )
-
-        rotation_angle = transform_local_ellipse_angle_to_local_coords(
-            param_config.rotation,
-            np.zeros_like(self._obs_loc.main_range, dtype=np.float64),
-        )
-
-        if param_config.yflip != 1:
-            raise ValueError(
-                f"Expected SurfaceConfig.yflip == 1, got {param_config.yflip}"
+        cached_rho = self._load_rho_from_storage(param_config.name)
+        if cached_rho is not None:
+            rho_flat = cached_rho
+        else:
+            xpos, ypos = transform_positions_to_local_field_coordinates(
+                (param_config.xori, param_config.yori),
+                param_config.rotation,
+                self._obs_loc.xpos,
+                self._obs_loc.ypos,
             )
 
-        rho_matrix = calc_rho_for_2d_grid_layer(
-            nx=param_config.ncol,
-            ny=param_config.nrow,
-            xinc=param_config.xinc,
-            yinc=param_config.yinc,
-            obs_xpos=xpos,
-            obs_ypos=ypos,
-            obs_main_range=self._obs_loc.main_range,
-            obs_perp_range=self._obs_loc.main_range,
-            obs_anisotropy_angle=rotation_angle,
-            axis_orientation=AxisOrientation.LEFT_HANDED,
-        )
+            rotation_angle = transform_local_ellipse_angle_to_local_coords(
+                param_config.rotation,
+                np.zeros_like(self._obs_loc.main_range, dtype=np.float64),
+            )
 
-        rho_flat = rho_matrix.reshape(-1, rho_matrix.shape[-1])
+            if param_config.yflip != 1:
+                raise ValueError(
+                    f"Expected SurfaceConfig.yflip == 1, got {param_config.yflip}"
+                )
+
+            rho_matrix = calc_rho_for_2d_grid_layer(
+                nx=param_config.ncol,
+                ny=param_config.nrow,
+                xinc=param_config.xinc,
+                yinc=param_config.yinc,
+                obs_xpos=xpos,
+                obs_ypos=ypos,
+                obs_main_range=self._obs_loc.main_range,
+                obs_perp_range=self._obs_loc.main_range,
+                obs_anisotropy_angle=rotation_angle,
+                axis_orientation=AxisOrientation.LEFT_HANDED,
+            )
+
+            rho_flat = rho_matrix.reshape(-1, rho_matrix.shape[-1])
+
+            if self._obs_loc.observation_keys:
+                rho_sparse = sp.sparse.csc_matrix(rho_flat)
+                buf = io.BytesIO()
+                sp.sparse.save_npz(buf, rho_sparse)
+                self._progress_callback(
+                    AnalysisRhoMatrixEvent(
+                        param_name=param_config.name,
+                        observation_keys=self._obs_loc.observation_keys,
+                        shape=rho_flat.shape,
+                        data_type=str(rho_flat.dtype),
+                        matrix_bytes=buf.getvalue(),
+                    )
+                )
+
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
             if update_idx.size == 0:

--- a/src/ert/analysis/_update_strategies/_protocol.py
+++ b/src/ert/analysis/_update_strategies/_protocol.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, Self
 
 import numpy as np
@@ -100,6 +100,9 @@ class ObservationLocations:
 
     location_mask: npt.NDArray[np.bool_]
     """Boolean mask indicating which observations have valid location data."""
+
+    observation_keys: list[str] = field(default_factory=list)
+    """Observation keys for the located observations (same order as xpos/ypos)."""
 
 
 @dataclass(frozen=True)

--- a/src/ert/analysis/event.py
+++ b/src/ert/analysis/event.py
@@ -102,3 +102,12 @@ class AnalysisScalingEvent(AnalysisEvent):
     scaling_bytes: bytes = Field(exclude=True)
     num_observations: int
     num_groups: int
+
+
+class AnalysisRhoMatrixEvent(AnalysisEvent):
+    event_type: Literal["AnalysisRhoMatrixEvent"] = "AnalysisRhoMatrixEvent"
+    param_name: str
+    observation_keys: list[str]
+    shape: tuple[int, int]
+    data_type: str
+    matrix_bytes: bytes = Field(exclude=True)

--- a/src/ert/run_models/update_run_model.py
+++ b/src/ert/run_models/update_run_model.py
@@ -10,6 +10,7 @@ from ert.analysis.event import (
     AnalysisErrorEvent,
     AnalysisEvent,
     AnalysisMatrixEvent,
+    AnalysisRhoMatrixEvent,
     AnalysisScalingEvent,
     AnalysisStatusEvent,
     AnalysisTimeEvent,
@@ -67,6 +68,7 @@ class UpdateRunModel(RunModel, UpdateRunModelConfig):
             enkf_truncation=self.analysis_settings.enkf_truncation,
             correlation_threshold=self.analysis_settings.correlation_threshold,
             progress_callback=progress_callback,
+            experiment=prior.experiment,
         )
 
         smoother_update(
@@ -195,6 +197,8 @@ class UpdateRunModel(RunModel, UpdateRunModelConfig):
                 ensemble.save_blob(event)
             case AnalysisScalingEvent():
                 ensemble.save_blob(event)
+            case AnalysisRhoMatrixEvent():
+                ensemble.experiment.save_blob(event)
             case AnalysisCompleteEvent():
                 ensemble.save_blob(event)
                 self.send_event(

--- a/src/ert/storage/blob_data.py
+++ b/src/ert/storage/blob_data.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import logging
+import os
+import uuid as _uuid
 from enum import StrEnum
-from typing import Annotated, Literal
+from pathlib import Path
+from typing import Annotated, Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Discriminator
+from pydantic import BaseModel, ConfigDict, Discriminator, TypeAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class BlobType(StrEnum):
     OBSERVATION_REPORT = "observation_report"
     MATRIX = "matrix"
     SCALING_FACTORS = "scaling_factors"
+    RHO_MATRIX = "rho_matrix"
 
 
 class ObservationReportData(BaseModel):
@@ -17,8 +24,7 @@ class ObservationReportData(BaseModel):
     update_algorithm: str
 
 
-class MatrixStorageData(BaseModel):
-    blob_type: Literal[BlobType.MATRIX] = BlobType.MATRIX
+class _MatrixBase(BaseModel):
     update_algorithm: str
     sparse: bool = False
     shape: tuple[int, int] = (0, 0)
@@ -26,11 +32,34 @@ class MatrixStorageData(BaseModel):
     parameter_group_sizes: dict[str, int] = {}
 
 
+class MatrixStorageData(_MatrixBase):
+    blob_type: Literal[BlobType.MATRIX] = BlobType.MATRIX
+
+
 class ScalingFactorsData(BaseModel):
     blob_type: Literal[BlobType.SCALING_FACTORS] = BlobType.SCALING_FACTORS
     update_algorithm: str
     num_observations: int
     num_groups: int
+
+
+class RhoStorageData(_MatrixBase):
+    blob_type: Literal[BlobType.RHO_MATRIX] = BlobType.RHO_MATRIX
+    param_name: str
+    observation_keys: list[str] = []
+
+
+BlobInfo = (
+    MatrixStorageData | ObservationReportData | ScalingFactorsData | RhoStorageData
+)
+
+
+# _StorageWriter Protocol avoids importing LocalStorage directly (circular import) while
+#  providing a typed interface for _write_transaction.
+class _StorageWriter(Protocol):
+    def _write_transaction(
+        self, filename: str | os.PathLike[str], data: bytes
+    ) -> None: ...
 
 
 class BlobStorageData(BaseModel):
@@ -41,6 +70,79 @@ class BlobStorageData(BaseModel):
     file_type: str
     name: str
     blob_info: Annotated[
-        MatrixStorageData | ObservationReportData | ScalingFactorsData,
+        MatrixStorageData | ObservationReportData | ScalingFactorsData | RhoStorageData,
         Discriminator("blob_type"),
     ]
+
+    @classmethod
+    def save_blob(
+        cls,
+        *,
+        name: str,
+        data: bytes,
+        blob_info: BlobInfo,
+        file_type: str,
+        storage: _StorageWriter,
+        blob_dir: Path,
+    ) -> BlobStorageData:
+        """Create a blob record and persist *data* plus its JSON sidecar.
+
+        A random 8-hex-character ID is generated; files are written as
+        ``<id>.blob`` and ``<id>.blob.json`` inside *blob_dir*.
+
+        Returns the :class:`BlobStorageData` instance that was persisted.
+        """
+        blob_id = _uuid.uuid4().hex[:8]
+        uri = f"{blob_id}.blob"
+        instance = cls(
+            uri=uri,
+            file_size=len(data),
+            file_type=file_type,
+            name=name,
+            blob_info=blob_info,
+        )
+        blob_dir.mkdir(parents=True, exist_ok=True)
+        storage._write_transaction(blob_dir / uri, data)
+        storage._write_transaction(
+            blob_dir / f"{uri}.json",
+            instance.model_dump_json(indent=2).encode("utf-8"),
+        )
+        return instance
+
+    @classmethod
+    def load_all(
+        cls,
+        blob_dir: Path,
+        blob_type: BlobType | None = None,
+    ) -> list[BlobStorageData]:
+        """Return metadata for every blob in *blob_dir*, optionally filtered by type."""
+        if not blob_dir.exists():
+            return []
+        adapter: TypeAdapter[BlobStorageData] = TypeAdapter(BlobStorageData)
+        results = []
+        for json_path in blob_dir.glob("*.json"):
+            meta = adapter.validate_json(json_path.read_bytes())
+            if blob_type is None or meta.blob_info.blob_type == blob_type:
+                results.append(meta)
+        return results
+
+    @staticmethod
+    def read_bytes(blob_dir: Path, uri: str) -> bytes:
+        """Return raw bytes for the blob identified by *uri* inside *blob_dir*.
+
+        Raises
+        ------
+        FileNotFoundError
+            If *uri* escapes *blob_dir* (path traversal) or does not exist.
+        """
+        resolved_dir = blob_dir.resolve()
+        blob_path = (resolved_dir / uri).resolve()
+        try:
+            blob_path.relative_to(resolved_dir)
+        except ValueError:
+            logger.warning("Blob URI %s resolves outside of blob directory", uri)
+            raise FileNotFoundError(uri) from None
+        if not blob_path.exists():
+            logger.warning("Blob file %s not found", uri)
+            raise FileNotFoundError(uri)
+        return blob_path.read_bytes()

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -6,7 +6,6 @@ import io
 import logging
 import os
 import time
-import uuid as _uuid
 from collections import Counter
 from collections.abc import Iterable
 from datetime import UTC, datetime
@@ -21,7 +20,7 @@ import pandas as pd
 import polars as pl
 import resfo
 import xarray as xr
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from ert.config import (
@@ -65,9 +64,6 @@ if TYPE_CHECKING:
     from .local_storage import LocalStorage
 
 logger = logging.getLogger(__name__)
-
-
-_blob_adapter: TypeAdapter[BlobStorageData] = TypeAdapter(BlobStorageData)
 
 
 class EverestRealizationInfo(TypedDict):
@@ -1340,32 +1336,11 @@ class LocalEnsemble(BaseMode):
         blob_type: BlobType | None = None,
     ) -> list[BlobStorageData]:
         """List blob metadata, filtered by type."""
-        blob_dir = self._path / BLOB_DATA_DIR
-        if not blob_dir.exists():
-            return []
-        results = []
-        for json_path in blob_dir.glob("*.json"):
-            meta = _blob_adapter.validate_json(json_path.read_bytes())
-            if blob_type is None or meta.blob_info.blob_type == blob_type:
-                results.append(meta)
-        return results
+        return BlobStorageData.load_all(self._path / BLOB_DATA_DIR, blob_type)
 
-    def load_blob(
-        self,
-        uri: str,
-    ) -> bytes:
-        """Load blob bytes by URI"""
-        blob_dir = (self._path / BLOB_DATA_DIR).resolve()
-        blob_path = (blob_dir / uri).resolve()
-        try:
-            blob_path.relative_to(blob_dir)
-        except ValueError:
-            logger.warning("Blob URI %s resolves outside of blob directory", uri)
-            raise FileNotFoundError(uri) from None
-        if not blob_path.exists():
-            logger.warning("Blob file %s not found", uri)
-            raise FileNotFoundError(uri)
-        return blob_path.read_bytes()
+    def load_blob(self, uri: str) -> bytes:
+        """Load blob bytes by URI."""
+        return BlobStorageData.read_bytes(self._path / BLOB_DATA_DIR, uri)
 
     @require_write
     def save_blob(
@@ -1373,19 +1348,13 @@ class LocalEnsemble(BaseMode):
         blob_event: AnalysisCompleteEvent | AnalysisMatrixEvent | AnalysisScalingEvent,
     ) -> None:
         blob_dir = self._path / BLOB_DATA_DIR
-        blob_dir.mkdir(parents=True, exist_ok=True)
-        blob_id = _uuid.uuid4().hex[:8]
-        uri = f"{blob_id}.blob"
-        blob_data: BlobStorageData
         if blob_event.event_type == "AnalysisMatrixEvent":
             file_type = (
                 "application/x-npz" if blob_event.sparse else "application/x-npy"
             )
-            blob_data = BlobStorageData(
-                uri=uri,
-                file_size=len(blob_event.matrix_bytes),
-                file_type=file_type,
+            BlobStorageData.save_blob(
                 name=blob_event.name,
+                data=blob_event.matrix_bytes,
                 blob_info=MatrixStorageData(
                     update_algorithm=blob_event.update_algorithm,
                     sparse=blob_event.sparse,
@@ -1393,21 +1362,23 @@ class LocalEnsemble(BaseMode):
                     data_type=blob_event.data_type,
                     parameter_group_sizes=blob_event.parameter_group_sizes,
                 ),
+                file_type=file_type,
+                storage=self._storage,
+                blob_dir=blob_dir,
             )
-            data = blob_event.matrix_bytes
         elif blob_event.event_type == "AnalysisScalingEvent":
-            blob_data = BlobStorageData(
-                uri=uri,
-                file_size=len(blob_event.scaling_bytes),
-                file_type="application/parquet",
+            BlobStorageData.save_blob(
                 name="scaling_factors",
+                data=blob_event.scaling_bytes,
                 blob_info=ScalingFactorsData(
                     update_algorithm=blob_event.update_algorithm,
                     num_observations=blob_event.num_observations,
                     num_groups=blob_event.num_groups,
                 ),
+                file_type="application/parquet",
+                storage=self._storage,
+                blob_dir=blob_dir,
             )
-            data = blob_event.scaling_bytes
         else:
             buf = io.BytesIO()
             pl.DataFrame(
@@ -1415,22 +1386,16 @@ class LocalEnsemble(BaseMode):
                 schema=blob_event.data.header,
                 orient="row",
             ).write_parquet(buf)
-            data = buf.getvalue()
-            blob_data = BlobStorageData(
-                uri=uri,
-                file_size=len(data),
-                file_type="application/parquet",
+            BlobStorageData.save_blob(
                 name="observation_report",
+                data=buf.getvalue(),
                 blob_info=ObservationReportData(
                     update_algorithm=blob_event.update_algorithm,
                 ),
+                file_type="application/parquet",
+                storage=self._storage,
+                blob_dir=blob_dir,
             )
-
-        self._storage._write_transaction(blob_dir / uri, data)
-        self._storage._write_transaction(
-            blob_dir / f"{uri}.json",
-            blob_data.model_dump_json(indent=2).encode("utf-8"),
-        )
 
     @require_write
     def save_batch_dataframes(self, dataframes: BatchDataframes) -> None:

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import logging
 import shutil
@@ -12,7 +13,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import UUID
 
+import numpy as np
+import numpy.typing as npt
 import polars as pl
+import scipy as sp
 from pydantic import BaseModel, Field, TypeAdapter
 from surfio import IrapSurface
 from typing_extensions import TypedDict
@@ -35,9 +39,14 @@ from ert.config._observations import Observation
 from ert.config.parsing.hook_runtime import HookRuntime
 from ert.config.response_config import DerivedResponseConfig
 
+from .blob_data import BlobStorageData, BlobType, RhoStorageData
 from .mode import BaseMode, Mode, require_write
 
+BLOB_DATA_DIR = "blobs"
+
 if TYPE_CHECKING:
+    from ert.analysis.event import AnalysisRhoMatrixEvent
+
     from .local_ensemble import LocalEnsemble
     from .local_storage import LocalStorage
 
@@ -652,6 +661,70 @@ class LocalExperiment(BaseMode):
             if b.has_gradient_results
         ]
 
+    def load_blobs(
+        self,
+        blob_type: BlobType | None = None,
+    ) -> list[BlobStorageData]:
+        """List blob metadata stored at experiment level, filtered by type."""
+        return BlobStorageData.load_all(self._path / BLOB_DATA_DIR, blob_type)
+
+    def load_blob(self, uri: str) -> bytes:
+        """Load blob bytes by URI from the experiment-level blob directory."""
+        return BlobStorageData.read_bytes(self._path / BLOB_DATA_DIR, uri)
+
+    def load_rho_matrix(
+        self, param_name: str, observation_keys: list[str] | None = None
+    ) -> npt.NDArray[np.floating] | None:
+        """Load a cached rho matrix for the given parameter name.
+
+        When *observation_keys* is provided the stored blob's observation
+        keys must be a superset of the requested keys.  Some observations
+        may have been deactivated since the blob was created, so the blob
+        can legitimately contain *more* keys than the current active set.
+        However, if the current set contains keys absent from the blob the
+        matrix is invalid and ``None`` is returned so it is recomputed.
+        """
+        for blob in self.load_blobs(BlobType.RHO_MATRIX):
+            if (
+                isinstance(blob.blob_info, RhoStorageData)
+                and blob.blob_info.param_name == param_name
+            ):
+                if observation_keys is not None and not set(observation_keys).issubset(
+                    blob.blob_info.observation_keys
+                ):
+                    logger.info(
+                        "Cached rho matrix for %r is missing observation keys "
+                        "%s, skipping",
+                        param_name,
+                        sorted(
+                            set(observation_keys) - set(blob.blob_info.observation_keys)
+                        ),
+                    )
+                    return None
+                data = self.load_blob(blob.uri)
+                sparse_matrix = sp.sparse.load_npz(io.BytesIO(data))
+                return sparse_matrix.toarray()
+        return None
+
+    @require_write
+    def save_blob(self, event: AnalysisRhoMatrixEvent) -> None:
+        """Save the rho-matrix blob emitted during a distance-localization update."""
+        BlobStorageData.save_blob(
+            name=event.param_name,
+            data=event.matrix_bytes,
+            blob_info=RhoStorageData(
+                update_algorithm="distance",
+                sparse=True,
+                shape=event.shape,
+                data_type=event.data_type,
+                param_name=event.param_name,
+                observation_keys=event.observation_keys,
+            ),
+            file_type="application/x-npz",
+            storage=self._storage,
+            blob_dir=self._path / BLOB_DATA_DIR,
+        )
+
     def export_dataframes(
         self,
     ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
@@ -858,5 +931,9 @@ class LocalExperiment(BaseMode):
 
     def write_status_snapshot(self, iteration: int, data: bytes) -> None:
         snapshot_path = self.status_snapshot_path(iteration)
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        self._storage._write_transaction(snapshot_path, data)
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        self._storage._write_transaction(snapshot_path, data)
         snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         self._storage._write_transaction(snapshot_path, data)

--- a/tests/ert/unit_tests/analysis/test_distance_localization.py
+++ b/tests/ert/unit_tests/analysis/test_distance_localization.py
@@ -7,9 +7,11 @@ from ert.analysis._update_strategies._protocol import (
     ObservationContext,
     ObservationLocations,
 )
+from ert.analysis.event import AnalysisRhoMatrixEvent
 from ert.config import Field, LocalizationType, SurfaceConfig
 from ert.field_utils import AxisOrientation, ErtboxParameters, FieldFileFormat
 from ert.storage import open_storage
+from ert.storage.blob_data import BlobType, RhoStorageData
 
 
 def _noop_callback(_event: object) -> None:
@@ -531,3 +533,98 @@ def test_that_distance_localization_respects_non_zero_variance_mask(
 
     np.testing.assert_allclose(posterior[0, :], prior[0, :])
     assert not np.allclose(posterior[1:, :], prior[1:, :])
+
+
+@pytest.mark.parametrize(
+    ("param_type", "param_config_fn", "n_params"),
+    [
+        (Field, lambda: _field_config(4, 4, 1), 16),
+        (SurfaceConfig, lambda: _surface_config(4, 4), 16),
+    ],
+)
+def test_that_distance_localization_stores_and_reuses_rho_blob(
+    tmp_path,
+    param_type,
+    param_config_fn,
+    n_params,
+):
+    param_config = param_config_fn()
+    n_real = 20
+    rng = np.random.default_rng(99)
+    param_ensemble = rng.standard_normal((n_params, n_real))
+
+    obs_keys = ["WOPR:OP1", "FOPR"]
+    obs_context = ObservationContext(
+        responses=np.vstack([param_ensemble[0], param_ensemble[-1]]),
+        observation_values=np.array([1.0, -1.0]),
+        observation_errors=np.array([0.1, 0.1]),
+        observation_perturbations=rng.standard_normal((2, n_real)) * 0.1,
+        observation_locations=ObservationLocations(
+            xpos=np.array([0.5, 2.5]),
+            ypos=np.array([0.5, 2.5]),
+            main_range=np.array([2.0, 2.0]),
+            location_mask=np.ones(2, dtype=bool),
+            observation_keys=obs_keys,
+        ),
+    )
+
+    with open_storage(tmp_path / "storage", mode="w") as storage:
+        experiment = storage.create_experiment()
+
+        # First run: compute rho, emit event, save blob
+        iter0_events: list[AnalysisRhoMatrixEvent] = []
+
+        def save_callback(event):
+            if isinstance(event, AnalysisRhoMatrixEvent):
+                iter0_events.append(event)
+                experiment.save_blob(event)
+
+        updater1 = DistanceLocalizationUpdate(
+            enkf_truncation=0.99,
+            param_type=param_type,
+            progress_callback=save_callback,
+            experiment=experiment,
+        )
+        updater1.prepare(obs_context)
+        result1 = updater1.update(
+            param_ensemble=param_ensemble.copy(),
+            param_config=param_config,
+            non_zero_variance_mask=np.ones(n_params, dtype=bool),
+        )
+
+        assert len(iter0_events) == 1
+        assert iter0_events[0].param_name == param_config.name
+        assert iter0_events[0].observation_keys == obs_keys
+
+        blobs = experiment.load_blobs(BlobType.RHO_MATRIX)
+        assert len(blobs) == 1
+        assert isinstance(blobs[0].blob_info, RhoStorageData)
+        assert blobs[0].blob_info.param_name == param_config.name
+        assert blobs[0].blob_info.observation_keys == obs_keys
+
+        loaded_rho = experiment.load_rho_matrix(param_config.name)
+        assert loaded_rho is not None
+        assert loaded_rho.shape == iter0_events[0].shape
+
+        # Second run: should load from cache, no new events emitted
+        iter1_events: list[AnalysisRhoMatrixEvent] = []
+
+        def track_callback(event):
+            if isinstance(event, AnalysisRhoMatrixEvent):
+                iter1_events.append(event)
+
+        updater2 = DistanceLocalizationUpdate(
+            enkf_truncation=0.99,
+            param_type=param_type,
+            progress_callback=track_callback,
+            experiment=experiment,
+        )
+        updater2.prepare(obs_context)
+        result2 = updater2.update(
+            param_ensemble=param_ensemble.copy(),
+            param_config=param_config,
+            non_zero_variance_mask=np.ones(n_params, dtype=bool),
+        )
+
+        assert len(iter1_events) == 0, "Expected no new rho events on second run"
+        np.testing.assert_allclose(result1, result2)

--- a/tests/ert/unit_tests/storage/test_rho_matrix_storage.py
+++ b/tests/ert/unit_tests/storage/test_rho_matrix_storage.py
@@ -1,0 +1,133 @@
+import io
+import json
+
+import numpy as np
+import scipy as sp
+
+from ert.analysis.event import AnalysisRhoMatrixEvent
+from ert.storage import open_storage
+from ert.storage.blob_data import BlobType, RhoStorageData
+
+
+def _make_rho_event(
+    param_name: str = "FIELD_A",
+    shape: tuple[int, int] = (6, 2),
+    observation_keys: list[str] | None = None,
+) -> tuple[AnalysisRhoMatrixEvent, np.ndarray]:
+    rng = np.random.default_rng(42)
+    dense = rng.random(shape).astype(np.float64)
+    dense[dense < 0.5] = 0.0
+    sparse = sp.sparse.csc_matrix(dense)
+    buf = io.BytesIO()
+    sp.sparse.save_npz(buf, sparse)
+    event = AnalysisRhoMatrixEvent(
+        param_name=param_name,
+        observation_keys=observation_keys or ["OBS_1", "OBS_2"],
+        shape=shape,
+        data_type=str(dense.dtype),
+        matrix_bytes=buf.getvalue(),
+    )
+    return event, dense
+
+
+def test_that_load_rho_matrix_returns_none_when_no_blob_exists(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+
+        assert experiment.load_rho_matrix("NONEXISTENT") is None
+
+
+def test_that_rho_matrix_metadata_contains_observation_keys(tmp_path):
+    obs_keys = ["WOPR:OP1", "WGPR:OP2", "FOPR"]
+    event, _ = _make_rho_event(observation_keys=obs_keys, shape=(6, 3))
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        experiment.save_blob(event)
+
+        blobs = experiment.load_blobs(BlobType.RHO_MATRIX)
+
+    assert len(blobs) == 1
+    blob = blobs[0]
+    assert isinstance(blob.blob_info, RhoStorageData)
+    assert blob.blob_info.param_name == "FIELD_A"
+    assert blob.blob_info.observation_keys == obs_keys
+    assert blob.blob_info.sparse is True
+    assert blob.blob_info.shape == (6, 3)
+    assert blob.file_type == "application/x-npz"
+
+
+def test_that_rho_matrix_blob_files_are_written_to_disk(tmp_path):
+    event, _ = _make_rho_event()
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        experiment.save_blob(event)
+
+        blob_dir = experiment._path / "blobs"
+        assert blob_dir.is_dir()
+
+        blob_files = list(blob_dir.glob("*.blob"))
+        json_files = list(blob_dir.glob("*.blob.json"))
+        assert len(blob_files) == 1
+        assert len(json_files) == 1
+
+        meta = json.loads(json_files[0].read_text(encoding="utf-8"))
+        assert meta["blob_info"]["blob_type"] == "rho_matrix"
+        assert meta["blob_info"]["param_name"] == "FIELD_A"
+        assert meta["file_size"] > 0
+
+
+def test_that_load_rho_matrix_distinguishes_parameters_by_name(tmp_path):
+    event_a, dense_a = _make_rho_event(
+        param_name="PORO", shape=(4, 3), observation_keys=["O1", "O2", "O3"]
+    )
+    event_b, dense_b = _make_rho_event(
+        param_name="PERM", shape=(5, 2), observation_keys=["O4", "O5"]
+    )
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        experiment.save_blob(event_a)
+        experiment.save_blob(event_b)
+
+        loaded_a = experiment.load_rho_matrix("PORO")
+        loaded_b = experiment.load_rho_matrix("PERM")
+
+    assert loaded_a is not None
+    assert loaded_b is not None
+    np.testing.assert_array_equal(loaded_a, dense_a)
+    np.testing.assert_array_equal(loaded_b, dense_b)
+
+
+def test_that_load_rho_matrix_validates_observation_keys(tmp_path):
+    """Cached rho is valid for subset/equal keys, stale when keys are missing."""
+    stored_keys = ["OBS_A", "OBS_B", "OBS_C"]
+    event, dense = _make_rho_event(
+        param_name="PORO", shape=(4, 3), observation_keys=stored_keys
+    )
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment()
+        experiment.save_blob(event)
+
+        # full set of observation keys — should return cached matrix
+        result = experiment.load_rho_matrix("PORO", observation_keys=stored_keys)
+        assert result is not None
+        np.testing.assert_array_equal(result, dense)
+
+        # subset of observation keys — should return cached matrix
+        result = experiment.load_rho_matrix("PORO", observation_keys=["OBS_A", "OBS_C"])
+        assert result is not None
+        np.testing.assert_array_equal(result, dense)
+
+        # no observation keys specified — should return cached matrix
+        result = experiment.load_rho_matrix("PORO", observation_keys=None)
+        assert result is not None
+        np.testing.assert_array_equal(result, dense)
+
+        # missing observation keys — should be treated as invalid and return None
+        result = experiment.load_rho_matrix(
+            "PORO", observation_keys=["OBS_A", "OBS_NEW"]
+        )
+        assert result is None


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/ert/issues/12996


**Approach**
Make use of BlobStorageData on the experiment level to internalize rho matrices.
The main idea is to have the following API:
```python
ensemble.save_blob(...)
ensemble.load_blob(...)
experiment.save_blob(...)
experiment.load_blob(...)
```

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
