### PR TITLE
Make observations deactivated dialog scrollable

### DIFF
--- a/src/ert/gui/experiments/view/update.py
+++ b/src/ert/gui/experiments/view/update.py
@@ -6,11 +6,14 @@ from datetime import timedelta
 from typing import override
 
 import humanize
+from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSlot as Slot
 from PyQt6.QtGui import QColor, QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
+    QDialog,
+    QDialogButtonBox,
     QGridLayout,
     QHBoxLayout,
     QHeaderView,
@@ -127,15 +130,27 @@ class ReportLogTable(UpdateLogTable):
             )
 
             missing_realizations = hidden_item.text()
-            reasoning = "Missing responses from active realizations:\n\n" + str(
-                missing_realizations
-            )
-            QMessageBox.information(
-                self,
-                "Observation deactivated",
-                reasoning,
-                QMessageBox.StandardButton.Ok,
-            )
+
+            dialog = QDialog(self)
+            dialog.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+            dialog.setWindowTitle("Observation deactivated")
+            dialog.resize(500, 500)
+            dialog.setSizeGripEnabled(True)
+
+            layout = QVBoxLayout(dialog)
+            layout.addWidget(QLabel("Missing responses from active realizations:"))
+
+            text_edit = QTextEdit()
+            text_edit.setReadOnly(True)
+            text_edit.setPlainText(missing_realizations)
+            text_edit.setViewportMargins(15, 0, 0, 0)
+            layout.addWidget(text_edit)
+
+            buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+            buttons.accepted.connect(dialog.accept)
+            layout.addWidget(buttons)
+
+            dialog.exec()
 
 
 class UpdateWidget(QWidget):

--- a/tests/ert/unit_tests/gui/run_analysis/test_update_widget.py
+++ b/tests/ert/unit_tests/gui/run_analysis/test_update_widget.py
@@ -3,7 +3,13 @@ from uuid import uuid4
 import numpy as np
 import pytest
 from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtWidgets import QMessageBox, QTableWidget
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QTableWidget,
+    QTextEdit,
+)
 from pytestqt.qtbot import QtBot
 
 from ert.analysis.event import DataSection
@@ -85,12 +91,20 @@ def verify_disabled_observations_dialog_shows_on_click(
     qtbot, report_table, nan_message, row, column
 ):
     def handle_disabled_observations_blocking_dialog(qtbot, report_table, nan_message):
-        message_box = report_table.findChild(QMessageBox)
+        dialog = report_table.findChild(QDialog)
+        assert dialog is not None
         try:
-            assert message_box.text() == nan_message
+            label = dialog.findChild(QLabel)
+            assert label is not None
+            assert label.text() == "Missing responses from active realizations:"
+
+            text_edit = dialog.findChild(QTextEdit)
+            assert text_edit is not None
+            assert text_edit.toPlainText() == nan_message
         finally:
+            button_box = dialog.findChild(QDialogButtonBox)
             qtbot.mouseClick(
-                message_box.button(QMessageBox.StandardButton.Ok),
+                button_box.button(QDialogButtonBox.StandardButton.Ok),
                 Qt.MouseButton.LeftButton,
             )
 
@@ -118,7 +132,7 @@ def test_that_report_log_table_only_shows_message_on_nan_status_click(qtbot: QtB
     ]
 
     nan_rows = [1]
-    nan_message = "Missing responses from active realizations:\n\n1, 3"
+    nan_message = "1, 3"
 
     report_table = ReportLogTable(DataSection(header=headers, data=observations))
     qtbot.addWidget(report_table)
@@ -132,16 +146,22 @@ def test_that_report_log_table_only_shows_message_on_nan_status_click(qtbot: QtB
             )
         else:
             click_on_table_cell(qtbot, report_table, row, column)
-            assert report_table.findChild(QMessageBox) is None
+            dialog = report_table.findChild(QDialog)
+            assert dialog is None or not dialog.isVisible()
 
     def verify_that_data_column_click_does_not_produce_dialog(row, column):
         click_on_table_cell(qtbot, report_table, row, column)
-        assert report_table.findChild(QMessageBox) is None
+        dialog = report_table.findChild(QDialog)
+        assert dialog is None or not dialog.isVisible()
 
-    assert report_table.horizontalHeader().isSectionHidden(hidden_column)
+    header = report_table.horizontalHeader()
+    assert header is not None
+    assert header.isSectionHidden(hidden_column)
 
     for row in range(len(observations)):
-        assert report_table.item(row, status_column).text() == observations[row][0]
+        item = report_table.item(row, status_column)
+        assert item is not None
+        assert item.text() == observations[row][0]
 
         verify_that_status_column_click_shows_dialog_for_missing_observations_only(
             row, status_column
@@ -164,8 +184,8 @@ def test_that_report_log_table_matches_data_on_sort(qtbot: QtBot):
     row100 = 0
     row200 = 1
 
-    nan_message100 = "Missing responses from active realizations:\n\n10"
-    nan_message200 = "Missing responses from active realizations:\n\n11"
+    nan_message100 = "10"
+    nan_message200 = "11"
 
     verify_disabled_observations_dialog_shows_on_click(
         qtbot, report_table, nan_message100, row100, status_column


### PR DESCRIPTION
**Issue**
Resolves #13818


**Approach**
For some reason thought that it was good enough before.

Before
<img width="493" height="637" alt="image" src="https://github.com/user-attachments/assets/d6a0035b-9383-4fe6-8251-9e68a8500e31" />

After
<img width="1489" height="846" alt="image" src="https://github.com/user-attachments/assets/86af2df9-a868-46ef-b86f-064fd223e8ae" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
