### PR TITLE
Add better error and logs when opening corrupt storage

### DIFF
--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -96,29 +96,42 @@ class MultipleDataAssimilation(
         if self.restart_run:
             id_ = self.prior_ensemble_id
             assert id_ is not None
-            try:  # noqa: PLW0717
+
+            try:
                 ensemble_id = UUID(id_)
                 prior = self._storage.get_ensemble(ensemble_id)
-                experiment = prior.experiment
-                self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
-                self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
-                assert isinstance(prior, Ensemble)
-                if self._start_iteration != prior.iteration + 1:
-                    raise ValueError(
-                        "Experiment misconfigured, got starting "
-                        f"iteration: {self._start_iteration},"
-                        f"restart iteration = {prior.iteration + 1}"
-                    )
+            except (KeyError, ValueError) as err:
+                logger.error(f"Could not load prior ensemble '{id_}': {err}")
+                raise ErtRunError(
+                    f"Prior ensemble with ID: {id_} does not exist"
+                ) from err
+
+            experiment = prior.experiment
+            self.set_env_key("_ERT_EXPERIMENT_ID", str(experiment.id))
+            self.set_env_key("_ERT_ENSEMBLE_ID", str(prior.id))
+            assert isinstance(prior, Ensemble)
+            if self._start_iteration != prior.iteration + 1:
+                raise ErtRunError(
+                    "Experiment misconfigured, got starting "
+                    f"iteration: {self._start_iteration}, "
+                    f"restart iteration = {prior.iteration + 1}"
+                )
+
+            try:
                 target_experiment = self._storage.create_experiment(
                     experiment_config=self._create_experiment_for_restart(
                         experiment.experiment_config
                     ),
                     name=f"Restart from {prior.name}",
                 )
-
-            except (KeyError, ValueError) as err:
+            except Exception as err:
+                logger.exception(
+                    f"Failed to create restart experiment from prior ensemble "
+                    f"'{prior.name}' (ID: {id_})"
+                )
                 raise ErtRunError(
-                    f"Prior ensemble with ID: {id_} does not exists"
+                    f"Could not restart from prior ensemble '{prior.name}' "
+                    f"(ID: {id_}): {err}"
                 ) from err
         else:
             self.run_workflows(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -103,7 +103,7 @@ class MultipleDataAssimilation(
             except (KeyError, ValueError) as err:
                 logger.error(f"Could not load prior ensemble '{id_}': {err}")
                 raise ErtRunError(
-                    f"Prior ensemble with ID: {id_} does not exist"
+                    f"Prior ensemble with ID: {id_} does not exist or is broken"
                 ) from err
 
             experiment = prior.experiment

--- a/tests/ert/ui_tests/cli/test_restarting_esmda.py
+++ b/tests/ert/ui_tests/cli/test_restarting_esmda.py
@@ -1,15 +1,21 @@
+import json
+from argparse import Namespace
 from collections.abc import Callable
 from pathlib import Path
+from queue import SimpleQueue
 from textwrap import dedent
+from unittest.mock import MagicMock
 
 import pytest
 from polars import Float32, Series
 from polars.testing import assert_series_equal
 
+from ert.config import ErtConfig
 from ert.mode_definitions import (
     ENSEMBLE_EXPERIMENT_MODE,
     ES_MDA_MODE,
 )
+from ert.run_models import ErtRunError, create_model
 from ert.storage import open_storage
 
 from .run_cli import run_cli
@@ -177,3 +183,97 @@ def test_that_running_esmda_from_restart_uses_previous_observations_and_paramete
         experiment.observations["gen_data"]["std"],
         Series("std", [0.5, 1.5, 3.0, 6.0, 12.0], dtype=Float32),
     )
+
+
+@pytest.fixture
+def poly_prior_ensemble_id(
+    use_tmpdir,
+    ert_config,
+    parameters,
+    poly_eval,
+    ert_script,
+    observations,
+    observations_data,
+):
+    Path("config.ert").write_text(ert_config, encoding="utf-8")
+    Path("coeff_priors").write_text(parameters, encoding="utf-8")
+    Path("ERT_EVAL").write_text(poly_eval, encoding="utf-8")
+    Path("observations").write_text(observations(), encoding="utf-8")
+    Path("obs_data.txt").write_text(observations_data, encoding="utf-8")
+    Path("ert_eval.py").write_text(ert_script, encoding="utf-8")
+    Path("ert_eval.py").chmod(0o755)
+
+    run_cli(
+        ENSEMBLE_EXPERIMENT_MODE,
+        "--disable-monitoring",
+        "config.ert",
+    )
+
+    with open_storage("storage") as storage:
+        ensemble = storage.get_experiment_by_name(
+            "ensemble-experiment"
+        ).get_ensemble_by_name("default")
+        return str(ensemble.id)
+
+
+def _build_esmda_restart_model(prior_ensemble_id: str):
+    config = ErtConfig.from_file("config.ert")
+    return create_model(
+        config,
+        Namespace(
+            mode=ES_MDA_MODE,
+            realizations=None,
+            target_ensemble="iter-<ITER>",
+            weights="1,1",
+            restart_run=True,
+            prior_ensemble_id=prior_ensemble_id,
+            experiment_name="restart-experiment",
+        ),
+        SimpleQueue(),
+    )
+
+
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
+def test_that_restarting_esmda_with_invalid_prior_ensemble_id_gives_error_message(
+    poly_prior_ensemble_id,
+):
+    model = _build_esmda_restart_model(poly_prior_ensemble_id)
+
+    model.prior_ensemble_id = "not-a-valid-uuid"
+
+    with pytest.raises(
+        ErtRunError,
+        match="Prior ensemble with ID: not-a-valid-uuid does not exist or is broken",
+    ):
+        model.run_experiment(MagicMock())
+
+
+@pytest.mark.usefixtures("use_site_configurations_with_no_queue_options")
+def test_that_restarting_esmda_from_prior_with_localized_gen_obs_gives_error_message(
+    poly_prior_ensemble_id,
+):
+    with open_storage("storage", mode="w") as storage:
+        experiment = storage.get_experiment_by_name("ensemble-experiment")
+        index_path = experiment._path / "index.json"
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+
+        # Add invalid keys to observation to trigger validation failure
+        for observation in index["experiment"]["observations"]:
+            observation["east"] = None
+            observation["north"] = None
+            observation["radius"] = None
+        index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    model = _build_esmda_restart_model(poly_prior_ensemble_id)
+
+    try:
+        with pytest.raises(
+            ErtRunError,
+            match=(
+                f"Could not restart from prior ensemble 'default' "
+                f"\\(ID: {poly_prior_ensemble_id}\\):"
+            ),
+        ):
+            model.run_experiment(MagicMock())
+    finally:
+        model._clean_env_context()

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -21,6 +21,7 @@ from hypothesis import assume, given, note
 from hypothesis.extra.numpy import arrays
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule
 from pandas import DataFrame, ExcelWriter
+from pydantic import ValidationError
 from resfo_utilities.testing import summaries, summary_variables
 
 from ert.config import (
@@ -441,6 +442,48 @@ def test_open_storage_with_corrupted_storage(tmp_path):
     os.remove(tmp_path / "storage" / "index.json")
     with pytest.raises(ErtStorageException, match="No index\\.json"):
         open_storage(tmp_path / "storage", mode="w")
+
+
+def test_that_create_experiment_rejects_general_observation_with_rft_locality_keys(
+    tmp_path,
+):
+    general_observation = {
+        "type": "general_observation",
+        "name": "POLY_OBS",
+        "data": "POLY_RES",
+        "value": 1.0,
+        "error": 0.1,
+        "restart": 0,
+        "index": 0,
+    }
+    experiment_config = {
+        "observations": [general_observation],
+        "response_configuration": [
+            GenDataConfig(keys=["POLY_RES"]).model_dump(mode="json")
+        ],
+    }
+
+    with open_storage(tmp_path / "storage", mode="w") as storage:
+        storage.create_experiment(experiment_config=experiment_config, name="clean")
+
+        polluted_observation = {
+            **general_observation,
+            "east": None,
+            "north": None,
+            "radius": None,
+        }
+        experiment_config["observations"] = [polluted_observation]
+
+        with pytest.raises(ValidationError) as exc_info:
+            storage.create_experiment(
+                experiment_config=experiment_config, name="polluted"
+            )
+
+    message = str(exc_info.value)
+    assert "general_observation.east" in message
+    assert "general_observation.north" in message
+    assert "general_observation.radius" in message
+    assert "Extra inputs are not permitted" in message
 
 
 def test_that_open_storage_in_read_mode_with_newer_version_throws_exception(tmp_path):

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -21,7 +21,6 @@ from hypothesis import assume, given, note
 from hypothesis.extra.numpy import arrays
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, initialize, rule
 from pandas import DataFrame, ExcelWriter
-from pydantic import ValidationError
 from resfo_utilities.testing import summaries, summary_variables
 
 from ert.config import (
@@ -442,48 +441,6 @@ def test_open_storage_with_corrupted_storage(tmp_path):
     os.remove(tmp_path / "storage" / "index.json")
     with pytest.raises(ErtStorageException, match="No index\\.json"):
         open_storage(tmp_path / "storage", mode="w")
-
-
-def test_that_create_experiment_rejects_general_observation_with_rft_locality_keys(
-    tmp_path,
-):
-    general_observation = {
-        "type": "general_observation",
-        "name": "POLY_OBS",
-        "data": "POLY_RES",
-        "value": 1.0,
-        "error": 0.1,
-        "restart": 0,
-        "index": 0,
-    }
-    experiment_config = {
-        "observations": [general_observation],
-        "response_configuration": [
-            GenDataConfig(keys=["POLY_RES"]).model_dump(mode="json")
-        ],
-    }
-
-    with open_storage(tmp_path / "storage", mode="w") as storage:
-        storage.create_experiment(experiment_config=experiment_config, name="clean")
-
-        polluted_observation = {
-            **general_observation,
-            "east": None,
-            "north": None,
-            "radius": None,
-        }
-        experiment_config["observations"] = [polluted_observation]
-
-        with pytest.raises(ValidationError) as exc_info:
-            storage.create_experiment(
-                experiment_config=experiment_config, name="polluted"
-            )
-
-    message = str(exc_info.value)
-    assert "general_observation.east" in message
-    assert "general_observation.north" in message
-    assert "general_observation.radius" in message
-    assert "Extra inputs are not permitted" in message
 
 
 def test_that_open_storage_in_read_mode_with_newer_version_throws_exception(tmp_path):


### PR DESCRIPTION
**Issue**
Resolves #13842 


**Approach**
Tightened up error handling and logging for ensemble in storage.


(Screenshot of new behavior in GUI if applicable)
New error screen when loading invalid fields
<img width="1486" height="815" alt="bilde" src="https://github.com/user-attachments/assets/b1154900-2cfe-4130-8c64-d87afa6695f7" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
