### PR TITLE
13306 non unique experiment and ensemble names when using manual update

### DIFF
--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -18,6 +18,7 @@ from ert.gui.ertwidgets import (
     StringBox,
     Suggestor,
     TargetEnsembleModel,
+    TextModel,
 )
 from ert.gui.experiments.experiment_config_panel import ExperimentConfigPanel
 from ert.mode_definitions import MANUAL_ENIF_UPDATE_MODE, MANUAL_UPDATE_MODE
@@ -35,6 +36,7 @@ class Arguments:
     ensemble_id: str
     target_ensemble: str
     ensemble_size: int
+    experiment_name: str
 
 
 class ManualUpdatePanel(ExperimentConfigPanel):
@@ -104,6 +106,14 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         self._realizations_from_fs()
         layout.addRow("Active realizations", self._active_realizations_field)
 
+        self._experiment_name_field = StringBox(
+            TextModel(""),
+            placeholder_text="Manual update",
+        )
+
+        self._experiment_name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._experiment_name_field)
+
         self._active_realizations_field.getValidationSupport().validationChanged.connect(
             self.experiment_configuration_changed
         )
@@ -144,6 +154,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
             realizations=self._active_realizations_field.text(),
             target_ensemble=self._ensemble_format_model.getValue(),  # type: ignore
             ensemble_size=self._ensemble_size,
+            experiment_name=self._experiment_name_field.get_text,
         )
 
     def _realizations_from_fs(self) -> None:

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -74,6 +74,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         ]
         self._ensemble_selector = EnsembleSelector(notifier, filters=filters)
         layout.addRow("Ensemble:", self._ensemble_selector)
+
         runpath_label = CopyableLabel(text=run_path)
         layout.addRow("Runpath:", runpath_label)
 
@@ -107,11 +108,20 @@ class ManualUpdatePanel(ExperimentConfigPanel):
 
         self._experiment_name_field = StringBox(
             TextModel(""),
-            placeholder_text="Manual update",
+            placeholder_text="Manual update"
+            if notifier.current_ensemble is None
+            else f"Manual update of {notifier.current_ensemble.name}",
         )
 
         self._experiment_name_field.setMinimumWidth(250)
         layout.addRow("Experiment name:", self._experiment_name_field)
+        self._ensemble_selector.ensemble_selected.connect(
+            lambda ensemble: self._experiment_name_field.setPlaceholderText(
+                f"Manual update of {ensemble.name}"
+                if ensemble is not None
+                else "Manual update"
+            )
+        )
 
         self._active_realizations_field.getValidationSupport().validationChanged.connect(
             self.experiment_configuration_changed
@@ -198,3 +208,9 @@ class ManualUpdatePanel(ExperimentConfigPanel):
     def experimentTypeChanged(self, w: QWidget) -> None:
         if isinstance(w, ManualUpdatePanel):
             self._realizations_from_fs()
+
+            self._experiment_name_field.setPlaceholderText(
+                f"Manual update of {self._ensemble_selector.selected_ensemble.name}"
+                if self._ensemble_selector.selected_ensemble is not None
+                else "Manual update"
+            )

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -18,6 +18,7 @@ from ert.gui.ertwidgets import (
     StringBox,
     Suggestor,
     TargetEnsembleModel,
+    TextModel,
 )
 from ert.gui.experiments.experiment_config_panel import ExperimentConfigPanel
 from ert.mode_definitions import MANUAL_ENIF_UPDATE_MODE, MANUAL_UPDATE_MODE
@@ -35,6 +36,7 @@ class Arguments:
     ensemble_id: str
     target_ensemble: str
     ensemble_size: int
+    experiment_name: str
 
 
 class ManualUpdatePanel(ExperimentConfigPanel):
@@ -103,6 +105,14 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         self._realizations_from_fs()
         layout.addRow("Active realizations", self._active_realizations_field)
 
+        self._experiment_name_field = StringBox(
+            TextModel(""),
+            placeholder_text="Manual update",
+        )
+
+        self._experiment_name_field.setMinimumWidth(250)
+        layout.addRow("Experiment name:", self._experiment_name_field)
+
         self._active_realizations_field.getValidationSupport().validationChanged.connect(
             self.experiment_configuration_changed
         )
@@ -143,6 +153,7 @@ class ManualUpdatePanel(ExperimentConfigPanel):
             realizations=self._active_realizations_field.text(),
             target_ensemble=self._ensemble_format_model.getValue(),  # type: ignore
             ensemble_size=self._ensemble_size,
+            experiment_name=self._experiment_name_field.get_text,
         )
 
     def _realizations_from_fs(self) -> None:

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -68,7 +68,7 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
 
         return self._storage.create_experiment(
             experiment_config=experiment_config,
-            name=f"Manual update of {self._prior.name}",
+            name=self.experiment_name,
         )
 
     def check_if_runpath_exists(self) -> bool:

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -321,6 +321,7 @@ def _setup_manual_update(
         ert_templates=config.ert_templates,
         observations=config.observation_declarations,
         shape_registry=config.shape_registry,
+        experiment_name=args.experiment_name,
     )
     return ManualUpdate(**runmodel_config.model_dump(), status_queue=status_queue)
 
@@ -361,6 +362,7 @@ def _setup_manual_update_enif(
         log_path=config.analysis_config.log_path,
         observations=config.observation_declarations,
         shape_registry=config.shape_registry,
+        experiment_name=args.experiment_name,
     )
 
 

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -318,6 +318,7 @@ def _setup_manual_update(
         log_path=config.analysis_config.log_path,
         ert_templates=config.ert_templates,
         shape_registry=config.shape_registry,
+        experiment_name=args.experiment_name,
     )
     return ManualUpdate(**runmodel_config.model_dump(), status_queue=status_queue)
 
@@ -353,6 +354,7 @@ def _setup_manual_update_enif(
         log_path=config.analysis_config.log_path,
         ert_templates=config.ert_templates,
         shape_registry=config.shape_registry,
+        experiment_name=args.experiment_name,
     )
     return ManualUpdateEnIF(**runmodel_config.model_dump(), status_queue=status_queue)
 

--- a/src/ert/run_models/run_model_configs.py
+++ b/src/ert/run_models/run_model_configs.py
@@ -306,6 +306,7 @@ class ManualUpdateConfig(UpdateRunModelConfig):
     experiment_type: ExperimentType = ExperimentType.MANUAL_UPDATE
     ensemble_id: str
     ert_templates: list[tuple[str, str]]
+    experiment_name: str
 
     def to_experiment_config(
         self, *, prior_experiment_config: ExperimentConfig
@@ -326,6 +327,7 @@ class ManualUpdateConfig(UpdateRunModelConfig):
             "observations": prior_experiment_config.get("observations", []),
             **self._common_fields(),
             "experiment_type": ExperimentType.MANUAL_UPDATE,
+            "experiment_name": self.experiment_name,
         }
 
 

--- a/src/ert/run_models/run_model_configs.py
+++ b/src/ert/run_models/run_model_configs.py
@@ -303,6 +303,7 @@ class ManualUpdateConfig(UpdateRunModelConfig):
     ensemble_id: str
     ert_templates: list[tuple[str, str]]
     shape_registry: ShapeRegistry | None = None
+    experiment_name: str
 
     def to_experiment_config(
         self, *, prior_experiment_config: ExperimentConfig
@@ -323,6 +324,7 @@ class ManualUpdateConfig(UpdateRunModelConfig):
             "observations": prior_experiment_config.get("observations", []),
             **self._common_fields(),
             "experiment_type": ExperimentType.MANUAL_UPDATE,
+            "experiment_name": self.experiment_name,
         }
         if shape_registry is not None:
             experiment_config["shape_registry"] = shape_registry

--- a/tests/ert/ui_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/ert/ui_tests/gui/test_full_manual_update_workflow.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import QComboBox, QToolButton, QTreeView, QWidget
 from ert.data import MeasuredData
 from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.experiments.evaluate_ensemble_panel import EvaluateEnsemblePanel
+from ert.gui.experiments.manual_update_panel import ManualUpdatePanel
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import StorageWidget
 from ert.run_models.evaluate_ensemble import EvaluateEnsemble
@@ -36,6 +37,10 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
         QComboBox, "manual_update_method_dropdown"
     )
     update_mode_dropdown.setCurrentText(mode)
+
+    manual_update_panel = get_child(experiment_panel, ManualUpdatePanel)
+    manual_update_panel._experiment_name_field.setText("my manual update")
+
     with contextlib.suppress(FileNotFoundError):
         shutil.rmtree("poly_out")
 
@@ -66,7 +71,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
     assert model is not None
     assert model.rowCount() == 2
     assert model.data(model.index(1, 0)) == "ensemble_experiment"
-    assert model.data(model.index(0, 0)) == "Manual update of iter-0"
+    assert model.data(model.index(0, 0)) == "my manual update"
     assert "iter-1" in model.index(0, 0, model.index(0, 0)).data(0)
 
     experiments_panel.close()
@@ -76,7 +81,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
     simulation_mode_combo.setCurrentText(EvaluateEnsemble.name())
 
     idx = simulation_settings._ensemble_selector.findData(
-        "Manual update of iter-0 : iter-1",
+        "my manual update : iter-1",
         Qt.ItemDataRole.DisplayRole,
         Qt.MatchFlag.MatchStartsWith,
     )
@@ -96,7 +101,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
 
     df_prior: pl.DataFrame = ensemble_prior.load_scalars()
 
-    exp_posterior = storage.get_experiment_by_name("Manual update of iter-0")
+    exp_posterior = storage.get_experiment_by_name("my manual update")
     ensemble_posterior = exp_posterior.get_ensemble_by_name("iter-1")
     df_posterior: pl.DataFrame = ensemble_posterior.load_scalars()
 

--- a/tests/ert/ui_tests/gui/test_full_manual_update_workflow.py
+++ b/tests/ert/ui_tests/gui/test_full_manual_update_workflow.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import QComboBox, QToolButton, QTreeView, QWidget
 
 from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.experiments.evaluate_ensemble_panel import EvaluateEnsemblePanel
+from ert.gui.experiments.manual_update_panel import ManualUpdatePanel
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import StorageWidget
 from ert.run_models.evaluate_ensemble import EvaluateEnsemble
@@ -35,6 +36,10 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
         QComboBox, "manual_update_method_dropdown"
     )
     update_mode_dropdown.setCurrentText(mode)
+
+    manual_update_panel = get_child(experiment_panel, ManualUpdatePanel)
+    manual_update_panel._experiment_name_field.setText("my manual update")
+
     with contextlib.suppress(FileNotFoundError):
         shutil.rmtree("poly_out")
 
@@ -65,7 +70,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
     assert model is not None
     assert model.rowCount() == 2
     assert model.data(model.index(1, 0)) == "ensemble_experiment"
-    assert model.data(model.index(0, 0)) == "Manual update of iter-0"
+    assert model.data(model.index(0, 0)) == "my manual update"
     assert "iter-1" in model.index(0, 0, model.index(0, 0)).data(0)
 
     experiments_panel.close()
@@ -75,7 +80,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
     simulation_mode_combo.setCurrentText(EvaluateEnsemble.name())
 
     idx = simulation_settings._ensemble_selector.findData(
-        "Manual update of iter-0 : iter-1",
+        "my manual update : iter-1",
         Qt.ItemDataRole.DisplayRole,
         Qt.MatchFlag.MatchStartsWith,
     )
@@ -95,7 +100,7 @@ def test_manual_analysis_workflow(ensemble_experiment_has_run, qtbot, mode):
 
     df_prior: pl.DataFrame = ensemble_prior.load_scalars()
 
-    exp_posterior = storage.get_experiment_by_name("Manual update of iter-0")
+    exp_posterior = storage.get_experiment_by_name("my manual update")
     ensemble_posterior = exp_posterior.get_ensemble_by_name("iter-1")
     df_posterior: pl.DataFrame = ensemble_posterior.load_scalars()
 

--- a/tests/ert/unit_tests/gui/experiments/test_manual_update.py
+++ b/tests/ert/unit_tests/gui/experiments/test_manual_update.py
@@ -172,3 +172,45 @@ def test_that_panel_does_not_crash_when_no_realization_has_parameters(
     assert realization_selector is not None
     assert not realization_selector.text()
     assert not panel.isConfigurationValid()
+
+
+def test_that_empty_experiment_name_field_defaults_to_manual_update(
+    qtbot: QtBot,
+) -> None:
+    notifier = ErtNotifier()
+    notifier._storage = MockStorage()
+    notifier._storage._setup_mocked_run(
+        "mock_ensemble0",
+        "mock_experiment0",
+        [REALIZATION_FINISHED_SUCCESSFULLY, REALIZATION_FINISHED_SUCCESSFULLY],
+    )
+    panel = ManualUpdatePanel(
+        analysis_config=AnalysisConfig(minimum_required_realizations=1),
+        run_path="",
+        notifier=notifier,
+    )
+    qtbot.addWidget(panel)
+
+    assert panel.get_experiment_arguments().experiment_name == "Manual update"
+
+
+def test_that_experiment_name_field_is_used_in_experiment_arguments(
+    qtbot: QtBot,
+) -> None:
+    notifier = ErtNotifier()
+    notifier._storage = MockStorage()
+    notifier._storage._setup_mocked_run(
+        "mock_ensemble0",
+        "mock_experiment0",
+        [REALIZATION_FINISHED_SUCCESSFULLY, REALIZATION_FINISHED_SUCCESSFULLY],
+    )
+    panel = ManualUpdatePanel(
+        analysis_config=AnalysisConfig(minimum_required_realizations=1),
+        run_path="",
+        notifier=notifier,
+    )
+    qtbot.addWidget(panel)
+
+    panel._experiment_name_field.setText("my custom experiment")
+
+    assert panel.get_experiment_arguments().experiment_name == "my custom experiment"

--- a/tests/ert/unit_tests/gui/experiments/test_manual_update.py
+++ b/tests/ert/unit_tests/gui/experiments/test_manual_update.py
@@ -174,7 +174,7 @@ def test_that_panel_does_not_crash_when_no_realization_has_parameters(
     assert not panel.isConfigurationValid()
 
 
-def test_that_empty_experiment_name_field_defaults_to_manual_update(
+def test_that_empty_experiment_name_field_defaults_to_manual_update_of_mock_ensemble0(
     qtbot: QtBot,
 ) -> None:
     notifier = ErtNotifier()
@@ -191,7 +191,10 @@ def test_that_empty_experiment_name_field_defaults_to_manual_update(
     )
     qtbot.addWidget(panel)
 
-    assert panel.get_experiment_arguments().experiment_name == "Manual update"
+    assert (
+        panel.get_experiment_arguments().experiment_name
+        == "Manual update of mock_ensemble0"
+    )
 
 
 def test_that_experiment_name_field_is_used_in_experiment_arguments(

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
@@ -198,5 +198,6 @@
   },
   "experiment_type": "Manual Update",
   "ensemble_id": "00000000-0000-0000-0000-000000000000",
-  "ert_templates": []
+  "ert_templates": [],
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/heat_equationconfig.ert/config.json
@@ -232,5 +232,6 @@
         "radius": 20.0
       }
     }
-  }
+  },
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -188,5 +188,6 @@
   },
   "experiment_type": "Manual Update",
   "ensemble_id": "00000000-0000-0000-0000-000000000000",
-  "ert_templates": []
+  "ert_templates": [],
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -193,5 +193,6 @@
   "ert_templates": [],
   "shape_registry": {
     "shapes": {}
-  }
+  },
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -171,5 +171,6 @@
       "test-data/ert/snake_oil.snake_oil.ert/templates/snake_oil_template.txt",
       "snake_oil_params.txt"
     ]
-  ]
+  ],
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_manual_update_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -186,5 +186,6 @@
   ],
   "shape_registry": {
     "shapes": {}
-  }
+  },
+  "experiment_name": "my_experiment"
 }

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -752,6 +752,7 @@ def test_that_dumped_manual_update_matches_snapshot(
             realizations="1,2",
             ensemble_id=str(prior.id),
             target_ensemble="posterior<ITER>",
+            experiment_name="my_experiment",
         ),
         case=f"{config_dir}.{config_file}",
     )

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -753,6 +753,7 @@ def test_that_dumped_manual_update_matches_snapshot(
             realizations="1,2",
             ensemble_id=str(prior.id),
             target_ensemble="posterior<ITER>",
+            experiment_name="my_experiment",
         ),
         case=f"{config_dir}.{config_file}",
     )

--- a/tests/ert/unit_tests/run_models/test_manual_update.py
+++ b/tests/ert/unit_tests/run_models/test_manual_update.py
@@ -56,6 +56,7 @@ def test_that_manual_update_from_ensemble_experiment_supports_all_update_modes(
             mode=mode,
             ensemble_id=ensemble_id_to_update,
             target_ensemble="updated_ens%d",
+            experiment_name="my manual update",
         ),
         status_queue=queue.SimpleQueue(),
     )
@@ -66,8 +67,6 @@ def test_that_manual_update_from_ensemble_experiment_supports_all_update_modes(
     manual_update_model.start_simulations_thread(evaluator_server_config)
 
     with open_storage(manual_update_model.storage_path, mode="r") as storage:
-        manual_update_exp = next(
-            e for e in storage.experiments if e.name.startswith("Manual update")
-        )
+        manual_update_exp = storage.get_experiment_by_name("my manual update")
         posterior_ens = manual_update_exp.get_ensemble_by_name("updated_ens1")
         assert posterior_ens is not None


### PR DESCRIPTION
**Issue**
Resolves #13306 

Added a new text box for entering an experiment name

<img width="1556" height="836" alt="image" src="https://github.com/user-attachments/assets/dcdcd443-3b46-4da1-b2f4-56a4a964c257" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
