### PR TITLE
Update macos runner images to macos 26

### DIFF
--- a/.github/actions/install_dependencies_qt/action.yml
+++ b/.github/actions/install_dependencies_qt/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Ubuntu dependencies
-      if: inputs.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install libegl1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         test-type: [ 'test' ]
-        os: [ 'macos-latest' ]
+        os: [ 'macos-26' ]
         python-version: [ '3.14' ]
 
     uses: ./.github/workflows/test_everest.yml
@@ -146,7 +146,7 @@ jobs:
       matrix:
         test-type: [ 'performance-and-unit-tests', 'gui-tests', 'cli-tests' ]
         python-version: [ '3.14' ]
-        os: [ 'macos-latest']
+        os: [ 'macos-26']
 
     uses: ./.github/workflows/test_ert.yml
     with:

--- a/.github/workflows/test_ert.yml
+++ b/.github/workflows/test_ert.yml
@@ -29,7 +29,7 @@ jobs:
         submodules: true
         lfs: true
 
-    - if: ${{ inputs.os == 'macos-latest' }}
+    - if: ${{ runner.os == 'macOS' }}
       run: echo "ERT_TESTS_RUN_ON_MAC_CI=true" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/install_dependencies_qt

--- a/.github/workflows/test_everest.yml
+++ b/.github/workflows/test_everest.yml
@@ -40,7 +40,7 @@ jobs:
         fetch-depth: 0
         filter: tree:0
 
-    - if: ${{ inputs.os == 'macos-latest' }}
+    - if: ${{ runner.os == 'macOS' }}
       run: echo "ERT_TESTS_RUN_ON_MAC_CI=true" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/install_dependencies_qt


### PR DESCRIPTION
macos-latest have started to sometimes point to macos-26, this intentionally updates the image. graphite-maps only has wheels for 26 at the moment.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
