### PR TITLE
Remove mention of long gone CAREFULL_COPY

### DIFF
--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -39,8 +39,6 @@ class CarefulCopyFile(ForwardModelStepPlugin):
                 argument has a directory component, that directory will be created.
                 This is an extension of the normal :code:`cp` command
                 which will *not* create directories in this way.
-                This supersedes an older version called :code:`CAREFULL_COPY`
-                and should be used instead.
                 """
             ),
             examples="""


### PR DESCRIPTION
This relic from the past can still be seen in logs, where they get an error message that this step does not exist. There is no chance that these people needs this statement to be present in the docs in order to understand how to fix.

**Issue**
Resolves old gruff