### PR TITLE
Further decouple RFTConfig from observations

### DIFF
--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -206,18 +206,6 @@ def _handle_rft_observation(
         else None
     )
 
-    data_to_read = rft_config.data_to_read
-    if rft_observation.well not in data_to_read:
-        rft_config.data_to_read[rft_observation.well] = {}
-
-    well_dict = data_to_read[rft_observation.well]
-    if rft_observation.date not in well_dict:
-        well_dict[rft_observation.date] = []
-
-    property_list = well_dict[rft_observation.date]
-    if rft_observation.property not in property_list:
-        property_list.append(rft_observation.property)
-
     if rft_observation.error <= 0.0:
         raise ObservationConfigError.with_context(
             "Observation uncertainty must be strictly > 0", rft_observation.well

--- a/src/ert/config/_create_observation_dataframes.py
+++ b/src/ert/config/_create_observation_dataframes.py
@@ -19,12 +19,10 @@ from ._observations import (
 )
 from ._shapes import CircleShapeConfig, ShapeRegistry
 from .parsing import ErrorInfo, ObservationConfigError
-from .rft_config import RFTConfig
 
 
 def create_observation_dataframes(
     observations: Sequence[Observation],
-    rft_config: RFTConfig | None,
     shape_registry: ShapeRegistry | None = None,
 ) -> dict[str, pl.DataFrame]:
     if not observations:
@@ -51,19 +49,12 @@ def create_observation_dataframes(
                         )
                     )
                 case RFTObservation():
-                    if rft_config is None:
-                        raise TypeError(
-                            "create_observation_dataframes requires "
-                            "rft_config is not None when using RFTObservation"
-                        )
                     if shape_registry is None:
                         raise TypeError(
                             "create_observation_dataframes requires "
                             "shape_registry is not None when using RFTObservation"
                         )
-                    grouped["rft"].append(
-                        _handle_rft_observation(rft_config, obs, shape_registry)
-                    )
+                    grouped["rft"].append(_handle_rft_observation(obs, shape_registry))
                 case BreakthroughObservation():
                     grouped["breakthrough"].append(
                         _handle_breakthrough_observation(
@@ -194,7 +185,6 @@ def _rft_observation_schema() -> dict[str, Any]:
 
 
 def _handle_rft_observation(
-    rft_config: RFTConfig,
     rft_observation: RFTObservation,
     shape_registry: ShapeRegistry,
 ) -> pl.DataFrame:

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -17,7 +17,6 @@ from numpy.random import SeedSequence
 from pydantic import BaseModel, Field, model_validator
 from pydantic import ValidationError as PydanticValidationError
 
-from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.substitutions import Substitutions
 
 from ._design_matrix_validator import DesignMatrixValidator
@@ -1207,7 +1206,7 @@ class ErtConfig(BaseModel):
         zonemap = config_dict.get(ConfigKeys.ZONEMAP)
         if zonemap:
             zonemap = substituter.substitute(zonemap)
-        try:  # noqa: PLW0717
+        try:
             cls_config = cls(
                 substitutions=substitutions,
                 ensemble_config=ensemble_config,
@@ -1232,51 +1231,8 @@ class ErtConfig(BaseModel):
                 shape_registry=shape_registry,
             )
 
-            # The observations are created here because create_observation_dataframes
-            # will perform additional validation which needs the context in
-            # obs_configs which is stripped by pydantic
-            has_rft_observations = any(
-                isinstance(o, RFTObservation) for o in obs_configs
-            )
-            if (
-                has_rft_observations
-                and "rft" not in ensemble_config.response_configs
-                and summary_file_base_name
-            ):
-                ensemble_config.response_configs["rft"] = RFTConfig(
-                    input_files=[summary_file_base_name],
-                    data_to_read={},
-                    zonemap=cls_config.zonemap,
-                    approximate_missing_values=config_dict.get(
-                        ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False
-                    ),
-                )
-
-            bt_obs = [o for o in obs_configs if isinstance(o, BreakthroughObservation)]
-
-            if (
-                bt_obs
-                and "breakthrough" not in ensemble_config.derived_response_configs
-            ):
-                ensemble_config.derived_response_configs["breakthrough"] = (
-                    BreakthroughConfig(
-                        keys=[f"BREAKTHROUGH:{o.key}" for o in bt_obs],
-                        summary_keys=[o.key for o in bt_obs],
-                        thresholds=[o.threshold for o in bt_obs],
-                        observed_dates=[o.date for o in bt_obs],
-                    )
-                )
-
-            # PS:
-            # This mutates the rft config and is necessary for the moment
-            # Consider changing this pattern
-            _ = create_observation_dataframes(
-                observations=obs_configs,
-                rft_config=cast(
-                    RFTConfig | None, ensemble_config.response_configs.get("rft")
-                ),
-                shape_registry=shape_registry,
-            )
+            cls_config.derive_rft_response_input_from_observations(config_dict)
+            cls_config.derive_breakthrough_response_input_from_observations()
 
             cls_config.random_seed_generator.user_defined_seed = config_dict.get(
                 ConfigKeys.RANDOM_SEED
@@ -1285,6 +1241,61 @@ class ErtConfig(BaseModel):
         except PydanticValidationError as err:
             raise ConfigValidationError.from_pydantic(err) from err
         return cls_config
+
+    def derive_rft_response_input_from_observations(
+        self, config_dict: ConfigDict
+    ) -> None:
+        observations = self.observation_declarations
+        ensemble_config = self.ensemble_config
+
+        rft_observations = [o for o in observations if isinstance(o, RFTObservation)]
+        if not rft_observations:
+            return
+
+        summary_file_base_name = self.runpath_config.summary_file_base_name
+        if "rft" not in ensemble_config.response_configs and summary_file_base_name:
+            ensemble_config.response_configs["rft"] = RFTConfig(
+                input_files=[summary_file_base_name],
+                data_to_read={},
+                zonemap=self.zonemap,
+                approximate_missing_values=config_dict.get(
+                    ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False
+                ),
+            )
+
+        if "rft" not in ensemble_config.response_configs:
+            return
+
+        rft_config = cast(RFTConfig, ensemble_config.response_configs.get("rft"))
+        data_to_read = rft_config.data_to_read
+
+        for rft_observation in rft_observations:
+            if rft_observation.well not in data_to_read:
+                data_to_read[rft_observation.well] = {}
+
+            well_dict = data_to_read[rft_observation.well]
+            if rft_observation.date not in well_dict:
+                well_dict[rft_observation.date] = []
+
+            property_list = well_dict[rft_observation.date]
+            if rft_observation.property not in property_list:
+                property_list.append(rft_observation.property)
+
+    def derive_breakthrough_response_input_from_observations(self) -> None:
+        observations = self.observation_declarations
+        ensemble_config = self.ensemble_config
+
+        bt_obs = [o for o in observations if isinstance(o, BreakthroughObservation)]
+
+        if "breakthrough" not in ensemble_config.derived_response_configs and bt_obs:
+            ensemble_config.derived_response_configs["breakthrough"] = (
+                BreakthroughConfig(
+                    keys=[f"BREAKTHROUGH:{o.key}" for o in bt_obs],
+                    summary_keys=[o.key for o in bt_obs],
+                    thresholds=[o.threshold for o in bt_obs],
+                    observed_dates=[o.date for o in bt_obs],
+                )
+            )
 
     @classmethod
     def _create_list_of_forward_model_steps_to_run(

--- a/src/ert/run_models/initial_ensemble_run_model.py
+++ b/src/ert/run_models/initial_ensemble_run_model.py
@@ -1,7 +1,5 @@
 import numpy as np
-import polars as pl
 
-from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.ensemble_evaluator.config import EvaluatorServerConfig
 from ert.run_arg import create_run_arguments
 from ert.run_models.run_model import RunModel
@@ -38,21 +36,3 @@ class InitialEnsembleRunModel(RunModel, InitialEnsembleRunModelConfig):
             evaluator_server_config,
         )
         return ensemble_storage
-
-    def observation_dataframes(self) -> dict[str, pl.DataFrame]:
-        if self.observations is None:
-            return {}
-
-        rft_config = next(
-            (r for r in self.response_configuration if r.type == "rft"),
-            None,
-        )
-
-        shape_registry = self._storage.get_experiment_by_name(
-            self.experiment_name
-        ).shape_registry
-        return create_observation_dataframes(
-            observations=self.observations,
-            rft_config=rft_config,
-            shape_registry=shape_registry,
-        )

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -231,16 +231,6 @@ class LocalExperiment(BaseMode):
             output_path = path / "observations"
             output_path.mkdir(parents=True, exist_ok=True)
 
-            responses_list = experiment_config.get("response_configuration", [])
-            rft_config_json = next(
-                (r for r in responses_list if r.get("type") == "rft"), None
-            )
-            rft_config = (
-                _responses_adapter.validate_python(rft_config_json)
-                if rft_config_json is not None
-                else None
-            )
-
             obs_adapter = TypeAdapter(Observation)  # type: ignore
             obs_objs: list[Observation] = [
                 obs_adapter.validate_python(od) for od in observation_declarations
@@ -252,9 +242,7 @@ class LocalExperiment(BaseMode):
                 if shape_registry_data
                 else ShapeRegistry()
             )
-            datasets = create_observation_dataframes(
-                obs_objs, rft_config, shape_registry
-            )
+            datasets = create_observation_dataframes(obs_objs, shape_registry)
             for response_type, df in datasets.items():
                 storage._to_parquet_transaction(output_path / response_type, df)
 
@@ -517,22 +505,12 @@ class LocalExperiment(BaseMode):
         output_path = self.mount_point / "observations"
         output_path.mkdir(parents=True, exist_ok=True)
 
-        rft_cfg = None
-        try:
-            responses_list = self.experiment_config.get("response_configuration", [])
-            for r in responses_list:
-                if r.get("type") == "rft":
-                    rft_cfg = _responses_adapter.validate_python(r)
-                    break
-        except Exception:
-            rft_cfg = None
-
         obs_adapter = TypeAdapter(Observation)  # type: ignore
         obs_objs: list[Observation] = [
             obs_adapter.validate_python(od) for od in serialized_observations
         ]
 
-        datasets = create_observation_dataframes(obs_objs, rft_cfg, self.shape_registry)
+        datasets = create_observation_dataframes(obs_objs, self.shape_registry)
         for response_type, df in datasets.items():
             self._storage._to_parquet_transaction(output_path / response_type, df)
 

--- a/tests/ert/defaults_generator.py
+++ b/tests/ert/defaults_generator.py
@@ -8,9 +8,10 @@ from ert.config._observations import (
     SeismicObservation,
     SummaryObservation,
 )
+from ert.config.parsing.observations_parser import ObservationType
 
 
-def _create_general_observation(
+def create_general_observation(
     name: str = "general_observation",
     data: str = "FIELD_WPR_DIFF",
     value: float = 2.0,
@@ -28,7 +29,35 @@ def _create_general_observation(
     )
 
 
-def _create_summary_observation(
+def create_general_observation_dict(
+    name: str = "general_observation",
+    data: str = "RES",
+    value: float | None = 1,
+    error: float | None = 1,
+    obs_file: str | None = None,
+    restart: int | None = None,
+    index_list: str | None = None,
+) -> dict:
+    if obs_file is not None:
+        value = None
+        error = None
+    return {
+        k: v
+        for k, v in {
+            "type": ObservationType.GENERAL,
+            "name": name,
+            "DATA": data,
+            "VALUE": value,
+            "ERROR": error,
+            "RESTART": restart,
+            "INDEX_LIST": index_list,
+            "OBS_FILE": obs_file,
+        }.items()
+        if v is not None
+    }
+
+
+def create_summary_observation(
     name: str = "summary_observation",
     key: str = "FOPR",
     date: str = "2020-01-01",
@@ -44,7 +73,24 @@ def _create_summary_observation(
     )
 
 
-def _create_breakthrough_observation(
+def create_summary_observation_dict(
+    name: str = "summary_observation",
+    key: str = "FOPR",
+    date: str = "2020-01-01",
+    value: float = 1.0,
+    error: float = 0.1,
+) -> dict:
+    return {
+        "type": ObservationType.SUMMARY,
+        "name": name,
+        "KEY": key,
+        "DATE": date,
+        "VALUE": value,
+        "ERROR": error,
+    }
+
+
+def create_breakthrough_observation(
     name: str = "breakthrough_observation",
     key: str = "WWCT:OP1",
     date: datetime.datetime = datetime.datetime(2000, 3, 2, 13, 0, 0),  # noqa: DTZ001
@@ -60,7 +106,24 @@ def _create_breakthrough_observation(
     )
 
 
-def _create_rft_observation(
+def create_breakthrough_observation_dict(
+    name: str = "breakthrough_observation",
+    key: str = "WWCT:OP1",
+    date: datetime.datetime = datetime.datetime(2000, 3, 2, 13, 0, 0),  # noqa: DTZ001
+    error: float = 10.0,
+    threshold: float = 0.2,
+) -> dict:
+    return {
+        "type": ObservationType.BREAKTHROUGH,
+        "name": name,
+        "KEY": key,
+        "ERROR": str(error),
+        "DATE": date.isoformat(),
+        "THRESHOLD": threshold,
+    }
+
+
+def create_rft_observation(
     name: str = "rft_observation",
     well: str = "WELL1",
     date: str = "2020-01-01",
@@ -88,7 +151,34 @@ def _create_rft_observation(
     )
 
 
-def _create_seismic_observation(
+def create_rft_observation_dict(
+    name: str = "rft_observation",
+    well: str = "WELL1",
+    date: str = "2020-01-01",
+    prop: str = "PRESSURE",
+    east: float = 100.0,
+    north: float = 200.0,
+    tvd: float = 25.0,
+    zone: str | None = None,
+    value: float = 150.0,
+    error: float = 5.0,
+) -> dict:
+    return {
+        "type": ObservationType.RFT,
+        "name": name,
+        "WELL": well,
+        "DATE": date,
+        "PROPERTY": prop,
+        "EAST": east,
+        "NORTH": north,
+        "TVD": tvd,
+        "VALUE": value,
+        "ERROR": error,
+        "ZONE": zone,
+    }
+
+
+def create_seismic_observation(
     name: str = "seismic_observation",
     filepath: Path = Path("obs.csv"),
     east: float = 1.0,
@@ -104,3 +194,10 @@ def _create_seismic_observation(
         value=value,
         error=error,
     )
+
+
+def create_seismic_observation_dict(
+    name: str = "seismic_observation",
+    csv: str = "obs.csv",
+) -> dict:
+    return {"type": ObservationType.SEISMIC, "name": name, "CSV": csv}

--- a/tests/ert/performance_tests/test_memory_usage.py
+++ b/tests/ert/performance_tests/test_memory_usage.py
@@ -114,7 +114,7 @@ def fill_storage_with_data(poly_template: Path, ert_config: ErtConfig) -> None:
     with open_storage(path, mode="w") as storage:
         ens_config = ert_config.ensemble_config
         observations = create_observation_dataframes(
-            ert_config.observation_declarations, None
+            ert_config.observation_declarations
         )
         experiment_id = storage.create_experiment(
             experiment_config={

--- a/tests/ert/unit_tests/config/test_bulk_summary_config.py
+++ b/tests/ert/unit_tests/config/test_bulk_summary_config.py
@@ -320,7 +320,7 @@ def test_that_summary_bulk_config_resolves_csv_in_subdirectory_from_main_config(
 
     ert_conf = ErtConfig.from_file("config.ert")
     obs = create_observation_dataframes(
-        ert_conf.observation_declarations, None, ert_conf.shape_registry
+        ert_conf.observation_declarations, ert_conf.shape_registry
     )
     assert len(obs["summary"]) == 3
     assert len(obs["breakthrough"]) == 1

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2855,7 +2855,6 @@ def test_that_breakthrough_observations_can_be_internalized_in_ert_config():
 
     breakthrough_observations = create_observation_dataframes(
         config.observation_declarations,
-        None,
         config.shape_registry,
     )["breakthrough"]
     assert breakthrough_observations["observation_key"].to_list() == ["BRT_OBS"]

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -29,7 +29,7 @@ from ert.config.parsing.observations_parser import (
     observations_parser,
 )
 from ert.namespace import Namespace
-from tests.ert.defaults_generator import _create_seismic_observation
+from tests.ert.defaults_generator import create_seismic_observation
 
 observation_contents = stlark.from_lark(observations_parser)
 
@@ -858,7 +858,7 @@ def test_that_seismic_observation_instantiates(file_context_token):
         shape_registry=shape_registry,
     )
     assert obs == [
-        _create_seismic_observation(
+        create_seismic_observation(
             name="NAME",
             filepath=Path("obs.csv"),
             east=461231.5537527473,
@@ -866,7 +866,7 @@ def test_that_seismic_observation_instantiates(file_context_token):
             value=-0.0003566695393886,
             error=0.005,
         ),
-        _create_seismic_observation(
+        create_seismic_observation(
             name="NAME",
             filepath=Path("obs.csv"),
             east=461156.9532936567,
@@ -1002,7 +1002,7 @@ def test_that_seismic_observation_defaults_all_names_to_filename(file_context_to
         shape_registry=shape_registry,
     )
     assert obs == [
-        _create_seismic_observation(
+        create_seismic_observation(
             name="obs",
             filepath=Path("obs.csv"),
             east=1.0,
@@ -1010,7 +1010,7 @@ def test_that_seismic_observation_defaults_all_names_to_filename(file_context_to
             value=1.0,
             error=0.005,
         ),
-        _create_seismic_observation(
+        create_seismic_observation(
             name="obs",
             filepath=Path("obs.csv"),
             east=1.0,

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -34,6 +34,10 @@ from ert.config.rft_config import RFTConfig
 from ert.gui.plotting.ert_plots.observations import _plotObservations
 from ert.gui.plotting.utils import PlotConfig
 from ert.namespace import Namespace
+from tests.ert.defaults_generator import (
+    create_breakthrough_observation_dict,
+    create_summary_observation_dict,
+)
 
 pytestmark = pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 
@@ -163,26 +167,8 @@ def test_that_when_history_source_is_simulated_the_summary_vector_is_used():
 @pytest.mark.parametrize(
     "observation_dict",
     [
-        pytest.param(
-            {
-                "type": ObservationType.SUMMARY,
-                "name": "FOPR",
-                "KEY": "FOPR",
-                "VALUE": "1",
-                "ERROR": "1",
-                "DATE": "",
-            }
-        ),
-        pytest.param(
-            {
-                "type": ObservationType.BREAKTHROUGH,
-                "name": "breakthrough",
-                "KEY": "WWCT:OP_1",
-                "ERROR": "1",
-                "THRESHOLD": "0.2",
-                "DATE": "",
-            }
-        ),
+        pytest.param(create_summary_observation_dict()),
+        pytest.param(create_breakthrough_observation_dict()),
     ],
 )
 def test_date_parsing_in_observations(datestring, errors, observation_dict):

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -36,6 +36,7 @@ from ert.gui.plotting.utils import PlotConfig
 from ert.namespace import Namespace
 from tests.ert.defaults_generator import (
     create_breakthrough_observation_dict,
+    create_rft_observation_dict,
     create_summary_observation_dict,
 )
 
@@ -309,7 +310,7 @@ def test_that_summary_observations_can_use_restart_for_index_if_time_map_is_give
     assert list(observations["time"]) == [datetime.fromisoformat(time_map[restart])]
 
 
-def test_that_rft_config_is_created_from_observations():
+def test_that_rft_observation_dataframes_are_created():
     ert_config = ErtConfig.from_dict(
         {
             "ECLBASE": "ECLIPSE_CASE",
@@ -355,7 +356,70 @@ def test_that_rft_config_is_created_from_observations():
             }
         ),
     )
-    assert rft_config.data_to_read == {"well": {"2013-03-31": ["PRESSURE"]}}
+
+
+def test_that_rft_config_is_created_from_observations():
+    ert_config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "ECLIPSE_CASE",
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    create_rft_observation_dict(
+                        well="well", date="2013-03-31", prop="PRESSURE"
+                    ),
+                    create_rft_observation_dict(
+                        well="well2", date="2013-03-31", prop="PRESSURE"
+                    ),
+                    create_rft_observation_dict(
+                        well="well", date="2015-03-31", prop="PRESSURE"
+                    ),
+                    create_rft_observation_dict(
+                        well="well", date="2013-03-31", prop="DEPTH"
+                    ),
+                ],
+            ),
+        }
+    )
+    assert "rft" in ert_config.ensemble_config.response_configs
+    rft_config = cast(RFTConfig, ert_config.ensemble_config.response_configs["rft"])
+    assert rft_config.data_to_read == {
+        "well": {"2013-03-31": ["PRESSURE", "DEPTH"], "2015-03-31": ["PRESSURE"]},
+        "well2": {"2013-03-31": ["PRESSURE"]},
+    }
+
+
+def test_that_rft_config_is_created_from_mix_of_observations_and_responses():
+    ert_config = ErtConfig.from_dict(
+        {
+            "ECLBASE": "ECLIPSE_CASE",
+            "RFT": [{"WELL": "well", "DATE": "2013-03-31", "PROPERTIES": "DEPTH"}],
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    create_rft_observation_dict(
+                        well="well", date="2013-03-31", prop="PRESSURE"
+                    ),
+                ],
+            ),
+        }
+    )
+    rft_config = cast(RFTConfig, ert_config.ensemble_config.response_configs["rft"])
+    assert rft_config.data_to_read == {"well": {"2013-03-31": ["DEPTH", "PRESSURE"]}}
+
+
+def test_that_rft_config_requires_eclbase_to_be_created_from_observations():
+    ert_config = ErtConfig.from_dict(
+        {
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    create_rft_observation_dict(),
+                ],
+            ),
+        }
+    )
+    assert "rft" not in ert_config.ensemble_config.response_configs
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -123,7 +123,7 @@ def make_refcase_observations(
 
     migrated_config = ErtConfig.from_file("config.ert")
     return create_observation_dataframes(
-        migrated_config.observation_declarations, None, migrated_config.shape_registry
+        migrated_config.observation_declarations, migrated_config.shape_registry
     )
 
 
@@ -249,7 +249,6 @@ def test_that_summary_observations_can_use_restart_for_index_if_refcase_is_given
         migrated_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
             migrated_config.observation_declarations,
-            None,
             migrated_config.shape_registry,
         )["summary"]
 
@@ -303,7 +302,7 @@ def test_that_summary_observations_can_use_restart_for_index_if_time_map_is_give
 
     migrated_config = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        migrated_config.observation_declarations, None, migrated_config.shape_registry
+        migrated_config.observation_declarations, migrated_config.shape_registry
     )["summary"]
 
     # RESTART is a 1-based index; Python lists are 0-based.
@@ -333,9 +332,8 @@ def test_that_rft_observation_dataframes_are_created():
             ),
         }
     )
-    rft_config = cast(RFTConfig, ert_config.ensemble_config.response_configs["rft"])
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, rft_config, ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )["rft"]
     assert_frame_equal(
         observations,
@@ -454,7 +452,7 @@ def test_that_the_date_keyword_sets_the_summary_index_without_time_map_or_refcas
 
     migrated = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        migrated.observation_declarations, None, migrated.shape_registry
+        migrated.observation_declarations, migrated.shape_registry
     )["summary"]
 
     assert list(observations["time"]) == [datetime.fromisoformat(date)]
@@ -488,7 +486,6 @@ def test_that_general_observations_can_use_restart_even_without_refcase_and_time
     )
     observations = create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )
 
@@ -527,7 +524,7 @@ def test_that_the_date_keyword_sets_the_general_index_by_looking_up_time_map():
     run_convert_observations(Namespace(config="config.ert"))
     ert_config = ErtConfig.from_file("config.ert")
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, None, ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )
     assert observations["gen_data"].to_dicts()[0]["report_step"] == restart
 
@@ -596,7 +593,7 @@ def test_that_the_date_keyword_sets_the_report_step_by_looking_up_refcase(
         run_convert_observations(Namespace(config="config.ert"))
         ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ert_config.observation_declarations, None, ert_config.shape_registry
+            ert_config.observation_declarations, ert_config.shape_registry
         )
         assert observations["gen_data"].to_dicts()[0]["report_step"] == restart
 
@@ -846,7 +843,6 @@ def test_that_indices_from_file_and_list_are_read(
 
         observations = create_observation_dataframes(
             observations=obs,
-            rft_config=None,
             shape_registry=None,
         )
         assert list(observations["gen_data"]["index"]) == [0, 2, 4, 6, 8]
@@ -1326,7 +1322,7 @@ def test_that_history_observations_values_are_fetched_from_refcase(
         run_convert_observations(Namespace(config="config.ert"))
         ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ert_config.observation_declarations, None, ert_config.shape_registry
+            ert_config.observation_declarations, ert_config.shape_registry
         )["summary"]
 
         steps = len(unsmry.steps)
@@ -1524,7 +1520,7 @@ def test_that_history_observation_errors_are_calculated_correctly(tmpdir):
         run_convert_observations(Namespace(config="config.ert"))
         ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ert_config.observation_declarations, None, ert_config.shape_registry
+            ert_config.observation_declarations, ert_config.shape_registry
         )["summary"]
 
         assert list(observations["response_key"]) == ["FGPR", "FOPR", "FWPR"]
@@ -1568,7 +1564,7 @@ def test_that_segment_defaults_are_applied(tmpdir):
         run_convert_observations(Namespace(config="config.ert"))
         ert_config = ErtConfig.from_file("config.ert")
         observations = create_observation_dataframes(
-            ert_config.observation_declarations, None, ert_config.shape_registry
+            ert_config.observation_declarations, ert_config.shape_registry
         )["summary"]
 
         # default error_min is 0.1
@@ -1595,7 +1591,6 @@ def test_that_summary_default_error_min_is_applied():
     )
     observations = create_observation_dataframes(
         obs,
-        rft_config=None,
         shape_registry=None,
     )
 
@@ -2035,7 +2030,6 @@ def test_that_general_observations_are_instantiated_with_localization_attributes
     ert_config = ert_config_from_parser(obs_config_contents)
     gen_obs = create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )["gen_data"]
     for loc_kw in ["east", "north", "radius"]:
@@ -2063,7 +2057,6 @@ def test_that_breakthrough_observations_df_have_obs_value_zero():
     ert_config = ert_config_from_parser(obs_config_contents)
     brt_obs = create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )["breakthrough"]
     assert brt_obs["observations"].to_list() == [0]
@@ -2089,7 +2082,6 @@ def test_that_breakthrough_observations_appends_to_breakthrough_config_responses
     ert_config = ert_config_from_parser(obs_config_contents)
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )
     breakthrough_config = ert_config.ensemble_config.derived_response_configs[
@@ -2116,7 +2108,6 @@ def test_that_breakthrough_responses_are_derived_from_summary():
     ert_config = ert_config_from_parser(obs_config_contents)
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )
 
@@ -2155,7 +2146,6 @@ def test_that_unreachable_breakthrough_thresholds_has_none_response():
     ert_config = ert_config_from_parser(obs_config_contents)
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )
 
@@ -2200,7 +2190,6 @@ def test_that_combined_reachable_and_unreachable_breakthrough_thresholds_are_tur
     ert_config = ert_config_from_parser(obs_config_contents)
     create_observation_dataframes(
         observations=ert_config.observation_declarations,
-        rft_config=None,
         shape_registry=ert_config.shape_registry,
     )
 
@@ -2457,7 +2446,7 @@ def test_that_seismic_observation_dataframes_are_created(
         }
     )
     observations = create_observation_dataframes(
-        ert_config.observation_declarations, None, ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )["seismic"]
     assert_frame_equal(
         observations,

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -602,10 +602,6 @@ def test_that_location_outside_of_the_grid_maps_to_none(mock_resfo_file, egrid):
 
 def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
     provided_radius = 2400
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={"*": {"*": ["*"]}},
-    )
     shape_registry = ShapeRegistry()
     shape_id = shape_registry.register(
         CircleShapeConfig(
@@ -626,7 +622,7 @@ def test_that_handle_rft_observations_prioritize_provided_radius_over_default():
         tvd=2000.0,
         shape_id=shape_id,
     )
-    df = _handle_rft_observation(rft_config, rft_observation, shape_registry)
+    df = _handle_rft_observation(rft_observation, shape_registry)
     assert "radius" in df.columns
     assert df["radius"].to_list() == [provided_radius]
     assert df["radius"].dtype == pl.Float32

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -22,6 +22,7 @@ from ert.config.parsing import ConfigValidationError, ObservationType
 from ert.config.response_config import _RESPONSE_WARNING_LIMIT
 from ert.config.rft_config import _get_zonemap, _read_egrid
 from ert.warnings import PostExperimentWarning
+from tests.ert.defaults_generator import create_rft_observation_dict
 from tests.ert.rft_generator import cell_start, create_egrid, float_arr
 
 
@@ -659,19 +660,7 @@ def test_that_when_the_zonemap_is_an_absolute_path_then_the_runpath_is_not_prepe
             "OBS_CONFIG": (
                 "obsconf",
                 [
-                    {
-                        "type": ObservationType.RFT,
-                        "name": "NAME",
-                        "WELL": "WELL",
-                        "VALUE": "700",
-                        "ERROR": "0.1",
-                        "DATE": "2000-01-01",
-                        "PROPERTY": "PRESSURE",
-                        "NORTH": 1.0,
-                        "EAST": 1.0,
-                        "TVD": 0.5,
-                        "ZONE": "zone2",
-                    },
+                    create_rft_observation_dict(),
                 ],
             ),
         }
@@ -731,19 +720,7 @@ def test_that_substitutions_are_applied_to_zonemap_filename(
             "OBS_CONFIG": (
                 "obsconf",
                 [
-                    {
-                        "type": ObservationType.RFT,
-                        "name": "NAME",
-                        "WELL": "WELL",
-                        "VALUE": "700",
-                        "ERROR": "0.1",
-                        "DATE": "2000-01-01",
-                        "PROPERTY": "PRESSURE",
-                        "NORTH": 1.0,
-                        "EAST": 1.0,
-                        "TVD": 0.5,
-                        "ZONE": "zone1",
-                    },
+                    create_rft_observation_dict(),
                 ],
             ),
         }
@@ -780,18 +757,7 @@ def test_that_missing_egrid_with_locations_raises_invalid_response_file(
             "OBS_CONFIG": (
                 "obsconf",
                 [
-                    {
-                        "type": ObservationType.RFT,
-                        "name": "NAME",
-                        "WELL": "WELL",
-                        "VALUE": "700",
-                        "ERROR": "0.1",
-                        "DATE": "2000-01-01",
-                        "PROPERTY": "PRESSURE",
-                        "NORTH": 1.0,
-                        "EAST": 1.0,
-                        "TVD": 1.0,
-                    },
+                    create_rft_observation_dict(),
                 ],
             ),
         }
@@ -1318,20 +1284,7 @@ def test_that_approximate_missing_rft_values_keyword_sets_interpolation_to_true_
     if rft_obs_config:
         config_dict["OBS_CONFIG"] = (
             "obsconf",
-            [
-                {
-                    "type": ObservationType.RFT,
-                    "name": "NAME",
-                    "WELL": "WELL",
-                    "VALUE": "700",
-                    "ERROR": "0.1",
-                    "DATE": "2000-01-01",
-                    "PROPERTY": "PRESSURE",
-                    "NORTH": 1.0,
-                    "EAST": 1.0,
-                    "TVD": 0.5,
-                }
-            ],
+            [create_rft_observation_dict()],
         )
 
     config = ErtConfig.from_dict(config_dict)

--- a/tests/ert/unit_tests/config/test_seismic_config.py
+++ b/tests/ert/unit_tests/config/test_seismic_config.py
@@ -6,9 +6,9 @@ import pytest
 from ert.config._create_observation_dataframes import _handle_seismic_observation
 from ert.config._observations import SeismicObservation
 from ert.config.ert_config import ErtConfig
-from ert.config.parsing.observations_parser import ObservationType
 from ert.config.response_config import InvalidResponseFile
 from ert.config.seismic_config import SeismicConfig
+from tests.ert.defaults_generator import create_seismic_observation_dict
 
 
 def test_that_seismic_observation_response_key_matches_simulated_response_key(
@@ -43,11 +43,7 @@ def test_that_seismic_observation_response_key_matches_simulated_response_key(
             "OBS_CONFIG": (
                 "obsconf",
                 [
-                    {
-                        "type": ObservationType.SEISMIC,
-                        "name": "OBS1",
-                        "CSV": obs_path,
-                    },
+                    create_seismic_observation_dict(csv=obs_path),
                 ],
             ),
         }

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -83,7 +83,7 @@ def create_observations(config, obs_config):
 
     ert_config = ErtConfig.from_file("config.ert")
     return create_observation_dataframes(
-        ert_config.observation_declarations, None, ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )
 
 
@@ -215,7 +215,7 @@ def test_that_adding_one_localized_observation_to_snake_oil_case_can_be_internal
     Path("observations/observations.txt").write_text(new_obs_content, encoding="utf-8")
     ert_config = ErtConfig.from_file("snake_oil.ert")
     summary = create_observation_dataframes(
-        ert_config.observation_declarations, None, ert_config.shape_registry
+        ert_config.observation_declarations, ert_config.shape_registry
     )["summary"]
     assert summary["east"].dtype == pl.Float32
     assert summary["north"].dtype == pl.Float32

--- a/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
+++ b/tests/ert/unit_tests/dark_storage/test_http_endpoints.py
@@ -16,11 +16,11 @@ from ert.dark_storage.common import get_storage_api_version
 from ert.dark_storage.endpoints.observations import _get_observations
 from ert.storage import open_storage
 from tests.ert.defaults_generator import (
-    _create_breakthrough_observation,
-    _create_general_observation,
-    _create_rft_observation,
-    _create_seismic_observation,
-    _create_summary_observation,
+    create_breakthrough_observation,
+    create_general_observation,
+    create_rft_observation,
+    create_seismic_observation,
+    create_summary_observation,
 )
 
 
@@ -431,26 +431,26 @@ def test_that_observations_are_sorted_on_x_axis_column(tmp_path):
     storage_path = tmp_path / "storage"
     observations = [
         *[
-            _create_summary_observation(name="SUMMARY_OBSERVATION", date=date)
+            create_summary_observation(name="SUMMARY_OBSERVATION", date=date)
             for date in ["2010-11-01", "2010-07-01", "2010-12-01"]
         ],
         *[
-            _create_general_observation(name="GENERAL_OBSERVATION", index=index)
+            create_general_observation(name="GENERAL_OBSERVATION", index=index)
             for index in [11, 7, 12]
         ],
         *[
-            _create_breakthrough_observation(
+            create_breakthrough_observation(
                 name="BREAKTHROUGH_OBSERVATION",
                 date=datetime.datetime(2010, month, 1),  # noqa: DTZ001
             )
             for month in [11, 7, 12]
         ],
         *[
-            _create_rft_observation(name="RFT_OBSERVATION", tvd=tvd)
+            create_rft_observation(name="RFT_OBSERVATION", tvd=tvd)
             for tvd in [11.0, 7.0, 12.0]
         ],
         *[
-            _create_seismic_observation(
+            create_seismic_observation(
                 name="SEISMIC_OBSERVATION",
                 east=east,
                 north=north,

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -19,6 +19,13 @@ from ert.gui.tools.manage_experiments.storage_info_widget import (
     _EnsembleWidgetTabs,
 )
 from ert.run_models.event import FullSnapshotEvent, status_event_to_json
+from tests.ert.defaults_generator import (
+    create_breakthrough_observation_dict,
+    create_general_observation_dict,
+    create_rft_observation_dict,
+    create_seismic_observation_dict,
+    create_summary_observation_dict,
+)
 from tests.ert.utils import SnapshotBuilder
 
 
@@ -58,14 +65,9 @@ def test_that_missing_response_for_observation_response_key_does_not_crash(
             "OBS_CONFIG": (
                 "obs_config",
                 [
-                    {
-                        "type": ObservationType.SUMMARY,
-                        "name": "sumobs",
-                        "KEY": observation_key,
-                        "DATE": date.isoformat(),
-                        "VALUE": 1.0,
-                        "ERROR": 1.0,
-                    }
+                    create_summary_observation_dict(
+                        key=observation_key, date=date.isoformat()
+                    ),
                 ],
             ),
         }
@@ -107,14 +109,7 @@ def test_that_breakthrough_experiment_does_not_crash(qtbot, storage):
             "OBS_CONFIG": (
                 "obs_config",
                 [
-                    {
-                        "type": ObservationType.BREAKTHROUGH,
-                        "name": "BRT_OP1",
-                        "KEY": key,
-                        "ERROR": "3",
-                        "DATE": (date + timedelta(days=5)).isoformat(),
-                        "THRESHOLD": 0.4,
-                    }
+                    create_breakthrough_observation_dict(key=key, date=date),
                 ],
             ),
         }
@@ -507,7 +502,6 @@ def test_that_many_realizations_in_rft_affect_responses_not_observation_tree(
 
 @pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
-    date = datetime(year=2000, month=1, day=1).date()  # noqa: DTZ001
     config = ErtConfig.from_dict(
         {
             "NUM_REALIZATIONS": 1,
@@ -516,32 +510,8 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
             "OBS_CONFIG": (
                 "obs_config",
                 [
-                    {
-                        "type": ObservationType.RFT,
-                        "name": "RFT",
-                        "WELL": "WELL",
-                        "VALUE": "700",
-                        "ERROR": "0.1",
-                        "DATE": date.isoformat(),
-                        "PROPERTY": "PRESSURE",
-                        "EAST": 10.0,
-                        "NORTH": 11.0,
-                        "TVD": 12.0,
-                        "ZONE": "zone",
-                    },
-                    {
-                        "type": ObservationType.RFT,
-                        "name": "RFT_index_key_duplicate",
-                        "WELL": "WELL",
-                        "VALUE": "700",
-                        "ERROR": "0.1",
-                        "DATE": date.isoformat(),
-                        "PROPERTY": "PRESSURE",
-                        "EAST": 10.0,
-                        "NORTH": 11.0,
-                        "TVD": 12.0,
-                        "ZONE": "zone",
-                    },
+                    create_rft_observation_dict(name="RFT"),
+                    create_rft_observation_dict(name="RFT_index_key_duplicate"),
                 ],
             ),
         }
@@ -568,128 +538,66 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
     [
         pytest.param(
             [
-                {
-                    "type": ObservationType.BREAKTHROUGH,
-                    "name": "BRT_OP1",
-                    "KEY": "WWCT:OP1",
-                    "ERROR": "3",
-                    "DATE": datetime(year=2000, month=1, day=1).isoformat(),  # noqa: DTZ001
-                    "THRESHOLD": 0.4,
-                },
-                {
-                    "type": ObservationType.BREAKTHROUGH,
-                    "name": "BRT_OP2",
-                    "KEY": "WWCT:OP1",
-                    "ERROR": "3",
-                    "DATE": datetime(year=2000, month=1, day=9).isoformat(),  # noqa: DTZ001
-                    "THRESHOLD": 0.7,
-                },
+                create_breakthrough_observation_dict(
+                    name="BRT_OP1",
+                    threshold=0.4,
+                    date=datetime(year=2000, month=1, day=1),  # noqa: DTZ001
+                ),
+                create_breakthrough_observation_dict(
+                    name="BRT_OP2",
+                    threshold=0.7,
+                    date=datetime(year=2000, month=1, day=9),  # noqa: DTZ001
+                ),
             ],
             ["0.4", "0.7"],
             id="breakthrough",
         ),
         pytest.param(
             [
-                {
-                    "type": ObservationType.RFT,
-                    "name": "RFT2",
-                    "WELL": "WELL",
-                    "VALUE": "700",
-                    "ERROR": "0.1",
-                    "DATE": "2000-01-01",
-                    "PROPERTY": "PRESSURE",
-                    "EAST": 11.0,
-                    "NORTH": 5.0,
-                    "TVD": 4.0,
-                    "ZONE": "zone",
-                },
-                {
-                    "type": ObservationType.RFT,
-                    "name": "RFT1",
-                    "WELL": "WELL",
-                    "VALUE": "700",
-                    "ERROR": "0.1",
-                    "DATE": "2000-01-01",
-                    "PROPERTY": "PRESSURE",
-                    "EAST": 5.0,
-                    "NORTH": 6.0,
-                    "TVD": 7.0,
-                    "ZONE": "zone",
-                },
+                create_rft_observation_dict(
+                    name="RFT2", east=11.0, north=5.0, tvd=4.0, zone="zone"
+                ),
+                create_rft_observation_dict(
+                    name="RFT1", east=5.0, north=6.0, tvd=7.0, zone="zone"
+                ),
             ],
             ["5.0, 6.0, 7.0, zone", "11.0, 5.0, 4.0, zone"],
             id="rft",
         ),
         pytest.param(
             [
-                {
-                    "type": ObservationType.RFT,
-                    "name": "RFT2",
-                    "WELL": "WELL",
-                    "VALUE": "700",
-                    "ERROR": "0.1",
-                    "DATE": "2000-01-01",
-                    "PROPERTY": "PRESSURE",
-                    "EAST": 700.0,
-                    "NORTH": 500.0,
-                    "TVD": 400.0,
-                },
-                {
-                    "type": ObservationType.RFT,
-                    "name": "RFT1",
-                    "WELL": "WELL",
-                    "VALUE": "700",
-                    "ERROR": "0.1",
-                    "DATE": "2000-01-01",
-                    "PROPERTY": "PRESSURE",
-                    "EAST": 5.0,
-                    "NORTH": 6.0,
-                    "TVD": 7.0,
-                },
+                create_rft_observation_dict(
+                    name="RFT2", east=700.0, north=500.0, tvd=400.0
+                ),
+                create_rft_observation_dict(name="RFT1", east=5.0, north=6.0, tvd=7.0),
             ],
             ["5.0, 6.0, 7.0, None", "700.0, 500.0, 400.0, None"],
             id="rft without zone",
         ),
         pytest.param(
             [
-                {
-                    "type": ObservationType.SUMMARY,
-                    "name": "FOPR_1",
-                    "KEY": "FOPR",
-                    "VALUE": "1",
-                    "ERROR": "1",
-                    "DATE": "2023-03-15",
-                },
-                {
-                    "type": ObservationType.SUMMARY,
-                    "name": "FOPR_2",
-                    "KEY": "FOPR",
-                    "VALUE": "1",
-                    "ERROR": "1",
-                    "DATE": "2024-11-07",
-                },
+                create_summary_observation_dict(name="FOPR_1", date="2023-03-15"),
+                create_summary_observation_dict(name="FOPR_2", date="2024-11-07"),
             ],
             ["2023-03-15", "2024-11-07"],
             id="summary",
         ),
         pytest.param(
             [
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "GOBS1",
-                    "DATA": "GEN",
-                    "RESTART": "11",
-                    "INDEX_LIST": "60,400,1200,1600,1800",
-                    "OBS_FILE": "gen_obs_data.txt",
-                },
-                {
-                    "type": ObservationType.GENERAL,
-                    "name": "GOBS2",
-                    "DATA": "GEN",
-                    "RESTART": "100",
-                    "INDEX_LIST": "60,400,1200,1600,1800",
-                    "OBS_FILE": "gen_obs_data.txt",
-                },
+                create_general_observation_dict(
+                    name="GOBS1",
+                    data="GEN",
+                    restart=11,
+                    index_list="60,400,1200,1600,1800",
+                    obs_file="gen_obs_data.txt",
+                ),
+                create_general_observation_dict(
+                    name="GOBS2",
+                    data="GEN",
+                    restart=100,
+                    index_list="60,400,1200,1600,1800",
+                    obs_file="gen_obs_data.txt",
+                ),
             ],
             [
                 "11, 60",
@@ -707,16 +615,12 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
         ),
         pytest.param(
             [
-                {
-                    "type": ObservationType.SEISMIC,
-                    "name": "SEISMIC1",
-                    "CSV": "seismic--20250101_20240101.csv",
-                },
-                {
-                    "type": ObservationType.SEISMIC,
-                    "name": "SEISMIC2",
-                    "CSV": "seismic--20260101_20240101.csv",
-                },
+                create_seismic_observation_dict(
+                    name="SEISMIC1", csv="seismic--20250101_20240101.csv"
+                ),
+                create_seismic_observation_dict(
+                    name="SEISMIC2", csv="seismic--20260101_20240101.csv"
+                ),
             ],
             ["99.0, 200.0", "100.0, 200.0"],
             id="seismic",

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -30,7 +30,7 @@ from ert.storage import (
 from ert.storage.local_storage import _LOCAL_STORAGE_VERSION, LocalStorage
 from ert.storage.mode import ModeError
 from tests.ert.defaults_generator import (
-    _create_summary_observation,
+    create_summary_observation,
 )
 from tests.ert.unit_tests.storage._storage_test_helpers import (
     RaisingWriteNamedTemporaryFile,
@@ -705,7 +705,7 @@ def test_that_get_observations_and_responses_adds_qc_error_on_summary_mismatch(
 
         summary_config = SummaryConfig(input_files=["not_relevant"], keys=["*"])
 
-        summary_observation = _create_summary_observation(
+        summary_observation = create_summary_observation(
             name="Summary_OBS",
             key="FOPR",
             date=obs_date.isoformat(),

--- a/tests/ert/unit_tests/storage/test_rft_observations_and_responses.py
+++ b/tests/ert/unit_tests/storage/test_rft_observations_and_responses.py
@@ -18,7 +18,7 @@ from ert.storage import open_storage
 from ert.storage.local_ensemble import (
     _write_responses_to_storage,
 )
-from tests.ert.defaults_generator import _create_rft_observation
+from tests.ert.defaults_generator import create_rft_observation
 
 
 def rft_response(
@@ -71,7 +71,7 @@ def rft_observation(
     tvd=1000.0,
     zone=None,
 ):
-    return _create_rft_observation(
+    return create_rft_observation(
         name=name,
         well=well,
         date=date,
@@ -551,7 +551,7 @@ def test_that_get_observations_and_responses_interpolates_rft_values(
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_returns_joined_data():
     with _create_rft_ensemble(
-        1, [_create_rft_observation(zone="Z1")], zonemap="1 Z1"
+        1, [create_rft_observation(zone="Z1")], zonemap="1 Z1"
     ) as ensemble:
         realization = 0
         ensemble.save_response(
@@ -608,7 +608,7 @@ def test_that_get_rft_observations_and_responses_returns_joined_data():
 def test_that_get_rft_observations_and_responses_includes_approximated_values_when_enabled(  # noqa: E501
     approximate_missing_values, expected_approximated_values
 ):
-    observation = _create_rft_observation(zone="zone1")
+    observation = create_rft_observation(zone="zone1")
     with _create_rft_ensemble(
         1, [observation], approximate_missing_values=approximate_missing_values
     ) as ensemble:
@@ -657,8 +657,8 @@ def test_that_get_rft_observations_is_active_based_on_matching_pressure_response
     and False if not
     """
     observations = [
-        _create_rft_observation(),
-        _create_rft_observation(
+        create_rft_observation(),
+        create_rft_observation(
             name="obs2",
             tvd=30.0,
             md=60.0,
@@ -688,14 +688,14 @@ def test_that_get_rft_observations_is_active_based_on_matching_pressure_response
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_sets_valid_zone_with_null_equality():
     observations = [
-        _create_rft_observation(zone="Z1"),
-        _create_rft_observation(
+        create_rft_observation(zone="Z1"),
+        create_rft_observation(
             name="obs2",
             tvd=30.0,
             md=60.0,
             value=160.0,
         ),
-        _create_rft_observation(
+        create_rft_observation(
             name="obs3",
             tvd=35.0,
             md=70.0,
@@ -734,11 +734,11 @@ def test_that_get_rft_observations_and_responses_sets_valid_zone_with_null_equal
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_order_is_row_index_within_well():
     observations = [
-        _create_rft_observation(name="obs1", tvd=25.0, md=50.0),
-        _create_rft_observation(name="obs2", tvd=30.0, md=60.0),
-        _create_rft_observation(name="obs3", tvd=35.0, md=70.0),
-        _create_rft_observation(well="WELL2", name="obs4", tvd=40.0, md=80.0),
-        _create_rft_observation(well="WELL2", name="obs5", tvd=45.0, md=90.0),
+        create_rft_observation(name="obs1", tvd=25.0, md=50.0),
+        create_rft_observation(name="obs2", tvd=30.0, md=60.0),
+        create_rft_observation(name="obs3", tvd=35.0, md=70.0),
+        create_rft_observation(well="WELL2", name="obs4", tvd=40.0, md=80.0),
+        create_rft_observation(well="WELL2", name="obs5", tvd=45.0, md=90.0),
     ]
 
     with _create_rft_ensemble(1, observations) as ensemble:
@@ -771,7 +771,7 @@ def test_that_get_rft_observations_and_responses_handles_multiple_realizations(
     response_values: list[float], prop: str
 ):
     with _create_rft_ensemble(
-        len(response_values), [_create_rft_observation()]
+        len(response_values), [create_rft_observation()]
     ) as ensemble:
         for i, r in enumerate(response_values):
             ensemble.save_response(
@@ -803,7 +803,7 @@ def test_that_get_rft_observations_and_responses_raises_error_for_no_observation
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_raises_error_when_response_not_saved():
     with (
-        _create_rft_ensemble(1, [_create_rft_observation()]) as ensemble,
+        _create_rft_ensemble(1, [create_rft_observation()]) as ensemble,
         pytest.raises(KeyError, match="No response for key rft"),
     ):
         ensemble.get_rft_observations_and_responses()
@@ -811,7 +811,7 @@ def test_that_get_rft_observations_and_responses_raises_error_when_response_not_
 
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_raises_error_when_location_metadata_not_saved():  # noqa: E501
-    with _create_rft_ensemble(1, [_create_rft_observation()]) as ensemble:
+    with _create_rft_ensemble(1, [create_rft_observation()]) as ensemble:
         ensemble.save_response("rft", _create_rft_response_df(), 0)
         with pytest.raises(FileNotFoundError, match="observation_location_metadata"):
             ensemble.get_rft_observations_and_responses()
@@ -820,7 +820,7 @@ def test_that_get_rft_observations_and_responses_raises_error_when_location_meta
 @pytest.mark.usefixtures("use_tmpdir")
 def test_that_get_rft_observations_and_responses_adds_missing_saturation_columns():
     realization = 0
-    with _create_rft_ensemble(1, [_create_rft_observation()]) as ensemble:
+    with _create_rft_ensemble(1, [create_rft_observation()]) as ensemble:
         # Save a response that does not contain saturations
         ensemble.save_response("rft", _create_rft_response_df(), realization)
         ensemble.save_observation_location_metadata(
@@ -840,8 +840,8 @@ def test_that_get_rft_observations_and_responses_maps_report_step_from_summary_t
     tmp_path,
 ):
     observations = [
-        _create_rft_observation(date="2020-01-15"),
-        _create_rft_observation(
+        create_rft_observation(date="2020-01-15"),
+        create_rft_observation(
             date="2020-02-15",
             name="obs2",
             tvd=30.0,
@@ -908,7 +908,7 @@ def test_that_rft_artifacts_are_saved_atomically(caplog):
         ):
             num_realizations = 5
             observations = [
-                _create_rft_observation(),
+                create_rft_observation(),
             ]
 
             with _create_rft_ensemble(num_realizations, observations) as ensemble:

--- a/tests/ert/unit_tests/storage/test_stateful_storage.py
+++ b/tests/ert/unit_tests/storage/test_stateful_storage.py
@@ -286,7 +286,7 @@ class StatefulStorageTest(RuleBasedStateMachine):
         model_experiment = Experiment(experiment_id)
         model_experiment.parameters = parameters
         model_experiment.responses = responses
-        model_experiment.observations = create_observation_dataframes(obs, None)
+        model_experiment.observations = create_observation_dataframes(obs)
 
         # Ensure that there is at least one ensemble in the experiment
         # to avoid https://github.com/equinor/ert/issues/7040


### PR DESCRIPTION
**Issue**
Relates to #13912 as makes it nicer to derive response input data from observations.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
