### PR TITLE
Add method to redact sensitive logs

### DIFF
--- a/src/ert/logging/__init__.py
+++ b/src/ert/logging/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+import re
 import sys
 from collections.abc import Callable
 from datetime import datetime
@@ -92,3 +93,38 @@ def suppress_logs(logs_to_suppress: list[str]) -> Callable[[logging.LogRecord], 
         return True
 
     return log_filter
+
+
+class ObjectAttributeFilter(logging.Filter):
+    def __init__(self, objects: list[str], attributes: list[str]) -> None:
+        super().__init__()
+        self._obj_regex = rf"\b(?:{'|'.join(objects)})\([^\)]*\)"
+        self._attr_regex = rf"(?:{'|'.join(attributes)})=((?:'[^']*'|[^\s,\)]+))"
+
+    def _redact(self, msg: str | Any) -> str | Any:
+        # Record.msg is implemented as str | Any, but should be str in
+        # most cases according to the documentation.
+        # In our case, it is sometimes an exception, for example TimeoutError.
+        # This will return early should the record message not be a str.
+        if not isinstance(msg, str):
+            return msg
+
+        # Mutating msg will alter the indices of the succeeding- but not
+        # preceding text. Reversing the matches allows us to safely mutate
+        # the string from back to front.
+        for obj_match in reversed(list(re.finditer(self._obj_regex, msg))):
+            for attr_match in reversed(
+                list(re.finditer(self._attr_regex, obj_match.group()))
+            ):
+                attr = attr_match.group()
+                attr_value = attr.split("=")[1]
+                match_censored = re.sub(attr_value, "REDACTED", attr)
+
+                attr_start = obj_match.start() + attr_match.start()
+                attr_end = attr_start + len(attr)
+                msg = msg[:attr_start] + match_censored + msg[attr_end:]
+        return msg
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = self._redact(record.msg)
+        return True

--- a/src/ert/logging/logger.conf
+++ b/src/ert/logging/logger.conf
@@ -4,10 +4,16 @@ formatters:
     (): ert.logging.TerminalFormatter
   simple_with_threading:
     format: '%(asctime)s - %(name)s - %(threadName)s - %(levelname)s - %(message)s'
+filters:
+  redact_sensitive_attributes:
+    (): ert.logging.ObjectAttributeFilter
+    objects: [SummaryObservation, RFTObservation, BreakthroughObservation, GeneralObservation, ShapeRegistry]
+    attributes: [value, east, north]
 handlers:
   file:
     level: DEBUG
     formatter: simple_with_threading
+    filters: [redact_sensitive_attributes]
     (): ert.logging.TimestampedFileHandler
     use_log_dir_from_env: true
   terminal:

--- a/tests/ert/unit_tests/shared/test_log_filtering.py
+++ b/tests/ert/unit_tests/shared/test_log_filtering.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock
+
+from ert.logging import ObjectAttributeFilter
+
+
+def test_that_sensitive_attribute_is_only_redacted_from_sensitive_objects():
+    record = MagicMock(msg="Obj1(val=20) Obj2(val=30)")
+    ObjectAttributeFilter(["Obj1"], ["val"]).filter(record)
+    assert record.msg == "Obj1(val=REDACTED) Obj2(val=30)"
+
+
+def test_that_object_sharing_suffix_with_sensitive_object_is_not_matched():
+    record = MagicMock(msg="Obj(val=20) NotAObj(val=30)")
+    ObjectAttributeFilter(["Obj"], ["val"]).filter(record)
+    assert record.msg == "Obj(val=REDACTED) NotAObj(val=30)"
+
+
+def test_that_inner_objects_of_sensitive_objects_also_gets_attributes_redacted():
+    record = MagicMock(msg="Obj(val=20, inner=InnerObj(val=30))")
+    ObjectAttributeFilter(["Obj"], ["val"]).filter(record)
+    assert record.msg == "Obj(val=REDACTED, inner=InnerObj(val=REDACTED))"
+
+
+def test_that_redaction_from_no_matches_leaves_string_unchanged():
+    record = MagicMock(msg="Obj(val=20, inner=InnerObj(val=30))")
+    ObjectAttributeFilter(["Foo"], ["val"]).filter(record)
+    assert record.msg == "Obj(val=20, inner=InnerObj(val=30))"
+
+
+def test_that_noise_between_object_and_attributes_results_in_unfiltered_record():
+    original_record = "Obj noise (val=20, inner=InnerObj(val=30))"
+    record = MagicMock(msg=original_record)
+    ObjectAttributeFilter(["Obj"], ["val"]).filter(record)
+    assert record.msg == original_record
+
+
+def test_that_space_between_object_and_attributes_results_in_unfiltered_record():
+    original_record = "Obj (val=20, inner=InnerObj(val=30))"
+    record = MagicMock(msg=original_record)
+    ObjectAttributeFilter(["Obj"], ["val"]).filter(record)
+    assert record.msg == original_record
+
+
+def test_that_sensitive_object_inside_not_sensitive_object_gets_values_redacted():
+    original_record = "NotSensitive(val=20, inner=Sensitive(val=30))"
+    record = MagicMock(msg=original_record)
+    ObjectAttributeFilter(["Sensitive"], ["val"]).filter(record)
+    assert record.msg == "NotSensitive(val=20, inner=Sensitive(val=REDACTED))"
+
+
+def test_that_sensitive_observation_info_is_redacted_from_a_large_log_example(caplog):
+    sensitive_objects = ["SensitiveObservation", "ShapeRegistry"]
+    sensitive_attributes = ["value", "date", "north", "east"]
+
+    sensitive_attributes_ = {
+        "value": "42.42",
+        "date": "'2012-10-10T00:00:00'",
+        "east": "99",
+        "north": "71",
+    }
+    insensitive_attributes = {
+        "value": "24.24",
+        "date": "'2013-01-10T00:00:00'",
+        "radius": "100",
+    }
+
+    sensitive_obs = (
+        "SensitiveObservation(type='summary_observation', name='WOPR_OP1_102', "
+        f"value={sensitive_attributes_['value']}, error=4.0, key='WOPR:OP1', "
+        f"date={sensitive_attributes_['date']}, shape_id=0, error_mode=None, "
+        f"error_min=None)"
+    )
+    insensitive_obs = (
+        "CasualObservation(type='summary_observation', name='WOPR_OP2_217', "
+        f"value={insensitive_attributes['value']}, error=4.0, key='WOPR:OP2', "
+        f"date={insensitive_attributes['date']}, shape_id=None, error_mode=None, "
+        f"error_min=None)"
+    )
+    shape_registry = (
+        "ShapeRegistry(shapes={0: CircleShapeConfig(shape_id=0, "
+        f"type='circle', "
+        f"east={sensitive_attributes_['east']}, "
+        f"north={sensitive_attributes_['north']}, "
+        f"radius={insensitive_attributes['radius']}}})"
+    )
+
+    noise = " Hello, I am a log. I have nothing to do with sensitive information. "
+    record = MagicMock(
+        msg=(
+            noise
+            + sensitive_obs
+            + noise
+            + insensitive_obs
+            + noise
+            + shape_registry
+            + noise
+        )
+    )
+
+    ObjectAttributeFilter(sensitive_objects, sensitive_attributes).filter(record)
+    for sensitive_value in sensitive_attributes_.values():
+        assert sensitive_value not in record.msg
+
+    for insensitive_value in insensitive_attributes.values():
+        assert insensitive_value in record.msg
+
+    # Assert that noise is unchanged
+    assert record.msg.count(noise) == 4


### PR DESCRIPTION
This methods takes in names of serialized object and names of sensitive attributes and replaces the sensitive attributes of the named objects with "REDACTED".

**Issue**
Resolves issue in Scout repository

I have had issues writing a test for the second commit, as if I try to instantiate any logger instance, the environment changes in the test, causing the test asserting that the environment is left unchanged.

I gave it a shot to "undo" all the changes to the logging environment, but it would not reset to how it was before.
I believe I read somewhere that the history to the logger environment is immutable, even if the state goes back to what it was before the changes.
