### PR TITLE
Fix resdata deprecations

### DIFF
--- a/test-data/ert/poly_template/poly_eval.py.j2
+++ b/test-data/ert/poly_template/poly_eval.py.j2
@@ -72,10 +72,10 @@ def make_summary(count, x_size, coeffs, update_steps):
             "summary/POLY_SUMMARY", datetime.datetime(2010, 1, 1), 10, 10, 10
         )
         for s in range(count):
-            ecl_sum.addVariable(f"PSUM{s}")
+            ecl_sum.add_variable(f"PSUM{s}")
 
         for x in range(x_size * update_steps):
-            t_step = ecl_sum.addTStep(x // update_steps + 1, sim_days=x + 1)
+            t_step = ecl_sum.add_t_step(x // update_steps + 1, sim_days=x + 1)
             for s in range(count):
                 t_step[f"PSUM{s}"] = _evaluate(coeffs[s % len(coeffs)], x)
 

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -119,7 +119,7 @@ def test_that_make_observations_migrates_observations():
     summary.add_variable("FWPRH", unit="SM3/DAY")
 
     # first step: start_date (2010-03-31)
-    t0 = summary.addTStep(1, sim_days=0)
+    t0 = summary.add_t_step(1, sim_days=0)
     t0["FOPR"] = 1
     t0["FOPRH"] = 2
     t0["FWPR"] = 3
@@ -128,7 +128,7 @@ def test_that_make_observations_migrates_observations():
     # second step: 2015-06-13
     second_date = datetime(2015, 6, 13)  # noqa: DTZ001
     days_between = (second_date - start_date).days
-    t1 = summary.addTStep(1, sim_days=days_between)
+    t1 = summary.add_t_step(1, sim_days=days_between)
     t1["FOPR"] = 1
     t1["FOPRH"] = 2
     t1["FWPR"] = 3

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -82,7 +82,7 @@ def run_simulator(summary_values=SUMMARY_VALUES):
     mini_step_count = 10
 
     for mini_step in range(mini_step_count):
-        t_step = summary.addTStep(1, sim_days=mini_step_count + mini_step)
+        t_step = summary.add_t_step(1, sim_days=mini_step_count + mini_step)
         for key, value in summary_values.items():
             t_step[key] = value
 


### PR DESCRIPTION



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
