### PR TITLE
Remove logging of potential sensitive observation configurations

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1349,10 +1349,15 @@ class ErtConfig(BaseModel):
         # of message length, the limit is set to 80% of
         # MAX_MESSAGE_LENGTH_APP_INSIGHTS = 32768
         SAFE_MESSAGE_LENGTH_LIMIT = 26214  # <= MAX_MESSAGE_LENGTH_APP_INSIGHTS * 0.8
+        sensitive_keys = ["OBS_CONFIG"]
+        content_dict_to_log = {
+            k: (v if k not in sensitive_keys else "<REDACTED>")
+            for k, v in content_dict.items()
+        }
         try:
-            config_dict_content = pprint.pformat(content_dict)
+            config_dict_content = pprint.pformat(content_dict_to_log)
         except Exception as err:
-            config_dict_content = str(content_dict)
+            config_dict_content = str(content_dict_to_log)
             logger.warning(
                 "Logging of config dict could not be formatted for "
                 f"enhanced readability. {err}"

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -772,6 +772,13 @@ def create_list_of_forward_model_steps_to_run(
     return fm_steps
 
 
+def log_shape_registry(shape_registry: ShapeRegistry) -> None:
+    shape_count = Counter(
+        type(shape).__name__ for shape in shape_registry.shapes.values()
+    )
+    logger.info(f"Count of shapes in ShapeRegistry: {dict(shape_count)}")
+
+
 def log_observation_keys(
     observations: list[ObservationDict],
 ) -> None:
@@ -782,11 +789,13 @@ def log_observation_keys(
         for key in o
         if key not in {"name", "type"}
     )
-
-    logger.info(
-        f"Count of observation types:\n\t{dict(observation_type_counts)}\n"
-        f"Count of observation keywords:\n\t{dict(observation_keyword_counts)}"
+    observation_summary_keys = Counter(
+        o["KEY"].split(":")[0] for o in observations if "KEY" in o
     )
+
+    logger.info(f"Count of observation types: {dict(observation_type_counts)}")
+    logger.info(f"Count of observation keywords: {dict(observation_keyword_counts)}")
+    logger.info(f"Count of summary keywords: {dict(observation_summary_keys)}")
 
 
 RESERVED_KEYWORDS = ["realization", "IENS", "ITER"]
@@ -1093,6 +1102,7 @@ class ErtConfig(BaseModel):
                     obs_config_input,
                     shape_registry=shape_registry,
                 )
+                log_shape_registry(shape_registry)
                 if not obs_configs:
                     raise ObservationConfigError.with_context(
                         f"Empty observations file: {obs_config_file}",

--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -233,10 +233,14 @@ class RunModel(RunModelConfig, ABC):
             "run_paths",
             "substitutions",
         ]
+        sensitive_keys = [
+            "observations",
+            "shape_registry",
+        ]
         settings_dict = {
-            key: value
-            for key, value in self.__dict__.items()
-            if key not in keys_to_drop
+            k: (v if k not in sensitive_keys else "<REDACTED>")
+            for k, v in self.__dict__.items()
+            if k not in keys_to_drop
         }
 
         logger.info(f"Running '{self.name()}'\n\nSettings: {settings_dict}")

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -19,18 +19,22 @@ from xlsxwriter import Workbook
 
 from ert import ErtScript, ErtScriptWorkflow
 from ert.config import (
+    CircleShapeConfig,
     ConfigValidationError,
     ErtConfig,
     ESSettings,
     HookRuntime,
     QueueSystem,
     RFTConfig,
+    ShapeRegistry,
 )
 from ert.config._create_observation_dataframes import create_observation_dataframes
 from ert.config.ert_config import (
     RandomSeedGenerator,
     _split_string_into_sections,
     create_forward_model_json,
+    log_observation_keys,
+    log_shape_registry,
 )
 from ert.config.forward_model_step import (
     ForwardModelStepPlugin,
@@ -3183,3 +3187,44 @@ def test_that_gen_kw_defaults_to_none_with_update_false(change_to_tmpdir):
     ert_config = ErtConfig.from_file("config.ert")
     param = ert_config.ensemble_config.parameter_configs["MY_PARAM"]
     assert param.update_strategy is None
+
+
+def test_that_log_observation_keys_logs_count_of_summary_keys(caplog):
+    caplog.set_level(logging.INFO)
+    wopr_count = 5
+    bpr_count = 3
+    mock_type = MagicMock(value="summary")
+    observations = [
+        *[{"type": mock_type, "KEY": "WOPR:FOO"}] * wopr_count,
+        *[{"type": mock_type, "KEY": "BPR:1,1,1"}] * bpr_count,
+    ]
+    log_observation_keys(observations)
+    assert "Count of summary keywords:" in caplog.text
+    assert f"'WOPR': {wopr_count}" in caplog.text
+    assert f"'BPR': {bpr_count}" in caplog.text
+
+
+def test_that_log_observation_keys_doesnt_fail_given_misconfigured_summarykey():
+    well_summary_missing_well = "WOPR"
+    block_summary_missing_indices = "BPR"
+    observations = [
+        {"type": MagicMock(value="summary"), "KEY": well_summary_missing_well},
+        {"type": MagicMock(value="summary"), "KEY": block_summary_missing_indices},
+    ]
+    log_observation_keys(observations)
+
+
+def test_that_log_observation_keys_doesnt_fail_given_no_keys(caplog):
+    caplog.set_level(logging.INFO)
+    observations = [{"type": MagicMock(value="summary")}]
+    log_observation_keys(observations)
+    assert "Count of summary keywords: {}" in caplog.text
+
+
+def test_that_log_shape_registry_logs_count_of_shapes(caplog):
+    caplog.set_level(logging.INFO)
+    shape_registry = ShapeRegistry()
+    for i in range(10):
+        shape_registry.register(CircleShapeConfig(north=i, east=i, radius=i))
+    log_shape_registry(shape_registry)
+    assert "Count of shapes in ShapeRegistry: {'CircleShapeConfig': 10}" in caplog.text

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -14,6 +14,7 @@ from pydantic import ConfigDict
 
 from _ert.events import EESnapshotUpdate
 from ert.config import (
+    CircleShapeConfig,
     ErtConfig,
     ModelConfig,
     ObservationType,
@@ -820,10 +821,7 @@ async def test_that_status_snapshot_write_failure_does_not_mask_evaluation_error
     assert "Failed to persist status snapshot" in caplog.text
 
 
-def test_that_ert_config_and_run_model_gets_serialized_observations_and_shape_registry_redacted(  # noqa: E501
-    caplog,
-):
-    caplog.set_level(logging.INFO)
+def _ert_config_dict():
     summary_obs_dict = ObservationDict(
         {
             "type": ObservationType.SUMMARY,
@@ -840,7 +838,7 @@ def test_that_ert_config_and_run_model_gets_serialized_observations_and_shape_re
         },
         context=MagicMock(),
     )
-    config_dict = {
+    return {
         "NUM_REALIZATIONS": 1,
         "ECLBASE": "ECLIPSE_CASE",
         "OBS_CONFIG": (
@@ -848,8 +846,14 @@ def test_that_ert_config_and_run_model_gets_serialized_observations_and_shape_re
             [summary_obs_dict],
         ),
     }
-    ert_config = ErtConfig.from_dict(config_dict)
 
+
+def test_that_ert_config_and_run_model_does_not_log_sensitive_information(
+    caplog, use_tmpdir
+):
+    caplog.set_level(logging.INFO)
+    config_dict = _ert_config_dict()
+    ert_config = ErtConfig.from_dict(config_dict)
     ert_config._log_config_dict(config_dict)
     assert "'OBS_CONFIG': '<REDACTED>'" in caplog.text
 
@@ -863,3 +867,16 @@ def test_that_ert_config_and_run_model_gets_serialized_observations_and_shape_re
     model.log_at_startup()
     assert "'observations': '<REDACTED>'" in caplog.text
     assert "'shape_registry': '<REDACTED>'" in caplog.text
+
+
+def test_that_ert_config_logs_insensitive_information_about_observations_and_shapes(
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    config_dict = _ert_config_dict()
+    ErtConfig.from_dict(config_dict)
+    assert "Count of summary keywords: {'FOPR': 1}" in caplog.text
+    assert (
+        f"Count of shapes in ShapeRegistry: {{'{CircleShapeConfig.__name__}': 1}}"
+        in caplog.text
+    )

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -13,13 +13,23 @@ import pytest
 from pydantic import ConfigDict
 
 from _ert.events import EESnapshotUpdate
-from ert.config import ErtConfig, ModelConfig, QueueConfig, QueueSystem, ShapeRegistry
+from ert.config import (
+    ErtConfig,
+    ModelConfig,
+    ObservationType,
+    QueueConfig,
+    QueueSystem,
+    ShapeRegistry,
+)
+from ert.config.parsing import ObservationDict
 from ert.config.queue_config import LsfQueueOptions
 from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig, StartEvent
 from ert.ensemble_evaluator.evaluator import ParallelismViolation
 from ert.ensemble_evaluator.event import FullSnapshotEvent
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
+from ert.mode_definitions import TEST_RUN_MODE
 from ert.plugins import ErtRuntimePlugins
+from ert.run_models import create_model
 from ert.run_models.run_model import (
     RunModel,
     UserCancelled,
@@ -808,3 +818,48 @@ async def test_that_status_snapshot_write_failure_does_not_mask_evaluation_error
         await brm.run_ensemble_evaluator_async(AsyncMock(), ensemble, AsyncMock())
 
     assert "Failed to persist status snapshot" in caplog.text
+
+
+def test_that_ert_config_and_run_model_gets_serialized_observations_and_shape_registry_redacted(  # noqa: E501
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    summary_obs_dict = ObservationDict(
+        {
+            "type": ObservationType.SUMMARY,
+            "name": "FOPR_OBS",
+            "KEY": "FOPR",
+            "VALUE": "1.0",
+            "ERROR": "0.1",
+            "DATE": "2020-01-01",
+            "LOCALIZATION": {
+                "EAST": "100.0",
+                "NORTH": "200.0",
+                "RADIUS": "3000",
+            },
+        },
+        context=MagicMock(),
+    )
+    config_dict = {
+        "NUM_REALIZATIONS": 1,
+        "ECLBASE": "ECLIPSE_CASE",
+        "OBS_CONFIG": (
+            "obs_config",
+            [summary_obs_dict],
+        ),
+    }
+    ert_config = ErtConfig.from_dict(config_dict)
+
+    ert_config._log_config_dict(config_dict)
+    assert "'OBS_CONFIG': '<REDACTED>'" in caplog.text
+
+    args = MagicMock(
+        mode=TEST_RUN_MODE,
+        realizations="0",
+        experiment_name="foo",
+        current_ensemble="bar",
+    )
+    model = create_model(ert_config, args, MagicMock())
+    model.log_at_startup()
+    assert "'observations': '<REDACTED>'" in caplog.text
+    assert "'shape_registry': '<REDACTED>'" in caplog.text


### PR DESCRIPTION

**Issue**
Resolves issue in Scout repository

We drop all logs of both the Obs config file and the serialized observations object.

The only information we lose which we might be interested in are the summary keywords and ShapeRegistry shapes (without attributes). This is now logged in `log_observation_keys` and `log_shape_registry` and is not sensitive. We strip away any other parts of the summary key, like well name or block indices - as we are not interested in those. 
