### PR TITLE
Improve config and monitoring code

### DIFF
--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -51,6 +51,7 @@ class EverestBatchResultEvent(BaseModel, extra="forbid"):
     everest_event: Literal["OPTIMIZATION_RESULT",]
     result_type: Literal["FunctionResult", "GradientResult"]
     results: dict[str, Any] | None = None
+    failures: dict[int, list[int]] | None = None
 
 
 class RunModelTimeEvent(RunModelEvent):

--- a/src/ert/run_models/event.py
+++ b/src/ert/run_models/event.py
@@ -50,8 +50,8 @@ class EverestBatchResultEvent(BaseModel, extra="forbid"):
     event_type: Literal["EverestBatchResultEvent"] = "EverestBatchResultEvent"
     everest_event: Literal["OPTIMIZATION_RESULT",]
     result_type: Literal["FunctionResult", "GradientResult"]
-    results: dict[str, Any] | None = None
-    failures: dict[int, list[int]] | None = None
+    results: dict[str, Any] = {}
+    failures: dict[int, list[int]] = {}
 
 
 class RunModelTimeEvent(RunModelEvent):

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -723,11 +723,15 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
 
             failures = defaultdict(list)
             if ens.everest_realization_info is not None:
-                for r in ens.everest_realization_info:
-                    if ens.has_failure(r):
-                        m = ens.everest_realization_info[r]["model_realization"]
-                        p = ens.everest_realization_info[r]["perturbation"]
-                        failures[m].append(p)
+                for realization in ens.everest_realization_info:
+                    if ens.has_failure(realization):
+                        model_realization = ens.everest_realization_info[realization][
+                            "model_realization"
+                        ]
+                        perturbation = ens.everest_realization_info[realization][
+                            "perturbation"
+                        ]
+                        failures[model_realization].append(perturbation)
 
             self.send_event(
                 EverestBatchResultEvent(

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -626,23 +626,25 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
             target_ensemble.save_batch_dataframes(dataframes=batch_dict)
             target_ensemble.update_improvement_flag(is_improvement=False)
 
-        for r in results:
+        for result in results:
             batches = (
                 self._experiment.ensembles_with_function_results
-                if isinstance(r, FunctionResults)
+                if isinstance(result, FunctionResults)
                 else self._experiment.ensembles_with_gradient_results
             )
-            ens = next((ens for ens in batches if ens.iteration == r.batch_id), None)
+            ens = next(
+                (ens for ens in batches if ens.iteration == result.batch_id), None
+            )
             if ens is None:
                 continue
 
             results_dict: dict[str, Any] | None = None
-            if isinstance(r, FunctionResults):
+            if isinstance(result, FunctionResults):
                 results_dict = {}
                 if ens.realization_controls is not None:
                     results_dict |= {
                         "controls": ens.realization_controls.drop(
-                            "realization", "simulation_id"
+                            "batch_id", "realization", "simulation_id"
                         ).to_dicts()[0],
                     }
 
@@ -719,14 +721,25 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                         "perturbation_constraints": perturbation_gradient_dicts
                     }
 
+            failures = defaultdict(list)
+            if ens.everest_realization_info is not None:
+                for r in ens.everest_realization_info:
+                    if ens.has_failure(r):
+                        m = ens.everest_realization_info[r]["model_realization"]
+                        p = ens.everest_realization_info[r]["perturbation"]
+                        failures[m].append(p)
+
             self.send_event(
                 EverestBatchResultEvent(
-                    batch=r.batch_id,
+                    batch=result.batch_id,
                     everest_event="OPTIMIZATION_RESULT",
-                    result_type="FunctionResult"
-                    if isinstance(r, FunctionResults)
-                    else "GradientResult",
+                    result_type=(
+                        "FunctionResult"
+                        if isinstance(result, FunctionResults)
+                        else "GradientResult"
+                    ),
                     results=results_dict,
+                    failures={k: v for k, v in failures.items() if v} or None,
                 )
             )
 

--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -638,9 +638,8 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
             if ens is None:
                 continue
 
-            results_dict: dict[str, Any] | None = None
+            results_dict: dict[str, Any] = {}
             if isinstance(result, FunctionResults):
-                results_dict = {}
                 if ens.realization_controls is not None:
                     results_dict |= {
                         "controls": ens.realization_controls.drop(
@@ -672,7 +671,6 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                         ).to_dicts()
                     }
             else:
-                results_dict = {}
                 objective_gradient = (
                     ens.batch_objective_gradient.drop("batch_id")
                     .sort("control_name")
@@ -743,7 +741,7 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
                         else "GradientResult"
                     ),
                     results=results_dict,
-                    failures={k: v for k, v in failures.items() if v} or None,
+                    failures={k: v for k, v in failures.items() if v},
                 )
             )
 

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -261,30 +261,31 @@ class _DetachedMonitor:
 
         lines = [self._make_header(f"Optimization progress (Batch #{batch})")]
 
-        if controls := cli_monitor_data.get("controls"):
-            width = _get_max_width(controls.keys())
-            lines.append(
-                self._join_one_newline_indent(
-                    [
-                        f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                        for name, value in controls.items()
-                    ]
+        if cli_monitor_data.get("result_type") == "FunctionResult":
+            if controls := cli_monitor_data.get("controls"):
+                width = _get_max_width(controls.keys())
+                lines.append(
+                    self._join_one_newline_indent(
+                        [
+                            f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
+                            for name, value in controls.items()
+                        ]
+                    )
                 )
-            )
-        if expected_objectives := cli_monitor_data.get("expected_objectives"):
-            width = _get_max_width(expected_objectives.keys())
-            lines.append(
-                self._join_one_newline_indent(
-                    [
-                        f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                        for name, value in expected_objectives.items()
-                    ]
+            if expected_objectives := cli_monitor_data.get("expected_objectives"):
+                width = _get_max_width(expected_objectives.keys())
+                lines.append(
+                    self._join_one_newline_indent(
+                        [
+                            f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
+                            for name, value in expected_objectives.items()
+                        ]
+                    )
                 )
-            )
-        if objective_value := cli_monitor_data.get("objective_value"):
-            lines.append(
-                f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"
-            )
+            if objective_value := cli_monitor_data.get("objective_value"):
+                lines.append(
+                    f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"
+                )
 
         if failures := cli_monitor_data.get("failures", {}):
             failed_lines = []

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import traceback
 from collections import defaultdict
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, KeysView, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -137,7 +137,7 @@ def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) 
     sys.exit()
 
 
-def _get_max_width(sequence: list[Any]) -> int:
+def _get_max_width(sequence: Sequence[str] | KeysView[str]) -> int:
     return max(len(item) for item in sequence)
 
 
@@ -261,27 +261,22 @@ class _DetachedMonitor:
 
         lines = [self._make_header(f"Optimization progress (Batch #{batch})")]
 
+        def mkline(data: dict[str, Any], width: int) -> str:
+            width = _get_max_width(data.keys())
+            return self._join_one_newline_indent(
+                [
+                    f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
+                    for name, value in data.items()
+                ]
+            )
+
         if cli_monitor_data.get("result_type") == "FunctionResult":
             if controls := cli_monitor_data.get("controls"):
                 width = _get_max_width(controls.keys())
-                lines.append(
-                    self._join_one_newline_indent(
-                        [
-                            f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                            for name, value in controls.items()
-                        ]
-                    )
-                )
+                lines.append(mkline(controls, width))
             if expected_objectives := cli_monitor_data.get("expected_objectives"):
                 width = _get_max_width(expected_objectives.keys())
-                lines.append(
-                    self._join_one_newline_indent(
-                        [
-                            f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                            for name, value in expected_objectives.items()
-                        ]
-                    )
-                )
+                lines.append(mkline(expected_objectives, width))
             if objective_value := cli_monitor_data.get("objective_value"):
                 lines.append(
                     f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -287,7 +287,7 @@ class _DetachedMonitor:
                     f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"
                 )
 
-        if failures := cli_monitor_data.get("failures", {}):
+        if failures := cli_monitor_data["failures"]:
             failed_lines = []
             if failed_functions := [r for r, p in failures.items() if -1 in p]:
                 s = "s" if len(failed_functions) > 1 else ""

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -2,13 +2,13 @@ import argparse
 import json
 import logging.config
 import os
+import shutil
 import sys
 import traceback
 from collections import defaultdict
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from itertools import groupby
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, ClassVar
@@ -40,6 +40,7 @@ from everest.detached import (
     wait_for_server_to_stop,
 )
 from everest.strings import EVEREST, OPT_PROGRESS_ID, SIM_PROGRESS_ID
+from everest.util import format_list
 
 JOB_SUCCESS = "Finished"
 JOB_RUNNING = "Running"
@@ -97,7 +98,8 @@ def setup_logging(options: argparse.Namespace) -> Generator[None, None, None]:
 
 
 def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) -> None:
-    print("\n" + "=" * 80)
+    width = min(shutil.get_terminal_size(fallback=(78, 24)).columns, 100)
+    print("\n" + "=" * width)
     if options.config.server_queue_system == QueueSystem.LOCAL:
         print(
             f"KeyboardInterrupt (ID: {signum}) has been caught. \n"
@@ -128,7 +130,7 @@ def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) 
             "To kill the running optimization use command:\n"
             f"  `everest kill {config_file}`"
         )
-    print("=" * 80)
+    print("=" * width)
     sys.tracebacklimit = 0
     sys.stdout = open(os.devnull, "w", encoding="utf-8")  # ruff: ignore[builtin-open, open-file-with-context-handler] SIM115
     sys.stderr = open(os.devnull, "w", encoding="utf-8")  # ruff: ignore[builtin-open, open-file-with-context-handler] SIM115
@@ -137,25 +139,6 @@ def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) 
 
 def _get_max_width(sequence: list[Any]) -> int:
     return max(len(item) for item in sequence)
-
-
-def _format_list(values: Sequence[int]) -> str:
-    """Formats a sequence of integers into a comma separated string of ranges.
-
-    For instance: {1, 3, 4, 5, 7, 8, 10} -> "1, 3-5, 7-8, 10"
-    """
-    grouped = (
-        tuple(y for _, y in x)
-        for _, x in groupby(enumerate(sorted(values)), lambda x: x[0] - x[1])
-    )
-    return ", ".join(
-        (
-            "-".join([str(sub_group[0]), str(sub_group[-1])])
-            if len(sub_group) > 1
-            else str(sub_group[0])
-        )
-        for sub_group in grouped
-    )
 
 
 @dataclass
@@ -177,7 +160,7 @@ class JobProgress:
         JOB_FAILURE: ansi.RED,
     }
 
-    def _status_string(self, max_widths: dict[str, int]) -> str:
+    def progress_str(self, max_widths: dict[str, int]) -> str:
         string = []
         for state in [JOB_RUNNING, JOB_SUCCESS, JOB_FAILURE]:
             number_of_simulations = len(self.status[state])
@@ -186,28 +169,17 @@ class JobProgress:
             string.append(f"{color}{number_of_simulations:>{width}}{ansi.RESET}")
         return "/".join(string)
 
-    def progress_str(self, max_widths: dict[str, int]) -> str:
-        msg = ""
-        for state in [JOB_SUCCESS, JOB_FAILURE]:
-            simulations_list = _format_list(self.status[state])
-            width = _get_max_width([simulations_list])
-            if width > 0:
-                color = self.STATUS_COLOR[state]
-                msg += f" | {color}{state}: {simulations_list:<{width}}{ansi.RESET}"
-
-        return self._status_string(max_widths) + msg
-
 
 class _DetachedMonitor:
-    WIDTH = 78
     INDENT = 2
     FLOAT_FMT = ".5g"
 
     def __init__(self) -> None:
         self._clear_lines: int = 0
-        self._batches_done = set[int]()
         self._last_reported_batch: int = -1
+        self._last_reported_opt_progress: int = -1
         self._snapshots: dict[int, EnsembleSnapshot] = {}
+        self._width = min(shutil.get_terminal_size(fallback=(78, 24)).columns, 100)
 
     def update(self, status: dict[str, Any]) -> None:
         try:  # ruff: ignore[too-many-statements-in-try-clause]
@@ -215,8 +187,9 @@ class _DetachedMonitor:
                 opt_status = status[OPT_PROGRESS_ID]
                 if opt_status:
                     msg = self._get_opt_progress_single_batch(opt_status)
-                    ansi.ansi_print(msg + "\n")
-                    self._clear_lines = 0
+                    if msg:
+                        ansi.ansi_print(msg + "\n")
+                        self._clear_lines = 0
             if SIM_PROGRESS_ID in status:
                 match status[SIM_PROGRESS_ID]:
                     case EndEvent(msg=msg):
@@ -254,19 +227,6 @@ class _DetachedMonitor:
         except Exception:
             logging.getLogger(EVEREST).debug(traceback.format_exc())
 
-    def get_opt_progress(self, context_status: dict[str, Any]) -> tuple[str, int]:
-        cli_monitor_data = context_status["cli_monitor_data"]
-        messages = []
-        first_batch = -1
-        for idx, batch in enumerate(cli_monitor_data["batches"]):
-            if batch not in self._batches_done:
-                if first_batch < 0:
-                    first_batch = batch
-                self._batches_done.add(batch)
-                msg = self._get_opt_progress_batch(cli_monitor_data, batch, idx)
-                messages.append(msg)
-        return self._join_two_newlines(messages), first_batch
-
     def _get_opt_progress_batch(
         self, cli_monitor_data: dict[str, Any], batch: int, idx: int
     ) -> str:
@@ -296,29 +256,57 @@ class _DetachedMonitor:
 
     def _get_opt_progress_single_batch(self, cli_monitor_data: dict[str, Any]) -> str:
         batch: int = cli_monitor_data.get("batch", 0)
-        header = self._make_header(f"Optimization progress (Batch #{batch})")
-        width = _get_max_width(cli_monitor_data["controls"].keys())
-        controls = self._join_one_newline_indent(
-            [
-                f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                for name, value in cli_monitor_data["controls"].items()
-            ]
-        )
-        expected_objectives = cli_monitor_data["expected_objectives"]
-        width = _get_max_width(expected_objectives.keys())
-        objectives = self._join_one_newline_indent(
-            [
-                f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
-                for name, value in expected_objectives.items()
-            ]
-        )
-        objective_value = cli_monitor_data["objective_value"]
-        total_objective = (
-            f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"
-        )
-        return self._join_two_newlines_indent(
-            (header, controls, objectives, total_objective)
-        )
+        if batch == self._last_reported_opt_progress:
+            return ""
+
+        lines = [self._make_header(f"Optimization progress (Batch #{batch})")]
+
+        if controls := cli_monitor_data.get("controls"):
+            width = _get_max_width(controls.keys())
+            lines.append(
+                self._join_one_newline_indent(
+                    [
+                        f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
+                        for name, value in controls.items()
+                    ]
+                )
+            )
+        if expected_objectives := cli_monitor_data.get("expected_objectives"):
+            width = _get_max_width(expected_objectives.keys())
+            lines.append(
+                self._join_one_newline_indent(
+                    [
+                        f"{name:>{width}}: {value:{self.FLOAT_FMT}}"
+                        for name, value in expected_objectives.items()
+                    ]
+                )
+            )
+        if objective_value := cli_monitor_data.get("objective_value"):
+            lines.append(
+                f"Total normalized objective: {objective_value:{self.FLOAT_FMT}}"
+            )
+
+        if failures := cli_monitor_data.get("failures", {}):
+            failed_lines = []
+            if failed_functions := [r for r, p in failures.items() if -1 in p]:
+                s = "s" if len(failed_functions) > 1 else ""
+                failed_lines.append(
+                    f"{ansi.RED}Failed function evaluation{s} for realization{s}: "
+                    f"{format_list(failed_functions)}{ansi.RESET}"
+                )
+            for k, v in failures.items():
+                if p := [item for item in v if item >= 0]:
+                    s = "s" if len(p) > 1 else ""
+                    failed_lines.append(
+                        f"{ansi.RED}Failed perturbation{s} for realization {k}: "
+                        f"{format_list(p)}{ansi.RESET}"
+                    )
+            if failed_lines:
+                lines.append(self._join_one_newline_indent(failed_lines))
+
+        self._last_reported_opt_progress = batch
+
+        return self._join_two_newlines_indent(lines)
 
     @staticmethod
     def _get_progress_summary(status: dict[str, int]) -> str:
@@ -362,8 +350,7 @@ class _DetachedMonitor:
                 if job.errors:
                     print_lines.extend(
                         [
-                            f"{ansi.RED}{job.name:>{width}}: Failed: {err}, "
-                            f"realizations: {_format_list(job.errors[err])}{ansi.RESET}"
+                            f"{ansi.RED}{job.name:>{width}}: {err}{ansi.RESET}"
                             for err in job.errors
                         ]
                     )
@@ -402,9 +389,8 @@ class _DetachedMonitor:
     def _join_two_newlines(cls, sequence: Sequence[str]) -> str:
         return "\n\n".join(sequence)
 
-    @classmethod
-    def _make_header(cls, msg: str, color: str = ansi.BLACK) -> str:
-        header = msg.center(len(msg) + 2).center(cls.WIDTH, "=")
+    def _make_header(self, msg: str, color: str = ansi.BLACK) -> str:
+        header = msg.center(len(msg) + 2).center(self._width, "=")
         return f"{color}{header}{ansi.RESET}"
 
     def _clear(self) -> None:

--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -897,6 +897,16 @@ to read summary data from forward model, do:
         check_for_duplicate_names([w.name for w in wells], "well", "name")
         return wells
 
+    @model_validator(mode="after")
+    def validate_min_realizations_success(self) -> Self:
+        realization_num = len(self.model.realizations)
+        if (
+            self.optimization.min_realizations_success is None
+            or self.optimization.min_realizations_success > realization_num
+        ):
+            self.optimization.min_realizations_success = realization_num
+        return self
+
     @field_validator("output_constraints")
     @no_type_check
     @classmethod

--- a/src/everest/config/optimization_config.py
+++ b/src/everest/config/optimization_config.py
@@ -195,7 +195,8 @@ class OptimizationConfig(BaseModel, extra="forbid"):
                succeeds if this is at least equal to `min_realizations_success`.
 
             Note: The value of `min_pert_success` is internally adjusted to be
-            capped by `perturbation_num`.
+            capped by `perturbation_num`. If it is not provided, it is set equal
+            to `perturbation_num`.
             """
         ),
     )
@@ -227,16 +228,19 @@ class OptimizationConfig(BaseModel, extra="forbid"):
             report an error.
 
             Note: The value of `min_realizations_success` is internally adjusted
-            to be capped by the number of realizations. It is possible to set
-            the minimum number of successful realizations equal to zero. Some
-            optimization algorithms are able to handle this and will proceed
-            even if all realizations failed. Most algorithms are not capable of
-            this and will internally adjust the value to be equal to one.
+            to be capped by the number of realizations. If it is not provided,
+            it is set equal to the number of realizations.
+
+            It is possible to set the minimum number of successful realizations
+            equal to zero. Some optimization algorithms are able to handle this
+            and will proceed even if all realizations failed. Most algorithms
+            are not capable of this and will internally adjust the value to be
+            equal to one.
             """
         ),
     )
-    perturbation_num: int | None = Field(
-        default=None,
+    perturbation_num: int = Field(
+        default=5,
         gt=0,
         description=dedent(
             """
@@ -372,6 +376,15 @@ class OptimizationConfig(BaseModel, extra="forbid"):
         self.backend = None
         self.algorithm = algorithm
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_min_pert_success(self) -> Self:
+        if (
+            self.min_pert_success is None
+            or self.min_pert_success > self.perturbation_num
+        ):
+            self.min_pert_success = self.perturbation_num
         return self
 
     @property

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -211,24 +211,20 @@ def server_is_running(url: str, cert: str, auth: tuple[str, str]) -> bool:
 def get_opt_status_from_batch_result_event(
     event: EverestBatchResultEvent,
 ) -> dict[str, Any]:
-    if not event.results:
-        return {}
-
-    assert event.batch is not None
-
-    if event.result_type == "FunctionResult":
-        return {
-            "batch": event.batch,
-            "controls": event.results["controls"],
-            "objective_value": event.results["total_objective_value"],
-            "expected_objectives": event.results["objectives"],
-            "failures": event.failures,
-        }
-
-    return {
+    status = {
+        "result_type": event.result_type,
         "batch": event.batch,
         "failures": event.failures,
     }
+    if event.results and event.result_type == "FunctionResult":
+        status.update(
+            {
+                "controls": event.results["controls"],
+                "objective_value": event.results["total_objective_value"],
+                "expected_objectives": event.results["objectives"],
+            }
+        )
+    return status
 
 
 def start_monitor(

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -216,11 +216,18 @@ def get_opt_status_from_batch_result_event(
 
     assert event.batch is not None
 
+    if event.result_type == "FunctionResult":
+        return {
+            "batch": event.batch,
+            "controls": event.results["controls"],
+            "objective_value": event.results["total_objective_value"],
+            "expected_objectives": event.results["objectives"],
+            "failures": event.failures,
+        }
+
     return {
         "batch": event.batch,
-        "controls": event.results["controls"],
-        "objective_value": event.results["total_objective_value"],
-        "expected_objectives": event.results["objectives"],
+        "failures": event.failures,
     }
 
 
@@ -254,14 +261,13 @@ def start_monitor(
                     message = websocket.recv(timeout=1.0)
                     event = status_event_from_json(message)
                     if isinstance(event, EverestBatchResultEvent):
-                        if event.result_type == "FunctionResult":
-                            callback(
-                                {
-                                    OPT_PROGRESS_ID: get_opt_status_from_batch_result_event(  # ruff: ignore[line-too-long]
-                                        event
-                                    )
-                                }
-                            )
+                        callback(
+                            {
+                                OPT_PROGRESS_ID: get_opt_status_from_batch_result_event(
+                                    event
+                                )
+                            }
+                        )
                     else:
                         callback({SIM_PROGRESS_ID: event})
                 except TimeoutError:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -237,10 +237,8 @@ def _parse_optimization(
             ropt_gradient["number_of_perturbations"] == 1
         )
 
-        assert ever_opt.min_pert_success is not None
         ropt_gradient["perturbation_min_success"] = ever_opt.min_pert_success
 
-        assert ever_opt.min_realizations_success is not None
         ropt_realizations["realization_min_success"] = ever_opt.min_realizations_success
 
         if (cvar_opts := ever_opt.cvar) is not None:

--- a/src/everest/optimizer/everest2ropt.py
+++ b/src/everest/optimizer/everest2ropt.py
@@ -231,20 +231,17 @@ def _parse_optimization(
 
         ropt_backend["parallel"] = ever_opt.parallel
 
-        if ever_opt.perturbation_num is not None:
-            ropt_gradient["number_of_perturbations"] = ever_opt.perturbation_num
-            # For a single perturbation, use the ensemble for gradient calculation:
-            ropt_gradient["merge_realizations"] = (
-                ropt_gradient["number_of_perturbations"] == 1
-            )
+        ropt_gradient["number_of_perturbations"] = ever_opt.perturbation_num
+        # For a single perturbation, use the ensemble for gradient calculation:
+        ropt_gradient["merge_realizations"] = (
+            ropt_gradient["number_of_perturbations"] == 1
+        )
 
-        if ever_opt.min_pert_success is not None:
-            ropt_gradient["perturbation_min_success"] = ever_opt.min_pert_success
+        assert ever_opt.min_pert_success is not None
+        ropt_gradient["perturbation_min_success"] = ever_opt.min_pert_success
 
-        if ever_opt.min_realizations_success is not None:
-            ropt_realizations["realization_min_success"] = (
-                ever_opt.min_realizations_success
-            )
+        assert ever_opt.min_realizations_success is not None
+        ropt_realizations["realization_min_success"] = ever_opt.min_realizations_success
 
         if (cvar_opts := ever_opt.cvar) is not None:
             # set up the configuration of the realization filter that implements cvar:

--- a/src/everest/util/__init__.py
+++ b/src/everest/util/__init__.py
@@ -1,5 +1,12 @@
 from ropt.version import version as ropt_version
 
+from ._utils import format_list
+
+__all__ = [
+    "format_list",
+]
+
+
 try:
     from ert.shared.version import version as ert_version
 except ImportError:

--- a/src/everest/util/_utils.py
+++ b/src/everest/util/_utils.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+from itertools import groupby
+
+
+def format_list(values: Sequence[int]) -> str:
+    """Formats a sequence of integers into a comma separated string of ranges.
+
+    For instance: {1, 3, 4, 5, 7, 8, 10} -> "1, 3-5, 7-8, 10"
+    """
+    grouped = (
+        tuple(y for _, y in x)
+        for _, x in groupby(enumerate(sorted(values)), lambda x: x[0] - x[1])
+    )
+    return ", ".join(
+        (
+            "-".join([str(sub_group[0]), str(sub_group[-1])])
+            if len(sub_group) > 1
+            else str(sub_group[0])
+        )
+        for sub_group in grouped
+    )

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
@@ -14,10 +14,10 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 0,
           "point.x.0": 0.25,
           "point.x.1": 0.25,
           "point.x.2": 0.25
@@ -56,6 +56,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -229,10 +230,10 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 1,
           "point.x.0": 0.258899,
           "point.x.1": 0.138638,
           "point.x.2": 0.172665
@@ -271,6 +272,7 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -444,10 +446,10 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 2,
           "point.x.0": 0.321688,
           "point.x.1": -0.002276,
           "point.x.2": 0.136291
@@ -486,6 +488,7 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -659,10 +662,10 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 3,
           "point.x.0": 0.242329,
           "point.x.1": 0.025213,
           "point.x.2": 0.245514
@@ -701,6 +704,7 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -874,10 +878,10 @@
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 4,
           "point.x.0": 0.144529,
           "point.x.1": 0.017082,
           "point.x.2": 0.365267
@@ -916,6 +920,7 @@
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_advanced.yml/snapshot.json
@@ -14,7 +14,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -56,7 +56,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -230,7 +230,7 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -272,7 +272,7 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -446,7 +446,7 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -488,7 +488,7 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -662,7 +662,7 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -704,7 +704,7 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [
@@ -878,7 +878,7 @@
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -920,7 +920,7 @@
       "batch": 4,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "constraint_gradient": [

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
@@ -14,10 +14,10 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 0,
           "point.x": 0.1,
           "point.y": 0.1,
           "point.z": 0.1
@@ -39,6 +39,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [
@@ -106,10 +107,10 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 1,
           "point.x": 0.900386,
           "point.y": 0.900548,
           "point.z": 0.899338
@@ -141,10 +142,10 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 2,
           "point.x": 0.500148,
           "point.y": 0.500228,
           "point.z": 0.499624
@@ -176,6 +177,7 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_minimal.yml/snapshot.json
@@ -14,7 +14,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -39,7 +39,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [
@@ -107,7 +107,7 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -142,7 +142,7 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -177,7 +177,7 @@
       "batch": 3,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
@@ -14,10 +14,10 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 0,
           "point.x": 0.0,
           "point.y": 0.0,
           "point.z": 0.0
@@ -41,6 +41,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [
@@ -119,10 +120,10 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 1,
           "point.x": -0.004202,
           "point.y": -0.011298,
           "point.z": 1.0
@@ -156,10 +157,10 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
+      "failures": null,
       "result_type": "FunctionResult",
       "results": {
         "controls": {
-          "batch_id": 2,
           "point.x": -0.002101,
           "point.y": -0.005648,
           "point.z": 0.499928

--- a/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
+++ b/tests/everest/snapshots/test_everest_runmodel_events/test_everest_events/config_multiobj.yml/snapshot.json
@@ -14,7 +14,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -41,7 +41,7 @@
       "batch": 0,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "GradientResult",
       "results": {
         "objective_gradient_values": [
@@ -120,7 +120,7 @@
       "batch": 1,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {
@@ -157,7 +157,7 @@
       "batch": 2,
       "event_type": "EverestBatchResultEvent",
       "everest_event": "OPTIMIZATION_RESULT",
-      "failures": null,
+      "failures": {},
       "result_type": "FunctionResult",
       "results": {
         "controls": {

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_advanced.yml/ropt_config.json
@@ -11,7 +11,8 @@
   "gradient": {
     "evaluation_policy": "speculative",
     "merge_realizations": false,
-    "number_of_perturbations": 5
+    "number_of_perturbations": 5,
+    "perturbation_min_success": 5
   },
   "linear_constraints": {
     "coefficients": [
@@ -80,6 +81,7 @@
     "stdout": "optimizer.stdout"
   },
   "realizations": {
+    "realization_min_success": 2,
     "weights": [
       0.25,
       0.75

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_minimal.yml/ropt_config.json
@@ -9,6 +9,11 @@
       "method": "mean"
     }
   ],
+  "gradient": {
+    "merge_realizations": false,
+    "number_of_perturbations": 5,
+    "perturbation_min_success": 5
+  },
   "names": {
     "nonlinear_constraint": [],
     "objective": [
@@ -44,6 +49,7 @@
     "stdout": "optimizer.stdout"
   },
   "realizations": {
+    "realization_min_success": 1,
     "weights": [
       1.0
     ]

--- a/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
+++ b/tests/everest/snapshots/test_ropt_initialization/test_everest2ropt_snapshot/config_multiobj.yml/ropt_config.json
@@ -11,7 +11,8 @@
   ],
   "gradient": {
     "merge_realizations": false,
-    "number_of_perturbations": 5
+    "number_of_perturbations": 5,
+    "perturbation_min_success": 5
   },
   "names": {
     "nonlinear_constraint": [],
@@ -51,6 +52,7 @@
     "stdout": "optimizer.stdout"
   },
   "realizations": {
+    "realization_min_success": 1,
     "weights": [
       1.0
     ]

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -177,7 +177,7 @@ def snapshot_update_event_with_fm_message():
 
 
 @pytest.mark.slow
-def test_failed_jobs_monitor(
+def test_that_the_monitor_shows_failed_jobs(
     monkeypatch, full_snapshot_event, snapshot_update_failure_event, capsys
 ):
     server_mock = MagicMock()
@@ -197,11 +197,7 @@ def test_failed_jobs_monitor(
     )
     captured = capsys.readouterr()
     expected = [
-<<<<<<< HEAD
-        "===================== Running forward models (Batch #0) ======================\n",  # ruff: ignore[line-too-long]
-=======
         "============ Running forward models (Batch #0) =============\n",
->>>>>>> 519aff1506 (Update everest monitoring code)
         "  Waiting: 0 | Pending: 0 | Running: 0 | Finished: 0 | Failed: 1\n",
         (
             "  fm_step_0: 1/0/1"
@@ -216,7 +212,9 @@ def test_failed_jobs_monitor(
 
 
 @pytest.mark.slow
-def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys):
+def test_that_the_monitor_shows_running_jobs(
+    monkeypatch, full_snapshot_event, snapshot_update_event, capsys
+):
     server_mock = MagicMock()
     connection_mock = MagicMock(spec=ClientConnection)
     connection_mock.recv.side_effect = [
@@ -237,11 +235,7 @@ def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys
         )
     captured = capsys.readouterr()
     expected = [
-<<<<<<< HEAD
-        "===================== Running forward models (Batch #0) ======================\n",  # ruff: ignore[line-too-long]
-=======
         "============ Running forward models (Batch #0) =============\n",
->>>>>>> 519aff1506 (Update everest monitoring code)
         "  Waiting: 0 | Pending: 0 | Running: 0 | Finished: 1 | Failed: 0\n",
         "  fm_step_0: 1/1/0\n",
     ]
@@ -253,7 +247,7 @@ def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys
 
 
 @pytest.mark.slow
-def test_forward_model_message_reaches_the_cli(
+def test_that_a_forward_model_message_reaches_the_cli(
     monkeypatch, full_snapshot_event, snapshot_update_event_with_fm_message, capsys
 ):
     server_mock = MagicMock()
@@ -293,7 +287,7 @@ def test_forward_model_message_reaches_the_cli(
 
 
 @pytest.mark.slow
-def test_failed_everest_batch_result_event(
+def test_that_a_failed_everest_batch_result_event_is_shown(
     monkeypatch, everest_batch_result_event, capsys
 ):
     server_mock = MagicMock()
@@ -305,10 +299,11 @@ def test_failed_everest_batch_result_event(
     server_mock.return_value.__enter__.return_value = connection_mock
     monkeypatch.setattr(everest.detached.client, "connect", server_mock)
     monkeypatch.setattr(everest.detached.client, "ssl", MagicMock())
-    partial(everest.detached.start_monitor, polling_interval=0.1)
-    run_detached_monitor(
-        ("some/url", "cert", ("username", "password")), run_id="test-run-id"
-    )
+    patched = partial(everest.detached.start_monitor, polling_interval=0.1)
+    with patch("everest.bin.utils.start_monitor", patched):
+        run_detached_monitor(
+            ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+        )
     captured = capsys.readouterr()
     expected = [
         "============= Optimization progress (Batch #0) =============\n",

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -302,7 +302,7 @@ def test_that_a_failed_everest_batch_result_event_is_shown(
     patched = partial(everest.detached.start_monitor, polling_interval=0.1)
     with patch("everest.bin.utils.start_monitor", patched):
         run_detached_monitor(
-            ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+            ("some/url", "cert", ("username", "password")), experiment_id="test-run-id"
         )
     captured = capsys.readouterr()
     expected = [

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -1,4 +1,6 @@
 import json
+import os
+import shutil
 import string
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -18,6 +20,7 @@ from ert.ensemble_evaluator import (
 )
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshotMetadata
 from ert.resources import all_shell_script_fm_steps
+from ert.run_models.event import EverestBatchResultEvent
 from everest.bin.utils import run_detached_monitor
 from tests.ert.utils import SnapshotBuilder
 
@@ -27,6 +30,13 @@ METADATA = EnsembleSnapshotMetadata(
     sorted_real_ids=[],
     sorted_fm_step_ids=defaultdict(list),
 )
+
+
+@pytest.fixture(autouse=True)
+def fixed_terminal_width(monkeypatch):
+    monkeypatch.setattr(
+        shutil, "get_terminal_size", lambda *args, **kwargs: os.terminal_size((60, 24))
+    )
 
 
 @pytest.fixture
@@ -98,6 +108,18 @@ def snapshot_update_event():
         realization_count=4,
         status_count={"Finished": 1, "Running": 0, "Unknown": 0},
         iteration=0,
+    )
+    return json.dumps(jsonable_encoder(event))
+
+
+@pytest.fixture
+def everest_batch_result_event():
+    event = EverestBatchResultEvent(
+        batch=0,
+        everest_event="OPTIMIZATION_RESULT",
+        result_type="GradientResult",
+        results={"dummy": "ignored"},
+        failures={0: [-1], 1: [0, 1, 2]},
     )
     return json.dumps(jsonable_encoder(event))
 
@@ -175,12 +197,15 @@ def test_failed_jobs_monitor(
     )
     captured = capsys.readouterr()
     expected = [
+<<<<<<< HEAD
         "===================== Running forward models (Batch #0) ======================\n",  # ruff: ignore[line-too-long]
+=======
+        "============ Running forward models (Batch #0) =============\n",
+>>>>>>> 519aff1506 (Update everest monitoring code)
         "  Waiting: 0 | Pending: 0 | Running: 0 | Finished: 0 | Failed: 1\n",
         (
-            "  fm_step_0: 1/0/1 | Failed: 1"
-            "  fm_step_0: Failed: "
-            "The run is cancelled due to reaching MAX_RUNTIME, realizations: 1\n"
+            "  fm_step_0: 1/0/1"
+            "  fm_step_0: The run is cancelled due to reaching MAX_RUNTIME\n"
         ),
     ]
     # Ignore whitespace
@@ -212,9 +237,13 @@ def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys
         )
     captured = capsys.readouterr()
     expected = [
+<<<<<<< HEAD
         "===================== Running forward models (Batch #0) ======================\n",  # ruff: ignore[line-too-long]
+=======
+        "============ Running forward models (Batch #0) =============\n",
+>>>>>>> 519aff1506 (Update everest monitoring code)
         "  Waiting: 0 | Pending: 0 | Running: 0 | Finished: 1 | Failed: 0\n",
-        "  fm_step_0: 1/1/0 | Finished: 1\n",
+        "  fm_step_0: 1/1/0\n",
     ]
     expected.extend([f"{name}: 2/0/0" for name in all_shell_script_fm_steps])
     # Ignore whitespace
@@ -245,9 +274,9 @@ def test_forward_model_message_reaches_the_cli(
     captured = capsys.readouterr()
 
     expected = [
-        "===================== Running forward models (Batch #0) ======================\n",  # ruff: ignore[line-too-long]
+        "============ Running forward models (Batch #0) =============\n",
         "  Waiting: 0 | Pending: 0 | Running: 0 | Finished: 1 | Failed: 0\n",
-        "  fm_step_0: 1/1/0 | Finished: 1\n",
+        "  fm_step_0: 1/1/0\n",
     ]
     expected.append("Something went wrong!\n")
     expected.extend(
@@ -261,3 +290,33 @@ def test_forward_model_message_reaches_the_cli(
     assert captured.out.translate({ord(c): None for c in string.whitespace}) == "".join(
         expected
     ).translate({ord(c): None for c in string.whitespace})
+
+
+@pytest.mark.slow
+def test_failed_everest_batch_result_event(
+    monkeypatch, everest_batch_result_event, capsys
+):
+    server_mock = MagicMock()
+    connection_mock = MagicMock(spec=ClientConnection)
+    connection_mock.recv.side_effect = [
+        everest_batch_result_event,
+        json.dumps(jsonable_encoder(EndEvent(failed=True, msg="Failed"))),
+    ]
+    server_mock.return_value.__enter__.return_value = connection_mock
+    monkeypatch.setattr(everest.detached.client, "connect", server_mock)
+    monkeypatch.setattr(everest.detached.client, "ssl", MagicMock())
+    partial(everest.detached.start_monitor, polling_interval=0.1)
+    run_detached_monitor(
+        ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+    )
+    captured = capsys.readouterr()
+    expected = [
+        "============= Optimization progress (Batch #0) =============\n",
+        "  Failed function evaluation for realization: 0\n",
+        "  Failed perturbations for realization 1: 0-2\n",
+    ]
+    # Ignore whitespace
+    output = captured.out.translate({ord(c): None for c in string.whitespace})
+    assert output.startswith(
+        "".join(expected).translate({ord(c): None for c in string.whitespace})
+    )


### PR DESCRIPTION
**Issue**
Resolves #12454


**Approach**
Two commits:
1. Update everest config code:
   - Add explicit validation to set default values for the minimum number of successful realizations and perturbations in the optimization config, instead of relying on implicit defaults.
   - Update the doc strings accordingly.
2. Update everest monitoring code:
   - Replace/remove the realization numbers for finished/failed realizations with just their count, because these numbers are only used internally by everest and do not correspond with the everest model realization numbers.
   - Add the numbers for failed realizations and for failed perturbations to the monitoring output for each finalized batch.

(Screenshot of new behavior in GUI if applicable)
<img width="729" height="352" alt="image" src="https://github.com/user-attachments/assets/59016277-b569-4e6e-a0f3-05f25944d9ec" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
