### PR TITLE
Fix logging of missing wildcard rft responses

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -316,7 +316,7 @@ class RFTConfig(ResponseConfig):
             well_times_to_warn.remove(wildcard_well_time)
 
         formatted_items = [
-            f"{well}: {time}" for well, time in sorted(well_times_to_warn)
+            f"{well=} : {time=}" for well, time in sorted(well_times_to_warn)
         ]
         _warn_about_missing_responses(
             formatted_items, "well(s) at time(s)", rft_filename

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -291,17 +291,15 @@ class RFTConfig(ResponseConfig):
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry],
         rft_filename: str,
     ) -> None:
-        well_time_keys = {
+        well_times = {
             (well, time)
             for well, time_dict in self.data_to_read.items()
             for time in time_dict
             if well != "*"
         }
-        well_time_keys_rft_data = {(well, time.isoformat()) for well, time in rft_data}
+        well_times_with_response = {(well, time.isoformat()) for well, time in rft_data}
 
-        well_times_to_warn: set[tuple[str, str]] = (
-            well_time_keys - well_time_keys_rft_data
-        )
+        well_times_to_warn: set[tuple[str, str]] = well_times - well_times_with_response
 
         # Only warn about wells with wildcard times if well have
         # no responses at any time.

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -295,7 +295,6 @@ class RFTConfig(ResponseConfig):
             (well, time)
             for well, time_dict in self.data_to_read.items()
             for time in time_dict
-            if well != "*"
         }
         well_times_with_response = {(well, time.isoformat()) for well, time in rft_data}
 
@@ -303,8 +302,11 @@ class RFTConfig(ResponseConfig):
 
         # Only warn about wells with wildcard times if well have
         # no responses at any time.
-        wells_with_responses = {well for well, time in rft_data}
+        wells_with_responses = {well for well, time in well_times_with_response}
+        times_with_responses = {time for well, time in well_times_with_response}
         for well, time in copy(well_times_to_warn):
+            if well == "*" and time in times_with_responses:
+                well_times_to_warn.remove((well, time))
             if time == "*" and well in wells_with_responses:
                 well_times_to_warn.remove((well, time))
 

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from collections import defaultdict
+from copy import copy
 from dataclasses import InitVar, dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -294,14 +295,23 @@ class RFTConfig(ResponseConfig):
             (well, time)
             for well, time_dict in self.data_to_read.items()
             for time in time_dict
+            if well != "*"
         }
         well_time_keys_rft_data = {(well, time.isoformat()) for well, time in rft_data}
-        well_time_without_response: set[tuple[str, str]] = (
+
+        well_times_to_warn: set[tuple[str, str]] = (
             well_time_keys - well_time_keys_rft_data
         )
 
+        # Only warn about wells with wildcard times if well have
+        # no responses at any time.
+        wells_with_responses = {well for well, time in rft_data}
+        for well, time in copy(well_times_to_warn):
+            if time == "*" and well in wells_with_responses:
+                well_times_to_warn.remove((well, time))
+
         formatted_items = [
-            f"{well}: {time}" for well, time in sorted(well_time_without_response)
+            f"{well}: {time}" for well, time in sorted(well_times_to_warn)
         ]
         _warn_about_missing_responses(
             formatted_items, "well(s) at time(s)", rft_filename

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -300,8 +300,8 @@ class RFTConfig(ResponseConfig):
 
         well_times_to_warn: set[tuple[str, str]] = well_times - well_times_with_response
 
-        # Only warn about wells with wildcard times if well have
-        # no responses at any time.
+        # Given well / time wildcard, only warn if there are no responses for
+        # the corresponding well / time value
         wells_with_responses = {well for well, time in well_times_with_response}
         times_with_responses = {time for well, time in well_times_with_response}
         for well, time in copy(well_times_to_warn):
@@ -310,6 +310,7 @@ class RFTConfig(ResponseConfig):
             if time == "*" and well in wells_with_responses:
                 well_times_to_warn.remove((well, time))
 
+        # Only warn about wildcard well and time if there are no responses
         if (wildcard_well_time := ("*", "*")) in well_times and len(
             well_times_with_response
         ) > 0:

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -310,6 +310,11 @@ class RFTConfig(ResponseConfig):
             if time == "*" and well in wells_with_responses:
                 well_times_to_warn.remove((well, time))
 
+        if (wildcard_well_time := ("*", "*")) in well_times and len(
+            well_times_with_response
+        ) > 0:
+            well_times_to_warn.remove(wildcard_well_time)
+
         formatted_items = [
             f"{well}: {time}" for well, time in sorted(well_times_to_warn)
         ]

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1422,3 +1422,39 @@ def test_that_wildcard_times_are_warned_about_given_no_well_response(
     expected_warning = ["Could not find responses for well(s) at time(s)", "WELL: *"]
     # Assert one warning contains all expected warnings
     assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+
+
+def test_that_wildcard_wells_are_warned_about_given_no_time_response(
+    setup_mock_resfo_file,
+):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "*": {"2010-10-10": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    expected_warning = [
+        "Could not find responses for well(s) at time(s)",
+        "*: 2010-10-10",
+    ]
+    # Assert one warning contains all expected warnings
+    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+
+
+def test_that_wildcard_wells_with_time_response_are_not_warned_about(
+    setup_mock_resfo_file,
+):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "*": {"2000-01-01": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
+            "error", PostExperimentWarning
+        )
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1458,3 +1458,47 @@ def test_that_wildcard_wells_with_time_response_are_not_warned_about(
             "error", PostExperimentWarning
         )
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+
+def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_about(
+    mock_resfo_file, egrid
+):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [],
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        egrid,
+    )
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "*": {"*": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    expected_warning = [
+        "Could not find responses for well(s) at time(s)",
+        "*: *",
+    ]
+    # Assert one warning contains all expected warnings
+    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+
+
+def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(
+    setup_mock_resfo_file,
+):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "*": {"*": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
+            "error", PostExperimentWarning
+        )
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1325,7 +1325,7 @@ def test_that_missing_response_for_rft_well_raises_warning(setup_mock_resfo_file
 
     expected_warnings = [
         "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
-        "NOT_A_WELL: 2000-01-01",
+        "well='NOT_A_WELL' : time='2000-01-01'",
     ]
     assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
 
@@ -1346,7 +1346,7 @@ def test_that_one_existing_and_one_missing_rft_response_warns_about_the_one_miss
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
     expected_warnings = [
         "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
-        "WELL: 4000-01-01",
+        "well='WELL' : time='4000-01-01'",
     ]
     assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
 
@@ -1419,9 +1419,12 @@ def test_that_wildcard_times_are_warned_about_given_no_well_response(
     with pytest.warns(PostExperimentWarning) as warnings:
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
-    expected_warning = ["Could not find responses for well(s) at time(s)", "WELL: *"]
+    expected_warnings = [
+        "Could not find responses for well(s) at time(s)",
+        "well='DIFFERENT_WELL' : time='*'",
+    ]
     # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
 def test_that_wildcard_wells_are_warned_about_given_no_time_response(
@@ -1436,12 +1439,12 @@ def test_that_wildcard_wells_are_warned_about_given_no_time_response(
     with pytest.warns(PostExperimentWarning) as warnings:
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
-    expected_warning = [
+    expected_warnings = [
         "Could not find responses for well(s) at time(s)",
-        "*: 2010-10-10",
+        "well='*' : time='2010-10-10'",
     ]
     # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
 def test_that_wildcard_wells_with_time_response_are_not_warned_about(
@@ -1480,12 +1483,12 @@ def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_ab
     with pytest.warns(PostExperimentWarning) as warnings:
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
-    expected_warning = [
+    expected_warnings = [
         "Could not find responses for well(s) at time(s)",
-        "*: *",
+        "well='*' : time='*'",
     ]
     # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)
+    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
 def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -1288,7 +1289,8 @@ def test_that_approximate_missing_rft_values_keyword_sets_interpolation_to_true_
     assert rft_config.approximate_missing_values is expected_setting
 
 
-def test_that_missing_response_for_rft_well_raises_warning(mock_resfo_file, egrid):
+@pytest.fixture(name="setup_mock_resfo_file")
+def setup_mock_resfo_file(mock_resfo_file, egrid):
     mock_resfo_file(
         "/tmp/does_not_exist/BASE.RFT",
         [
@@ -1309,6 +1311,8 @@ def test_that_missing_response_for_rft_well_raises_warning(mock_resfo_file, egri
         egrid,
     )
 
+
+def test_that_missing_response_for_rft_well_raises_warning(setup_mock_resfo_file):
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={
@@ -1327,23 +1331,8 @@ def test_that_missing_response_for_rft_well_raises_warning(mock_resfo_file, egri
 
 
 def test_that_one_existing_and_one_missing_rft_response_warns_about_the_one_missing(
-    mock_resfo_file, egrid
+    setup_mock_resfo_file,
 ):
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.RFT",
-        [
-            *cell_start(date=(1, 1, 2000), well_name="WELL"),
-            ("PRESSURE", float_arr([100.0, 200.0])),
-            ("SWAT    ", float_arr([0.1, 0.2])),
-            ("SGAS    ", float_arr([0.3, 0.4])),
-            ("DEPTH   ", float_arr([20.0, 30.0])),
-        ],
-    )
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.EGRID",
-        egrid,
-    )
-
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={
@@ -1362,21 +1351,7 @@ def test_that_one_existing_and_one_missing_rft_response_warns_about_the_one_miss
     assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
 
 
-def test_that_many_missing_response_warnings_are_truncated(mock_resfo_file, egrid):
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.RFT",
-        [
-            *cell_start(date=(1, 1, 2000), well_name="WELL"),
-            ("PRESSURE", float_arr([100.0, 200.0])),
-            ("SWAT    ", float_arr([0.1, 0.2])),
-            ("SGAS    ", float_arr([0.3, 0.4])),
-            ("DEPTH   ", float_arr([20.0, 30.0])),
-        ],
-    )
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.EGRID",
-        egrid,
-    )
+def test_that_many_missing_response_warnings_are_truncated(setup_mock_resfo_file):
     num_missing_responses = 9
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
@@ -1400,3 +1375,50 @@ def test_that_many_missing_response_warnings_are_truncated(mock_resfo_file, egri
     match = re.search(r"and (\d+) other missing responses", last_line)
     excess_warnings = int(match.group(1))
     assert excess_warnings == num_missing_responses - _RESPONSE_WARNING_LIMIT
+
+
+def test_that_wildcard_wells_are_not_warned_about(setup_mock_resfo_file):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "*": {"2000-01-01": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
+            "error", PostExperimentWarning
+        )
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+
+def test_that_wildcard_times_are_not_warned_about_given_any_well_response(
+    setup_mock_resfo_file,
+):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "WELL": {"*": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
+            "error", PostExperimentWarning
+        )
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+
+def test_that_wildcard_times_are_warned_about_given_no_well_response(
+    setup_mock_resfo_file,
+):
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={
+            "DIFFERENT_WELL": {"*": ["PRESSURE", "SWAT"]},
+        },
+    )
+    with pytest.warns(PostExperimentWarning) as warnings:
+        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    expected_warning = ["Could not find responses for well(s) at time(s)", "WELL: *"]
+    # Assert one warning contains all expected warnings
+    assert any(all(e_w in str(w) for e_w in expected_warning) for w in warnings)

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1447,22 +1447,6 @@ def test_that_wildcard_wells_are_warned_about_given_no_time_response(
     assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
-def test_that_wildcard_wells_with_time_response_are_not_warned_about(
-    setup_mock_resfo_file,
-):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "*": {"2000-01-01": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
-            "error", PostExperimentWarning
-        )
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-
 def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_about(
     mock_resfo_file, egrid
 ):


### PR DESCRIPTION
The wildcard options for well and times have not been considered when this was first implemented.

This change will not log missing wildcard wells and only log wildcard times if there are no responses at any time for the given well.

**Issue**
Resolves #13968 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
