### PR TITLE
Set up design system

### DIFF
--- a/src/ert/gui/resources/gui/themes/dark.qss
+++ b/src/ert/gui/resources/gui/themes/dark.qss
@@ -1,0 +1,4 @@
+QWidget {
+    background-color: #1e1e1e;
+    color: #f0f0f0;
+}

--- a/src/ert/gui/resources/gui/themes/light.qss
+++ b/src/ert/gui/resources/gui/themes/light.qss
@@ -1,0 +1,4 @@
+QWidget {
+    background-color: #ffffff;
+    color: #202020;
+}

--- a/src/ert/gui/theming/__init__.py
+++ b/src/ert/gui/theming/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .manager import ThemeManager
+from .theme import Theme
+
+__all__ = [
+    "Theme",
+    "ThemeManager",
+]

--- a/src/ert/gui/theming/__init__.py
+++ b/src/ert/gui/theming/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from .manager import ThemeManager
-from .theme import Theme
+from .manager import ColorSchemeManager
+from .theme import ColorScheme
 
 __all__ = [
-    "Theme",
-    "ThemeManager",
+    "ColorScheme",
+    "ColorSchemeManager",
 ]

--- a/src/ert/gui/theming/manager.py
+++ b/src/ert/gui/theming/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import cast
 
 from PyQt6.QtCore import QObject, Qt, pyqtSignal
@@ -8,7 +9,12 @@ from PyQt6.QtWidgets import QApplication
 
 from .theme import Theme, load_qss
 
+logger = logging.getLogger(__name__)
+
 _STYLE_HINTS_MISSING = "styleHints() unavailable; is a QGuiApplication running?"
+_QAPPLICATION_MISSING = (
+    "QApplication instance not found; construct a QApplication before applying a theme."
+)
 
 _DARK_BASE_VALUE_THRESHOLD = 70
 """HSV ``value`` cutoff (0-255) below which the palette's base colour is
@@ -60,31 +66,15 @@ def _palette_fallback() -> Theme:
 
 
 class ThemeManager(QObject):
-    """Central owner of the active :class:`Theme` for the ERT GUI.
-
-    Responsibilities:
-
-    * Determine the initial theme from the OS colour scheme.
-    * Load the matching QSS file and apply it to the running
-      :class:`~PyQt6.QtWidgets.QApplication`.
-    * Emit :attr:`theme_changed` whenever the active theme flips, so widgets
-      that hold theme-dependent state can react.
-    * Follow the OS colour scheme automatically until the caller pins a
-      specific theme via :meth:`set_theme`.
-
-    A :class:`~PyQt6.QtWidgets.QApplication` must already exist when the
-    manager is constructed.
-    """
-
     theme_changed = pyqtSignal(Theme)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._follow_system: bool = True
+        self._follows_system_theme: bool = True
         self._current_theme: Theme = detect_system_theme()
         hints = _require_style_hints()
         hints.colorSchemeChanged.connect(self._on_system_scheme_changed)
-        self.apply()
+        self.apply_stylesheet_from_qss()
 
     @property
     def current_theme(self) -> Theme:
@@ -92,32 +82,39 @@ class ThemeManager(QObject):
 
     @property
     def follows_system(self) -> bool:
-        return self._follow_system
+        return self._follows_system_theme
 
     def set_theme(self, theme: Theme) -> None:
         """Pin the manager to ``theme`` and stop following the OS scheme."""
-        self._follow_system = False
+        self._follows_system_theme = False
         self._set_theme_internal(theme)
 
     def follow_system(self) -> None:
         """Resume following the OS colour scheme; re-syncs immediately."""
-        self._follow_system = True
+        self._follows_system_theme = True
         self._set_theme_internal(detect_system_theme())
 
-    def apply(self) -> None:
-        """Load and install the QSS for the currently active theme."""
+    def apply_stylesheet_from_qss(self) -> None:
         app = cast(QApplication | None, QApplication.instance())
         if app is None:
+            raise RuntimeError(_QAPPLICATION_MISSING)
+        try:
+            stylesheet = load_qss(self._current_theme)
+        except (OSError, UnicodeDecodeError):
+            logger.exception(
+                "Failed to load QSS for theme '%s'; keeping previous styling.",
+                self._current_theme.value,
+            )
             return
-        app.setStyleSheet(load_qss(self._current_theme))
+        app.setStyleSheet(stylesheet)
 
     def _on_system_scheme_changed(self, _scheme: Qt.ColorScheme) -> None:
-        if self._follow_system:
+        if self._follows_system_theme:
             self._set_theme_internal(detect_system_theme())
 
     def _set_theme_internal(self, theme: Theme) -> None:
         if theme == self._current_theme:
             return
         self._current_theme = theme
-        self.apply()
+        self.apply_stylesheet_from_qss()
         self.theme_changed.emit(theme)

--- a/src/ert/gui/theming/manager.py
+++ b/src/ert/gui/theming/manager.py
@@ -116,8 +116,8 @@ class ThemeManager(QObject):
             self._set_theme_internal(detect_system_theme())
 
     def _set_theme_internal(self, theme: Theme) -> None:
-        changed = theme != self._current_theme
+        if theme == self._current_theme:
+            return
         self._current_theme = theme
         self.apply()
-        if changed:
-            self.theme_changed.emit(theme)
+        self.theme_changed.emit(theme)

--- a/src/ert/gui/theming/manager.py
+++ b/src/ert/gui/theming/manager.py
@@ -7,13 +7,14 @@ from PyQt6.QtCore import QObject, Qt, pyqtSignal
 from PyQt6.QtGui import QGuiApplication, QStyleHints
 from PyQt6.QtWidgets import QApplication
 
-from .theme import Theme, load_qss
+from .theme import ColorScheme, load_qss
 
 logger = logging.getLogger(__name__)
 
 _STYLE_HINTS_MISSING = "styleHints() unavailable; is a QGuiApplication running?"
 _QAPPLICATION_MISSING = (
-    "QApplication instance not found; construct a QApplication before applying a theme."
+    "QApplication instance not found; construct a QApplication before applying "
+    "a colour scheme."
 )
 
 _DARK_BASE_VALUE_THRESHOLD = 70
@@ -34,87 +35,78 @@ def _require_style_hints() -> QStyleHints:
     return hints
 
 
-def detect_system_theme() -> Theme:
-    """Return the OS-reported colour scheme, or fall back to a palette heuristic.
+def detect_system_color_scheme() -> ColorScheme:
 
-    Uses ``QGuiApplication.styleHints().colorScheme()`` on Qt 6.5+.  When the
-    style hint returns ``Unknown`` (or the platform integration does not
-    report a value), the base-colour brightness of the current application
-    palette is inspected instead.
-
-    A running ``QApplication`` (or at least a ``QGuiApplication``) must exist
-    before calling this function.
-    """
     hints = _require_style_hints()
     scheme = hints.colorScheme()
     if scheme == Qt.ColorScheme.Dark:
-        return Theme.DARK
+        return ColorScheme.DARK
     if scheme == Qt.ColorScheme.Light:
-        return Theme.LIGHT
+        return ColorScheme.LIGHT
     return _palette_fallback()
 
 
-def _palette_fallback() -> Theme:
+def _palette_fallback() -> ColorScheme:
     app = cast(QApplication | None, QApplication.instance())
     if app is None:
-        return Theme.LIGHT
+        return ColorScheme.LIGHT
     return (
-        Theme.DARK
+        ColorScheme.DARK
         if app.palette().base().color().value() < _DARK_BASE_VALUE_THRESHOLD
-        else Theme.LIGHT
+        else ColorScheme.LIGHT
     )
 
 
-class ThemeManager(QObject):
-    theme_changed = pyqtSignal(Theme)
+class ColorSchemeManager(QObject):
+    color_scheme_changed = pyqtSignal(ColorScheme)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
-        self._follows_system_theme: bool = True
-        self._current_theme: Theme = detect_system_theme()
+        self._follows_system_color_scheme: bool = True
+        self._current_color_scheme: ColorScheme = detect_system_color_scheme()
         hints = _require_style_hints()
         hints.colorSchemeChanged.connect(self._on_system_scheme_changed)
         self.apply_stylesheet_from_qss()
 
     @property
-    def current_theme(self) -> Theme:
-        return self._current_theme
+    def current_color_scheme(self) -> ColorScheme:
+        return self._current_color_scheme
 
     @property
     def follows_system(self) -> bool:
-        return self._follows_system_theme
+        return self._follows_system_color_scheme
 
-    def set_theme(self, theme: Theme) -> None:
-        """Pin the manager to ``theme`` and stop following the OS scheme."""
-        self._follows_system_theme = False
-        self._set_theme_internal(theme)
+    def set_color_scheme(self, color_scheme: ColorScheme) -> None:
+        """Pin the manager to ``color_scheme`` and stop following the OS scheme."""
+        self._follows_system_color_scheme = False
+        self._set_color_scheme_internal(color_scheme)
 
     def follow_system(self) -> None:
         """Resume following the OS colour scheme; re-syncs immediately."""
-        self._follows_system_theme = True
-        self._set_theme_internal(detect_system_theme())
+        self._follows_system_color_scheme = True
+        self._set_color_scheme_internal(detect_system_color_scheme())
 
     def apply_stylesheet_from_qss(self) -> None:
         app = cast(QApplication | None, QApplication.instance())
         if app is None:
             raise RuntimeError(_QAPPLICATION_MISSING)
         try:
-            stylesheet = load_qss(self._current_theme)
+            stylesheet = load_qss(self._current_color_scheme)
         except (OSError, UnicodeDecodeError):
             logger.exception(
-                "Failed to load QSS for theme '%s'; keeping previous styling.",
-                self._current_theme.value,
+                "Failed to load QSS for colour scheme '%s'; keeping previous styling.",
+                self._current_color_scheme.value,
             )
             return
         app.setStyleSheet(stylesheet)
 
     def _on_system_scheme_changed(self, _scheme: Qt.ColorScheme) -> None:
-        if self._follows_system_theme:
-            self._set_theme_internal(detect_system_theme())
+        if self._follows_system_color_scheme:
+            self._set_color_scheme_internal(detect_system_color_scheme())
 
-    def _set_theme_internal(self, theme: Theme) -> None:
-        if theme == self._current_theme:
+    def _set_color_scheme_internal(self, color_scheme: ColorScheme) -> None:
+        if color_scheme == self._current_color_scheme:
             return
-        self._current_theme = theme
+        self._current_color_scheme = color_scheme
         self.apply_stylesheet_from_qss()
-        self.theme_changed.emit(theme)
+        self.color_scheme_changed.emit(color_scheme)

--- a/src/ert/gui/theming/manager.py
+++ b/src/ert/gui/theming/manager.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import cast
+
+from PyQt6.QtCore import QObject, Qt, pyqtSignal
+from PyQt6.QtGui import QGuiApplication, QStyleHints
+from PyQt6.QtWidgets import QApplication
+
+from .theme import Theme, load_qss
+
+_STYLE_HINTS_MISSING = "styleHints() unavailable; is a QGuiApplication running?"
+
+_DARK_BASE_VALUE_THRESHOLD = 70
+"""HSV ``value`` cutoff (0-255) below which the palette's base colour is
+considered dark enough to imply a dark theme.
+
+Chosen empirically: typical dark-mode base colours sit well under 70
+(Fusion dark ≈ 42), while light palettes are effectively white (255), so
+the midpoint is not needed and a low threshold avoids misclassifying
+dim-but-light themes as dark.
+"""
+
+
+def _require_style_hints() -> QStyleHints:
+    hints = QGuiApplication.styleHints()
+    if hints is None:
+        raise RuntimeError(_STYLE_HINTS_MISSING)
+    return hints
+
+
+def detect_system_theme() -> Theme:
+    """Return the OS-reported colour scheme, or fall back to a palette heuristic.
+
+    Uses ``QGuiApplication.styleHints().colorScheme()`` on Qt 6.5+.  When the
+    style hint returns ``Unknown`` (or the platform integration does not
+    report a value), the base-colour brightness of the current application
+    palette is inspected instead.
+
+    A running ``QApplication`` (or at least a ``QGuiApplication``) must exist
+    before calling this function.
+    """
+    hints = _require_style_hints()
+    scheme = hints.colorScheme()
+    if scheme == Qt.ColorScheme.Dark:
+        return Theme.DARK
+    if scheme == Qt.ColorScheme.Light:
+        return Theme.LIGHT
+    return _palette_fallback()
+
+
+def _palette_fallback() -> Theme:
+    app = cast(QApplication | None, QApplication.instance())
+    if app is None:
+        return Theme.LIGHT
+    return (
+        Theme.DARK
+        if app.palette().base().color().value() < _DARK_BASE_VALUE_THRESHOLD
+        else Theme.LIGHT
+    )
+
+
+class ThemeManager(QObject):
+    """Central owner of the active :class:`Theme` for the ERT GUI.
+
+    Responsibilities:
+
+    * Determine the initial theme from the OS colour scheme.
+    * Load the matching QSS file and apply it to the running
+      :class:`~PyQt6.QtWidgets.QApplication`.
+    * Emit :attr:`theme_changed` whenever the active theme flips, so widgets
+      that hold theme-dependent state can react.
+    * Follow the OS colour scheme automatically until the caller pins a
+      specific theme via :meth:`set_theme`.
+
+    A :class:`~PyQt6.QtWidgets.QApplication` must already exist when the
+    manager is constructed.
+    """
+
+    theme_changed = pyqtSignal(Theme)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._follow_system: bool = True
+        self._current_theme: Theme = detect_system_theme()
+        hints = _require_style_hints()
+        hints.colorSchemeChanged.connect(self._on_system_scheme_changed)
+        self.apply()
+
+    @property
+    def current_theme(self) -> Theme:
+        return self._current_theme
+
+    @property
+    def follows_system(self) -> bool:
+        return self._follow_system
+
+    def set_theme(self, theme: Theme) -> None:
+        """Pin the manager to ``theme`` and stop following the OS scheme."""
+        self._follow_system = False
+        self._set_theme_internal(theme)
+
+    def follow_system(self) -> None:
+        """Resume following the OS colour scheme; re-syncs immediately."""
+        self._follow_system = True
+        self._set_theme_internal(detect_system_theme())
+
+    def apply(self) -> None:
+        """Load and install the QSS for the currently active theme."""
+        app = cast(QApplication | None, QApplication.instance())
+        if app is None:
+            return
+        app.setStyleSheet(load_qss(self._current_theme))
+
+    def _on_system_scheme_changed(self, _scheme: Qt.ColorScheme) -> None:
+        if self._follow_system:
+            self._set_theme_internal(detect_system_theme())
+
+    def _set_theme_internal(self, theme: Theme) -> None:
+        changed = theme != self._current_theme
+        self._current_theme = theme
+        self.apply()
+        if changed:
+            self.theme_changed.emit(theme)

--- a/src/ert/gui/theming/theme.py
+++ b/src/ert/gui/theming/theme.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from enum import Enum
+from importlib.resources import files
+
+_THEMES_SUBPATH = "resources/gui/themes"
+
+
+class Theme(Enum):
+    """Identifier for a visual theme shipped with the ERT GUI.
+
+    The value is used as the base filename of the corresponding QSS file
+    under ``src/ert/gui/resources/gui/themes/``.
+    """
+
+    LIGHT = "light"
+    DARK = "dark"
+
+
+def load_qss(theme: Theme) -> str:
+    """Read the QSS file that corresponds to ``theme``.
+
+    Files are located via :mod:`importlib.resources` under the ``ert.gui``
+    package, so they are resolved correctly whether ERT is imported from a
+    source checkout or an installed wheel.  Missing files raise
+    ``FileNotFoundError`` — callers should treat this as a programming
+    error, not a runtime condition.
+    """
+    resource = files("ert.gui").joinpath(f"{_THEMES_SUBPATH}/{theme.value}.qss")
+    if not resource.is_file():
+        raise FileNotFoundError(
+            f"QSS file for theme '{theme.value}' not found at {resource}"
+        )
+    return resource.read_text(encoding="utf-8")

--- a/src/ert/gui/theming/theme.py
+++ b/src/ert/gui/theming/theme.py
@@ -18,14 +18,6 @@ class Theme(Enum):
 
 
 def load_qss(theme: Theme) -> str:
-    """Read the QSS file that corresponds to ``theme``.
-
-    Files are located via :mod:`importlib.resources` under the ``ert.gui``
-    package, so they are resolved correctly whether ERT is imported from a
-    source checkout or an installed wheel.  Missing files raise
-    ``FileNotFoundError`` — callers should treat this as a programming
-    error, not a runtime condition.
-    """
     resource = files("ert.gui").joinpath(f"{_THEMES_SUBPATH}/{theme.value}.qss")
     if not resource.is_file():
         raise FileNotFoundError(

--- a/src/ert/gui/theming/theme.py
+++ b/src/ert/gui/theming/theme.py
@@ -6,8 +6,8 @@ from importlib.resources import files
 _THEMES_SUBPATH = "resources/gui/themes"
 
 
-class Theme(Enum):
-    """Identifier for a visual theme shipped with the ERT GUI.
+class ColorScheme(Enum):
+    """Identifier for a visual colour scheme shipped with the ERT GUI.
 
     The value is used as the base filename of the corresponding QSS file
     under ``src/ert/gui/resources/gui/themes/``.
@@ -17,10 +17,10 @@ class Theme(Enum):
     DARK = "dark"
 
 
-def load_qss(theme: Theme) -> str:
-    resource = files("ert.gui").joinpath(f"{_THEMES_SUBPATH}/{theme.value}.qss")
+def load_qss(color_scheme: ColorScheme) -> str:
+    resource = files("ert.gui").joinpath(f"{_THEMES_SUBPATH}/{color_scheme.value}.qss")
     if not resource.is_file():
         raise FileNotFoundError(
-            f"QSS file for theme '{theme.value}' not found at {resource}"
+            f"QSS file for colour scheme '{color_scheme.value}' not found at {resource}"
         )
     return resource.read_text(encoding="utf-8")

--- a/tests/ert/unit_tests/gui/theming/test_qss_loading.py
+++ b/tests/ert/unit_tests/gui/theming/test_qss_loading.py
@@ -3,7 +3,21 @@ from __future__ import annotations
 import pytest
 
 from ert.gui.theming import Theme
+from ert.gui.theming import theme as theme_module
 from ert.gui.theming.theme import load_qss
+
+
+class _MissingResource:
+    def is_file(self) -> bool:
+        return False
+
+    def __str__(self) -> str:
+        return "<missing>"
+
+
+class _MissingPackage:
+    def joinpath(self, _name: str) -> _MissingResource:
+        return _MissingResource()
 
 
 @pytest.mark.parametrize("theme", list(Theme))
@@ -17,3 +31,12 @@ def test_that_qss_file_is_loaded_for_each_theme(theme: Theme) -> None:
 
 def test_that_dark_and_light_qss_differ() -> None:
     assert load_qss(Theme.DARK) != load_qss(Theme.LIGHT)
+
+
+def test_that_load_qss_raises_file_not_found_when_theme_file_is_missing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(theme_module, "files", lambda _pkg: _MissingPackage())
+
+    with pytest.raises(FileNotFoundError, match="dark"):
+        load_qss(Theme.DARK)

--- a/tests/ert/unit_tests/gui/theming/test_qss_loading.py
+++ b/tests/ert/unit_tests/gui/theming/test_qss_loading.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from ert.gui.theming import Theme
+from ert.gui.theming.theme import load_qss
+
+
+@pytest.mark.parametrize("theme", list(Theme))
+def test_that_qss_file_is_loaded_for_each_theme(theme: Theme) -> None:
+    content = load_qss(theme)
+    assert content.strip(), f"QSS for {theme.value} theme must not be empty"
+    assert "QWidget" in content, (
+        f"QSS for {theme.value} theme should style QWidget as a baseline"
+    )
+
+
+def test_that_dark_and_light_qss_differ() -> None:
+    assert load_qss(Theme.DARK) != load_qss(Theme.LIGHT)

--- a/tests/ert/unit_tests/gui/theming/test_qss_loading.py
+++ b/tests/ert/unit_tests/gui/theming/test_qss_loading.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from ert.gui.theming import Theme
+from ert.gui.theming import ColorScheme
 from ert.gui.theming import theme as theme_module
 from ert.gui.theming.theme import load_qss
 
@@ -20,17 +20,21 @@ class _MissingPackage:
         return _MissingResource()
 
 
-@pytest.mark.parametrize("theme", list(Theme))
-def test_that_qss_file_is_loaded_for_each_theme(theme: Theme) -> None:
-    content = load_qss(theme)
-    assert content.strip(), f"QSS for {theme.value} theme must not be empty"
+@pytest.mark.parametrize("color_scheme", list(ColorScheme))
+def test_that_qss_file_is_loaded_for_each_color_scheme(
+    color_scheme: ColorScheme,
+) -> None:
+    content = load_qss(color_scheme)
+    assert content.strip(), (
+        f"QSS for {color_scheme.value} colour scheme must not be empty"
+    )
     assert "QWidget" in content, (
-        f"QSS for {theme.value} theme should style QWidget as a baseline"
+        f"QSS for {color_scheme.value} colour scheme should style QWidget as a baseline"
     )
 
 
 def test_that_dark_and_light_qss_differ() -> None:
-    assert load_qss(Theme.DARK) != load_qss(Theme.LIGHT)
+    assert load_qss(ColorScheme.DARK) != load_qss(ColorScheme.LIGHT)
 
 
 def test_that_load_qss_raises_file_not_found_when_theme_file_is_missing(
@@ -39,4 +43,4 @@ def test_that_load_qss_raises_file_not_found_when_theme_file_is_missing(
     monkeypatch.setattr(theme_module, "files", lambda _pkg: _MissingPackage())
 
     with pytest.raises(FileNotFoundError, match="dark"):
-        load_qss(Theme.DARK)
+        load_qss(ColorScheme.DARK)

--- a/tests/ert/unit_tests/gui/theming/test_theme_detection.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_detection.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QGuiApplication
+
+from ert.gui.theming import Theme
+from ert.gui.theming.manager import detect_system_theme
+
+
+def test_that_detection_returns_dark_when_style_hints_report_dark(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Dark,
+    )
+    assert detect_system_theme() == Theme.DARK
+
+
+def test_that_detection_returns_light_when_style_hints_report_light(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Light,
+    )
+    assert detect_system_theme() == Theme.LIGHT
+
+
+def test_that_detection_falls_back_to_palette_when_scheme_is_unknown(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Unknown,
+    )
+    # With the default Qt palette used in tests the base colour is white
+    # (value 255), which is above ``_DARK_BASE_VALUE_THRESHOLD`` in
+    # ``_palette_fallback``, so the fallback path must resolve to LIGHT.
+    assert detect_system_theme() == Theme.LIGHT

--- a/tests/ert/unit_tests/gui/theming/test_theme_detection.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_detection.py
@@ -4,9 +4,12 @@ import pytest
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QGuiApplication, QPalette
 
-from ert.gui.theming import Theme
+from ert.gui.theming import ColorScheme
 from ert.gui.theming import manager as manager_module
-from ert.gui.theming.manager import _DARK_BASE_VALUE_THRESHOLD, detect_system_theme
+from ert.gui.theming.manager import (
+    _DARK_BASE_VALUE_THRESHOLD,
+    detect_system_color_scheme,
+)
 
 
 def _palette_with_base_value(value: int) -> QPalette:
@@ -23,7 +26,7 @@ def test_that_detection_returns_dark_when_style_hints_report_dark(
         "colorScheme",
         lambda: Qt.ColorScheme.Dark,
     )
-    assert detect_system_theme() == Theme.DARK
+    assert detect_system_color_scheme() == ColorScheme.DARK
 
 
 def test_that_detection_returns_light_when_style_hints_report_light(
@@ -34,7 +37,7 @@ def test_that_detection_returns_light_when_style_hints_report_light(
         "colorScheme",
         lambda: Qt.ColorScheme.Light,
     )
-    assert detect_system_theme() == Theme.LIGHT
+    assert detect_system_color_scheme() == ColorScheme.LIGHT
 
 
 def test_that_detection_falls_back_to_palette_when_scheme_is_unknown(
@@ -48,7 +51,7 @@ def test_that_detection_falls_back_to_palette_when_scheme_is_unknown(
     # With the default Qt palette used in tests the base colour is white
     # (value 255), which is above ``_DARK_BASE_VALUE_THRESHOLD`` in
     # ``_palette_fallback``, so the fallback path must resolve to LIGHT.
-    assert detect_system_theme() == Theme.LIGHT
+    assert detect_system_color_scheme() == ColorScheme.LIGHT
 
 
 def test_that_require_style_hints_raises_when_style_hints_are_unavailable(
@@ -67,34 +70,32 @@ def test_that_palette_fallback_returns_light_when_no_qapplication_exists(
     monkeypatch.setattr(
         manager_module.QApplication, "instance", staticmethod(lambda: None)
     )
-    assert manager_module._palette_fallback() == Theme.LIGHT
+    assert manager_module._palette_fallback() == ColorScheme.LIGHT
 
 
-def test_that_palette_fallback_returns_dark_when_base_value_is_below_threshold(
-    qtbot, monkeypatch
+@pytest.mark.parametrize(
+    ("base_value", "expected_scheme"),
+    [
+        pytest.param(
+            _DARK_BASE_VALUE_THRESHOLD - 1,
+            ColorScheme.DARK,
+            id="returns-dark-when-base-value-is-below-threshold",
+        ),
+        pytest.param(
+            _DARK_BASE_VALUE_THRESHOLD + 1,
+            ColorScheme.LIGHT,
+            id="returns-light-when-base-value-is-above-threshold",
+        ),
+        pytest.param(
+            _DARK_BASE_VALUE_THRESHOLD,
+            ColorScheme.LIGHT,
+            id="returns-light-when-base-value-equals-threshold",
+        ),
+    ],
+)
+def test_that_palette_fallback_resolves_scheme_from_base_value_threshold(
+    qtbot, monkeypatch, base_value, expected_scheme
 ) -> None:
     app = manager_module.QApplication.instance()
-    monkeypatch.setattr(
-        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD - 1)
-    )
-    assert manager_module._palette_fallback() == Theme.DARK
-
-
-def test_that_palette_fallback_returns_light_when_base_value_is_above_threshold(
-    qtbot, monkeypatch
-) -> None:
-    app = manager_module.QApplication.instance()
-    monkeypatch.setattr(
-        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD + 1)
-    )
-    assert manager_module._palette_fallback() == Theme.LIGHT
-
-
-def test_that_palette_fallback_returns_light_when_base_value_equals_threshold(
-    qtbot, monkeypatch
-) -> None:
-    app = manager_module.QApplication.instance()
-    monkeypatch.setattr(
-        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD)
-    )
-    assert manager_module._palette_fallback() == Theme.LIGHT
+    monkeypatch.setattr(app, "palette", lambda: _palette_with_base_value(base_value))
+    assert manager_module._palette_fallback() == expected_scheme

--- a/tests/ert/unit_tests/gui/theming/test_theme_detection.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_detection.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import pytest
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtGui import QColor, QGuiApplication, QPalette
 
 from ert.gui.theming import Theme
-from ert.gui.theming.manager import detect_system_theme
+from ert.gui.theming import manager as manager_module
+from ert.gui.theming.manager import _DARK_BASE_VALUE_THRESHOLD, detect_system_theme
+
+
+def _palette_with_base_value(value: int) -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Base, QColor.fromHsv(0, 0, value))
+    return palette
 
 
 def test_that_detection_returns_dark_when_style_hints_report_dark(
@@ -41,3 +49,52 @@ def test_that_detection_falls_back_to_palette_when_scheme_is_unknown(
     # (value 255), which is above ``_DARK_BASE_VALUE_THRESHOLD`` in
     # ``_palette_fallback``, so the fallback path must resolve to LIGHT.
     assert detect_system_theme() == Theme.LIGHT
+
+
+def test_that_require_style_hints_raises_when_style_hints_are_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module.QGuiApplication, "styleHints", staticmethod(lambda: None)
+    )
+    with pytest.raises(RuntimeError, match="styleHints"):
+        manager_module._require_style_hints()
+
+
+def test_that_palette_fallback_returns_light_when_no_qapplication_exists(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module.QApplication, "instance", staticmethod(lambda: None)
+    )
+    assert manager_module._palette_fallback() == Theme.LIGHT
+
+
+def test_that_palette_fallback_returns_dark_when_base_value_is_below_threshold(
+    qtbot, monkeypatch
+) -> None:
+    app = manager_module.QApplication.instance()
+    monkeypatch.setattr(
+        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD - 1)
+    )
+    assert manager_module._palette_fallback() == Theme.DARK
+
+
+def test_that_palette_fallback_returns_light_when_base_value_is_above_threshold(
+    qtbot, monkeypatch
+) -> None:
+    app = manager_module.QApplication.instance()
+    monkeypatch.setattr(
+        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD + 1)
+    )
+    assert manager_module._palette_fallback() == Theme.LIGHT
+
+
+def test_that_palette_fallback_returns_light_when_base_value_equals_threshold(
+    qtbot, monkeypatch
+) -> None:
+    app = manager_module.QApplication.instance()
+    monkeypatch.setattr(
+        app, "palette", lambda: _palette_with_base_value(_DARK_BASE_VALUE_THRESHOLD)
+    )
+    assert manager_module._palette_fallback() == Theme.LIGHT

--- a/tests/ert/unit_tests/gui/theming/test_theme_manager.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_manager.py
@@ -5,6 +5,7 @@ from PyQt6.QtGui import QGuiApplication
 from PyQt6.QtWidgets import QApplication
 
 from ert.gui.theming import Theme, ThemeManager
+from ert.gui.theming import manager as manager_module
 from ert.gui.theming.theme import load_qss
 
 
@@ -33,6 +34,24 @@ def test_that_setting_the_same_theme_does_not_emit_signal(qtbot) -> None:
     manager.set_theme(same)
 
     assert received == []
+
+
+def test_that_setting_the_same_theme_does_not_reapply_stylesheet(qtbot) -> None:
+    manager = ThemeManager()
+    same = manager.current_theme
+
+    apply_calls: list[None] = []
+    original_apply = manager.apply
+
+    def counting_apply() -> None:
+        apply_calls.append(None)
+        original_apply()
+
+    manager.apply = counting_apply  # type: ignore[method-assign]
+
+    manager.set_theme(same)
+
+    assert apply_calls == []
 
 
 def test_that_apply_installs_the_current_themes_stylesheet_on_qapplication(
@@ -104,4 +123,14 @@ def test_that_os_scheme_change_updates_theme_when_following_system(
     manager._on_system_scheme_changed(Qt.ColorScheme.Dark)
 
     assert manager.current_theme == Theme.DARK
-    assert received[-1] == Theme.DARK
+    assert received == [Theme.DARK]
+
+
+def test_that_apply_is_a_noop_when_no_qapplication_exists(qtbot, monkeypatch) -> None:
+    manager = ThemeManager()
+
+    monkeypatch.setattr(
+        manager_module.QApplication, "instance", staticmethod(lambda: None)
+    )
+    # Must not raise even though there is no QApplication to install QSS on.
+    manager.apply()

--- a/tests/ert/unit_tests/gui/theming/test_theme_manager.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_manager.py
@@ -7,7 +7,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QGuiApplication
 from PyQt6.QtWidgets import QApplication
 
-from ert.gui.theming import Theme, ThemeManager
+from ert.gui.theming import ColorScheme, ColorSchemeManager
 from ert.gui.theming import manager as manager_module
 from ert.gui.theming.theme import load_qss
 
@@ -19,59 +19,63 @@ def _restore_global_stylesheet(qapp):
     qapp.setStyleSheet(original)
 
 
-def test_that_manual_override_sets_current_theme_and_emits_signal(qtbot) -> None:
-    manager = ThemeManager()
-    starting_theme = manager.current_theme
-    target = Theme.LIGHT if starting_theme == Theme.DARK else Theme.DARK
+def test_that_manual_override_sets_current_color_scheme_and_emits_signal(qtbot) -> None:
+    manager = ColorSchemeManager()
+    starting_color_scheme = manager.current_color_scheme
+    target = (
+        ColorScheme.LIGHT
+        if starting_color_scheme == ColorScheme.DARK
+        else ColorScheme.DARK
+    )
 
-    received: list[Theme] = []
-    manager.theme_changed.connect(received.append)
+    received: list[ColorScheme] = []
+    manager.color_scheme_changed.connect(received.append)
 
-    manager.set_theme(target)
+    manager.set_color_scheme(target)
 
-    assert manager.current_theme == target
+    assert manager.current_color_scheme == target
     assert manager.follows_system is False
     assert received == [target]
 
 
-def test_that_setting_the_same_theme_does_not_emit_signal(qtbot) -> None:
-    manager = ThemeManager()
-    same = manager.current_theme
+def test_that_setting_the_same_color_scheme_does_not_emit_signal(qtbot) -> None:
+    manager = ColorSchemeManager()
+    same = manager.current_color_scheme
 
-    received: list[Theme] = []
-    manager.theme_changed.connect(received.append)
+    received: list[ColorScheme] = []
+    manager.color_scheme_changed.connect(received.append)
 
-    manager.set_theme(same)
+    manager.set_color_scheme(same)
 
     assert received == []
 
 
-def test_that_setting_the_same_theme_does_not_reapply_stylesheet(
+def test_that_setting_the_same_color_scheme_does_not_reapply_stylesheet(
     qtbot, monkeypatch
 ) -> None:
-    manager = ThemeManager()
-    same = manager.current_theme
+    manager = ColorSchemeManager()
+    same = manager.current_color_scheme
 
     spy = Mock(wraps=manager.apply_stylesheet_from_qss)
     monkeypatch.setattr(manager, "apply_stylesheet_from_qss", spy)
 
-    manager.set_theme(same)
+    manager.set_color_scheme(same)
 
     assert spy.call_count == 0
 
 
-def test_that_apply_installs_the_current_themes_stylesheet_on_qapplication(
+def test_that_apply_installs_the_current_color_schemes_stylesheet_on_qapplication(
     qtbot,
 ) -> None:
-    manager = ThemeManager()
-    manager.set_theme(Theme.DARK)
+    manager = ColorSchemeManager()
+    manager.set_color_scheme(ColorScheme.DARK)
 
     app = QApplication.instance()
     assert app is not None
-    assert app.styleSheet() == load_qss(Theme.DARK)
+    assert app.styleSheet() == load_qss(ColorScheme.DARK)
 
 
-def test_that_follow_system_resets_to_detected_theme_and_re_enables_auto_follow(
+def test_that_follow_system_resets_to_detected_color_scheme_and_re_enables_auto_follow(
     qtbot, monkeypatch
 ) -> None:
     monkeypatch.setattr(
@@ -79,33 +83,33 @@ def test_that_follow_system_resets_to_detected_theme_and_re_enables_auto_follow(
         "colorScheme",
         lambda: Qt.ColorScheme.Dark,
     )
-    manager = ThemeManager()
-    manager.set_theme(Theme.LIGHT)
+    manager = ColorSchemeManager()
+    manager.set_color_scheme(ColorScheme.LIGHT)
     assert manager.follows_system is False
 
     manager.follow_system()
 
     assert manager.follows_system is True
-    assert manager.current_theme == Theme.DARK
+    assert manager.current_color_scheme == ColorScheme.DARK
 
 
-def test_that_os_scheme_change_is_ignored_when_theme_is_pinned(qtbot) -> None:
-    manager = ThemeManager()
-    manager.set_theme(Theme.LIGHT)
+def test_that_os_scheme_change_is_ignored_when_color_scheme_is_pinned(qtbot) -> None:
+    manager = ColorSchemeManager()
+    manager.set_color_scheme(ColorScheme.LIGHT)
 
-    received: list[Theme] = []
-    manager.theme_changed.connect(received.append)
+    received: list[ColorScheme] = []
+    manager.color_scheme_changed.connect(received.append)
 
     manager._on_system_scheme_changed(Qt.ColorScheme.Dark)
 
-    assert manager.current_theme == Theme.LIGHT
+    assert manager.current_color_scheme == ColorScheme.LIGHT
     assert received == []
 
 
-def test_that_os_scheme_change_updates_theme_when_following_system(
+def test_that_os_scheme_change_updates_color_scheme_when_following_system(
     qtbot, monkeypatch
 ) -> None:
-    manager = ThemeManager()
+    manager = ColorSchemeManager()
     # Pin the detected scheme to Light BEFORE re-enabling follow-system, so
     # follow_system()'s immediate re-sync deterministically lands on LIGHT
     # regardless of the host OS colour scheme.
@@ -114,7 +118,7 @@ def test_that_os_scheme_change_updates_theme_when_following_system(
         "colorScheme",
         lambda: Qt.ColorScheme.Light,
     )
-    manager.set_theme(Theme.LIGHT)
+    manager.set_color_scheme(ColorScheme.LIGHT)
     manager.follow_system()
 
     monkeypatch.setattr(
@@ -123,19 +127,19 @@ def test_that_os_scheme_change_updates_theme_when_following_system(
         lambda: Qt.ColorScheme.Dark,
     )
 
-    received: list[Theme] = []
-    manager.theme_changed.connect(received.append)
+    received: list[ColorScheme] = []
+    manager.color_scheme_changed.connect(received.append)
 
     manager._on_system_scheme_changed(Qt.ColorScheme.Dark)
 
-    assert manager.current_theme == Theme.DARK
-    assert received == [Theme.DARK]
+    assert manager.current_color_scheme == ColorScheme.DARK
+    assert received == [ColorScheme.DARK]
 
 
 def test_that_apply_raises_runtime_error_when_no_qapplication_exists(
     qtbot, monkeypatch
 ) -> None:
-    manager = ThemeManager()
+    manager = ColorSchemeManager()
 
     monkeypatch.setattr(
         manager_module.QApplication, "instance", staticmethod(lambda: None)
@@ -148,12 +152,12 @@ def test_that_apply_raises_runtime_error_when_no_qapplication_exists(
 def test_that_apply_keeps_previous_stylesheet_and_logs_when_qss_is_missing(
     qtbot, monkeypatch, caplog
 ) -> None:
-    manager = ThemeManager()
+    manager = ColorSchemeManager()
     app = QApplication.instance()
     assert app is not None
     previous = app.styleSheet()
 
-    def _raise(_theme: Theme) -> str:
+    def _raise(_color_scheme: ColorScheme) -> str:
         raise FileNotFoundError("no qss")
 
     monkeypatch.setattr(manager_module, "load_qss", _raise)

--- a/tests/ert/unit_tests/gui/theming/test_theme_manager.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_manager.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtWidgets import QApplication
+
+from ert.gui.theming import Theme, ThemeManager
+from ert.gui.theming.theme import load_qss
+
+
+def test_that_manual_override_sets_current_theme_and_emits_signal(qtbot) -> None:
+    manager = ThemeManager()
+    starting_theme = manager.current_theme
+    target = Theme.LIGHT if starting_theme == Theme.DARK else Theme.DARK
+
+    received: list[Theme] = []
+    manager.theme_changed.connect(received.append)
+
+    manager.set_theme(target)
+
+    assert manager.current_theme == target
+    assert manager.follows_system is False
+    assert received == [target]
+
+
+def test_that_setting_the_same_theme_does_not_emit_signal(qtbot) -> None:
+    manager = ThemeManager()
+    same = manager.current_theme
+
+    received: list[Theme] = []
+    manager.theme_changed.connect(received.append)
+
+    manager.set_theme(same)
+
+    assert received == []
+
+
+def test_that_apply_installs_the_current_themes_stylesheet_on_qapplication(
+    qtbot,
+) -> None:
+    manager = ThemeManager()
+    manager.set_theme(Theme.DARK)
+
+    app = QApplication.instance()
+    assert app is not None
+    assert app.styleSheet() == load_qss(Theme.DARK)
+
+
+def test_that_follow_system_resets_to_detected_theme_and_re_enables_auto_follow(
+    qtbot, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Dark,
+    )
+    manager = ThemeManager()
+    manager.set_theme(Theme.LIGHT)
+    assert manager.follows_system is False
+
+    manager.follow_system()
+
+    assert manager.follows_system is True
+    assert manager.current_theme == Theme.DARK
+
+
+def test_that_os_scheme_change_is_ignored_when_theme_is_pinned(qtbot) -> None:
+    manager = ThemeManager()
+    manager.set_theme(Theme.LIGHT)
+
+    received: list[Theme] = []
+    manager.theme_changed.connect(received.append)
+
+    manager._on_system_scheme_changed(Qt.ColorScheme.Dark)
+
+    assert manager.current_theme == Theme.LIGHT
+    assert received == []
+
+
+def test_that_os_scheme_change_updates_theme_when_following_system(
+    qtbot, monkeypatch
+) -> None:
+    manager = ThemeManager()
+    # Pin the detected scheme to Light BEFORE re-enabling follow-system, so
+    # follow_system()'s immediate re-sync deterministically lands on LIGHT
+    # regardless of the host OS colour scheme.
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Light,
+    )
+    manager.set_theme(Theme.LIGHT)
+    manager.follow_system()
+
+    monkeypatch.setattr(
+        QGuiApplication.styleHints(),
+        "colorScheme",
+        lambda: Qt.ColorScheme.Dark,
+    )
+
+    received: list[Theme] = []
+    manager.theme_changed.connect(received.append)
+
+    manager._on_system_scheme_changed(Qt.ColorScheme.Dark)
+
+    assert manager.current_theme == Theme.DARK
+    assert received[-1] == Theme.DARK

--- a/tests/ert/unit_tests/gui/theming/test_theme_manager.py
+++ b/tests/ert/unit_tests/gui/theming/test_theme_manager.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from unittest.mock import Mock
+
+import pytest
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QGuiApplication
 from PyQt6.QtWidgets import QApplication
@@ -7,6 +10,13 @@ from PyQt6.QtWidgets import QApplication
 from ert.gui.theming import Theme, ThemeManager
 from ert.gui.theming import manager as manager_module
 from ert.gui.theming.theme import load_qss
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_stylesheet(qapp):
+    original = qapp.styleSheet()
+    yield
+    qapp.setStyleSheet(original)
 
 
 def test_that_manual_override_sets_current_theme_and_emits_signal(qtbot) -> None:
@@ -36,22 +46,18 @@ def test_that_setting_the_same_theme_does_not_emit_signal(qtbot) -> None:
     assert received == []
 
 
-def test_that_setting_the_same_theme_does_not_reapply_stylesheet(qtbot) -> None:
+def test_that_setting_the_same_theme_does_not_reapply_stylesheet(
+    qtbot, monkeypatch
+) -> None:
     manager = ThemeManager()
     same = manager.current_theme
 
-    apply_calls: list[None] = []
-    original_apply = manager.apply
-
-    def counting_apply() -> None:
-        apply_calls.append(None)
-        original_apply()
-
-    manager.apply = counting_apply  # type: ignore[method-assign]
+    spy = Mock(wraps=manager.apply_stylesheet_from_qss)
+    monkeypatch.setattr(manager, "apply_stylesheet_from_qss", spy)
 
     manager.set_theme(same)
 
-    assert apply_calls == []
+    assert spy.call_count == 0
 
 
 def test_that_apply_installs_the_current_themes_stylesheet_on_qapplication(
@@ -126,11 +132,34 @@ def test_that_os_scheme_change_updates_theme_when_following_system(
     assert received == [Theme.DARK]
 
 
-def test_that_apply_is_a_noop_when_no_qapplication_exists(qtbot, monkeypatch) -> None:
+def test_that_apply_raises_runtime_error_when_no_qapplication_exists(
+    qtbot, monkeypatch
+) -> None:
     manager = ThemeManager()
 
     monkeypatch.setattr(
         manager_module.QApplication, "instance", staticmethod(lambda: None)
     )
-    # Must not raise even though there is no QApplication to install QSS on.
-    manager.apply()
+
+    with pytest.raises(RuntimeError, match="QApplication instance not found"):
+        manager.apply_stylesheet_from_qss()
+
+
+def test_that_apply_keeps_previous_stylesheet_and_logs_when_qss_is_missing(
+    qtbot, monkeypatch, caplog
+) -> None:
+    manager = ThemeManager()
+    app = QApplication.instance()
+    assert app is not None
+    previous = app.styleSheet()
+
+    def _raise(_theme: Theme) -> str:
+        raise FileNotFoundError("no qss")
+
+    monkeypatch.setattr(manager_module, "load_qss", _raise)
+
+    with caplog.at_level("ERROR"):
+        manager.apply_stylesheet_from_qss()
+
+    assert app.styleSheet() == previous
+    assert "Failed to load QSS" in caplog.text


### PR DESCRIPTION
**Issue**
Resolves #13972 


**Approach**
In `gui/resources/themes`, I have added two `.qss`files to define the dark and light themes. They contain minimal code in order for the tests to pass.
In `gui/theming`, I have introduced a helper method that reads the `.qss` files to process them, along with a `Theme Manager` that handles the switch between the two themes.




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
