### PR TITLE
Add editable axis/title labels from plot

### DIFF
--- a/src/ert/gui/plotting/customization_dialog/customize_plot_dialog.py
+++ b/src/ert/gui/plotting/customization_dialog/customize_plot_dialog.py
@@ -106,8 +106,11 @@ class PlotCustomizer(QObject):
             for customization_view in self._customization_dialog:
                 customization_view.apply_customization(plot_config)
 
-        history.apply_changes(plot_config)
+        self.update_plot_config(plot_config)
 
+    def update_plot_config(self, plot_config: PlotConfig) -> None:
+        history = self._get_plot_config_history()
+        history.apply_changes(plot_config)
         self._emit_changed_signal()
 
     def _revert_customization(

--- a/src/ert/gui/plotting/customization_dialog/style_customization_view.py
+++ b/src/ert/gui/plotting/customization_dialog/style_customization_view.py
@@ -23,8 +23,6 @@ def _label_msg(label: str) -> str:
 
 class StyleCustomizationView(CustomizationView):
     title = WidgetProperty()
-    x_label = WidgetProperty()
-    y_label = WidgetProperty()
     default_style = WidgetProperty()
     history_style = WidgetProperty()
     observations_style = WidgetProperty()
@@ -38,19 +36,6 @@ class StyleCustomizationView(CustomizationView):
             f"The title of the plot. {_label_msg('title')}",
             placeholder="Title",
         )
-        self.add_line_edit(
-            "x_label",
-            "x-label",
-            f"The label of the x-axis. {_label_msg('label')}",
-            placeholder="x-label",
-        )
-        self.add_line_edit(
-            "y_label",
-            "y-label",
-            f"The label of the y-axis. {_label_msg('label')}",
-            placeholder="y-label",
-        )
-
         self.add_spacing()
 
         layout = QHBoxLayout()
@@ -77,8 +62,6 @@ class StyleCustomizationView(CustomizationView):
     @override
     def apply_customization(self, plot_config: "PlotConfig") -> None:
         plot_config.set_title(self.title)
-        plot_config.set_x_label(self.x_label)
-        plot_config.set_y_label(self.y_label)
         plot_config.set_default_style(self.default_style)
         plot_config.set_history_style(self.history_style)
         plot_config.set_observations_style(self.observations_style)
@@ -89,8 +72,6 @@ class StyleCustomizationView(CustomizationView):
             self.title = plot_config.title()
         else:
             self.title = ""
-        self.x_label = plot_config.x_label()
-        self.y_label = plot_config.y_label()
         self.default_style = plot_config.default_style()
         self.history_style = plot_config.history_style()
         self.observations_style = plot_config.observations_style()

--- a/src/ert/gui/plotting/customization_dialog/style_customization_view.py
+++ b/src/ert/gui/plotting/customization_dialog/style_customization_view.py
@@ -9,34 +9,13 @@ if TYPE_CHECKING:
     from ert.gui.plotting.utils import PlotConfig
 
 
-def _label_msg(label: str) -> str:
-    return (
-        f"Set to empty to use the default {label}.\n"
-        "It is also possible to use LaTeX. "
-        "Enclose expression with $...$ for example: \n"
-        "$\\alpha > \\beta$\n"
-        "$r^3$\n"
-        "$\\frac{1}{x}$\n"
-        "$\\sqrt{2}$"
-    )
-
-
 class StyleCustomizationView(CustomizationView):
-    title = WidgetProperty()
     default_style = WidgetProperty()
     history_style = WidgetProperty()
     observations_style = WidgetProperty()
 
     def __init__(self) -> None:
         CustomizationView.__init__(self)
-
-        self.add_line_edit(
-            "title",
-            "Title",
-            f"The title of the plot. {_label_msg('title')}",
-            placeholder="Title",
-        )
-        self.add_spacing()
 
         layout = QHBoxLayout()
 
@@ -61,17 +40,12 @@ class StyleCustomizationView(CustomizationView):
 
     @override
     def apply_customization(self, plot_config: "PlotConfig") -> None:
-        plot_config.set_title(self.title)
         plot_config.set_default_style(self.default_style)
         plot_config.set_history_style(self.history_style)
         plot_config.set_observations_style(self.observations_style)
 
     @override
     def revert_customization(self, plot_config: "PlotConfig") -> None:
-        if not plot_config.is_unnamed():
-            self.title = plot_config.title()
-        else:
-            self.title = ""
         self.default_style = plot_config.default_style()
         self.history_style = plot_config.history_style()
         self.observations_style = plot_config.observations_style()

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QApplication,
     QDialog,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QMainWindow,
     QSplitter,
@@ -730,16 +729,12 @@ class PlotWindow(QMainWindow):
                     if axis == "x"
                     else axis_object.get_ylabel()
                 )
-        dialog = QInputDialog(self)
-        dialog.setWindowTitle(title)
-        dialog.setLabelText(prompt)
-        dialog.setTextValue(current_label or "")
-        size_hint = dialog.sizeHint()
-        title_width = dialog.fontMetrics().horizontalAdvance(title)
-        dialog.resize(max(size_hint.width(), title_width + 175), size_hint.height())
-        if dialog.exec() != QDialog.DialogCode.Accepted:
+        new_label_text, accepted = self._general_options.get_text_input(
+            title, prompt, current_label
+        )
+        if not accepted:
             return
-        new_label = dialog.textValue() or None
+        new_label: str | None = new_label_text or None
         if axis == "x":
             plot_config.set_x_label(new_label)
         else:
@@ -748,17 +743,14 @@ class PlotWindow(QMainWindow):
 
     def _edit_title(self) -> None:
         title = "Edit title"
-        dialog = QInputDialog(self)
-        dialog.setWindowTitle(title)
-        dialog.setLabelText("New title:")
         plot_config = self._plot_customizer.get_plot_config()
-        dialog.setTextValue(plot_config.title())
-        size_hint = dialog.sizeHint()
-        title_width = dialog.fontMetrics().horizontalAdvance(title)
-        dialog.resize(max(size_hint.width(), title_width + 175), size_hint.height())
-        if dialog.exec() != QDialog.DialogCode.Accepted:
+        new_title, accepted = self._general_options.get_text_input(
+            title,
+            "New title:",
+            plot_config.title(),
+        )
+        if not accepted:
             return
-        new_title = dialog.textValue()
         if new_title:
             plot_config.set_title(new_title)
         else:

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -334,6 +334,7 @@ class PlotWindow(QMainWindow):
                 connection_point=self.updatePlot,
                 is_everest=self.is_everest,
             )
+            self._general_options.axisLabelEditRequested.connect(self._edit_axis_label)
             self._misfits_options = MisfitsOptions(self.updatePlot)
 
             right_container = QWidget()

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
     QApplication,
     QDialog,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QMainWindow,
     QSplitter,
@@ -176,6 +177,7 @@ class PlotWindow(QMainWindow):
         self.setMinimumHeight(650)
         self.setWindowTitle(f"Plotting - {config_file}")
         self.activateWindow()
+        self._axis_labels: dict[str, str | None] = {"x": None, "y": None}
         self._preferred_ensemble_x_axis_format = PlotContext.INDEX_AXIS
         self._api = PlotApi(ens_path)
 
@@ -568,6 +570,8 @@ class PlotWindow(QMainWindow):
             plot_config = PlotConfig.create_copy(
                 self._plot_customizer.get_plot_config()
             )
+            plot_config.set_x_label(self._axis_labels["x"])
+            plot_config.set_y_label(self._axis_labels["y"])
             plot_config.set_legend_enabled(self._general_options.legend_checkbox_state)
             plot_config.set_grid_enabled(self._general_options.grid_checkbox_state)
             plot_config.set_line_color_cycle(self._general_options.get_color_cycle())
@@ -701,11 +705,37 @@ class PlotWindow(QMainWindow):
     ) -> None:
         plot_widget = PlotWidget(name, plotter)
         plot_widget.customizationTriggered.connect(self.toggleCustomizeDialog)
+        plot_widget.axisLabelEditRequested.connect(self._edit_axis_label)
         plot_widget.layerIndexChanged.connect(self.layerIndexChanged)
 
         index = self._central_tab.addTab(plot_widget, name)
         self._plot_widgets.append(plot_widget)
         self._central_tab.setTabEnabled(index, enabled)
+
+    def _edit_axis_label(self, axis: str) -> None:
+        label_names = {"x": "x-label", "y": "y-label"}
+        if axis not in label_names:
+            raise ValueError(f"Unknown axis '{axis}'. Expected 'x' or 'y'.")
+        label_name = label_names[axis]
+        title = f"Edit {label_name}"
+        prompt = f"New {label_name}:"
+        plot_config = self._plot_customizer.get_plot_config()
+        current_label = plot_config.x_label() if axis == "x" else plot_config.y_label()
+        dialog = QInputDialog(self)
+        dialog.setWindowTitle(title)
+        dialog.setLabelText(prompt)
+        dialog.setTextValue(current_label)
+        size_hint = dialog.sizeHint()
+        title_width = dialog.fontMetrics().horizontalAdvance(title)
+        dialog.resize(max(size_hint.width(), title_width + 175), size_hint.height())
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        new_label = dialog.textValue() or None
+        if axis == "x":
+            plot_config.set_x_label(new_label)
+        else:
+            plot_config.set_y_label(new_label)
+        self._plot_customizer.update_plot_config(plot_config)
 
     @showWaitCursorWhileWaiting
     def keySelected(self) -> None:

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -177,7 +177,6 @@ class PlotWindow(QMainWindow):
         self.setMinimumHeight(650)
         self.setWindowTitle(f"Plotting - {config_file}")
         self.activateWindow()
-        self._axis_labels: dict[str, str | None] = {"x": None, "y": None}
         self._preferred_ensemble_x_axis_format = PlotContext.INDEX_AXIS
         self._api = PlotApi(ens_path)
 
@@ -335,6 +334,7 @@ class PlotWindow(QMainWindow):
                 is_everest=self.is_everest,
             )
             self._general_options.axisLabelEditRequested.connect(self._edit_axis_label)
+            self._general_options.titleEditRequested.connect(self._edit_title)
             self._misfits_options = MisfitsOptions(self.updatePlot)
 
             right_container = QWidget()
@@ -571,8 +571,6 @@ class PlotWindow(QMainWindow):
             plot_config = PlotConfig.create_copy(
                 self._plot_customizer.get_plot_config()
             )
-            plot_config.set_x_label(self._axis_labels["x"])
-            plot_config.set_y_label(self._axis_labels["y"])
             plot_config.set_legend_enabled(self._general_options.legend_checkbox_state)
             plot_config.set_grid_enabled(self._general_options.grid_checkbox_state)
             plot_config.set_line_color_cycle(self._general_options.get_color_cycle())
@@ -707,6 +705,7 @@ class PlotWindow(QMainWindow):
         plot_widget = PlotWidget(name, plotter)
         plot_widget.customizationTriggered.connect(self.toggleCustomizeDialog)
         plot_widget.axisLabelEditRequested.connect(self._edit_axis_label)
+        plot_widget.titleEditRequested.connect(self._edit_title)
         plot_widget.layerIndexChanged.connect(self.layerIndexChanged)
 
         index = self._central_tab.addTab(plot_widget, name)
@@ -722,10 +721,19 @@ class PlotWindow(QMainWindow):
         prompt = f"New {label_name}:"
         plot_config = self._plot_customizer.get_plot_config()
         current_label = plot_config.x_label() if axis == "x" else plot_config.y_label()
+        if current_label is None:
+            current_widget = self._central_tab.currentWidget()
+            if isinstance(current_widget, PlotWidget) and current_widget._figure.axes:
+                axis_object = current_widget._figure.axes[0]
+                current_label = (
+                    axis_object.get_xlabel()
+                    if axis == "x"
+                    else axis_object.get_ylabel()
+                )
         dialog = QInputDialog(self)
         dialog.setWindowTitle(title)
         dialog.setLabelText(prompt)
-        dialog.setTextValue(current_label)
+        dialog.setTextValue(current_label or "")
         size_hint = dialog.sizeHint()
         title_width = dialog.fontMetrics().horizontalAdvance(title)
         dialog.resize(max(size_hint.width(), title_width + 175), size_hint.height())
@@ -736,6 +744,28 @@ class PlotWindow(QMainWindow):
             plot_config.set_x_label(new_label)
         else:
             plot_config.set_y_label(new_label)
+        self._plot_customizer.update_plot_config(plot_config)
+
+    def _edit_title(self) -> None:
+        title = "Edit title"
+        dialog = QInputDialog(self)
+        dialog.setWindowTitle(title)
+        dialog.setLabelText("New title:")
+        plot_config = self._plot_customizer.get_plot_config()
+        dialog.setTextValue(plot_config.title())
+        size_hint = dialog.sizeHint()
+        title_width = dialog.fontMetrics().horizontalAdvance(title)
+        dialog.resize(max(size_hint.width(), title_width + 175), size_hint.height())
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        new_title = dialog.textValue()
+        if new_title:
+            plot_config.set_title(new_title)
+        else:
+            key_def = self.getSelectedKey()
+            if key_def is None:
+                return
+            plot_config.set_title(key_def.key)
         self._plot_customizer.update_plot_config(plot_config)
 
     @showWaitCursorWhileWaiting

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -5,8 +5,10 @@ from PyQt6.QtCore import QObject
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtWidgets import (
     QCheckBox,
+    QDialog,
     QGroupBox,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QPushButton,
     QVBoxLayout,
@@ -116,6 +118,25 @@ class GeneralPlotOptions(QObject):
 
     def get_widget(self) -> QGroupBox:
         return self._general_options
+
+    def get_text_input(
+        self,
+        title: str,
+        prompt: str,
+        current_text: str | None,
+    ) -> tuple[str, bool]:
+        dialog = QInputDialog(self._general_options)
+        dialog.setWindowTitle(title)
+        dialog.setLabelText(prompt)
+        dialog.setTextValue(current_text or "")
+        size_hint = dialog.sizeHint()
+        title_width = dialog.fontMetrics().horizontalAdvance(title)
+        dialog.resize(
+            max(size_hint.width(), title_width + 175),
+            size_hint.height(),
+        )
+        accepted = dialog.exec() == QDialog.DialogCode.Accepted
+        return dialog.textValue() or "", accepted
 
     @property
     def legend_checkbox_state(self) -> bool:

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -35,6 +35,15 @@ class GeneralPlotOptions(QObject):
     ) -> None:
         super().__init__()
 
+        def create_edit_button(
+            name: str,
+            callback: Callable[[], None],
+        ) -> QPushButton:
+            button = QPushButton(f"Edit {name}")
+            button.setObjectName(f"change_{name.replace('-', '_')}_button")
+            button.clicked.connect(callback)
+            return button
+
         (
             self._toggle_legend,
             self._toggle_grid,
@@ -43,7 +52,10 @@ class GeneralPlotOptions(QObject):
             self._toggle_log_scale,
         ) = [
             create_checkbox_with_tooltip(
-                name, tooltip, connection_point, initial_checked=checked
+                name,
+                tooltip,
+                connection_point,
+                initial_checked=checked,
             )
             for name, tooltip, checked in [
                 ("Legend", "Show or hide the legend", True),
@@ -54,28 +66,16 @@ class GeneralPlotOptions(QObject):
             ]
         ]
 
-        self._change_x_label = QPushButton("Edit x-label")
-        self._change_x_label.setObjectName("change_x_label_button")
-        self._change_x_label.clicked.connect(
-            lambda: self.axisLabelEditRequested.emit("x")
-        )
+        edit_buttons = QWidget()
+        edit_buttons_layout = QHBoxLayout(edit_buttons)
+        edit_buttons_layout.setContentsMargins(0, 0, 0, 0)
 
-        self._change_y_label = QPushButton("Edit y-label")
-        self._change_y_label.setObjectName("change_y_label_button")
-        self._change_y_label.clicked.connect(
-            lambda: self.axisLabelEditRequested.emit("y")
-        )
-
-        self._change_title = QPushButton("Edit title")
-        self._change_title.setObjectName("change_title_button")
-        self._change_title.clicked.connect(self.titleEditRequested.emit)
-
-        axis_label_buttons = QWidget()
-        axis_label_layout = QHBoxLayout(axis_label_buttons)
-        axis_label_layout.setContentsMargins(0, 0, 0, 0)
-        axis_label_layout.addWidget(self._change_x_label)
-        axis_label_layout.addWidget(self._change_y_label)
-        axis_label_layout.addWidget(self._change_title)
+        for name, callback in (
+            ("x-label", lambda: self.axisLabelEditRequested.emit("x")),
+            ("y-label", lambda: self.axisLabelEditRequested.emit("y")),
+            ("title", self.titleEditRequested.emit),
+        ):
+            edit_buttons_layout.addWidget(create_edit_button(name, callback))
 
         widgets: list[QWidget] = [
             self._toggle_legend,
@@ -95,20 +95,18 @@ class GeneralPlotOptions(QObject):
                     self._observations_color_edit,
                 ]
             )
+
         palette_container = QWidget()
         palette_layout = QVBoxLayout(palette_container)
         palette_layout.setContentsMargins(0, 0, 0, 0)
         palette_layout.setSpacing(2)
         palette_layout.addWidget(QLabel("Selected color palette:"))
+
         self._color_cycle_selector = PlotColorPaletteSelector(connection_point)
         palette_layout.addWidget(self._color_cycle_selector)
         palette_layout.addWidget(self._color_cycle_selector.get_custom_palette_button())
-        widgets.append(palette_container)
-        widgets.extend(
-            [
-                axis_label_buttons,
-            ]
-        )
+
+        widgets.extend([palette_container, edit_buttons])
 
         self._general_options = create_group_box(
             "General options",

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 class GeneralPlotOptions(QObject):
     axisLabelEditRequested = Signal(str)
+    titleEditRequested = Signal()
 
     def __init__(
         self,
@@ -63,11 +64,16 @@ class GeneralPlotOptions(QObject):
             lambda: self.axisLabelEditRequested.emit("y")
         )
 
+        self._change_title = QPushButton("Edit title")
+        self._change_title.setObjectName("change_title_button")
+        self._change_title.clicked.connect(self.titleEditRequested.emit)
+
         axis_label_buttons = QWidget()
         axis_label_layout = QHBoxLayout(axis_label_buttons)
         axis_label_layout.setContentsMargins(0, 0, 0, 0)
         axis_label_layout.addWidget(self._change_x_label)
         axis_label_layout.addWidget(self._change_y_label)
+        axis_label_layout.addWidget(self._change_title)
 
         widgets: list[QWidget] = [
             self._toggle_legend,

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -1,10 +1,14 @@
 import logging
 from collections.abc import Callable
 
+from PyQt6.QtCore import QObject
+from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtWidgets import (
     QCheckBox,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -17,13 +21,16 @@ from .plot_color_palette_selector import PlotColorPaletteSelector
 logger = logging.getLogger(__name__)
 
 
-class GeneralPlotOptions:
+class GeneralPlotOptions(QObject):
+    axisLabelEditRequested = Signal(str)
+
     def __init__(
         self,
         connection_point: Callable[..., object],
         *,
         is_everest: bool,
     ) -> None:
+        super().__init__()
 
         (
             self._toggle_legend,
@@ -44,6 +51,24 @@ class GeneralPlotOptions:
             ]
         ]
 
+        self._change_x_label = QPushButton("Edit x-label")
+        self._change_x_label.setObjectName("change_x_label_button")
+        self._change_x_label.clicked.connect(
+            lambda: self.axisLabelEditRequested.emit("x")
+        )
+
+        self._change_y_label = QPushButton("Edit y-label")
+        self._change_y_label.setObjectName("change_y_label_button")
+        self._change_y_label.clicked.connect(
+            lambda: self.axisLabelEditRequested.emit("y")
+        )
+
+        axis_label_buttons = QWidget()
+        axis_label_layout = QHBoxLayout(axis_label_buttons)
+        axis_label_layout.setContentsMargins(0, 0, 0, 0)
+        axis_label_layout.addWidget(self._change_x_label)
+        axis_label_layout.addWidget(self._change_y_label)
+
         widgets: list[QWidget] = [
             self._toggle_legend,
             self._toggle_grid,
@@ -62,7 +87,6 @@ class GeneralPlotOptions:
                     self._observations_color_edit,
                 ]
             )
-
         palette_container = QWidget()
         palette_layout = QVBoxLayout(palette_container)
         palette_layout.setContentsMargins(0, 0, 0, 0)
@@ -72,6 +96,11 @@ class GeneralPlotOptions:
         palette_layout.addWidget(self._color_cycle_selector)
         palette_layout.addWidget(self._color_cycle_selector.get_custom_palette_button())
         widgets.append(palette_container)
+        widgets.extend(
+            [
+                axis_label_buttons,
+            ]
+        )
 
         self._general_options = create_group_box(
             "General options",

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -19,7 +19,10 @@ logger = logging.getLogger(__name__)
 
 class GeneralPlotOptions:
     def __init__(
-        self, connection_point: Callable[..., object], *, is_everest: bool
+        self,
+        connection_point: Callable[..., object],
+        *,
+        is_everest: bool,
     ) -> None:
 
         (

--- a/src/ert/gui/plotting/widgets/plot_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_widget.py
@@ -119,6 +119,7 @@ class CustomNavigationToolbar(NavigationToolbar2QT):
 class PlotWidget(QWidget):
     customizationTriggered = Signal()
     axisLabelEditRequested = Signal(str)
+    titleEditRequested = Signal()
     layerIndexChanged = Signal(int)
     updateLayerWidget = Signal(int)
     resetLayerWidget = Signal()
@@ -185,7 +186,7 @@ class PlotWidget(QWidget):
                 obs_loc,
                 key_def,
             )
-            self._enable_axis_label_picking()
+            self._enable_text_picking()
             self._canvas.draw()
         except Exception as e:
             logger.exception(e)
@@ -201,10 +202,11 @@ class PlotWidget(QWidget):
                 "This stack trace is helpful for diagnosing the problem."
             )
 
-    def _enable_axis_label_picking(self) -> None:
+    def _enable_text_picking(self) -> None:
         for axes in self._figure.axes:
             axes.xaxis.label.set_picker(True)
             axes.yaxis.label.set_picker(True)
+            axes.title.set_picker(True)
 
     def _on_canvas_pick(self, event: PickEvent) -> None:
         for axes in self._figure.axes:
@@ -214,4 +216,8 @@ class PlotWidget(QWidget):
 
             if event.artist is axes.yaxis.label:
                 self.axisLabelEditRequested.emit("y")
+                return
+
+            if event.artist is axes.title:
+                self.titleEditRequested.emit()
                 return

--- a/src/ert/gui/plotting/widgets/plot_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_widget.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Protocol, override
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from matplotlib.backend_bases import PickEvent
 from matplotlib.backends.backend_qt5agg import (  # type: ignore
     FigureCanvas,
     NavigationToolbar2QT,
@@ -117,6 +118,7 @@ class CustomNavigationToolbar(NavigationToolbar2QT):
 
 class PlotWidget(QWidget):
     customizationTriggered = Signal()
+    axisLabelEditRequested = Signal(str)
     layerIndexChanged = Signal(int)
     updateLayerWidget = Signal(int)
     resetLayerWidget = Signal()
@@ -135,6 +137,7 @@ class PlotWidget(QWidget):
         self._figure = Figure()
         self._figure.set_layout_engine("tight")
         self._canvas = FigureCanvas(self._figure)
+        self._canvas.mpl_connect("pick_event", self._on_canvas_pick)
         self._canvas.setParent(self)
         self._canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self._canvas.setFocus()
@@ -182,6 +185,7 @@ class PlotWidget(QWidget):
                 obs_loc,
                 key_def,
             )
+            self._enable_axis_label_picking()
             self._canvas.draw()
         except Exception as e:
             logger.exception(e)
@@ -196,3 +200,18 @@ class PlotWidget(QWidget):
                 "An error occurred during plotting. "
                 "This stack trace is helpful for diagnosing the problem."
             )
+
+    def _enable_axis_label_picking(self) -> None:
+        for axes in self._figure.axes:
+            axes.xaxis.label.set_picker(True)
+            axes.yaxis.label.set_picker(True)
+
+    def _on_canvas_pick(self, event: PickEvent) -> None:
+        for axes in self._figure.axes:
+            if event.artist is axes.xaxis.label:
+                self.axisLabelEditRequested.emit("x")
+                return
+
+            if event.artist is axes.yaxis.label:
+                self.axisLabelEditRequested.emit("y")
+                return

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -2,7 +2,7 @@ import logging
 from unittest.mock import Mock
 
 import pytest
-from PyQt6.QtWidgets import QCheckBox
+from PyQt6.QtWidgets import QCheckBox, QPushButton
 
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
 from ert.gui.plotting.widgets.plot_controls.general_options import GeneralPlotOptions
@@ -85,6 +85,32 @@ def test_that_toggling_a_general_option_logs_sidebar_usage_once(
 
         checkbox.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+
+@pytest.mark.parametrize(
+    ("button_name", "axis"),
+    [
+        ("change_x_label_button", "x"),
+        ("change_y_label_button", "y"),
+    ],
+)
+def test_that_axis_label_button_requests_edit_for_its_axis(
+    qtbot,
+    button_name,
+    axis,
+) -> None:
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    widget = options.get_widget()
+    qtbot.addWidget(widget)
+    widget.show()
+    button = widget.findChild(QPushButton, button_name)
+    assert button is not None
+
+    requested_axis = Mock()
+    options.axisLabelEditRequested.connect(requested_axis)
+    button.click()
+
+    requested_axis.assert_called_once_with(axis)
 
 
 @pytest.mark.parametrize(

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -113,6 +113,21 @@ def test_that_axis_label_button_requests_edit_for_its_axis(
     requested_axis.assert_called_once_with(axis)
 
 
+def test_that_title_button_requests_title_edit(qtbot) -> None:
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    widget = options.get_widget()
+    qtbot.addWidget(widget)
+    widget.show()
+    button = widget.findChild(QPushButton, "change_title_button")
+    assert button is not None
+
+    title_edit_requested = Mock()
+    options.titleEditRequested.connect(title_edit_requested)
+    button.click()
+
+    title_edit_requested.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     ("history_visible", "observations_visible"),
     [

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -5,9 +5,8 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 from matplotlib.figure import Figure
-from PyQt6.QtCore import QSize, Qt
-from PyQt6.QtGui import QFontMetrics
-from PyQt6.QtWidgets import QApplication, QCheckBox, QDialog, QLabel, QPushButton
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
 
 from ert.config.distribution import RawSettings
@@ -948,220 +947,9 @@ def test_that_clicking_title_emits_edit_request(qtbot: QtBot) -> None:
     received.assert_called_once_with()
 
 
-@pytest.mark.parametrize(
-    ("axis", "configured_label"),
-    [
-        pytest.param("x", None, id="default-x-label"),
-        pytest.param("y", None, id="default-y-label"),
-        pytest.param("x", "Configured x", id="configured-x-label"),
-        pytest.param("y", "Configured y", id="configured-y-label"),
-    ],
-)
-def test_that_sidebar_axis_label_edit_uses_configured_label(
+def _create_plot_window_for_text_edit(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    axis: str,
-    configured_label: str | None,
-) -> None:
-    mock_plot_api_cls = MagicMock(spec=PlotApi)
-    mock_plot_api = MagicMock(spec=PlotApi)
-    mock_plot_api_cls.return_value = mock_plot_api
-
-    storage_version = "0.0"
-    mock_plot_api.api_version = storage_version
-    mock_plot_api.responses_api_key_defs = []
-    mock_plot_api.parameters_api_key_defs = []
-    mock_plot_api.get_all_ensembles.return_value = []
-
-    monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.get_storage_api_version",
-        lambda: storage_version,
-    )
-    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Rejected
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
-    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
-    qtbot.addWidget(plot_window)
-    plot_config = plot_window._plot_customizer.get_plot_config()
-    if axis == "x":
-        plot_config.set_x_label(configured_label)
-    else:
-        plot_config.set_y_label(configured_label)
-    plot_window._plot_customizer.update_plot_config(plot_config)
-
-    plot_window._edit_axis_label(axis)
-
-    dialog.setTextValue.assert_called_once_with(configured_label or "")
-
-
-@pytest.mark.parametrize(
-    ("axis", "visible_label"),
-    [
-        pytest.param("x", "Visible x label", id="x-axis"),
-        pytest.param("y", "Visible y label", id="y-axis"),
-    ],
-)
-def test_that_sidebar_axis_label_edit_uses_visible_label_without_override(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    axis: str,
-    visible_label: str,
-) -> None:
-    mock_plot_api_cls = MagicMock(spec=PlotApi)
-    mock_plot_api = MagicMock(spec=PlotApi)
-    mock_plot_api_cls.return_value = mock_plot_api
-    storage_version = "0.0"
-    mock_plot_api.api_version = storage_version
-    mock_plot_api.responses_api_key_defs = []
-    mock_plot_api.parameters_api_key_defs = []
-    mock_plot_api.get_all_ensembles.return_value = []
-
-    monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.get_storage_api_version",
-        lambda: storage_version,
-    )
-    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Rejected
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
-    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
-    qtbot.addWidget(plot_window)
-    current_widget = plot_window._central_tab.currentWidget()
-    assert isinstance(current_widget, PlotWidget)
-    axis_object = current_widget._figure.add_subplot(111)
-    if axis == "x":
-        axis_object.set_xlabel(visible_label)
-    else:
-        axis_object.set_ylabel(visible_label)
-
-    plot_window._edit_axis_label(axis)
-
-    dialog.setTextValue.assert_called_once_with(visible_label)
-
-
-@pytest.mark.parametrize(
-    ("axis", "current_label", "new_label"),
-    [
-        pytest.param("x", "Old x", "New x", id="x-axis"),
-        pytest.param("y", "Old y", "New y", id="y-axis"),
-    ],
-)
-def test_that_accepting_axis_label_edit_updates_persistent_config(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    axis: str,
-    current_label: str,
-    new_label: str,
-) -> None:
-    mock_plot_api_cls = MagicMock(spec=PlotApi)
-    mock_plot_api = MagicMock(spec=PlotApi)
-    mock_plot_api_cls.return_value = mock_plot_api
-
-    storage_version = "0.0"
-    mock_plot_api.api_version = storage_version
-    mock_plot_api.responses_api_key_defs = []
-    mock_plot_api.parameters_api_key_defs = []
-    mock_plot_api.get_all_ensembles.return_value = []
-
-    monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.get_storage_api_version",
-        lambda: storage_version,
-    )
-    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Accepted
-    dialog.textValue.return_value = new_label
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
-    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
-    qtbot.addWidget(plot_window)
-    plot_config = plot_window._plot_customizer.get_plot_config()
-    if axis == "x":
-        plot_config.set_x_label(current_label)
-    else:
-        plot_config.set_y_label(current_label)
-    plot_window._plot_customizer.update_plot_config(plot_config)
-
-    plot_window._edit_axis_label(axis)
-
-    persisted_config = plot_window._plot_customizer.get_plot_config()
-    assert (
-        persisted_config.x_label() if axis == "x" else persisted_config.y_label()
-    ) == new_label
-    dialog.setTextValue.assert_called_once_with(current_label)
-
-
-def test_that_cancelling_axis_label_edit_keeps_existing_label(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    mock_plot_api_cls = MagicMock(spec=PlotApi)
-    mock_plot_api = MagicMock(spec=PlotApi)
-    mock_plot_api_cls.return_value = mock_plot_api
-
-    storage_version = "0.0"
-    mock_plot_api.api_version = storage_version
-    mock_plot_api.responses_api_key_defs = []
-    mock_plot_api.parameters_api_key_defs = []
-    mock_plot_api.get_all_ensembles.return_value = []
-
-    monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.get_storage_api_version",
-        lambda: storage_version,
-    )
-    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Rejected
-    dialog.textValue.return_value = "Changed despite cancellation"
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
-    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
-    qtbot.addWidget(plot_window)
-    plot_config = plot_window._plot_customizer.get_plot_config()
-    plot_config.set_x_label("Existing label")
-    plot_window._plot_customizer.update_plot_config(plot_config)
-
-    plot_window._edit_axis_label("x")
-
-    assert plot_window._plot_customizer.get_plot_config().x_label() == "Existing label"
-    dialog.setTextValue.assert_called_once_with("Existing label")
-
-
-def _create_plot_window_for_title_edit(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    dialog: MagicMock,
 ) -> PlotWindow:
     mock_plot_api_cls = MagicMock(spec=PlotApi)
     mock_plot_api = MagicMock(spec=PlotApi)
@@ -1178,13 +966,133 @@ def _create_plot_window_for_title_edit(
         lambda: storage_version,
     )
     monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
+    return plot_window
+
+
+@pytest.mark.parametrize(
+    ("axis", "configured_label", "visible_label", "expected_label"),
+    [
+        pytest.param(
+            "x",
+            "Configured x",
+            "Visible x label",
+            "Configured x",
+            id="configured-x-label",
+        ),
+        pytest.param(
+            "y",
+            "Configured y",
+            "Visible y label",
+            "Configured y",
+            id="configured-y-label",
+        ),
+        pytest.param(
+            "x",
+            None,
+            "Visible x label",
+            "Visible x label",
+            id="visible-x-label",
+        ),
+        pytest.param(
+            "y",
+            None,
+            "Visible y label",
+            "Visible y label",
+            id="visible-y-label",
+        ),
+    ],
+)
+def test_that_sidebar_axis_label_edit_uses_configured_or_visible_label(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    axis: str,
+    configured_label: str | None,
+    visible_label: str | None,
+    expected_label: str,
+) -> None:
+    plot_window = _create_plot_window_for_text_edit(qtbot, monkeypatch)
+    get_text_input = MagicMock(return_value=("", False))
+    plot_window._general_options.get_text_input = get_text_input
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    if axis == "x":
+        plot_config.set_x_label(configured_label)
+    else:
+        plot_config.set_y_label(configured_label)
+    plot_window._plot_customizer.update_plot_config(plot_config)
+    current_widget = plot_window._central_tab.currentWidget()
+    assert isinstance(current_widget, PlotWidget)
+    if visible_label is not None:
+        axis_object = current_widget._figure.add_subplot(111)
+        if axis == "x":
+            axis_object.set_xlabel(visible_label)
+        else:
+            axis_object.set_ylabel(visible_label)
+
+    plot_window._edit_axis_label(axis)
+
+    get_text_input.assert_called_once_with(
+        f"Edit {axis}-label", f"New {axis}-label:", expected_label
+    )
+
+
+@pytest.mark.parametrize(
+    ("axis", "current_label", "new_label", "accepted"),
+    [
+        pytest.param("x", "Old x", "New x", True, id="x-axis-accepted"),
+        pytest.param("y", "Old y", "New y", True, id="y-axis-accepted"),
+        pytest.param(
+            "x",
+            "Existing label",
+            "Changed despite cancellation",
+            False,
+            id="x-axis-cancelled",
+        ),
+        pytest.param(
+            "x",
+            "Existing label",
+            "",
+            True,
+            id="x-axis-cleared",
+        ),
+    ],
+)
+def test_that_axis_label_edit_updates_or_preserves_persistent_config(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    axis: str,
+    current_label: str,
+    new_label: str,
+    accepted: bool,
+) -> None:
+    plot_window = _create_plot_window_for_text_edit(qtbot, monkeypatch)
+    get_text_input = MagicMock(return_value=(new_label, accepted))
+    plot_window._general_options.get_text_input = get_text_input
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    if axis == "x":
+        plot_config.set_x_label(current_label)
+    else:
+        plot_config.set_y_label(current_label)
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_axis_label(axis)
+
+    expected_label = (new_label or None) if accepted else current_label
+    persisted_config = plot_window._plot_customizer.get_plot_config()
+    assert (
+        persisted_config.x_label() if axis == "x" else persisted_config.y_label()
+    ) == expected_label
+    get_text_input.assert_called_once_with(
+        f"Edit {axis}-label", f"New {axis}-label:", current_label
+    )
+
+
+def _create_plot_window_for_title_edit(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> PlotWindow:
+    plot_window = _create_plot_window_for_text_edit(qtbot, monkeypatch)
     plot_window.getSelectedKey = MagicMock(
         return_value=MagicMock(key="some_key", dimensionality=1, metadata={})
     )
@@ -1192,26 +1100,28 @@ def _create_plot_window_for_title_edit(
 
 
 @pytest.mark.parametrize(
-    ("dialog_value", "expected_title"),
+    ("dialog_value", "expected_title", "accepted"),
     [
-        pytest.param("New title", "New title", id="custom-title"),
-        pytest.param("", "some_key", id="empty-title-restores-key-title"),
+        pytest.param("New title", "New title", True, id="custom-title"),
+        pytest.param("", "some_key", True, id="empty-title-restores-key-title"),
+        pytest.param(
+            "Changed despite cancellation",
+            "Existing title",
+            False,
+            id="cancelled-title",
+        ),
     ],
 )
-def test_that_accepting_title_edit_updates_persistent_config(
+def test_that_title_edit_updates_or_preserves_persistent_config(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
     dialog_value: str,
     expected_title: str,
+    accepted: bool,
 ) -> None:
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Accepted
-    dialog.textValue.return_value = dialog_value
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-
-    plot_window = _create_plot_window_for_title_edit(qtbot, monkeypatch, dialog)
+    plot_window = _create_plot_window_for_title_edit(qtbot, monkeypatch)
+    get_text_input = MagicMock(return_value=(dialog_value, accepted))
+    plot_window._general_options.get_text_input = get_text_input
     plot_window.updatePlot = MagicMock()
     plot_window._plot_customizer._emit_changed_signal = MagicMock()
     plot_config = plot_window._plot_customizer.get_plot_config()
@@ -1222,83 +1132,7 @@ def test_that_accepting_title_edit_updates_persistent_config(
 
     persisted_config = plot_window._plot_customizer.get_plot_config()
     assert persisted_config.title() == expected_title
-    dialog.setTextValue.assert_called_once_with("Existing title")
-
-
-def test_that_cancelling_title_edit_preserves_active_key_title(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Rejected
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-
-    plot_window = _create_plot_window_for_title_edit(qtbot, monkeypatch, dialog)
-    plot_window.updatePlot = MagicMock()
-    plot_window._plot_customizer._emit_changed_signal = MagicMock()
-    plot_config = plot_window._plot_customizer.get_plot_config()
-    plot_config.set_title("Existing title")
-    plot_window._plot_customizer.update_plot_config(plot_config)
-
-    plot_window._edit_title()
-
-    assert plot_window._plot_customizer.get_plot_config().title() == "Existing title"
-    dialog.setTextValue.assert_called_once_with("Existing title")
-
-
-@pytest.mark.slow
-def test_that_missing_title_override_preserves_key_title(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    mock_plot_api_cls = MagicMock(spec=PlotApi)
-    mock_plot_api = MagicMock(spec=PlotApi)
-    mock_plot_api_cls.return_value = mock_plot_api
-
-    storage_version = "0.0"
-    mock_plot_api.api_version = storage_version
-    mock_plot_api.responses_api_key_defs = []
-    mock_plot_api.parameters_api_key_defs = [
-        PlotApiKeyDefinition(
-            "some_key",
-            index_type=None,
-            metadata={"data_origin": "GEN_KW"},
-            observations=False,
-            dimensionality=1,
-            parameter=GenKwConfig(
-                name="some_key",
-                distribution=RawSettings(),
-                group="DESIGN_MATRIX",
-                input_source=DataSource.DESIGN_MATRIX,
-            ),
-        )
-    ]
-    mock_plot_api.get_all_ensembles.return_value = [
-        EnsembleObject(
-            "ensemble",
-            "ensemble",
-            False,
-            "experiment",
-            "2026-01-01T00:00:00",
-        )
-    ]
-    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: [1.0, 2.0, 3.0]})
-    mock_plot_api.has_history_data.return_value = False
-
-    monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.get_storage_api_version",
-        lambda: storage_version,
-    )
-    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
-
-    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
-    qtbot.addWidget(plot_window)
-    plot_window.updatePlot()
-
-    plot_widget = plot_window._central_tab.currentWidget()
-    assert plot_widget._figure.axes[0].get_title() == "some_key"
+    get_text_input.assert_called_once_with("Edit title", "New title:", "Existing title")
 
 
 @pytest.mark.slow
@@ -1346,19 +1180,9 @@ def test_that_clearing_custom_title_restores_key_title_when_rendering(
     )
     monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
 
-    dialog = MagicMock()
-    dialog.exec.return_value = QDialog.DialogCode.Accepted
-    dialog.textValue.return_value = ""
-    dialog.sizeHint.return_value = QSize(100, 100)
-    dialog.font.return_value = QApplication.font()
-    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
-    monkeypatch.setattr(
-        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
-        MagicMock(return_value=dialog),
-    )
-
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
+    plot_window._general_options.get_text_input = MagicMock(return_value=("", True))
     plot_window.updatePlot()
 
     plot_config = plot_window._plot_customizer.get_plot_config()

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -985,7 +985,7 @@ def test_that_sidebar_axis_label_edit_uses_configured_label(
     dialog.font.return_value = QApplication.font()
     dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 
@@ -1037,7 +1037,7 @@ def test_that_sidebar_axis_label_edit_uses_visible_label_without_override(
     dialog.font.return_value = QApplication.font()
     dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 
@@ -1093,7 +1093,7 @@ def test_that_accepting_axis_label_edit_updates_persistent_config(
     dialog.font.return_value = QApplication.font()
     dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 
@@ -1142,7 +1142,7 @@ def test_that_cancelling_axis_label_edit_keeps_existing_label(
     dialog.font.return_value = QApplication.font()
     dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 
@@ -1179,7 +1179,7 @@ def _create_plot_window_for_title_edit(
     )
     monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 
@@ -1353,7 +1353,7 @@ def test_that_clearing_custom_title_restores_key_title_when_rendering(
     dialog.font.return_value = QApplication.font()
     dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
     monkeypatch.setattr(
-        "ert.gui.plotting.plot_window.QInputDialog",
+        "ert.gui.plotting.widgets.plot_controls.general_options.QInputDialog",
         MagicMock(return_value=dialog),
     )
 

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -5,13 +5,15 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 from matplotlib.figure import Figure
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton
+from PyQt6.QtCore import QSize, Qt
+from PyQt6.QtGui import QFontMetrics
+from PyQt6.QtWidgets import QApplication, QCheckBox, QDialog, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
 
 from ert.config.distribution import RawSettings
 from ert.config.gen_kw_config import DataSource, GenKwConfig
 from ert.gui.plotting.ert_plots.gaussian_kde import plotGaussianKDE
+from ert.gui.plotting.ert_plots.histogram import HistogramPlot
 from ert.gui.plotting.models import DataTypeSeparator
 from ert.gui.plotting.plot_api import EnsembleObject, PlotApi, PlotApiKeyDefinition
 from ert.gui.plotting.plot_window import (
@@ -837,6 +839,273 @@ def test_that_gaussian_kde_plot_skips_categorical_data_without_raising():
 
     # Should not raise (categorical data is simply skipped).
     plotGaussianKDE(fig, ctx, {ensemble: categorical_df}, _observation_data=None)
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [
+        pytest.param("x", id="x-axis"),
+        pytest.param("y", id="y-axis"),
+    ],
+)
+def test_that_clicking_axis_label_emits_edit_request(
+    qtbot: QtBot,
+    axis: str,
+) -> None:
+    ensemble = EnsembleObject(
+        "ensemble",
+        "ensemble",
+        False,
+        "experiment",
+        "2026-01-01T00:00:00",
+    )
+
+    plot_context = PlotContext(
+        PlotConfig(),
+        ensembles=[ensemble],
+        ensembles_color_indexes=[0],
+        key="some_key",
+        layer=None,
+    )
+
+    def _plot_with_axis_labels(figure: Figure, *_args, **_kwargs) -> None:
+        axes = figure.add_subplot(111)
+        axes.set_xlabel("Old x label")
+        axes.set_ylabel("Old y label")
+
+    plotter = MagicMock()
+    plotter.dimensionality = 1
+    plotter.requires_observations = False
+    plotter.plot.side_effect = _plot_with_axis_labels
+
+    plot_widget = PlotWidget("Any", plotter)
+    qtbot.addWidget(plot_widget)
+
+    received: list[str] = []
+    plot_widget.axisLabelEditRequested.connect(received.append)
+
+    plot_widget.updatePlot(
+        plot_context,
+        {ensemble: pd.DataFrame({0: [1.0, 2.0, 3.0]})},
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    axes = plot_widget._figure.axes[0]
+    artist = axes.xaxis.label if axis == "x" else axes.yaxis.label
+    pick_event = type("PickEventStub", (), {"artist": artist})()
+    plot_widget._on_canvas_pick(pick_event)
+
+    assert received == [axis]
+
+
+@pytest.mark.parametrize(
+    ("axis", "configured_label"),
+    [
+        pytest.param("x", None, id="default-x-label"),
+        pytest.param("y", None, id="default-y-label"),
+        pytest.param("x", "Configured x", id="configured-x-label"),
+        pytest.param("y", "Configured y", id="configured-y-label"),
+    ],
+)
+def test_that_sidebar_axis_label_edit_uses_configured_label(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    axis: str,
+    configured_label: str | None,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = []
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Rejected
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    qtbot.addWidget(plot_window)
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    if axis == "x":
+        plot_config.set_x_label(configured_label)
+    else:
+        plot_config.set_y_label(configured_label)
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_axis_label(axis)
+
+    dialog.setTextValue.assert_called_once_with(configured_label)
+
+
+@pytest.mark.parametrize(
+    ("axis", "current_label", "new_label"),
+    [
+        pytest.param("x", "Old x", "New x", id="x-axis"),
+        pytest.param("y", "Old y", "New y", id="y-axis"),
+    ],
+)
+def test_that_accepting_axis_label_edit_updates_persistent_config(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    axis: str,
+    current_label: str,
+    new_label: str,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = []
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Accepted
+    dialog.textValue.return_value = new_label
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    qtbot.addWidget(plot_window)
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    if axis == "x":
+        plot_config.set_x_label(current_label)
+    else:
+        plot_config.set_y_label(current_label)
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_axis_label(axis)
+
+    persisted_config = plot_window._plot_customizer.get_plot_config()
+    assert (
+        persisted_config.x_label() if axis == "x" else persisted_config.y_label()
+    ) == new_label
+    dialog.setTextValue.assert_called_once_with(current_label)
+
+
+def test_that_cancelling_axis_label_edit_keeps_existing_label(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = []
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Rejected
+    dialog.textValue.return_value = "Changed despite cancellation"
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    qtbot.addWidget(plot_window)
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    plot_config.set_x_label("Existing label")
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_axis_label("x")
+
+    assert plot_window._plot_customizer.get_plot_config().x_label() == "Existing label"
+    dialog.setTextValue.assert_called_once_with("Existing label")
+
+
+def test_that_resetting_axis_label_restores_histogram_default_label(
+    qtbot: QtBot,
+) -> None:
+    ensemble = EnsembleObject(
+        "ensemble",
+        "ensemble",
+        False,
+        "experiment",
+        "2026-01-01T00:00:00",
+    )
+
+    plot_config = PlotConfig()
+    plot_config.set_x_label("Custom x-label")
+    plot_config.histogram = True
+
+    plot_context = PlotContext(
+        plot_config,
+        ensembles=[ensemble],
+        ensembles_color_indexes=[0],
+        key="some_key",
+        layer=None,
+    )
+
+    plot_widget = PlotWidget("Distribution", HistogramPlot())
+    qtbot.addWidget(plot_widget)
+
+    ensemble_data = {ensemble: pd.DataFrame({0: [1.0, 2.0, 3.0]})}
+
+    plot_widget.updatePlot(
+        plot_context,
+        ensemble_data,
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    assert plot_widget._figure.axes[0].get_xlabel() == "Custom x-label"
+
+    plot_config.set_x_label(None)
+
+    plot_widget.updatePlot(
+        plot_context,
+        ensemble_data,
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    assert plot_widget._figure.axes[0].get_xlabel() == "Value"
 
 
 def test_that_separators_are_included_in_everest(

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -262,7 +262,7 @@ def test_that_plotting_gen_kw_parameter_with_negative_values_hides_log_scale_che
         )
     ]
 
-    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
 
@@ -900,6 +900,54 @@ def test_that_clicking_axis_label_emits_edit_request(
     assert received == [axis]
 
 
+def test_that_clicking_title_emits_edit_request(qtbot: QtBot) -> None:
+    ensemble = EnsembleObject(
+        "ensemble",
+        "ensemble",
+        False,
+        "experiment",
+        "2026-01-01T00:00:00",
+    )
+
+    plot_context = PlotContext(
+        PlotConfig(),
+        ensembles=[ensemble],
+        ensembles_color_indexes=[0],
+        key="some_key",
+        layer=None,
+    )
+
+    def _plot_with_title(figure: Figure, *_args, **_kwargs) -> None:
+        axes = figure.add_subplot(111)
+        axes.set_title("Old title")
+
+    plotter = MagicMock()
+    plotter.dimensionality = 1
+    plotter.requires_observations = False
+    plotter.plot.side_effect = _plot_with_title
+
+    plot_widget = PlotWidget("Any", plotter)
+    qtbot.addWidget(plot_widget)
+
+    received = MagicMock()
+    plot_widget.titleEditRequested.connect(received)
+
+    plot_widget.updatePlot(
+        plot_context,
+        {ensemble: pd.DataFrame({0: [1.0, 2.0, 3.0]})},
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    pick_event = type(
+        "PickEventStub", (), {"artist": plot_widget._figure.axes[0].title}
+    )()
+    plot_widget._on_canvas_pick(pick_event)
+
+    received.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     ("axis", "configured_label"),
     [
@@ -941,7 +989,7 @@ def test_that_sidebar_axis_label_edit_uses_configured_label(
         MagicMock(return_value=dialog),
     )
 
-    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_config = plot_window._plot_customizer.get_plot_config()
     if axis == "x":
@@ -952,7 +1000,60 @@ def test_that_sidebar_axis_label_edit_uses_configured_label(
 
     plot_window._edit_axis_label(axis)
 
-    dialog.setTextValue.assert_called_once_with(configured_label)
+    dialog.setTextValue.assert_called_once_with(configured_label or "")
+
+
+@pytest.mark.parametrize(
+    ("axis", "visible_label"),
+    [
+        pytest.param("x", "Visible x label", id="x-axis"),
+        pytest.param("y", "Visible y label", id="y-axis"),
+    ],
+)
+def test_that_sidebar_axis_label_edit_uses_visible_label_without_override(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    axis: str,
+    visible_label: str,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = []
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Rejected
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
+    qtbot.addWidget(plot_window)
+    current_widget = plot_window._central_tab.currentWidget()
+    assert isinstance(current_widget, PlotWidget)
+    axis_object = current_widget._figure.add_subplot(111)
+    if axis == "x":
+        axis_object.set_xlabel(visible_label)
+    else:
+        axis_object.set_ylabel(visible_label)
+
+    plot_window._edit_axis_label(axis)
+
+    dialog.setTextValue.assert_called_once_with(visible_label)
 
 
 @pytest.mark.parametrize(
@@ -996,7 +1097,7 @@ def test_that_accepting_axis_label_edit_updates_persistent_config(
         MagicMock(return_value=dialog),
     )
 
-    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_config = plot_window._plot_customizer.get_plot_config()
     if axis == "x":
@@ -1045,7 +1146,7 @@ def test_that_cancelling_axis_label_edit_keeps_existing_label(
         MagicMock(return_value=dialog),
     )
 
-    plot_window = PlotWindow(config_file="", ens_path="", parent=None)
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_config = plot_window._plot_customizer.get_plot_config()
     plot_config.set_x_label("Existing label")
@@ -1055,6 +1156,218 @@ def test_that_cancelling_axis_label_edit_keeps_existing_label(
 
     assert plot_window._plot_customizer.get_plot_config().x_label() == "Existing label"
     dialog.setTextValue.assert_called_once_with("Existing label")
+
+
+def _create_plot_window_for_title_edit(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    dialog: MagicMock,
+) -> PlotWindow:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = []
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
+    qtbot.addWidget(plot_window)
+    plot_window.getSelectedKey = MagicMock(
+        return_value=MagicMock(key="some_key", dimensionality=1, metadata={})
+    )
+    return plot_window
+
+
+@pytest.mark.parametrize(
+    ("dialog_value", "expected_title"),
+    [
+        pytest.param("New title", "New title", id="custom-title"),
+        pytest.param("", "some_key", id="empty-title-restores-key-title"),
+    ],
+)
+def test_that_accepting_title_edit_updates_persistent_config(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    dialog_value: str,
+    expected_title: str,
+) -> None:
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Accepted
+    dialog.textValue.return_value = dialog_value
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+
+    plot_window = _create_plot_window_for_title_edit(qtbot, monkeypatch, dialog)
+    plot_window.updatePlot = MagicMock()
+    plot_window._plot_customizer._emit_changed_signal = MagicMock()
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    plot_config.set_title("Existing title")
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_title()
+
+    persisted_config = plot_window._plot_customizer.get_plot_config()
+    assert persisted_config.title() == expected_title
+    dialog.setTextValue.assert_called_once_with("Existing title")
+
+
+def test_that_cancelling_title_edit_preserves_active_key_title(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Rejected
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+
+    plot_window = _create_plot_window_for_title_edit(qtbot, monkeypatch, dialog)
+    plot_window.updatePlot = MagicMock()
+    plot_window._plot_customizer._emit_changed_signal = MagicMock()
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    plot_config.set_title("Existing title")
+    plot_window._plot_customizer.update_plot_config(plot_config)
+
+    plot_window._edit_title()
+
+    assert plot_window._plot_customizer.get_plot_config().title() == "Existing title"
+    dialog.setTextValue.assert_called_once_with("Existing title")
+
+
+@pytest.mark.slow
+def test_that_missing_title_override_preserves_key_title(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = [
+        PlotApiKeyDefinition(
+            "some_key",
+            index_type=None,
+            metadata={"data_origin": "GEN_KW"},
+            observations=False,
+            dimensionality=1,
+            parameter=GenKwConfig(
+                name="some_key",
+                distribution=RawSettings(),
+                group="DESIGN_MATRIX",
+                input_source=DataSource.DESIGN_MATRIX,
+            ),
+        )
+    ]
+    mock_plot_api.get_all_ensembles.return_value = [
+        EnsembleObject(
+            "ensemble",
+            "ensemble",
+            False,
+            "experiment",
+            "2026-01-01T00:00:00",
+        )
+    ]
+    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: [1.0, 2.0, 3.0]})
+    mock_plot_api.has_history_data.return_value = False
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
+    qtbot.addWidget(plot_window)
+    plot_window.updatePlot()
+
+    plot_widget = plot_window._central_tab.currentWidget()
+    assert plot_widget._figure.axes[0].get_title() == "some_key"
+
+
+@pytest.mark.slow
+def test_that_clearing_custom_title_restores_key_title_when_rendering(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    mock_plot_api.responses_api_key_defs = []
+    mock_plot_api.parameters_api_key_defs = [
+        PlotApiKeyDefinition(
+            "some_key",
+            index_type=None,
+            metadata={"data_origin": "GEN_KW"},
+            observations=False,
+            dimensionality=1,
+            parameter=GenKwConfig(
+                name="some_key",
+                distribution=RawSettings(),
+                group="DESIGN_MATRIX",
+                input_source=DataSource.DESIGN_MATRIX,
+            ),
+        )
+    ]
+    mock_plot_api.get_all_ensembles.return_value = [
+        EnsembleObject(
+            "ensemble",
+            "ensemble",
+            False,
+            "experiment",
+            "2026-01-01T00:00:00",
+        )
+    ]
+    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: [1.0, 2.0, 3.0]})
+    mock_plot_api.has_history_data.return_value = False
+
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    dialog = MagicMock()
+    dialog.exec.return_value = QDialog.DialogCode.Accepted
+    dialog.textValue.return_value = ""
+    dialog.sizeHint.return_value = QSize(100, 100)
+    dialog.font.return_value = QApplication.font()
+    dialog.fontMetrics.return_value = QFontMetrics(QApplication.font())
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.QInputDialog",
+        MagicMock(return_value=dialog),
+    )
+
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
+    qtbot.addWidget(plot_window)
+    plot_window.updatePlot()
+
+    plot_config = plot_window._plot_customizer.get_plot_config()
+    plot_config.set_title("Custom title")
+    plot_window._plot_customizer.update_plot_config(plot_config)
+    plot_window._edit_title()
+
+    plot_widget = plot_window._central_tab.currentWidget()
+    assert plot_widget._figure.axes[0].get_title() == "some_key"
 
 
 def test_that_resetting_axis_label_restores_histogram_default_label(


### PR DESCRIPTION
**Issue**
Resolves #13999
Resolves #14006 

**Approach**
Enable picking on the x- and y-axis labels and plot title after each render, and handle Matplotlib pick events on the canvas. Selecting one opens a pre-filled input dialog. Accepted changes are stored in the active key’s PlotConfig history and applied immediately through the existing refresh mechanism. Clearing the input restores the default text.

Also removes the axis-label and title controls from the customization style tab.

<img width="1128" height="807" alt="image" src="https://github.com/user-attachments/assets/872021e7-7f27-4f6b-9e36-6bfc5ae83418" />

<img width="564" height="468" alt="image" src="https://github.com/user-attachments/assets/9f9ab010-b196-4752-b3da-ef94bf391c85" />


- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [X] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
