### PR TITLE
Allow user to choose color palette through PlotColorPaletteSelector

### DIFF
--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -329,7 +329,7 @@ class PlotWindow(QMainWindow):
             )
 
             self._general_options = GeneralPlotOptions(
-                self.updatePlot,
+                connection_point=self.updatePlot,
                 is_everest=self.is_everest,
             )
             self._misfits_options = MisfitsOptions(self.updatePlot)
@@ -570,6 +570,7 @@ class PlotWindow(QMainWindow):
             )
             plot_config.set_legend_enabled(self._general_options.legend_checkbox_state)
             plot_config.set_grid_enabled(self._general_options.grid_checkbox_state)
+            plot_config.set_line_color_cycle(self._general_options.get_color_cycle())
             if not self.is_everest:
                 self._general_options.set_history_visible(history_data_available)
                 self._general_options.set_observations_visible(

--- a/src/ert/gui/plotting/utils/plot_color_palettes.py
+++ b/src/ert/gui/plotting/utils/plot_color_palettes.py
@@ -1,0 +1,63 @@
+from matplotlib import colormaps
+from matplotlib.colors import TABLEAU_COLORS, to_hex
+
+ALPHA_VALUE = 1.0
+
+TABLEAU_10_COLOR_CYCLE = [
+    (to_hex(color), ALPHA_VALUE) for color in TABLEAU_COLORS.values()
+]
+
+_okabe_ito = colormaps.get("okabe_ito")
+# Fallback in case matplotlib version < 3.11
+if _okabe_ito is None:
+    OKABE_ITO_COLOR_CYCLE = [
+        ("#E69F00", ALPHA_VALUE),  # Orange
+        ("#56B4E9", ALPHA_VALUE),  # Sky Blue
+        ("#009E73", ALPHA_VALUE),  # Bluish Green
+        ("#A4A49B", ALPHA_VALUE),  # Yellow
+        ("#0072B2", ALPHA_VALUE),  # Blue
+        ("#D55E00", ALPHA_VALUE),  # Vermillion
+        ("#CC79A7", ALPHA_VALUE),  # Reddish Purple
+    ]
+else:
+    # Skipping black color at index 0
+    # as this is only for specific lines
+    # (e.g history, observations, mean etc)
+    OKABE_ITO_COLOR_CYCLE = [
+        (to_hex(_okabe_ito(index)), ALPHA_VALUE) for index in range(1, _okabe_ito.N)
+    ]
+COLOR_BREWER_COLOR_CYCLE = [
+    ("#a6cee3", ALPHA_VALUE),
+    ("#1f78b4", ALPHA_VALUE),
+    ("#b2df8a", ALPHA_VALUE),
+    ("#33a02c", ALPHA_VALUE),
+    ("#fb9a99", ALPHA_VALUE),
+    ("#e31a1c", ALPHA_VALUE),
+    ("#fdbf6f", ALPHA_VALUE),
+    ("#ff7f00", ALPHA_VALUE),
+    ("#cab2d6", ALPHA_VALUE),
+    ("#6a3d9a", ALPHA_VALUE),
+    ("#ffff99", ALPHA_VALUE),
+    ("#b15928", ALPHA_VALUE),
+]
+PALETTES_WITH_DESCRIPTIONS: dict[str, tuple[list[tuple[str, float]], str]] = {
+    "Tableau 10 (default)": (
+        TABLEAU_10_COLOR_CYCLE,
+        (
+            "The Matplotlib default palette."
+            f"\nColorblind-safe palette ({len(TABLEAU_10_COLOR_CYCLE)} colors)"
+        ),
+    ),
+    "Okabe Ito": (
+        OKABE_ITO_COLOR_CYCLE,
+        f"Colorblind-safe palette ({len(OKABE_ITO_COLOR_CYCLE)} colors)",
+    ),
+    "Color Brewer": (
+        COLOR_BREWER_COLOR_CYCLE,
+        (
+            "Color palette from ColorBrewer "
+            f"({len(COLOR_BREWER_COLOR_CYCLE)} colors). "
+            "Good for qualitative data, but not colorblind-safe."
+        ),
+    ),
+}

--- a/src/ert/gui/plotting/utils/plot_config.py
+++ b/src/ert/gui/plotting/utils/plot_config.py
@@ -4,6 +4,7 @@ import itertools
 from copy import copy
 from typing import Any
 
+from .plot_color_palettes import TABLEAU_10_COLOR_CYCLE
 from .plot_limits import PlotLimits
 from .plot_style import PlotStyle
 
@@ -21,19 +22,7 @@ class PlotConfig:
         if self._plot_settings is None:
             self._plot_settings = {"SHOW_HISTORY": True}
 
-        okabe_ito_hex = [
-            "#E69F00",  # Orange
-            "#56B4E9",  # Sky Blue
-            "#009E73",  # Bluish Green
-            "#F0E442",  # Yellow
-            "#0072B2",  # Blue
-            "#D55E00",  # Vermillion
-            "#CC79A7",  # Reddish Purple
-            "#000000",  # Black
-        ]
-
-        alpha_value = 1.0
-        self.set_line_color_cycle([(colour, alpha_value) for colour in okabe_ito_hex])
+        self.set_line_color_cycle(TABLEAU_10_COLOR_CYCLE)
 
         self._legend_items: list[Any] = []
         self._legend_labels: list[str] = []

--- a/src/ert/gui/plotting/widgets/plot_controls/__init__.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/__init__.py
@@ -1,9 +1,11 @@
 from .everest_controls_plot_options import EverestControlsPlotOptions
 from .general_options import GeneralPlotOptions
 from .misfits_options import MisfitsOptions
+from .plot_color_palette_selector import PlotColorPaletteSelector
 
 __all__ = [
     "EverestControlsPlotOptions",
     "GeneralPlotOptions",
     "MisfitsOptions",
+    "PlotColorPaletteSelector",
 ]

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -1,13 +1,11 @@
 import logging
 from collections.abc import Callable
 
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QGroupBox,
-    QWidget,
-)
+from PyQt6.QtWidgets import QCheckBox, QGroupBox, QLabel, QWidget
 
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
+
+from .plot_color_palette_selector import PlotColorPaletteSelector
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +70,9 @@ class GeneralPlotOptions:
                     self._toggle_observations,
                 ]
             )
-
+        widgets.append(QLabel("Selected color palette:"))
+        self._color_cycle_selector = PlotColorPaletteSelector(connection_point)
+        widgets.append(self._color_cycle_selector)
         self._general_options = create_group_box(
             "General options",
             create_group_layout(widgets),
@@ -113,3 +113,6 @@ class GeneralPlotOptions:
 
     def is_log_visible(self) -> bool:
         return self._toggle_log_scale.isVisible()
+
+    def get_color_cycle(self) -> list[tuple[str, float]]:
+        return self._color_cycle_selector.get_color_cycle()

--- a/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QComboBox
+
+from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
+
+
+class PlotColorPaletteSelector(QComboBox):
+    def __init__(self, connection_point: Callable[..., object]) -> None:
+        super().__init__()
+
+        self.setObjectName("plot_color_palette_selector")
+
+        self.setToolTip(
+            "Select a color palette for the plot lines. "
+            "The selected palette will be applied to all plots."
+        )
+
+        for palette in PALETTES_WITH_DESCRIPTIONS:
+            self.addItem(palette)
+            self.setItemData(
+                self.count() - 1,
+                PALETTES_WITH_DESCRIPTIONS[palette][1],
+                Qt.ItemDataRole.ToolTipRole,
+            )
+        self.activated.connect(connection_point)
+
+    def get_color_cycle(self) -> list[tuple[str, float]]:
+        return PALETTES_WITH_DESCRIPTIONS[self.currentText()][0]

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -4,6 +4,7 @@ import pytest
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QCheckBox
 
+from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
 from ert.gui.plotting.widgets.plot_controls.general_options import GeneralPlotOptions
 
 
@@ -80,3 +81,24 @@ def test_that_everest_general_options_omit_history_and_observations(qtbot):
 
     assert not options._toggle_history.isVisible()
     assert not options._toggle_observations.isVisible()
+
+
+def test_that_palette_selector_returns_the_correct_color_cycle(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+
+    selector = options._color_cycle_selector
+    assert (
+        selector.get_color_cycle()
+        == PALETTES_WITH_DESCRIPTIONS[selector.currentText()][0]
+    )
+
+
+def test_that_palette_selector_child_can_be_found(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+
+    selector = options.get_widget().findChild(
+        type(options._color_cycle_selector), "plot_color_palette_selector"
+    )
+    assert selector is not None

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+from PyQt6.QtCore import Qt
+
+from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
+from ert.gui.plotting.widgets.plot_controls.plot_color_palette_selector import (
+    PlotColorPaletteSelector,
+)
+
+
+def test_that_color_cycle_selector_defaults_to_the_default_palette(qtbot):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+
+    assert selector.currentText() == next(iter(PALETTES_WITH_DESCRIPTIONS.keys()))
+    assert (
+        selector.get_color_cycle()
+        == PALETTES_WITH_DESCRIPTIONS[selector.currentText()][0]
+    )
+
+
+def test_that_palette_selector_color_cycle_matches_selected_palette(qtbot):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+
+    for palette in PALETTES_WITH_DESCRIPTIONS:
+        selector.setCurrentText(palette)
+        assert selector.get_color_cycle() == PALETTES_WITH_DESCRIPTIONS[palette][0]
+
+
+def test_that_changing_selection_via_keyboard_invokes_the_connection_point(qtbot):
+    connection_point = Mock()
+    selector = PlotColorPaletteSelector(connection_point)
+    qtbot.addWidget(selector)
+    selector.show()
+
+    qtbot.keyClick(selector, Qt.Key.Key_Down)
+
+    connection_point.assert_called_once()
+
+
+def test_that_each_palette_item_tooltip_matches_description_mapping(qtbot):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+
+    for index in range(selector.count()):
+        tooltip = selector.itemData(index, Qt.ItemDataRole.ToolTipRole)
+        assert tooltip == PALETTES_WITH_DESCRIPTIONS[selector.itemText(index)][1]


### PR DESCRIPTION
**Issue**
Resolves #13995

**Approach**
Dropdown menu with palettes, different palettes of different lengths can now be added
<img width="435" height="129" alt="Screenshot 2026-07-16 at 15 38 47" src="https://github.com/user-attachments/assets/8e0a62e1-423a-411b-934f-16f311ef1288" />

<img width="1493" height="824" alt="Screenshot 2026-07-16 at 13 49 23" src="https://github.com/user-attachments/assets/8ee011d7-22f1-42a6-af65-eb134a2f921d" />
<img width="1502" height="834" alt="Screenshot 2026-07-16 at 13 49 31" src="https://github.com/user-attachments/assets/1d8bfade-7f3b-46aa-80da-4c551174d6f8" />
<img width="1500" height="830" alt="Screenshot 2026-07-16 at 13 49 38" src="https://github.com/user-attachments/assets/24033090-4e32-45a8-9eb4-7832ff228e3d" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
