### PR TITLE
Add custom palette-functionality and move observation color modification to `Plot controls`

### DIFF
--- a/src/ert/gui/plotting/customization_dialog/color_chooser.py
+++ b/src/ert/gui/plotting/customization_dialog/color_chooser.py
@@ -35,9 +35,11 @@ class ColorBox(QFrame):
         color_dialog = QColorDialog(self._color, self)
         color_dialog.setWindowTitle("Select color")
         color_dialog.setOption(QColorDialog.ColorDialogOption.ShowAlphaChannel)
+        color_dialog.setOption(QColorDialog.ColorDialogOption.DontUseNativeDialog)
         color_dialog.accepted.connect(
             lambda: self.colorChanged.emit(color_dialog.selectedColor())
         )
+        color_dialog.setModal(True)
         color_dialog.open()
 
     @property

--- a/src/ert/gui/plotting/customization_dialog/style_customization_view.py
+++ b/src/ert/gui/plotting/customization_dialog/style_customization_view.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, cast, override
 
 from PyQt6.QtWidgets import QHBoxLayout
 
-from .color_chooser import ColorBox
 from .customization_view import CustomizationView, WidgetProperty
 from .style_chooser import STYLESET_TOGGLE, StyleChooser
 
@@ -29,8 +28,6 @@ class StyleCustomizationView(CustomizationView):
     default_style = WidgetProperty()
     history_style = WidgetProperty()
     observations_style = WidgetProperty()
-    color_cycle = WidgetProperty()
-    observations_color = WidgetProperty()
 
     def __init__(self) -> None:
         CustomizationView.__init__(self)
@@ -77,56 +74,6 @@ class StyleCustomizationView(CustomizationView):
 
         self.add_spacing(10)
 
-        color_layout = QHBoxLayout()
-
-        self._color_boxes = []
-        for name in ["#1", "#2", "#3", "#4", "#5"]:
-            color_box = self.create_color_box(name)
-            self._color_boxes.append(color_box)
-            color_layout.addWidget(color_box)
-
-        self.add_row("Color cycle", color_layout)  # type: ignore
-        self.update_property(
-            "color_cycle",
-            StyleCustomizationView.get_color_cycle,
-            StyleCustomizationView.set_color_cycle,
-        )
-
-        self._observations_color_box = self.create_color_box("observations_color")
-        self.add_row("Observations color", self._observations_color_box)
-        self.update_property(
-            "observations_color",
-            StyleCustomizationView.get_observations_color,
-            StyleCustomizationView.set_observations_color,
-        )
-
-    def get_observations_color(self) -> tuple[str, float]:
-        return (
-            self._observations_color_box.color.name(),
-            self._observations_color_box.color.alphaF(),
-        )
-
-    def set_observations_color(self, color_tuple: tuple[str, float]) -> None:
-        self._observations_color_box.color = color_tuple
-
-    @staticmethod
-    def create_color_box(name: str) -> ColorBox:
-        color_box = ColorBox(size=20)
-        color_box.setToolTip(name)
-        return color_box
-
-    def get_color_cycle(self) -> list[tuple[str, float]]:
-        return [
-            (color_box.color.name(), color_box.color.alphaF())
-            for color_box in self._color_boxes
-        ]
-
-    def set_color_cycle(self, color_cycle: list[tuple[str, float]]) -> None:
-        for index, color_tuple in enumerate(color_cycle):
-            if 0 <= index < len(self._color_boxes):
-                color_box = self._color_boxes[index]
-                color_box.color = color_tuple
-
     @override
     def apply_customization(self, plot_config: "PlotConfig") -> None:
         plot_config.set_title(self.title)
@@ -135,8 +82,6 @@ class StyleCustomizationView(CustomizationView):
         plot_config.set_default_style(self.default_style)
         plot_config.set_history_style(self.history_style)
         plot_config.set_observations_style(self.observations_style)
-        plot_config.set_observations_color(self.observations_color)
-        plot_config.set_line_color_cycle(self.color_cycle)
 
     @override
     def revert_customization(self, plot_config: "PlotConfig") -> None:
@@ -149,5 +94,3 @@ class StyleCustomizationView(CustomizationView):
         self.default_style = plot_config.default_style()
         self.history_style = plot_config.history_style()
         self.observations_style = plot_config.observations_style()
-        self.observations_color = plot_config.observations_color()
-        self.color_cycle = plot_config.line_color_cycle()

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -571,6 +571,7 @@ class PlotWindow(QMainWindow):
             plot_config.set_legend_enabled(self._general_options.legend_checkbox_state)
             plot_config.set_grid_enabled(self._general_options.grid_checkbox_state)
             plot_config.set_line_color_cycle(self._general_options.get_color_cycle())
+
             if not self.is_everest:
                 self._general_options.set_history_visible(history_data_available)
                 self._general_options.set_observations_visible(
@@ -583,6 +584,9 @@ class PlotWindow(QMainWindow):
                 plot_config.set_observations_enabled(
                     self._general_options.observations_checkbox_state
                     and key_def.observations
+                )
+                plot_config.set_observations_color(
+                    self._general_options.get_observations_color()
                 )
 
             plot_context = PlotContext(

--- a/src/ert/gui/plotting/utils/plot_color_palettes.py
+++ b/src/ert/gui/plotting/utils/plot_color_palettes.py
@@ -3,6 +3,8 @@ from matplotlib.colors import TABLEAU_COLORS, to_hex
 
 ALPHA_VALUE = 1.0
 
+MINIMUM_COLOR_CYCLE_LENGTH = 5
+
 TABLEAU_10_COLOR_CYCLE = [
     (to_hex(color), ALPHA_VALUE) for color in TABLEAU_COLORS.values()
 ]

--- a/src/ert/gui/plotting/widgets/plot_controls/__init__.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/__init__.py
@@ -1,9 +1,11 @@
+from .custom_palette_dialog import CustomPaletteDialog
 from .everest_controls_plot_options import EverestControlsPlotOptions
 from .general_options import GeneralPlotOptions
 from .misfits_options import MisfitsOptions
 from .plot_color_palette_selector import PlotColorPaletteSelector
 
 __all__ = [
+    "CustomPaletteDialog",
     "EverestControlsPlotOptions",
     "GeneralPlotOptions",
     "MisfitsOptions",

--- a/src/ert/gui/plotting/widgets/plot_controls/custom_palette_dialog.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/custom_palette_dialog.py
@@ -1,0 +1,50 @@
+from collections.abc import Sequence
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ert.gui.plotting.customization_dialog.color_chooser import ColorBox
+from ert.gui.plotting.utils.plot_color_palettes import MINIMUM_COLOR_CYCLE_LENGTH
+
+
+class CustomPaletteDialog(QDialog):
+    def __init__(
+        self,
+        color_cycle: Sequence[tuple[str, float]],
+        parent: QWidget | None = None,
+        *,
+        number_of_colors: int = MINIMUM_COLOR_CYCLE_LENGTH,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit custom palette")
+        self.setObjectName("custom_palette_dialog")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Select colors for the custom palette:"))
+
+        color_layout = QHBoxLayout()
+        self._color_boxes: list[ColorBox] = []
+        for i in range(number_of_colors):
+            color_box = ColorBox(size=20)
+            color_box.setToolTip(f"#{i + 1}")
+            if i < len(color_cycle):
+                color_box.color = color_cycle[i]
+            self._color_boxes.append(color_box)
+            color_layout.addWidget(color_box)
+        layout.addLayout(color_layout)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_color_cycle(self) -> list[tuple[str, float]]:
+        return [(box.color.name(), box.color.alphaF()) for box in self._color_boxes]

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 
-from PyQt6.QtWidgets import QCheckBox, QGroupBox, QLabel, QWidget
+from PyQt6.QtWidgets import QCheckBox, QGroupBox, QLabel, QVBoxLayout, QWidget
 
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
 
@@ -70,9 +70,17 @@ class GeneralPlotOptions:
                     self._toggle_observations,
                 ]
             )
-        widgets.append(QLabel("Selected color palette:"))
+
+        palette_container = QWidget()
+        palette_layout = QVBoxLayout(palette_container)
+        palette_layout.setContentsMargins(0, 0, 0, 0)
+        palette_layout.setSpacing(2)
+        palette_layout.addWidget(QLabel("Selected color palette:"))
         self._color_cycle_selector = PlotColorPaletteSelector(connection_point)
-        widgets.append(self._color_cycle_selector)
+        palette_layout.addWidget(self._color_cycle_selector)
+        palette_layout.addWidget(self._color_cycle_selector.get_custom_palette_button())
+        widgets.append(palette_container)
+
         self._general_options = create_group_box(
             "General options",
             create_group_layout(widgets),

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -21,55 +21,32 @@ class GeneralPlotOptions:
     def __init__(
         self, connection_point: Callable[..., object], *, is_everest: bool
     ) -> None:
-        def log_option_usage(checkbox: QCheckBox, option_name: str) -> None:
-            def log_usage(_checked: bool) -> None:
-                logger.info("Plot sidebar option used: '%s'", option_name)
-                checkbox.clicked.disconnect(log_usage)
 
-            checkbox.clicked.connect(log_usage)
-
-        self._toggle_legend = QCheckBox("Show Legend")
-        self._toggle_legend.setObjectName("legend_checkbox")
-        self._toggle_legend.setChecked(True)
-        self._toggle_legend.setToolTip("Show or hide the legend")
-        log_option_usage(self._toggle_legend, "Legend")
-        self._toggle_legend.stateChanged.connect(connection_point)
-
-        self._toggle_grid = QCheckBox("Show Grid")
-        self._toggle_grid.setObjectName("grid_checkbox")
-        self._toggle_grid.setChecked(True)
-        self._toggle_grid.setToolTip("Show or hide the grid")
-        log_option_usage(self._toggle_grid, "Grid")
-        self._toggle_grid.stateChanged.connect(connection_point)
-
-        self._toggle_history = QCheckBox("Show History")
-        self._toggle_history.setObjectName("history_checkbox")
-        self._toggle_history.setChecked(True)
-        self._toggle_history.setToolTip("Show or hide history data")
-        log_option_usage(self._toggle_history, "History")
-        self._toggle_history.stateChanged.connect(connection_point)
-
-        self._toggle_observations = QCheckBox("Show Observations")
-        self._toggle_observations.setObjectName("observations_checkbox")
-        self._toggle_observations.setChecked(True)
-        self._toggle_observations.setToolTip("Show or hide observations")
-        log_option_usage(self._toggle_observations, "Observations")
-        self._toggle_observations.stateChanged.connect(connection_point)
-
-        self._toggle_log_scale = QCheckBox("Log scale")
-        self._toggle_log_scale.setObjectName("log_scale_checkbox")
-        self._toggle_log_scale.setChecked(False)
-        self._toggle_log_scale.setVisible(False)
-
-        self._toggle_log_scale.setToolTip("Toggle data domain to log scale and back")
-        log_option_usage(self._toggle_log_scale, "Log scale")
-        self._toggle_log_scale.stateChanged.connect(connection_point)
+        (
+            self._toggle_legend,
+            self._toggle_grid,
+            self._toggle_history,
+            self._toggle_observations,
+            self._toggle_log_scale,
+        ) = [
+            create_checkbox_with_tooltip(
+                name, tooltip, connection_point, initial_checked=checked
+            )
+            for name, tooltip, checked in [
+                ("Legend", "Show or hide the legend", True),
+                ("Grid", "Show or hide the grid", True),
+                ("History", "Show or hide history data", True),
+                ("Observations", "Show or hide observations", True),
+                ("Log scale", "Toggle data domain to log scale and back", False),
+            ]
+        ]
 
         widgets: list[QWidget] = [
             self._toggle_legend,
             self._toggle_grid,
             self._toggle_log_scale,
         ]
+
         if not is_everest:
             self._observations_color_edit = ObservationColorEdit(
                 connection_point=connection_point,
@@ -142,3 +119,27 @@ class GeneralPlotOptions:
 
     def get_observations_color(self) -> tuple[str, float]:
         return self._observations_color_edit.get_observations_color()
+
+
+def log_option_usage(checkbox: QCheckBox, option_name: str) -> None:
+    def log_usage(_checked: bool) -> None:
+        logger.info("Plot sidebar option used: '%s'", option_name)
+        checkbox.clicked.disconnect(log_usage)
+
+    checkbox.clicked.connect(log_usage)
+
+
+def create_checkbox_with_tooltip(
+    name: str,
+    tooltip: str,
+    connection_point: Callable[..., object],
+    *,
+    initial_checked: bool = True,
+) -> QCheckBox:
+    checkbox = QCheckBox(name)
+    checkbox.setObjectName(f"{name.lower().replace(' ', '_')}_checkbox")
+    checkbox.setToolTip(tooltip)
+    checkbox.setChecked(initial_checked)
+    checkbox.stateChanged.connect(connection_point)
+    log_option_usage(checkbox, name)
+    return checkbox

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -1,10 +1,17 @@
 import logging
 from collections.abc import Callable
 
-from PyQt6.QtWidgets import QCheckBox, QGroupBox, QLabel, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QGroupBox,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
 
+from .observation_color import ObservationColorEdit
 from .plot_color_palette_selector import PlotColorPaletteSelector
 
 logger = logging.getLogger(__name__)
@@ -64,10 +71,15 @@ class GeneralPlotOptions:
             self._toggle_log_scale,
         ]
         if not is_everest:
+            self._observations_color_edit = ObservationColorEdit(
+                connection_point=connection_point,
+                observation_checkbox=self._toggle_observations,
+            )
             widgets.extend(
                 [
                     self._toggle_history,
                     self._toggle_observations,
+                    self._observations_color_edit,
                 ]
             )
 
@@ -118,9 +130,15 @@ class GeneralPlotOptions:
 
     def set_observations_visible(self, visible: bool) -> None:
         self._toggle_observations.setVisible(visible)
+        self._observations_color_edit.setVisible(
+            visible and self._toggle_observations.isChecked()
+        )
 
     def is_log_visible(self) -> bool:
         return self._toggle_log_scale.isVisible()
 
     def get_color_cycle(self) -> list[tuple[str, float]]:
         return self._color_cycle_selector.get_color_cycle()
+
+    def get_observations_color(self) -> tuple[str, float]:
+        return self._observations_color_edit.get_observations_color()

--- a/src/ert/gui/plotting/widgets/plot_controls/observation_color.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/observation_color.py
@@ -1,0 +1,48 @@
+from collections.abc import Callable
+
+from PyQt6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
+
+from ert.gui.plotting.customization_dialog.color_chooser import ColorBox
+from ert.gui.plotting.utils.plot_config import PlotConfig
+
+
+class ObservationColorEdit(QWidget):
+    def __init__(
+        self,
+        connection_point: Callable[..., object],
+        observation_checkbox: QCheckBox,
+    ) -> None:
+        super().__init__()
+
+        self._observations_color_box = ColorBox(size=15)
+        self._observations_color_box.color = PlotConfig().observations_color()
+        self._observations_color_box.colorChanged.connect(
+            lambda _color: connection_point()
+        )
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(20, 0, 0, 0)
+        layout.setSpacing(1)
+
+        color_row = QHBoxLayout()
+        color_row.setContentsMargins(0, 0, 0, 0)
+        color_row.setSpacing(6)
+        color_label = QLabel("Change observation color:")
+        label_font = color_label.font()
+        label_font.setItalic(True)
+        label_font.setPointSizeF(label_font.pointSizeF() * 0.9)
+        color_label.setFont(label_font)
+        color_row.addWidget(color_label)
+        color_row.addWidget(self._observations_color_box)
+        color_row.addStretch()
+
+        layout.addLayout(color_row)
+
+        observation_checkbox.toggled.connect(self.setVisible)
+        self.setVisible(observation_checkbox.isChecked())
+
+    def get_observations_color(self) -> tuple[str, float]:
+        return (
+            self._observations_color_box.color.name(),
+            self._observations_color_box.color.alphaF(),
+        )

--- a/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
@@ -1,14 +1,20 @@
 from collections.abc import Callable
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QComboBox
+from PyQt6.QtWidgets import QComboBox, QPushButton
 
+from ert.gui.icon_utils import load_icon
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
+from ert.gui.plotting.widgets.plot_controls import CustomPaletteDialog
 
 
 class PlotColorPaletteSelector(QComboBox):
+    CUSTOM_PALETTE_NAME = "Custom"
+
     def __init__(self, connection_point: Callable[..., object]) -> None:
         super().__init__()
+
+        self._connection_point = connection_point
 
         self.setObjectName("plot_color_palette_selector")
 
@@ -25,6 +31,45 @@ class PlotColorPaletteSelector(QComboBox):
                 Qt.ItemDataRole.ToolTipRole,
             )
         self.activated.connect(connection_point)
+        self.custom_palette_button = QPushButton(
+            load_icon("add_circle_outlined.svg"), "Create custom palette"
+        )
+        self.custom_palette_button.setToolTip(
+            "Edit the custom color palette. "
+            "The selected palette will be applied to all plots."
+        )
+        self.custom_palette_button.clicked.connect(self._open_custom_palette_dialog)
+
+    def _open_custom_palette_dialog(self) -> None:
+        if self.CUSTOM_PALETTE_NAME in PALETTES_WITH_DESCRIPTIONS:
+            dialog = CustomPaletteDialog(
+                PALETTES_WITH_DESCRIPTIONS[self.CUSTOM_PALETTE_NAME][0], self
+            )
+        else:
+            dialog = CustomPaletteDialog(self.get_color_cycle(), self)
+        if dialog.exec():
+            self.edit_palette(dialog.get_color_cycle())
+            self.setCurrentText(self.CUSTOM_PALETTE_NAME)
+            self._connection_point()  # Needed to trigger redraw
 
     def get_color_cycle(self) -> list[tuple[str, float]]:
         return PALETTES_WITH_DESCRIPTIONS[self.currentText()][0]
+
+    def edit_palette(self, color_cycle: list[tuple[str, float]]) -> None:
+        PALETTES_WITH_DESCRIPTIONS[self.CUSTOM_PALETTE_NAME] = (
+            color_cycle,
+            "Custom color palette. Applied to all plots.",
+        )
+        # Only want 1 custom palette
+        if self.findText(self.CUSTOM_PALETTE_NAME, Qt.MatchFlag.MatchFixedString) == -1:
+            self.addItem(self.CUSTOM_PALETTE_NAME)
+            self.setItemData(
+                self.count() - 1,
+                PALETTES_WITH_DESCRIPTIONS[self.CUSTOM_PALETTE_NAME][1],
+                Qt.ItemDataRole.ToolTipRole,
+            )
+        self.custom_palette_button.setIcon(load_icon("edit.svg"))
+        self.custom_palette_button.setText("Edit custom palette")
+
+    def get_custom_palette_button(self) -> "QPushButton":
+        return self.custom_palette_button

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_custom_palette_dialog.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_custom_palette_dialog.py
@@ -1,0 +1,21 @@
+from ert.gui.plotting.utils.plot_color_palettes import MINIMUM_COLOR_CYCLE_LENGTH
+from ert.gui.plotting.widgets.plot_controls.custom_palette_dialog import (
+    CustomPaletteDialog,
+)
+
+
+def test_that_dialog_seeds_color_boxes_from_the_given_cycle(qtbot):
+    color_cycle = [("#ff0000", 1.0), ("#00ff00", 1.0), ("#0000ff", 1.0)]
+    dialog = CustomPaletteDialog(color_cycle)
+    qtbot.addWidget(dialog)
+
+    returned = dialog.get_color_cycle()
+
+    assert returned[:3] == color_cycle
+
+
+def test_that_dialog_exposes_default_amount_of_color_boxes(qtbot):
+    dialog = CustomPaletteDialog([])
+    qtbot.addWidget(dialog)
+
+    assert len(dialog.get_color_cycle()) == MINIMUM_COLOR_CYCLE_LENGTH

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -47,6 +48,43 @@ def test_that_toggling_a_general_option_invokes_the_connection_point(
     checkbox.click()
 
     connection_point.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("checkbox_name", "option_name"),
+    [
+        ("legend_checkbox", "Legend"),
+        ("grid_checkbox", "Grid"),
+        ("history_checkbox", "History"),
+        ("observations_checkbox", "Observations"),
+        ("log_scale_checkbox", "Log scale"),
+    ],
+)
+def test_that_toggling_a_general_option_logs_sidebar_usage_once(
+    qtbot,
+    caplog,
+    checkbox_name,
+    option_name,
+) -> None:
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    widget = options.get_widget()
+    qtbot.addWidget(widget)
+    widget.show()
+
+    checkbox = widget.findChild(QCheckBox, checkbox_name)
+    if checkbox_name == "log_scale_checkbox":
+        checkbox.setVisible(True)
+    assert checkbox is not None
+    assert checkbox.isVisible()
+
+    expected_message = f"Plot sidebar option used: '{option_name}'"
+
+    with caplog.at_level(logging.INFO):
+        checkbox.click()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        checkbox.click()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QCheckBox
 
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
@@ -29,7 +28,7 @@ def test_that_general_options_has_expected_default_checkbox_states(qtbot):
         "log_scale_checkbox",
     ],
 )
-def test_that_toggling_a_general_option_invokes_the_connection_point2(
+def test_that_toggling_a_general_option_invokes_the_connection_point(
     qtbot,
     checkbox_name,
 ) -> None:
@@ -45,7 +44,7 @@ def test_that_toggling_a_general_option_invokes_the_connection_point2(
     assert checkbox is not None
     assert checkbox.isVisible()
 
-    qtbot.mouseClick(checkbox, Qt.MouseButton.LeftButton)
+    checkbox.click()
 
     connection_point.assert_called_once()
 

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_observation_color.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_observation_color.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+import pytest
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QCheckBox
+
+from ert.gui.plotting.utils.plot_config import PlotConfig
+from ert.gui.plotting.widgets.plot_controls.observation_color import (
+    ObservationColorEdit,
+)
+
+
+def _make_edit(qtbot, *, checked: bool = True):
+    checkbox = QCheckBox("Observations")
+    checkbox.setChecked(checked)
+    connection_point = Mock()
+    edit = ObservationColorEdit(
+        connection_point=connection_point,
+        observation_checkbox=checkbox,
+    )
+    qtbot.addWidget(checkbox)
+    qtbot.addWidget(edit)
+    return edit, checkbox, connection_point
+
+
+def test_that_default_observation_color_is_opaque_black(qtbot):
+    edit, _, _ = _make_edit(qtbot)
+
+    expected_color, expected_alpha = PlotConfig().observations_color()
+    color_name, alpha = edit.get_observations_color()
+    assert color_name == expected_color
+    assert alpha == pytest.approx(expected_alpha, abs=1e-2)
+
+
+def test_that_get_observations_color_reflects_updated_color_box(qtbot):
+    edit, _, _ = _make_edit(qtbot)
+
+    edit._observations_color_box.color = ("#ff0000", 0.5)
+
+    color_name, alpha = edit.get_observations_color()
+    assert color_name == "#ff0000"
+    assert alpha == pytest.approx(0.5, abs=1e-2)
+
+
+def test_that_changing_color_invokes_connection_point(qtbot):
+    edit, _, connection_point = _make_edit(qtbot)
+
+    edit._observations_color_box.colorChanged.emit(QColor("#00ff00"))
+
+    connection_point.assert_called_once()
+
+
+def test_that_widget_visibility_follows_checkbox_toggle(qtbot):
+    edit, checkbox, _ = _make_edit(qtbot, checked=True)
+    edit.show()
+
+    checkbox.setChecked(False)
+    assert not edit.isVisible()
+
+    checkbox.setChecked(True)
+    assert edit.isVisible()
+
+
+@pytest.mark.parametrize("checked", [True, False])
+def test_that_initial_visibility_mirrors_checkbox_state(qtbot, checked):
+    edit, _, _ = _make_edit(qtbot, checked=checked)
+
+    assert edit.isVisibleTo(edit.parentWidget()) is checked

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
@@ -1,11 +1,19 @@
 from unittest.mock import Mock
 
+import pytest
 from PyQt6.QtCore import Qt
 
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
+from ert.gui.plotting.widgets.plot_controls import plot_color_palette_selector
 from ert.gui.plotting.widgets.plot_controls.plot_color_palette_selector import (
     PlotColorPaletteSelector,
 )
+
+
+@pytest.fixture
+def cleanup_custom_palette():
+    yield
+    PALETTES_WITH_DESCRIPTIONS.pop(PlotColorPaletteSelector.CUSTOM_PALETTE_NAME, None)
 
 
 def test_that_color_cycle_selector_defaults_to_the_default_palette(qtbot):
@@ -46,3 +54,96 @@ def test_that_each_palette_item_tooltip_matches_description_mapping(qtbot):
     for index in range(selector.count()):
         tooltip = selector.itemData(index, Qt.ItemDataRole.ToolTipRole)
         assert tooltip == PALETTES_WITH_DESCRIPTIONS[selector.itemText(index)][1]
+
+
+def test_that_editing_palette_registers_a_single_custom_entry(
+    qtbot, cleanup_custom_palette
+):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+    custom_name = PlotColorPaletteSelector.CUSTOM_PALETTE_NAME
+    color_cycle = [("#111111", 1.0), ("#222222", 1.0)]
+
+    selector.edit_palette(color_cycle)
+
+    assert selector.findText(custom_name, Qt.MatchFlag.MatchFixedString) != -1
+    assert PALETTES_WITH_DESCRIPTIONS[custom_name][0] == color_cycle
+
+
+def test_that_re_editing_palette_does_not_duplicate_the_custom_entry(
+    qtbot, cleanup_custom_palette
+):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+    custom_name = PlotColorPaletteSelector.CUSTOM_PALETTE_NAME
+
+    selector.edit_palette([("#111111", 1.0)])
+    selector.edit_palette([("#333333", 1.0)])
+
+    matches = [
+        selector.itemText(i)
+        for i in range(selector.count())
+        if selector.itemText(i) == custom_name
+    ]
+    assert len(matches) == 1
+
+
+def test_that_get_color_cycle_returns_edited_colors_when_custom_is_selected(
+    qtbot, cleanup_custom_palette
+):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+    custom_name = PlotColorPaletteSelector.CUSTOM_PALETTE_NAME
+    color_cycle = [("#abcdef", 0.5), ("#123456", 1.0)]
+
+    selector.edit_palette(color_cycle)
+    selector.setCurrentText(custom_name)
+
+    assert selector.get_color_cycle() == color_cycle
+
+
+def test_that_accepting_the_palette_dialog_saves_selects_custom_and_redraws(
+    qtbot, monkeypatch, cleanup_custom_palette
+):
+    connection_point = Mock()
+    selector = PlotColorPaletteSelector(connection_point)
+    qtbot.addWidget(selector)
+    custom_name = PlotColorPaletteSelector.CUSTOM_PALETTE_NAME
+    edited_cycle = [("#0a0a0a", 1.0), ("#0b0b0b", 1.0)]
+
+    fake_dialog = Mock()
+    fake_dialog.exec.return_value = True
+    fake_dialog.get_color_cycle.return_value = edited_cycle
+    monkeypatch.setattr(
+        plot_color_palette_selector,
+        "CustomPaletteDialog",
+        Mock(return_value=fake_dialog),
+    )
+
+    selector._open_custom_palette_dialog()
+
+    assert selector.currentText() == custom_name
+    assert PALETTES_WITH_DESCRIPTIONS[custom_name][0] == edited_cycle
+    connection_point.assert_called_once()
+
+
+def test_that_cancelling_the_palette_dialog_does_not_register_a_custom_entry(
+    qtbot, monkeypatch, cleanup_custom_palette
+):
+    connection_point = Mock()
+    selector = PlotColorPaletteSelector(connection_point)
+    qtbot.addWidget(selector)
+    custom_name = PlotColorPaletteSelector.CUSTOM_PALETTE_NAME
+
+    fake_dialog = Mock()
+    fake_dialog.exec.return_value = False
+    monkeypatch.setattr(
+        plot_color_palette_selector,
+        "CustomPaletteDialog",
+        Mock(return_value=fake_dialog),
+    )
+
+    selector._open_custom_palette_dialog()
+
+    assert selector.findText(custom_name, Qt.MatchFlag.MatchFixedString) == -1
+    connection_point.assert_not_called()


### PR DESCRIPTION

**Issue**
Resolves #14000


**Approach**
Dynamic button, create new/edit

Adds a new additional palette to the list, if a custom palette doesn't already exist

When editing the palette will fetch initially from the selected palette, but then will use the set color cycle from the custom palette to ensure consistency

Using 5 as default number of colors to follow the initial color cycle functionality from the CustomizationDialog. This could be increased/decreased as needed or even be set dynamically by the user. 

Moved observation color to the `GeneralOptions`, only visible if observation-checkbox is visible

Also includes GeneralOptions refactoring and increase in test coverage

https://github.com/user-attachments/assets/94d67450-20fb-41d9-898c-1d801f07edf6




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
