### PR TITLE
Increase logging for plot options

### DIFF
--- a/src/ert/gui/plotting/utils/logging_utils.py
+++ b/src/ert/gui/plotting/utils/logging_utils.py
@@ -1,0 +1,13 @@
+import logging
+
+from PyQt6.QtCore import pyqtBoundSignal
+
+
+def log_plot_option_usage_once(
+    signal: pyqtBoundSignal, logger: logging.Logger, option_name: str
+) -> None:
+    def log_usage(*_args: object) -> None:
+        logger.info("Plot sidebar option used: '%s'", option_name)
+        signal.disconnect(log_usage)
+
+    signal.connect(log_usage)

--- a/src/ert/gui/plotting/widgets/plot_controls/custom_palette_dialog.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/custom_palette_dialog.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 
 from PyQt6.QtWidgets import (
@@ -10,7 +11,10 @@ from PyQt6.QtWidgets import (
 )
 
 from ert.gui.plotting.customization_dialog.color_chooser import ColorBox
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.plot_color_palettes import MINIMUM_COLOR_CYCLE_LENGTH
+
+logger = logging.getLogger(__name__)
 
 
 class CustomPaletteDialog(QDialog):
@@ -45,6 +49,7 @@ class CustomPaletteDialog(QDialog):
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
+        log_plot_option_usage_once(self.accepted, logger, "Custom palette colors")
 
     def get_color_cycle(self) -> list[tuple[str, float]]:
         return [(box.color.name(), box.color.alphaF()) for box in self._color_boxes]

--- a/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 
 from PyQt6.QtWidgets import (
@@ -6,7 +7,10 @@ from PyQt6.QtWidgets import (
     QRadioButton,
 )
 
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
+
+logger = logging.getLogger(__name__)
 
 
 class EverestControlsPlotOptions:
@@ -21,7 +25,11 @@ class EverestControlsPlotOptions:
         self._display_over_button_group.addButton(self._display_over_batches_radio)
         self._display_over_button_group.addButton(self._display_over_controls_radio)
         self._display_over_button_group.buttonClicked.connect(connection_point)
-
+        log_plot_option_usage_once(
+            self._display_over_button_group.buttonClicked,
+            logger,
+            "X-axis display option",
+        )
         self._display_over_group = create_group_box(
             "X-axis:",
             create_group_layout(

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
 
 from .observation_color import ObservationColorEdit
@@ -121,14 +122,6 @@ class GeneralPlotOptions:
         return self._observations_color_edit.get_observations_color()
 
 
-def log_option_usage(checkbox: QCheckBox, option_name: str) -> None:
-    def log_usage(_checked: bool) -> None:
-        logger.info("Plot sidebar option used: '%s'", option_name)
-        checkbox.clicked.disconnect(log_usage)
-
-    checkbox.clicked.connect(log_usage)
-
-
 def create_checkbox_with_tooltip(
     name: str,
     tooltip: str,
@@ -141,5 +134,5 @@ def create_checkbox_with_tooltip(
     checkbox.setToolTip(tooltip)
     checkbox.setChecked(initial_checked)
     checkbox.stateChanged.connect(connection_point)
-    log_option_usage(checkbox, name)
+    log_plot_option_usage_once(checkbox.clicked, logger, name)
     return checkbox

--- a/src/ert/gui/plotting/widgets/plot_controls/misfits_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/misfits_options.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 
 from PyQt6.QtWidgets import (
@@ -5,7 +6,10 @@ from PyQt6.QtWidgets import (
     QGroupBox,
 )
 
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
+
+logger = logging.getLogger(__name__)
 
 
 class MisfitsOptions:
@@ -34,6 +38,16 @@ class MisfitsOptions:
                     self._toggle_outliers,
                 ]
             ),
+        )
+        log_plot_option_usage_once(self._toggle_mean.stateChanged, logger, "Show mean")
+        log_plot_option_usage_once(
+            self._toggle_outliers.stateChanged, logger, "Show outliers"
+        )
+        log_plot_option_usage_once(
+            self._toggle_scatter_plot.stateChanged, logger, "Show scatter"
+        )
+        log_plot_option_usage_once(
+            self._toggle_box.stateChanged, logger, "Show box plot"
         )
 
     @property

--- a/src/ert/gui/plotting/widgets/plot_controls/observation_color.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/observation_color.py
@@ -1,9 +1,13 @@
+import logging
 from collections.abc import Callable
 
 from PyQt6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
 
 from ert.gui.plotting.customization_dialog.color_chooser import ColorBox
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.plot_config import PlotConfig
+
+logger = logging.getLogger(__name__)
 
 
 class ObservationColorEdit(QWidget):
@@ -18,6 +22,9 @@ class ObservationColorEdit(QWidget):
         self._observations_color_box.color = PlotConfig().observations_color()
         self._observations_color_box.colorChanged.connect(
             lambda _color: connection_point()
+        )
+        log_plot_option_usage_once(
+            self._observations_color_box.colorChanged, logger, "Observation color"
         )
 
         layout = QHBoxLayout(self)

--- a/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/plot_color_palette_selector.py
@@ -1,11 +1,15 @@
+import logging
 from collections.abc import Callable
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QComboBox, QPushButton
 
 from ert.gui.icon_utils import load_icon
+from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
 from ert.gui.plotting.widgets.plot_controls import CustomPaletteDialog
+
+logger = logging.getLogger(__name__)
 
 
 class PlotColorPaletteSelector(QComboBox):
@@ -31,6 +35,7 @@ class PlotColorPaletteSelector(QComboBox):
                 Qt.ItemDataRole.ToolTipRole,
             )
         self.activated.connect(connection_point)
+        log_plot_option_usage_once(self.activated, logger, "Color palette")
         self.custom_palette_button = QPushButton(
             load_icon("add_circle_outlined.svg"), "Create custom palette"
         )
@@ -39,6 +44,9 @@ class PlotColorPaletteSelector(QComboBox):
             "The selected palette will be applied to all plots."
         )
         self.custom_palette_button.clicked.connect(self._open_custom_palette_dialog)
+        log_plot_option_usage_once(
+            self.custom_palette_button.clicked, logger, "Create custom palette"
+        )
 
     def _open_custom_palette_dialog(self) -> None:
         if self.CUSTOM_PALETTE_NAME in PALETTES_WITH_DESCRIPTIONS:

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_custom_palette_dialog.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_custom_palette_dialog.py
@@ -1,3 +1,5 @@
+import logging
+
 from ert.gui.plotting.utils.plot_color_palettes import MINIMUM_COLOR_CYCLE_LENGTH
 from ert.gui.plotting.widgets.plot_controls.custom_palette_dialog import (
     CustomPaletteDialog,
@@ -19,3 +21,17 @@ def test_that_dialog_exposes_default_amount_of_color_boxes(qtbot):
     qtbot.addWidget(dialog)
 
     assert len(dialog.get_color_cycle()) == MINIMUM_COLOR_CYCLE_LENGTH
+
+
+def test_that_accepting_the_dialog_logs_sidebar_usage_once(qtbot, caplog):
+    dialog = CustomPaletteDialog([])
+    qtbot.addWidget(dialog)
+
+    expected_message = "Plot sidebar option used: 'Custom palette colors'"
+
+    with caplog.at_level(logging.INFO):
+        dialog.accept()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        dialog.accept()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 from PyQt6.QtCore import Qt
@@ -31,3 +32,23 @@ def test_that_toggling_everest_controls_plot_options_invokes_the_connection_poin
     qtbot.mouseClick(controls_radio, Qt.MouseButton.LeftButton)
 
     connection_point.assert_called()
+
+
+def test_that_selecting_x_axis_display_option_logs_sidebar_usage_once(qtbot, caplog):
+    options = EverestControlsPlotOptions(Mock())
+    widget = options.get_widget()
+    qtbot.addWidget(widget)
+    widget.show()
+
+    controls_radio = widget.findChild(QRadioButton, "display_over_controls_radio")
+    batches_radio = widget.findChild(QRadioButton, "display_over_batches_radio")
+    assert controls_radio is not None
+    assert batches_radio is not None
+    expected_message = "Plot sidebar option used: 'X-axis display option'"
+
+    with caplog.at_level(logging.INFO):
+        qtbot.mouseClick(controls_radio, Qt.MouseButton.LeftButton)
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        qtbot.mouseClick(batches_radio, Qt.MouseButton.LeftButton)
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_misfits_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_misfits_options.py
@@ -1,4 +1,7 @@
+import logging
 from unittest.mock import Mock
+
+import pytest
 
 from ert.gui.plotting.widgets.plot_controls.misfits_options import MisfitsOptions
 
@@ -36,3 +39,29 @@ def test_that_toggling_a_misfits_checkbox_invokes_the_connection_point(qtbot):
     options.scatter_checkbox_state = not options.scatter_checkbox_state
 
     connection_point.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("checkbox_attribute", "option_name"),
+    [
+        ("_toggle_mean", "Show mean"),
+        ("_toggle_outliers", "Show outliers"),
+        ("_toggle_scatter_plot", "Show scatter"),
+        ("_toggle_box", "Show box plot"),
+    ],
+)
+def test_that_toggling_a_misfits_option_logs_sidebar_usage_once(
+    qtbot, caplog, checkbox_attribute, option_name
+):
+    options = MisfitsOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+
+    checkbox = getattr(options, checkbox_attribute)
+    expected_message = f"Plot sidebar option used: '{option_name}'"
+
+    with caplog.at_level(logging.INFO):
+        checkbox.toggle()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        checkbox.toggle()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_observation_color.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_observation_color.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -66,3 +67,16 @@ def test_that_initial_visibility_mirrors_checkbox_state(qtbot, checked):
     edit, _, _ = _make_edit(qtbot, checked=checked)
 
     assert edit.isVisibleTo(edit.parentWidget()) is checked
+
+
+def test_that_changing_observation_color_logs_sidebar_usage_once(qtbot, caplog):
+    edit, _, _ = _make_edit(qtbot)
+
+    expected_message = "Plot sidebar option used: 'Observation color'"
+
+    with caplog.at_level(logging.INFO):
+        edit._observations_color_box.colorChanged.emit(QColor("#00ff00"))
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        edit._observations_color_box.colorChanged.emit(QColor("#0000ff"))
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_plot_color_palette_selector.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -147,3 +148,41 @@ def test_that_cancelling_the_palette_dialog_does_not_register_a_custom_entry(
 
     assert selector.findText(custom_name, Qt.MatchFlag.MatchFixedString) == -1
     connection_point.assert_not_called()
+
+
+def test_that_changing_palette_selection_logs_sidebar_usage_once(qtbot, caplog):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+
+    expected_message = "Plot sidebar option used: 'Color palette'"
+
+    with caplog.at_level(logging.INFO):
+        selector.activated.emit(1)
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        selector.activated.emit(2)
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+
+def test_that_clicking_create_custom_palette_button_logs_sidebar_usage_once(
+    qtbot, monkeypatch, caplog, cleanup_custom_palette
+):
+    selector = PlotColorPaletteSelector(Mock())
+    qtbot.addWidget(selector)
+
+    fake_dialog = Mock()
+    fake_dialog.exec.return_value = False
+    monkeypatch.setattr(
+        plot_color_palette_selector,
+        "CustomPaletteDialog",
+        Mock(return_value=fake_dialog),
+    )
+
+    expected_message = "Plot sidebar option used: 'Create custom palette'"
+
+    with caplog.at_level(logging.INFO):
+        selector.custom_palette_button.click()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+        selector.custom_palette_button.click()
+        assert [r.getMessage() for r in caplog.records].count(expected_message) == 1


### PR DESCRIPTION
**Issue**
Resolves #14005


**Approach**
Moved logging to util, added to all plot options (including non-`GeneralOptions`) 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
