### PR TITLE
Add visual cue for hovering over editable axis text

### DIFF
--- a/src/ert/gui/plotting/widgets/plot_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_widget.py
@@ -6,18 +6,21 @@ from typing import TYPE_CHECKING, Protocol, override
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from matplotlib.backend_bases import PickEvent
+from matplotlib.backend_bases import Event, MouseEvent, PickEvent
 from matplotlib.backends.backend_qt5agg import (  # type: ignore
     FigureCanvas,
     NavigationToolbar2QT,
 )
 from matplotlib.figure import Figure
+from matplotlib.font_manager import FontProperties
+from matplotlib.text import Text
 from PyQt6.QtCore import QStringListModel, Qt
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtCore import pyqtSlot as Slot
-from PyQt6.QtGui import QAction
+from PyQt6.QtGui import QAction, QCursor
 from PyQt6.QtWidgets import (
     QComboBox,
+    QToolTip,
     QVBoxLayout,
     QWidget,
     QWidgetAction,
@@ -139,9 +142,13 @@ class PlotWidget(QWidget):
         self._figure.set_layout_engine("tight")
         self._canvas = FigureCanvas(self._figure)
         self._canvas.mpl_connect("pick_event", self._on_canvas_pick)
+        self._canvas.mpl_connect("motion_notify_event", self._on_canvas_motion)
+        self._canvas.mpl_connect("figure_leave_event", self._on_canvas_leave)
         self._canvas.setParent(self)
         self._canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self._canvas.setFocus()
+        self._hovered_text_artist: Text | None = None
+        self._hovered_font_properties: FontProperties | None = None
 
         vbox = QVBoxLayout()
         vbox.addWidget(self._canvas)
@@ -203,10 +210,58 @@ class PlotWidget(QWidget):
             )
 
     def _enable_text_picking(self) -> None:
-        for axes in self._figure.axes:
-            axes.xaxis.label.set_picker(True)
-            axes.yaxis.label.set_picker(True)
-            axes.title.set_picker(True)
+        self._hovered_text_artist = None
+        self._hovered_font_properties = None
+        QToolTip.hideText()
+
+        for text_artist in self._editable_text_artists():
+            text_artist.set_picker(True)
+
+    def _editable_text_artists(self) -> list[Text]:
+        return [
+            text_artist
+            for axes in self._figure.axes
+            for text_artist in (axes.xaxis.label, axes.yaxis.label, axes.title)
+        ]
+
+    def _clear_hovered_text_artist(self) -> None:
+        if (
+            self._hovered_text_artist is not None
+            and self._hovered_font_properties is not None
+        ):
+            self._hovered_text_artist.set_fontproperties(self._hovered_font_properties)
+
+        self._hovered_text_artist = None
+        self._hovered_font_properties = None
+        QToolTip.hideText()
+
+    def _on_canvas_motion(self, event: MouseEvent) -> None:
+        hovered_text_artist = next(
+            (
+                text_artist
+                for text_artist in self._editable_text_artists()
+                if text_artist.contains(event)[0]
+            ),
+            None,
+        )
+        if hovered_text_artist is self._hovered_text_artist:
+            return
+
+        self._clear_hovered_text_artist()
+        if hovered_text_artist is None:
+            self._canvas.draw_idle()
+            return
+
+        self._hovered_text_artist = hovered_text_artist
+        self._hovered_font_properties = hovered_text_artist.get_fontproperties().copy()
+        hovered_text_artist.set_fontweight("bold")
+        QToolTip.showText(QCursor.pos(), "Click to edit", self._canvas)
+
+        self._canvas.draw_idle()
+
+    def _on_canvas_leave(self, _: Event) -> None:
+        self._clear_hovered_text_artist()
+        self._canvas.draw_idle()
 
     def _on_canvas_pick(self, event: PickEvent) -> None:
         for axes in self._figure.axes:

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -4,9 +4,10 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from matplotlib.backend_bases import Event, MouseEvent
 from matplotlib.figure import Figure
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton
+from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton, QToolTip
 from pytestqt.qtbot import QtBot
 
 from ert.config.distribution import RawSettings
@@ -945,6 +946,70 @@ def test_that_clicking_title_emits_edit_request(qtbot: QtBot) -> None:
     plot_widget._on_canvas_pick(pick_event)
 
     received.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "text_kind",
+    [
+        pytest.param("x-axis", id="x-axis"),
+        pytest.param("y-axis", id="y-axis"),
+        pytest.param("title", id="title"),
+    ],
+)
+def test_that_hovering_editable_text_shows_it_as_clickable(
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    text_kind: str,
+) -> None:
+    show_text = MagicMock()
+    monkeypatch.setattr(QToolTip, "showText", show_text)
+
+    plotter = MagicMock()
+    plotter.dimensionality = 1
+    plotter.requires_observations = False
+
+    def _plot_with_editable_text(figure: Figure, *_args, **_kwargs) -> None:
+        axes = figure.add_subplot(111)
+        axes.set_xlabel("X label")
+        axes.set_ylabel("Y label")
+        axes.set_title("Title")
+
+    plotter.plot.side_effect = _plot_with_editable_text
+    plot_widget = PlotWidget("Any", plotter)
+    qtbot.addWidget(plot_widget)
+    plot_widget.updatePlot(
+        PlotContext(
+            PlotConfig(),
+            ensembles=[],
+            ensembles_color_indexes=[],
+            key="key",
+            layer=None,
+        ),
+        {},
+        pd.DataFrame(),
+        {},
+        None,
+    )
+
+    axes = plot_widget._figure.axes[0]
+    text = {
+        "x-axis": axes.xaxis.label,
+        "y-axis": axes.yaxis.label,
+        "title": axes.title,
+    }[text_kind]
+    original_properties = text.get_fontproperties().copy()
+    x_pos, y_pos = text.get_window_extent().get_points().mean(axis=0)
+    event = MouseEvent("motion_notify_event", plot_widget._canvas, x_pos, y_pos)
+    plot_widget._on_canvas_motion(event)
+
+    assert text.get_fontweight() == "bold"
+    assert show_text.call_args.args[1:] == ("Click to edit", plot_widget._canvas)
+
+    plot_widget._on_canvas_leave(Event("figure_leave_event", plot_widget._canvas))
+
+    assert text.get_fontproperties() == original_properties
+    assert plot_widget._hovered_text_artist is None
+    assert plot_widget._hovered_font_properties is None
 
 
 def _create_plot_window_for_text_edit(


### PR DESCRIPTION
**Issue**
Resolves #14007

**Approach**
Have PlotWidget listen for Matplotlib mouse-move events and detect when the cursor is over editable plot text. On hover, store the text’s original font properties, make it bold, and show a tooltip. Restore the original properties when the cursor moves away.

<img width="911" height="803" alt="visual-cue3" src="https://github.com/user-attachments/assets/0c342cdd-8067-4c43-9b57-4c11ed98ab1c" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
