### PR TITLE
Revert SNAKE_OIL_PARAM_{param} to single param-group

### DIFF
--- a/test-data/ert/snake_oil/snake_oil.ert
+++ b/test-data/ert/snake_oil/snake_oil.ert
@@ -26,9 +26,9 @@ FORWARD_MODEL SNAKE_OIL_DIFF
 
 RUN_TEMPLATE templates/seed_template.txt seed.txt
 
-GEN_KW SNAKE_OIL_PARAM_BPR templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_BPR.txt
-GEN_KW SNAKE_OIL_PARAM_OP1 templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_OP1.txt
-GEN_KW SNAKE_OIL_PARAM_OP2 templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_OP2.txt
+GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_BPR.txt
+GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_OP1.txt
+GEN_KW SNAKE_OIL_PARAM templates/snake_oil_template.txt snake_oil_params.txt parameters/snake_oil_parameters_OP2.txt
 
 GEN_DATA SNAKE_OIL_OPR_DIFF RESULT_FILE:snake_oil_opr_diff_%d.txt REPORT_STEPS:199
 GEN_DATA SNAKE_OIL_WPR_DIFF RESULT_FILE:snake_oil_wpr_diff_%d.txt REPORT_STEPS:199

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_enif_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -175,7 +175,7 @@
         "min": 0.1,
         "max": 0.5
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -189,7 +189,7 @@
         "min": 0.2,
         "max": 0.7
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -203,7 +203,7 @@
         "min": 0.01,
         "max": 0.4
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -217,7 +217,7 @@
         "min": 3.0,
         "max": 5.0
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -231,7 +231,7 @@
         "min": 0.25,
         "max": 1.25
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -245,7 +245,7 @@
         "min": -0.1,
         "max": 0.1
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -259,7 +259,7 @@
         "min": 0.1,
         "max": 0.6
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -273,7 +273,7 @@
         "min": 5.0,
         "max": 12.0
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -287,7 +287,7 @@
         "min": 0.5,
         "max": 1.5
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -301,7 +301,7 @@
         "min": -0.2,
         "max": 0.2
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     }
   ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_experiment_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -159,7 +159,7 @@
         "min": 0.1,
         "max": 0.5
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -173,7 +173,7 @@
         "min": 0.2,
         "max": 0.7
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -187,7 +187,7 @@
         "min": 0.01,
         "max": 0.4
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -201,7 +201,7 @@
         "min": 3.0,
         "max": 5.0
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -215,7 +215,7 @@
         "min": 0.25,
         "max": 1.25
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -229,7 +229,7 @@
         "min": -0.1,
         "max": 0.1
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -243,7 +243,7 @@
         "min": 0.1,
         "max": 0.6
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -257,7 +257,7 @@
         "min": 5.0,
         "max": 12.0
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -271,7 +271,7 @@
         "min": 0.5,
         "max": 1.5
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -285,7 +285,7 @@
         "min": -0.2,
         "max": 0.2
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     }
   ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_ensemble_smoother_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -175,7 +175,7 @@
         "min": 0.1,
         "max": 0.5
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -189,7 +189,7 @@
         "min": 0.2,
         "max": 0.7
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -203,7 +203,7 @@
         "min": 0.01,
         "max": 0.4
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -217,7 +217,7 @@
         "min": 3.0,
         "max": 5.0
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -231,7 +231,7 @@
         "min": 0.25,
         "max": 1.25
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -245,7 +245,7 @@
         "min": -0.1,
         "max": 0.1
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -259,7 +259,7 @@
         "min": 0.1,
         "max": 0.6
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -273,7 +273,7 @@
         "min": 5.0,
         "max": 12.0
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -287,7 +287,7 @@
         "min": 0.5,
         "max": 1.5
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -301,7 +301,7 @@
         "min": -0.2,
         "max": 0.2
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     }
   ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -175,7 +175,7 @@
         "min": 0.1,
         "max": 0.5
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -189,7 +189,7 @@
         "min": 0.2,
         "max": 0.7
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -203,7 +203,7 @@
         "min": 0.01,
         "max": 0.4
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -217,7 +217,7 @@
         "min": 3.0,
         "max": 5.0
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -231,7 +231,7 @@
         "min": 0.25,
         "max": 1.25
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -245,7 +245,7 @@
         "min": -0.1,
         "max": 0.1
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -259,7 +259,7 @@
         "min": 0.1,
         "max": 0.6
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -273,7 +273,7 @@
         "min": 5.0,
         "max": 12.0
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -287,7 +287,7 @@
         "min": 0.5,
         "max": 1.5
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -301,7 +301,7 @@
         "min": -0.2,
         "max": 0.2
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     }
   ],

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_single_test_run_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_single_test_run_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -135,7 +135,7 @@
         "min": 0.1,
         "max": 0.5
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -149,7 +149,7 @@
         "min": 0.2,
         "max": 0.7
       },
-      "group": "SNAKE_OIL_PARAM_BPR",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -163,7 +163,7 @@
         "min": 0.01,
         "max": 0.4
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -177,7 +177,7 @@
         "min": 3.0,
         "max": 5.0
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -191,7 +191,7 @@
         "min": 0.25,
         "max": 1.25
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -205,7 +205,7 @@
         "min": -0.1,
         "max": 0.1
       },
-      "group": "SNAKE_OIL_PARAM_OP1",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -219,7 +219,7 @@
         "min": 0.1,
         "max": 0.6
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -233,7 +233,7 @@
         "min": 5.0,
         "max": 12.0
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -247,7 +247,7 @@
         "min": 0.5,
         "max": 1.5
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     },
     {
@@ -261,7 +261,7 @@
         "min": -0.2,
         "max": 0.2
       },
-      "group": "SNAKE_OIL_PARAM_OP2",
+      "group": "SNAKE_OIL_PARAM",
       "input_source": "sampled"
     }
   ],


### PR DESCRIPTION


**Issue**
Resolves #14016


**Approach**
Reverted from multiple parameter groups back to a single one. "Issue" seems to stem from how the seeding/sampling is done ([Link](https://github.com/equinor/ert/blob/5fae314d0c9bc80b71cf01a3073e21a162c2633a/src/ert/config/parameter_config.py#L142)). I guess it since its just that it was a different seed/prior sampling, so it just looked different. Unsure if this is something we care about  and/or if this is something that should be reverted.

Pre-revert:
```
seed = f(global_seed, group_name, param_name)  
       ├─ global_seed : RANDOM_SEED
       ├─ group_name  : SNAKE_OIL_PARAM_OP1
       └─ param_name  OP1_PERSISTENCE 
```
Post-revert
```
seed = f(global_seed, group_name, param_name)  
       ├─ global_seed : RANDOM_SEED
       ├─ group_name  : SNAKE_OIL_PARAM <- Now all share the same group again
       └─ param_name  : e.g. OP1_PERSISTENCE 
```       
_(I would like to thank Copilot for the illustration)_ 


**Visual example**
Pre-revert:
<img width="265" height="693" alt="Screenshot 2026-07-23 at 16 52 11" src="https://github.com/user-attachments/assets/25822d37-001d-4185-bcbc-585ccde7b717" />
Post-revert:
<img width="277" height="744" alt="Screenshot 2026-07-23 at 16 51 08" src="https://github.com/user-attachments/assets/16fff97a-9f10-41c5-85a5-72b9427b9d35" />


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
