### PR TITLE
Set style to `default` for all image comparison tests

### DIFF
--- a/tests/ert/ui_tests/gui/test_breakthrough_misfit_visualization.py
+++ b/tests/ert/ui_tests/gui/test_breakthrough_misfit_visualization.py
@@ -8,7 +8,7 @@ from tests.ert.ui_tests.gui.test_breakthrough_visualization import (
 plot_figure = create_breakthrough_figure(MISFITS)
 
 
-@pytest.mark.mpl_image_compare(tolerance=10.0)
+@pytest.mark.mpl_image_compare(tolerance=10.0, style="default")
 @pytest.mark.skip_mac_ci
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_breakthrough_misfit_visualization_images_are_unchanged(plot_figure):

--- a/tests/ert/ui_tests/gui/test_breakthrough_visualization.py
+++ b/tests/ert/ui_tests/gui/test_breakthrough_visualization.py
@@ -163,7 +163,7 @@ def create_breakthrough_figure(plot_tab_name: str):
 plot_figure = create_breakthrough_figure(ENSEMBLE)
 
 
-@pytest.mark.mpl_image_compare(tolerance=10.0)
+@pytest.mark.mpl_image_compare(tolerance=10.0, style="default")
 @pytest.mark.skip_mac_ci
 @pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
 def test_that_breakthrough_ensemble_visualization_images_are_unchanged(plot_figure):

--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -128,7 +128,7 @@ def plot_figure(
 # The tolerance is chosen by guess, in one bug we observed a
 # where locations of observations in the standard deviation plot
 # were off, we needed a tolerance of 5 to get tests to fail.
-@pytest.mark.mpl_image_compare(tolerance=5.0)
+@pytest.mark.mpl_image_compare(tolerance=5.0, style="default")
 @pytest.mark.skip_mac_ci  # test is slow
 @pytest.mark.xdist_group(name="uses_heat_equation_storage")
 def test_that_plot_images_are_unchanged(plot_figure):

--- a/tests/ert/ui_tests/gui/test_rft_visualizations.py
+++ b/tests/ert/ui_tests/gui/test_rft_visualizations.py
@@ -160,7 +160,7 @@ def plot_figure(qtbot: QtBot, request, rft_config: ErtConfig):
 # We had an issue where the mpl_image_compare decorator
 # was put on an inner function. That makes any failure not
 # report so it has to be on a top level test.
-@pytest.mark.mpl_image_compare(tolerance=10.0)
+@pytest.mark.mpl_image_compare(tolerance=10.0, style="default")
 @pytest.mark.skip_mac_ci  # test is slow
 def test_that_all_rft_visualizations_are_unchanged(plot_figure):
     return plot_figure

--- a/tests/ert/unit_tests/gui/plottery/test_histogram.py
+++ b/tests/ert/unit_tests/gui/plottery/test_histogram.py
@@ -59,7 +59,7 @@ def ensemble_to_data_map(request, plot_context):
     return dict.fromkeys(plot_context.ensembles(), request.param)
 
 
-@pytest.mark.mpl_image_compare(tolerance=10)
+@pytest.mark.mpl_image_compare(tolerance=10, style="default")
 def test_histogram(plot_context: PlotContext, ensemble_to_data_map):
     figure = Figure()
     HistogramPlot().plot(


### PR DESCRIPTION


**Approach**
Setting the style to `default`,  this means the screenshots will be better aligned with what we actually see in the GUI, rather than the simplistic style of `classic`.




- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
