### PR TITLE
Change layout engine to `constrained`

### DIFF
--- a/src/ert/gui/plotting/widgets/plot_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_widget.py
@@ -139,7 +139,7 @@ class PlotWidget(QWidget):
         self._name = name
         self._plotter = plotter
         self._figure = Figure()
-        self._figure.set_layout_engine("tight")
+        self._figure.set_layout_engine("constrained")
         self._canvas = FigureCanvas(self._figure)
         self._canvas.mpl_connect("pick_event", self._on_canvas_pick)
         self._canvas.mpl_connect("motion_notify_event", self._on_canvas_motion)


### PR DESCRIPTION
Resolves #13769

Reduces padding, will also allow us to use gridspecs if we want multiple plots and axis in the same figure


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).https://github.com/orgs/equinor/projects/84
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
