### PR TITLE
Allow users to set the title in `MisfitsPlot`

### DIFF
--- a/src/ert/gui/plotting/ert_plots/misfits.py
+++ b/src/ert/gui/plotting/ert_plots/misfits.py
@@ -259,7 +259,10 @@ class MisfitsPlot:
         index_string = "timestep" if summary_or_breakthrough else "index"
         plot_context.plotConfig().set_title(
             f"{plot_context.key()} (Signed Chi-squared misfits per {index_string})"
+            if plot_context.plotConfig().is_unnamed()
+            else f"{plot_context.plotConfig().title()} (Signed Chi-squared)"
         )
+
         PlotTools.finalizePlot(
             plot_context,
             figure,


### PR DESCRIPTION
Added default title, but if title is already set appends the `Signed Chi-squared`

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
