### PR TITLE
Improve plotter performance by adding caching to PlotApi requests

### DIFF
--- a/src/ert/gui/plotting/plot_api.py
+++ b/src/ert/gui/plotting/plot_api.py
@@ -4,7 +4,7 @@ import io
 import json
 import logging
 from dataclasses import dataclass
-from functools import cached_property
+from functools import cached_property, lru_cache
 from itertools import combinations as combi
 from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import quote
@@ -26,11 +26,15 @@ from ert.services import create_ertserver_client
 from ert.storage.local_experiment import _parameters_adapter as parameter_config_adapter
 from ert.storage.local_experiment import _responses_adapter as response_config_adapter
 from ert.storage.realization_storage_state import RealizationStorageState
+from ert.utils import process_arg
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+TIMEOUT = 120
 
 
 @dataclass(frozen=True, eq=True)
@@ -59,13 +63,12 @@ class PlotApi:
     def __init__(self, ens_path: Path) -> None:
         self.ens_path: Path = ens_path
         self._all_ensembles: list[EnsembleObject] | None = None
-        self._timeout = 120
 
     @property
     def api_version(self) -> str:
         with create_ertserver_client(self.ens_path) as client:
             try:
-                http_response = client.get("/version", timeout=self._timeout)
+                http_response = client.get("/version", timeout=TIMEOUT)
                 self._check_http_response(http_response)
                 api_version = str(http_response.json())
             except Exception as exc:
@@ -91,13 +94,13 @@ class PlotApi:
         self._all_ensembles = []
         with create_ertserver_client(self.ens_path) as client:
             try:  # noqa: PLW0717
-                http_response = client.get("/experiments", timeout=self._timeout)
+                http_response = client.get("/experiments", timeout=TIMEOUT)
                 self._check_http_response(http_response)
                 experiments = http_response.json()
                 for experiment in experiments:
                     for ensemble_id in experiment["ensemble_ids"]:
                         http_response = client.get(
-                            f"/ensembles/{ensemble_id}", timeout=self._timeout
+                            f"/ensembles/{ensemble_id}", timeout=TIMEOUT
                         )
                         self._check_http_response(http_response)
                         response_json: dict[str, Any] = http_response.json()
@@ -154,7 +157,7 @@ class PlotApi:
         all_params = {}
 
         with create_ertserver_client(self.ens_path) as client:
-            http_response = client.get("/experiments", timeout=self._timeout)
+            http_response = client.get("/experiments", timeout=TIMEOUT)
             self._check_http_response(http_response)
 
             for experiment in http_response.json():
@@ -181,7 +184,7 @@ class PlotApi:
         key_defs: dict[str, PlotApiKeyDefinition] = {}
 
         with create_ertserver_client(self.ens_path) as client:
-            http_response = client.get("/experiments", timeout=self._timeout)
+            http_response = client.get("/experiments", timeout=TIMEOUT)
             self._check_http_response(http_response)
 
             def update_keydef(plot_key_def: PlotApiKeyDefinition) -> None:
@@ -272,7 +275,7 @@ class PlotApi:
                 params={"filter_on": json.dumps(filter_on)}
                 if filter_on is not None
                 else None,
-                timeout=self._timeout,
+                timeout=TIMEOUT,
             )
             self._check_http_response(http_response)
 
@@ -341,16 +344,17 @@ class PlotApi:
             except ValueError:
                 return df
 
-    def data_for_gradient(self, ensemble_id: str, key: str) -> pd.DataFrame:
-        if "@" in key:
-            key = key.split("@", maxsplit=1)[0]
-        with create_ertserver_client(self.ens_path) as client:
+    @staticmethod
+    @process_arg(key="key", process=lambda s: s.split("@", maxsplit=1)[0])
+    @lru_cache(maxsize=256)
+    def data_for_gradient(ensemble_id: str, key: str, ens_path: Path) -> pd.DataFrame:
+        with create_ertserver_client(ens_path) as client:
             http_response = client.get(
                 f"/ensembles/{ensemble_id}/gradients/{PlotApi.escape(key)}",
                 headers={"accept": "application/x-parquet"},
-                timeout=self._timeout,
+                timeout=TIMEOUT,
             )
-            self._check_http_response(http_response)
+            PlotApi._check_http_response(http_response)
 
             stream = io.BytesIO(http_response.content)
             df = pd.read_parquet(stream)
@@ -366,13 +370,15 @@ class PlotApi:
                 }
             )
 
+    @staticmethod
+    @lru_cache(maxsize=128)
     def data_for_controls(
-        self, ensemble_id: str, parameter_keys: list[str]
+        ensemble_id: str, parameter_keys: tuple[str, ...], ens_path: Path
     ) -> pd.DataFrame:
         frames = []
 
         for parameter_key in parameter_keys:
-            df = self.data_for_parameter(ensemble_id, parameter_key)
+            df = PlotApi.data_for_parameter(ensemble_id, parameter_key, ens_path)
             if not df.empty and {"batch_id", "realization"}.issubset(df.columns):
                 value_cols = [
                     c for c in df.columns if c not in {"batch_id", "realization"}
@@ -388,14 +394,18 @@ class PlotApi:
             return pd.DataFrame()
         return pd.concat(frames, ignore_index=True)
 
-    def data_for_parameter(self, ensemble_id: str, parameter_key: str) -> pd.DataFrame:
-        with create_ertserver_client(self.ens_path) as client:
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def data_for_parameter(
+        ensemble_id: str, parameter_key: str, ens_path: Path
+    ) -> pd.DataFrame:
+        with create_ertserver_client(ens_path) as client:
             http_response = client.get(
                 f"/ensembles/{ensemble_id}/parameters/{PlotApi.escape(parameter_key)}",
                 headers={"accept": "application/x-parquet"},
-                timeout=self._timeout,
+                timeout=TIMEOUT,
             )
-            self._check_http_response(http_response)
+            PlotApi._check_http_response(http_response)
 
             stream = io.BytesIO(http_response.content)
             df = pd.read_parquet(stream)
@@ -415,7 +425,7 @@ class PlotApi:
 
     def observation_locations(self) -> pd.DataFrame:
         with create_ertserver_client(self.ens_path) as client:
-            http_response = client.get("/experiments", timeout=self._timeout)
+            http_response = client.get("/experiments", timeout=TIMEOUT)
             self._check_http_response(http_response)
             experiments = http_response.json()
 
@@ -424,7 +434,7 @@ class PlotApi:
                 experiment_id = str(experiment["id"])
                 http_response = client.get(
                     f"/experiments/{experiment_id}/observations",
-                    timeout=self._timeout,
+                    timeout=TIMEOUT,
                 )
                 self._check_http_response(http_response)
                 observations = http_response.json()
@@ -483,7 +493,7 @@ class PlotApi:
             with create_ertserver_client(self.ens_path) as client:
                 http_response = client.get(
                     f"/ensembles/{ensemble.id}/responses/{PlotApi.escape(actual_response_key)}/observations",
-                    timeout=self._timeout,
+                    timeout=TIMEOUT,
                     params={"filter_on": json.dumps(filter_on)}
                     if filter_on is not None
                     else None,
@@ -574,7 +584,7 @@ class PlotApi:
             http_response = client.get(
                 f"/ensembles/{ensemble.id}/parameters/{PlotApi.escape(key)}/std_dev",
                 params={"z": z},
-                timeout=self._timeout,
+                timeout=TIMEOUT,
             )
 
             if http_response.status_code == 200:

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -177,6 +177,7 @@ class PlotWindow(QMainWindow):
         self.setWindowTitle(f"Plotting - {config_file}")
         self.activateWindow()
         self._preferred_ensemble_x_axis_format = PlotContext.INDEX_AXIS
+        self._ens_path = ens_path
         self._api = PlotApi(ens_path)
 
         self.local_version = get_storage_api_version()
@@ -476,7 +477,9 @@ class PlotWindow(QMainWindow):
                 try:  # noqa: PLW0717
                     data = None
                     if is_gradient_plot:
-                        data = self._api.data_for_gradient(ensemble.id, key)
+                        data = PlotApi.data_for_gradient(
+                            ensemble.id, key, self._ens_path
+                        )
                     elif (
                         key_def.response is not None
                         or key_def.metadata.get("data_origin")
@@ -488,18 +491,20 @@ class PlotWindow(QMainWindow):
                             filter_on=key_def.filter_on,
                         )
                     elif is_controls_plot:
-                        data = self._api.data_for_controls(
+                        data = PlotApi.data_for_controls(
                             ensemble_id=ensemble.id,
-                            parameter_keys=selected_controls
-                            or self._everest_parameters,
+                            parameter_keys=tuple(selected_controls)
+                            or tuple(self._everest_parameters),
+                            ens_path=self._ens_path,
                         )
                     elif key_def.parameter is not None and (
                         key_def.parameter.type
                         in {"gen_kw", "everest_parameters", "everest_objective"}
                     ):
-                        data = self._api.data_for_parameter(
+                        data = PlotApi.data_for_parameter(
                             ensemble_id=ensemble.id,
                             parameter_key=key_def.parameter.name,
+                            ens_path=self._ens_path,
                         )
                 except BaseException as e:
                     return ensemble, e

--- a/src/ert/utils.py
+++ b/src/ert/utils.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import wraps
+from inspect import signature
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -70,3 +71,36 @@ def assert_schema(
             msg = f"Expected schema {schema}, got {df.schema}."
             raise AssertionError(msg)
     return df
+
+
+def process_arg(
+    key: str,
+    process: Callable[[Any], Any],
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    Returns a decorator that processes a function argument before calling it.
+    Useful in combination with caching,
+    where you want to normalize an argument before hashing.
+
+    Args:
+        key (str): Name of the argument to process.
+        process (Callable[[Any], Any]): Function to process the argument value.
+    """
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        sig = signature(func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound = sig.bind(*args, **kwargs)
+            value = bound.arguments.get(key)
+            bound.arguments[key] = process(value)
+            return func(*bound.args, **bound.kwargs)
+
+        for cache_attr in ("cache_info", "cache_clear", "cache_parameters"):
+            if (member := getattr(func, cache_attr, None)) is not None:
+                setattr(wrapper, cache_attr, member)
+
+        return wrapper
+
+    return decorator

--- a/tests/ert/performance_tests/test_dark_storage_performance.py
+++ b/tests/ert/performance_tests/test_dark_storage_performance.py
@@ -365,8 +365,10 @@ def test_plotter_on_all_snake_oil_responses_time(api_and_snake_oil_storage, benc
         # Cycle through all ensembles and get all responses
         for key_info in key_infos_params:
             for ensemble in all_ensembles:
-                api.data_for_parameter(
-                    ensemble_id=ensemble.id, parameter_key=key_info.parameter.name
+                PlotApi.data_for_parameter(
+                    ensemble_id=ensemble.id,
+                    parameter_key=key_info.parameter.name,
+                    ens_path=api.ens_path,
                 )
 
         for key_info in key_infos_responses:

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -124,7 +124,9 @@ def test_case_structure(api):
 def test_can_load_data_and_observations(api):
     responses = [("BPR:1,3,8", False), ("FOPR", True)]
     ensemble = next(x for x in api.get_all_ensembles() if x.name == "default_0")
-    data = api.data_for_parameter(ensemble.id, "SNAKE_OIL_PARAM:BPR_138_PERSISTENCE")
+    data = PlotApi.data_for_parameter(
+        ensemble.id, "SNAKE_OIL_PARAM:BPR_138_PERSISTENCE", api.ens_path
+    )
     assert not data.empty
 
     for key, has_observations in responses:
@@ -208,7 +210,7 @@ def api_and_storage(monkeypatch, tmp_path):
         monkeypatch.setenv("ERT_STORAGE_NO_TOKEN", "yup")
         monkeypatch.setenv("ERT_STORAGE_ENS_PATH", str(storage.path))
         api = PlotApi(ens_path)
-        yield api, storage
+        yield api, storage, ens_path
     if common._storage is not None:
         common._storage.close()
     common._storage = None
@@ -216,7 +218,7 @@ def api_and_storage(monkeypatch, tmp_path):
 
 
 def test_plot_api_handles_urlescape(api_and_storage):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
     key = "WBHP:46/3-7S"
     date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
 
@@ -275,7 +277,7 @@ def test_plot_api_handles_urlescape(api_and_storage):
 
 
 def test_plot_api_handles_empty_gen_kw(api_and_storage):
-    api, storage = api_and_storage
+    _, storage, ens_path = api_and_storage
     key = "gen_kw"
     name = "<poro>"
     experiment = storage.create_experiment(
@@ -294,7 +296,7 @@ def test_plot_api_handles_empty_gen_kw(api_and_storage):
         }
     )
     ensemble = storage.create_ensemble(experiment.id, ensemble_size=10)
-    assert api.data_for_parameter(str(ensemble.id), key).empty
+    assert PlotApi.data_for_parameter(str(ensemble.id), key, ens_path).empty
     ensemble.save_parameters(
         dataset=pl.DataFrame(
             {
@@ -303,16 +305,18 @@ def test_plot_api_handles_empty_gen_kw(api_and_storage):
             }
         ),
     )
-    assert api.data_for_parameter(str(ensemble.id), name).to_csv() == dedent(
-        """\
+    assert PlotApi.data_for_parameter(str(ensemble.id), name, ens_path).to_csv() == (
+        dedent(
+            """\
         Realization,0
         1,0.1
         """
+        )
     )
 
 
 def test_plot_api_handles_non_existant_gen_kw(api_and_storage):
-    api, storage = api_and_storage
+    _, storage, ens_path = api_and_storage
     experiment = storage.create_experiment(
         experiment_config={
             "parameter_configuration": [
@@ -328,12 +332,14 @@ def test_plot_api_handles_non_existant_gen_kw(api_and_storage):
         }
     )
     ensemble = storage.create_ensemble(experiment.id, ensemble_size=10)
-    assert api.data_for_parameter(str(ensemble.id), "gen_kw").empty
-    assert api.data_for_parameter(str(ensemble.id), "gen_kw:does_not_exist").empty
+    assert PlotApi.data_for_parameter(str(ensemble.id), "gen_kw", ens_path).empty
+    assert PlotApi.data_for_parameter(
+        str(ensemble.id), "gen_kw:does_not_exist", ens_path
+    ).empty
 
 
 def test_plot_api_handles_colons_in_parameter_keys(api_and_storage):
-    api, storage = api_and_storage
+    _, storage, ens_path = api_and_storage
     experiment = storage.create_experiment(
         experiment_config={
             "parameter_configuration": [
@@ -358,12 +364,12 @@ def test_plot_api_handles_colons_in_parameter_keys(api_and_storage):
             }
         ),
     )
-    test = api.data_for_parameter(str(ensemble.id), "subgroup:1:2:2")
+    test = PlotApi.data_for_parameter(str(ensemble.id), "subgroup:1:2:2", ens_path)
     assert test.to_numpy() == np.array([[10]])
 
 
 def test_that_multiple_observations_are_parsed_correctly(api_and_storage):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
 
     experiment = storage.create_experiment(
         experiment_config={
@@ -412,7 +418,7 @@ def test_that_multiple_observations_are_parsed_correctly(api_and_storage):
 
 
 def test_that_observations_for_empty_ensemble_returns_empty_data(api_and_storage):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
     experiment = storage.create_experiment(
         experiment_config={
             "parameter_configuration": [],
@@ -433,7 +439,7 @@ def test_that_observations_for_empty_ensemble_returns_empty_data(api_and_storage
 def test_that_data_for_response_is_empty_for_ensembles_without_responses(
     api_and_storage,
 ):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
 
     experiment = storage.create_experiment(
         name=None,
@@ -463,7 +469,7 @@ def test_that_data_for_response_is_empty_for_ensembles_without_responses(
 def test_that_response_key_has_observation_when_only_one_experiment_has_observations(
     api_and_storage,
 ):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
 
     date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
     experiment_with_observation = storage.create_experiment(
@@ -549,7 +555,7 @@ def test_that_response_key_has_observation_when_only_one_experiment_has_observat
 def test_that_response_keys_do_not_match_keys_that_are_substrings(
     api_and_storage, well_name
 ):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
     key = f"WBHP:{well_name}"
     date = datetime(year=2024, month=10, day=4)  # noqa: DTZ001
 
@@ -657,7 +663,7 @@ def _create_gradient_only_ensemble(storage):
 def test_that_data_for_response_returns_empty_for_gradient_only_ensemble(
     api_and_storage,
 ):
-    api, storage = api_and_storage
+    api, storage, _ = api_and_storage
     ensemble, objective_key = _create_gradient_only_ensemble(storage)
 
     # Gradient-only ensembles have no function evaluation results
@@ -671,11 +677,51 @@ def test_that_data_for_response_returns_empty_for_gradient_only_ensemble(
 def test_that_data_for_gradient_returns_empty_when_no_gradient_parquet_saved(
     api_and_storage,
 ):
-    api, storage = api_and_storage
+    _, storage, ens_path = api_and_storage
     ensemble, objective_key = _create_gradient_only_ensemble(storage)
 
     # No batch_objective_gradient.parquet was saved, so the gradient
     # endpoint returns an empty DataFrame. PlotApi must not crash.
-    result = api.data_for_gradient(str(ensemble.id), objective_key)
+    result = PlotApi.data_for_gradient(str(ensemble.id), objective_key, ens_path)
     assert isinstance(result, pd.DataFrame)
     assert result.empty
+
+
+def test_that_data_for_gradient_is_fetched_once_for_repeated_calls(api_and_storage):
+    _, storage, ens_path = api_and_storage
+    ensemble, objective_key = _create_gradient_only_ensemble(storage)
+
+    PlotApi.data_for_gradient.cache_clear()  # type: ignore
+
+    for i in range(5):
+        # The addition of @<some string> should result in the same cache key
+        # if the prefix is the same.
+        key = objective_key + "@filler" if i % 2 == 0 else objective_key
+        _ = PlotApi.data_for_gradient(str(ensemble.id), key, ens_path)
+
+    # hits, misses, maxsize, currsize
+    expected_cache_info = (4, 1, 256, 1)
+
+    assert (
+        PlotApi.data_for_gradient.cache_info() == expected_cache_info  # type: ignore
+    )
+
+
+def test_that_data_for_controls_and_parameters_is_fetched_once_for_repeated_calls(api):
+
+    PlotApi.data_for_controls.cache_clear()
+    PlotApi.data_for_parameter.cache_clear()
+
+    ensemble = next(x for x in api.get_all_ensembles() if x.name == "default_0")
+
+    for _ in range(5):
+        _ = PlotApi.data_for_controls(
+            ensemble.id, ("SNAKE_OIL_PARAM:BPR_138_PERSISTENCE",), api.ens_path
+        )
+
+    # hits, misses, maxsize, currsize
+    expected_cache_info_controls = (4, 1, 128, 1)
+    expected_cache_info_parameters = (0, 1, 256, 1)
+
+    assert PlotApi.data_for_controls.cache_info() == expected_cache_info_controls
+    assert PlotApi.data_for_parameter.cache_info() == expected_cache_info_parameters

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -244,12 +244,14 @@ def test_that_plotting_gen_kw_parameter_with_negative_values_hides_log_scale_che
         plot_api_key_def_negative,
     ]
 
-    def mock_data_for_parameter(ensemble_id: str, parameter_key: str) -> pd.DataFrame:
+    def mock_data_for_parameter(
+        ensemble_id: str, parameter_key: str, ens_path: Path
+    ) -> pd.DataFrame:
         if parameter_key == "gen_kw_a":
             return pd.DataFrame({0: [0.1, 0.5, 0.9]})
         return pd.DataFrame({0: [-0.1, -0.5, -0.9]})
 
-    mock_plot_api.data_for_parameter.side_effect = mock_data_for_parameter
+    mock_plot_api_cls.data_for_parameter.side_effect = mock_data_for_parameter
     mock_plot_api.has_history_data.return_value = False
 
     mock_plot_api.get_all_ensembles.return_value = [
@@ -624,7 +626,9 @@ def test_that_log_scale_state_is_preserved_when_switching_plot_tabs(
 
     mock_plot_api.responses_api_key_defs = []
     mock_plot_api.parameters_api_key_defs = [key_def]
-    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: [0.1, 0.5, 0.9]})
+    mock_plot_api_cls.data_for_parameter.return_value = pd.DataFrame(
+        {0: [0.1, 0.5, 0.9]}
+    )
     mock_plot_api.has_history_data.return_value = False
     mock_plot_api.get_all_ensembles.return_value = [
         EnsembleObject(
@@ -719,7 +723,7 @@ def test_that_density_tabs_show_log_scale_only_for_valid_gen_kw_values(
 
     mock_plot_api.responses_api_key_defs = []
     mock_plot_api.parameters_api_key_defs = [key_def]
-    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: values})
+    mock_plot_api_cls.data_for_parameter.return_value = pd.DataFrame({0: values})
     mock_plot_api.has_history_data.return_value = False
     mock_plot_api.get_all_ensembles.return_value = [
         EnsembleObject(
@@ -789,7 +793,7 @@ def test_that_plot_window_ignores_negative_check_for_non_numeric_columns(
     mock_plot_api.parameters_api_key_defs = [plot_api_key_def]
 
     def mixed_dtype_data_for_parameter(
-        ensemble_id: str, parameter_key: str
+        ensemble_id: str, parameter_key: str, ens_path: Path
     ) -> pd.DataFrame:
         assert parameter_key == "animal_type"
         return pd.DataFrame(
@@ -798,7 +802,7 @@ def test_that_plot_window_ignores_negative_check_for_non_numeric_columns(
             }
         )
 
-    mock_plot_api.data_for_parameter.side_effect = mixed_dtype_data_for_parameter
+    mock_plot_api_cls.data_for_parameter.side_effect = mixed_dtype_data_for_parameter
     mock_plot_api.has_history_data.return_value = False
     mock_plot_api.get_all_ensembles.return_value = [
         EnsembleObject(
@@ -1236,7 +1240,9 @@ def test_that_clearing_custom_title_restores_key_title_when_rendering(
             "2026-01-01T00:00:00",
         )
     ]
-    mock_plot_api.data_for_parameter.return_value = pd.DataFrame({0: [1.0, 2.0, 3.0]})
+    mock_plot_api_cls.data_for_parameter.return_value = pd.DataFrame(
+        {0: [1.0, 2.0, 3.0]}
+    )
     mock_plot_api.has_history_data.return_value = False
 
     monkeypatch.setattr(


### PR DESCRIPTION
**Issue**
resolves ~ #14032 

**Approach**
Add caching to `data_for_gradient`, `data_for_controls` and `data_for_parameter` requests. Caching a standard classmethod is anti pattern and violates ruff rule `B019`

> Using the functools.lru_cache and functools.cache decorators on methods can lead to memory leaks, as the global cache will retain a reference to the instance, preventing it from being garbage collected.

This has been dealt with by marking affected requests as static.

In addition a decorator has been added to process function arguments. This is so that we do not create "duplicate cache keys".

Old:

https://github.com/user-attachments/assets/c4bad8ab-f13e-4b3d-89df-68a3b0ae86a3



New:



https://github.com/user-attachments/assets/199acecf-f330-47d7-bd0f-135826f7135d






- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
