### PR TITLE
Use widget rather than index for tab

### DIFF
--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -67,10 +67,6 @@ from .widgets.plot_controls import (
 from .widgets.plot_ensemble_selection_widget import EnsembleSelectionWidget
 from .widgets.plot_widget import Plotter, PlotWidget
 
-RESPONSE_DEFAULT = 0
-GEN_KW_DEFAULT = 3
-STD_DEV_DEFAULT = 7
-
 EVEREST_UPPER_BATCH_LIMIT = 20
 
 logger = logging.getLogger(__name__)
@@ -231,23 +227,20 @@ class PlotWindow(QMainWindow):
             self._central_tab.currentChanged.connect(self.current_tab_changed)
             self.log_plot_tab_usage(self._central_tab.tabText(0), default=True)
 
-            self._prev_tab_widget_index = -1
-            self._current_tab_index = -1
             self._prev_key_dimensionality = -1
             self._prev_key: str | None = None
             self._prev_key_origin: str | None = None
-            self._prev_tab_widget_index_map: dict[int, int] = {}
             if self.is_everest:
-                self._prev_tab_widget_index_map = {
-                    1: 0,
-                    2: 1,
-                    3: 0,  # Fallback
+                self._default_tab_for_dimensionality = {
+                    1: self._widget_by_name(ENSEMBLE),
+                    2: self._widget_by_name(EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT),
+                    3: self._widget_by_name(ENSEMBLE),  # Fallback
                 }
             else:
-                self._prev_tab_widget_index_map = {
-                    2: RESPONSE_DEFAULT,
-                    1: GEN_KW_DEFAULT,
-                    3: STD_DEV_DEFAULT,
+                self._default_tab_for_dimensionality = {
+                    1: self._widget_by_name(HISTOGRAM),
+                    2: self._widget_by_name(ENSEMBLE),
+                    3: self._widget_by_name(STD_DEV),
                 }
 
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
@@ -355,7 +348,6 @@ class PlotWindow(QMainWindow):
 
     @Slot(int)
     def current_tab_changed(self, index: int) -> None:
-        self._current_tab_index = index
         self.update_plot()
         self.log_plot_tab_usage(self._central_tab.tabText(index))
 
@@ -660,6 +652,15 @@ class PlotWindow(QMainWindow):
         self._plot_widgets.append(plot_widget)
         self._central_tab.setTabEnabled(index, enabled)
 
+    def _find_widget_by_name(self, name: str) -> PlotWidget | None:
+        return next((w for w in self._plot_widgets if w.name == name), None)
+
+    def _widget_by_name(self, name: str) -> PlotWidget:
+        widget = self._find_widget_by_name(name)
+        if widget is None:
+            raise ValueError(f"No plot tab named '{name}'")
+        return widget
+
     def _edit_axis_label(self, axis: str) -> None:
         label_names = {"x": "x-label", "y": "y-label"}
         if axis not in label_names:
@@ -767,12 +768,6 @@ class PlotWindow(QMainWindow):
         def everest_data_origin_check(origin: list[str]) -> bool:
             return key_def.metadata.get("data_origin") in origin
 
-        def everest_widget_locator(widget_name: str) -> PlotWidget | None:
-            return next(
-                (w for w in self._plot_widgets if w.name == widget_name),
-                None,
-            )
-
         everest_plot_and_origin = [
             (EVEREST_OBJECTIVE_FUNCTION_PLOT, ["everest_objectives"]),
             (EVEREST_BATCH_OBJECTIVE_FUNCTION_PLOT, ["everest_batch_objectives"]),
@@ -785,15 +780,17 @@ class PlotWindow(QMainWindow):
             widget_tuple_list: list[tuple[str, list[str]]],
         ) -> None:
             for widget_name, origin in widget_tuple_list:
-                widget = everest_widget_locator(widget_name)
-                if widget:
-                    if everest_data_origin_check(origin):
-                        if widget not in available_widgets:
-                            available_widgets.append(widget)
-                    elif widget in available_widgets:
-                        available_widgets.remove(widget)
+                widget = self._widget_by_name(widget_name)
+                if everest_data_origin_check(origin):
+                    if widget not in available_widgets:
+                        available_widgets.append(widget)
+                elif widget in available_widgets:
+                    available_widgets.remove(widget)
 
-        everest_available_widget_selection(everest_plot_and_origin)
+        if self.is_everest:
+            everest_available_widget_selection(everest_plot_and_origin)
+
+        previous_widget = self._central_tab.currentWidget()
 
         # Enabling/disabling tab triggers the
         # current_tab_changed event which also triggers
@@ -809,22 +806,19 @@ class PlotWindow(QMainWindow):
         current_widget = self._central_tab.currentWidget()
 
         if 0 < self._prev_key_dimensionality != key_def.dimensionality:
-            if self._current_tab_index == -1:
-                self._current_tab_index = self._prev_tab_widget_index
-            self._prev_tab_widget_index_map[self._prev_key_dimensionality] = (
-                self._current_tab_index
-            )
-            current_widget = self._central_tab.widget(
-                self._prev_tab_widget_index_map[key_def.dimensionality]
-            )
-            self._current_tab_index = -1
+            if isinstance(previous_widget, PlotWidget):
+                self._default_tab_for_dimensionality[self._prev_key_dimensionality] = (
+                    previous_widget
+                )
+            current_widget = self._default_tab_for_dimensionality[
+                key_def.dimensionality
+            ]
 
         if current_widget not in available_widgets and available_widgets:
             current_widget = available_widgets[0]
 
         self._central_tab.setCurrentWidget(current_widget)
         self._central_tab.currentChanged.connect(self.current_tab_changed)
-        self._prev_tab_widget_index = self._central_tab.currentIndex()
         self._prev_key_dimensionality = key_def.dimensionality
         self._prev_key = key_def.key
         self._prev_key_origin = key_def.metadata.get("data_origin")

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -41,8 +41,6 @@ from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.main import ErtMainWindow, GUILogHandler, _setup_main_window
 from ert.gui.main_window import SidebarToolButton
 from ert.gui.plotting.plot_window import (
-    GEN_KW_DEFAULT,
-    RESPONSE_DEFAULT,
     PlotApi,
     PlotWindow,
 )
@@ -394,7 +392,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
 
         # check default selections
         click_plotter_item(response_index)
-        assert plot_window._central_tab.currentIndex() == RESPONSE_DEFAULT
+        assert plot_window._central_tab.currentIndex() == tab_index_by_text("Ensemble")
 
         # no log scale checkbox yet
         cb = get_log_checkbox()
@@ -402,7 +400,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
         assert not cb.isVisible()
 
         click_plotter_item(gen_kw_index)
-        assert plot_window._central_tab.currentIndex() == GEN_KW_DEFAULT
+        assert plot_window._central_tab.currentIndex() == tab_index_by_text("Histogram")
 
         # alter selections
         click_plotter_item(response_index)

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -24,6 +24,8 @@ from ert.gui.plotting.plot_window import (
 from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.utils.plot_maps import (
     DISTRIBUTION,
+    ENSEMBLE,
+    ERT_PLOT_MAP,
     GAUSSIAN_KDE,
     HISTOGRAM,
     STATISTICS,
@@ -677,6 +679,104 @@ def test_that_log_scale_state_is_preserved_when_switching_plot_tabs(
     qtbot.waitUntil(log_checkbox.isVisible, timeout=5000)
 
     assert log_checkbox.isChecked()
+
+
+def _plot_window_with_response_and_gen_kw_keys(
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+) -> PlotWindow:
+    mock_plot_api_cls = MagicMock(spec=PlotApi)
+    mock_plot_api = MagicMock(spec=PlotApi)
+    mock_plot_api_cls.return_value = mock_plot_api
+
+    storage_version = "0.0"
+    mock_plot_api.api_version = storage_version
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.get_storage_api_version",
+        lambda: storage_version,
+    )
+    monkeypatch.setattr("ert.gui.plotting.plot_window.PlotApi", mock_plot_api_cls)
+
+    mock_plot_api.responses_api_key_defs = [
+        PlotApiKeyDefinition(
+            "POLY_RES",
+            index_type="VALUE",
+            metadata={"data_origin": "gen_data"},
+            observations=False,
+            dimensionality=2,
+            response=MagicMock(type="gen_data"),
+        )
+    ]
+    mock_plot_api.parameters_api_key_defs = [
+        PlotApiKeyDefinition(
+            "gen_kw",
+            index_type=None,
+            metadata={"data_origin": "GEN_KW"},
+            observations=False,
+            dimensionality=1,
+            parameter=GenKwConfig(
+                name="gen_kw",
+                distribution={"name": "uniform", "min": 0, "max": 1},
+            ),
+        )
+    ]
+    mock_plot_api.has_history_data.return_value = False
+    mock_plot_api.get_all_ensembles.return_value = []
+
+    plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
+    qtbot.addWidget(plot_window)
+    plot_window.show()
+    return plot_window
+
+
+def _select_data_type_key(plot_window: PlotWindow, key: str) -> None:
+    filter_model = plot_window._data_type_keys_widget.filter_model
+    for row in range(filter_model.rowCount()):
+        index = filter_model.index(row, 0)
+        if str(filter_model.data(index)) == key:
+            plot_window._data_type_keys_widget.data_type_keys_widget.setCurrentIndex(
+                index
+            )
+            return
+    raise AssertionError(f"Data type key '{key}' not found")
+
+
+def _current_tab_name(plot_window: PlotWindow) -> str:
+    return plot_window._central_tab.tabText(plot_window._central_tab.currentIndex())
+
+
+def test_that_default_plot_tab_is_unaffected_by_plot_map_ordering(
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reversing the plot map changes every tab position, so a default tab
+    # resolved by position would land on the wrong plot type.
+    monkeypatch.setattr(
+        "ert.gui.plotting.plot_window.ERT_PLOT_MAP",
+        dict(reversed(list(ERT_PLOT_MAP.items()))),
+    )
+
+    plot_window = _plot_window_with_response_and_gen_kw_keys(qtbot, monkeypatch)
+
+    _select_data_type_key(plot_window, "POLY_RES")
+    _select_data_type_key(plot_window, "gen_kw")
+    assert _current_tab_name(plot_window) == HISTOGRAM
+
+    _select_data_type_key(plot_window, "POLY_RES")
+    assert _current_tab_name(plot_window) == ENSEMBLE
+
+
+def test_that_plot_tab_last_used_for_a_data_type_is_restored_when_returning_to_it(
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plot_window = _plot_window_with_response_and_gen_kw_keys(qtbot, monkeypatch)
+
+    _select_data_type_key(plot_window, "gen_kw")
+    plot_window._central_tab.setCurrentWidget(
+        plot_window._find_widget_by_name(GAUSSIAN_KDE)
+    )
+
+    _select_data_type_key(plot_window, "POLY_RES")
+    _select_data_type_key(plot_window, "gen_kw")
+    assert _current_tab_name(plot_window) == GAUSSIAN_KDE
 
 
 @pytest.mark.parametrize("tab_name", [HISTOGRAM, DISTRIBUTION, GAUSSIAN_KDE])


### PR DESCRIPTION
Rather than using hard coded indexes in the testing and `plot_window` just use the existing plot widgets 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

