### PR TITLE
Added `CollapsibleSection` to allow users to collapse `Plot controls` options

### DIFF
--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -57,7 +57,11 @@ from .utils import PlotConfig, PlotContext
 from .utils.observation_locations import transform_observation_locations
 from .utils.plot_color_palettes import TABLEAU_10_COLOR_CYCLE
 from .utils.plot_types import ObservationPlotLocations
-from .utils.qt_creator import create_group_box, create_group_layout, create_side_panel
+from .utils.qt_creator import (
+    create_group_layout,
+    create_side_panel,
+)
+from .widgets.collapsible_section import CollapsibleSection
 from .widgets.data_type_keys_widget import DataTypeKeysWidget
 from .widgets.everest_control_selection_widget import EverestControlSelectionWidget
 from .widgets.plot_controls import (
@@ -281,13 +285,16 @@ class PlotWindow(QMainWindow):
                 self.update_plot
             )
 
-            self._everest_controls_group = create_group_box(
-                "Select control(s)",
+            self._everest_controls_group = CollapsibleSection(
+                "Select control(s):",
                 create_group_layout([self._everest_control_selection_widget]),
+                expanded=True,
             )
-            self._ensemble_group = create_group_box(
+
+            self._ensemble_group = CollapsibleSection(
                 "Select ensemble(s)",
                 create_group_layout([self._ensemble_selection_widget]),
+                expanded=True,
             )
 
             self._everest_controls_plot_options = EverestControlsPlotOptions(
@@ -314,6 +321,7 @@ class PlotWindow(QMainWindow):
                     self._statistics_options.get_widget(),
                 ]
             )
+            right_layout.addStretch(1)
             right_container.setLayout(right_layout)
 
             self._everest_controls_group.setVisible(False)
@@ -760,7 +768,7 @@ class PlotWindow(QMainWindow):
 
         max_selected = self._ensemble_selection_widget.get_maximum_ensemble_limit()
         str_num_of_ens = f" up to {max_selected}" if self.is_everest else ""
-        self._ensemble_group.setTitle(
+        self._ensemble_group.set_title(
             f"Select{str_num_of_ens} batches"
             if self.is_everest
             else f"Select up to {max_selected} ensembles"

--- a/src/ert/gui/plotting/utils/qt_creator.py
+++ b/src/ert/gui/plotting/utils/qt_creator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from logging import Logger
 
@@ -7,6 +9,7 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -23,6 +26,7 @@ def create_side_panel(title: str, widget: QWidget) -> QWidget:
     title_label = QLabel(title)
     title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
     title_label.setStyleSheet("padding-bottom: 7px;")
+    title_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
 
     layout.addWidget(title_label)
     layout.addWidget(widget)

--- a/src/ert/gui/plotting/widgets/collapsible_section.py
+++ b/src/ert/gui/plotting/widgets/collapsible_section.py
@@ -1,0 +1,53 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QSizePolicy,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class CollapsibleSection(QWidget):
+    def __init__(
+        self, title: str, content_layout: QVBoxLayout, *, expanded: bool = False
+    ) -> None:
+        super().__init__()
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
+
+        self._toggle_button = QToolButton()
+        self._toggle_button.setStyleSheet(
+            "QToolButton { border: none; text-align: left; padding: 4px 2px;"
+            " font-style: italic; }"
+            "QToolButton:hover { background-color: rgba(128, 128, 128, 40); }"
+        )
+        self._toggle_button.setToolButtonStyle(
+            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self._toggle_button.setText(title)
+        self._toggle_button.setCheckable(True)
+        self._toggle_button.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        self._toggle_button.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        self._content_widget = QWidget()
+        self._content_widget.setLayout(content_layout)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setSpacing(0)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(self._toggle_button)
+        main_layout.addWidget(self._content_widget)
+
+        self._toggle_button.toggled.connect(self._on_toggled)
+        self._toggle_button.setChecked(expanded)
+        self._on_toggled(expanded)
+
+    def _on_toggled(self, checked: bool) -> None:
+        self._toggle_button.setArrowType(
+            Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow
+        )
+        self._content_widget.setVisible(checked)
+
+    def set_title(self, title: str) -> None:
+        self._toggle_button.setText(title)

--- a/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
@@ -1,15 +1,11 @@
 import logging
 from collections.abc import Callable
 
-from PyQt6.QtWidgets import (
-    QGroupBox,
-)
-
 from ert.gui.plotting.utils.qt_creator import (
     create_checkbox_with_tooltip,
-    create_group_box,
     create_group_layout,
 )
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +30,7 @@ class BoxplotOptions:
             ]
         ]
 
-        self._boxplot_options = create_group_box(
+        self._boxplot_options = CollapsibleSection(
             "Boxplot options",
             create_group_layout(
                 [
@@ -78,5 +74,5 @@ class BoxplotOptions:
     def box_checkbox_state(self, value: bool) -> None:
         self._toggle_box.setChecked(value)
 
-    def get_widget(self) -> QGroupBox:
+    def get_widget(self) -> CollapsibleSection:
         return self._boxplot_options

--- a/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
@@ -3,12 +3,14 @@ from collections.abc import Callable
 
 from PyQt6.QtWidgets import (
     QButtonGroup,
-    QGroupBox,
     QRadioButton,
 )
 
 from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
-from ert.gui.plotting.utils.qt_creator import create_group_box, create_group_layout
+from ert.gui.plotting.utils.qt_creator import (
+    create_group_layout,
+)
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ class EverestControlsPlotOptions:
             logger,
             "X-axis display option",
         )
-        self._display_over_group = create_group_box(
+        self._display_over_group = CollapsibleSection(
             "X-axis:",
             create_group_layout(
                 [
@@ -40,7 +42,7 @@ class EverestControlsPlotOptions:
             ),
         )
 
-    def get_widget(self) -> QGroupBox:
+    def get_widget(self) -> CollapsibleSection:
         return self._display_over_group
 
     def is_batches_selected(self) -> bool:

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -5,7 +5,6 @@ from PyQt6.QtCore import QObject
 from PyQt6.QtCore import pyqtSignal as Signal
 from PyQt6.QtWidgets import (
     QDialog,
-    QGroupBox,
     QHBoxLayout,
     QInputDialog,
     QLabel,
@@ -16,9 +15,9 @@ from PyQt6.QtWidgets import (
 
 from ert.gui.plotting.utils.qt_creator import (
     create_checkbox_with_tooltip,
-    create_group_box,
     create_group_layout,
 )
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 
 from .observation_color import ObservationColorEdit
 from .plot_color_palette_selector import PlotColorPaletteSelector
@@ -108,13 +107,13 @@ class GeneralPlotOptions(QObject):
 
         widgets.extend([palette_container, edit_buttons])
 
-        self._general_options = create_group_box(
+        self._general_options = CollapsibleSection(
             "General options",
             create_group_layout(widgets),
         )
         self._general_options.setObjectName("general_options")
 
-    def get_widget(self) -> QGroupBox:
+    def get_widget(self) -> CollapsibleSection:
         return self._general_options
 
     def get_text_input(

--- a/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
@@ -4,11 +4,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from PyQt6.QtWidgets import QGroupBox
-
 from ert.gui.plotting.utils.qt_creator import (
     create_checkbox_with_tooltip,
-    create_group_box,
     create_group_layout,
     create_labeled_row,
     create_spinbox_with_tooltip,
@@ -17,6 +14,7 @@ from ert.gui.plotting.utils.statistics_style import (
     DEFAULT_ENABLED_STATISTICS,
     STATISTICS,
 )
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 
 if TYPE_CHECKING:
     from ert.gui.plotting.utils import PlotConfig
@@ -57,7 +55,7 @@ class StatisticsOptions:
             logger=logger,
         )
 
-        self._statistics_options = create_group_box(
+        self._statistics_options = CollapsibleSection(
             "Statistics options",
             create_group_layout(
                 [
@@ -82,5 +80,5 @@ class StatisticsOptions:
             if checkbox.isChecked()
         }
 
-    def get_widget(self) -> QGroupBox:
+    def get_widget(self) -> CollapsibleSection:
         return self._statistics_options

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDoubleSpinBox,
-    QGroupBox,
     QLabel,
     QMenuBar,
     QMessageBox,
@@ -45,6 +44,7 @@ from ert.gui.plotting.plot_window import (
     PlotWindow,
 )
 from ert.gui.plotting.widgets import DataTypeKeysWidget, EnsembleSelectListWidget
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 from ert.gui.tools.event_viewer import add_gui_log_handler
 from ert.gui.tools.manage_experiments import ManageExperimentsPanel
 from ert.gui.tools.manage_experiments.storage_widget import AddWidget, StorageWidget
@@ -311,7 +311,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
         case_selection = get_child(
             plot_window, EnsembleSelectListWidget, "ensemble_selector"
         )
-        general_options = get_child(plot_window, QGroupBox, "general_options")
+        general_options = get_child(plot_window, CollapsibleSection, "general_options")
         for checkbox_name in (
             "legend_checkbox",
             "grid_checkbox",

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
@@ -65,3 +65,10 @@ def test_that_toggling_a_boxplot_option_logs_sidebar_usage_once(
 
         checkbox.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+
+def test_that_boxplot_options_defaults_to_collapsed_state(qtbot):
+    options = BoxplotOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+
+    assert not options.get_widget()._toggle_button.isChecked()

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
@@ -1,8 +1,7 @@
 import logging
 from unittest.mock import Mock
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QRadioButton
+from PyQt6.QtWidgets import QRadioButton, QToolButton
 
 from ert.gui.plotting.widgets.plot_controls.everest_controls_plot_options import (
     EverestControlsPlotOptions,
@@ -29,7 +28,7 @@ def test_that_toggling_everest_controls_plot_options_invokes_the_connection_poin
 
     controls_radio = widget.findChild(QRadioButton, "display_over_controls_radio")
     assert controls_radio is not None
-    qtbot.mouseClick(controls_radio, Qt.MouseButton.LeftButton)
+    controls_radio.click()
 
     connection_point.assert_called()
 
@@ -39,6 +38,7 @@ def test_that_selecting_x_axis_display_option_logs_sidebar_usage_once(qtbot, cap
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
+    widget.findChild(QToolButton).setChecked(True)  # expand the section
 
     controls_radio = widget.findChild(QRadioButton, "display_over_controls_radio")
     batches_radio = widget.findChild(QRadioButton, "display_over_batches_radio")
@@ -47,8 +47,15 @@ def test_that_selecting_x_axis_display_option_logs_sidebar_usage_once(qtbot, cap
     expected_message = "Plot sidebar option used: 'X-axis display option'"
 
     with caplog.at_level(logging.INFO):
-        qtbot.mouseClick(controls_radio, Qt.MouseButton.LeftButton)
+        controls_radio.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
 
-        qtbot.mouseClick(batches_radio, Qt.MouseButton.LeftButton)
+        batches_radio.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
+
+
+def test_that_everest_controls_plot_options_defaults_to_collapsed_state(qtbot):
+    options = EverestControlsPlotOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+
+    assert not options.get_widget()._toggle_button.isChecked()

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -2,9 +2,10 @@ import logging
 from unittest.mock import Mock
 
 import pytest
-from PyQt6.QtWidgets import QCheckBox, QPushButton
+from PyQt6.QtWidgets import QCheckBox, QPushButton, QToolButton
 
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 from ert.gui.plotting.widgets.plot_controls.general_options import GeneralPlotOptions
 
 
@@ -17,6 +18,12 @@ def test_that_general_options_has_expected_default_checkbox_states(qtbot):
     assert options.history_checkbox_state is True
     assert options.observations_checkbox_state is True
     assert options.log_checkbox_state is False
+
+
+def _expand(section: CollapsibleSection) -> None:
+    button = section.findChild(QToolButton)
+    assert button is not None
+    button.setChecked(True)
 
 
 @pytest.mark.parametrize(
@@ -38,6 +45,7 @@ def test_that_toggling_a_general_option_invokes_the_connection_point(
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
+    _expand(widget)
 
     checkbox = widget.findChild(QCheckBox, checkbox_name)
     if checkbox_name == "log_scale_checkbox":
@@ -70,10 +78,11 @@ def test_that_toggling_a_general_option_logs_sidebar_usage_once(
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
+    _expand(widget)
 
     checkbox = widget.findChild(QCheckBox, checkbox_name)
     if checkbox_name == "log_scale_checkbox":
-        checkbox.setVisible(True)
+        options.set_log_visible(True)
     assert checkbox is not None
     assert checkbox.isVisible()
 
@@ -103,6 +112,7 @@ def test_that_axis_label_button_requests_edit_for_its_axis(
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
+    _expand(widget)
     button = widget.findChild(QPushButton, button_name)
     assert button is not None
 
@@ -118,6 +128,7 @@ def test_that_title_button_requests_title_edit(qtbot) -> None:
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
+    _expand(widget)
     button = widget.findChild(QPushButton, "change_title_button")
     assert button is not None
 
@@ -145,6 +156,7 @@ def test_that_history_and_observations_visibility_can_be_set(
     options = GeneralPlotOptions(Mock(), is_everest=False)
     qtbot.addWidget(options.get_widget())
     options.get_widget().show()
+    _expand(options.get_widget())
 
     options.set_history_visible(history_visible)
     options.set_observations_visible(observations_visible)
@@ -156,7 +168,7 @@ def test_that_history_and_observations_visibility_can_be_set(
 def test_that_everest_general_options_omit_history_and_observations(qtbot):
     options = GeneralPlotOptions(Mock(), is_everest=True)
     qtbot.addWidget(options.get_widget())
-
+    _expand(options.get_widget())
     assert not options._toggle_history.isVisible()
     assert not options._toggle_observations.isVisible()
 

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_window.py
@@ -7,7 +7,14 @@ import pytest
 from matplotlib.backend_bases import Event, MouseEvent
 from matplotlib.figure import Figure
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel, QPushButton, QToolTip
+from PyQt6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QToolTip,
+)
 from pytestqt.qtbot import QtBot
 
 from ert.config.breakthrough_config import BreakthroughConfig
@@ -32,6 +39,7 @@ from ert.gui.plotting.utils.plot_maps import (
     STATISTICS,
 )
 from ert.gui.plotting.widgets import DataTypeKeysWidget
+from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 from ert.gui.plotting.widgets.plot_widget import PlotWidget
 from ert.services import ErtServerController
 
@@ -272,6 +280,8 @@ def test_that_plotting_gen_kw_parameter_with_negative_values_hides_log_scale_che
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
 
     plot_widget = plot_window._central_tab.currentWidget()
     assert plot_widget is not None
@@ -358,7 +368,8 @@ def test_that_history_and_observations_checkboxes_match_data_availability(
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
-
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
     history_checkbox = plot_window.findChild(QCheckBox, name="history_checkbox")
     assert history_checkbox is not None
     is_history_key = key.endswith("H") or "H:" in key
@@ -415,7 +426,8 @@ def test_that_history_and_observations_checkbox_state_update_when_switching_keys
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
-
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
     history_checkbox = plot_window.findChild(QCheckBox, name="history_checkbox")
     observations_checkbox = plot_window.findChild(
         QCheckBox, name="observations_checkbox"
@@ -508,6 +520,8 @@ def test_that_general_option_checkboxes_change_rendered_plot(
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
 
     statistics_index = next(
         index
@@ -648,6 +662,8 @@ def test_that_log_scale_state_is_preserved_when_switching_plot_tabs(
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
 
     tab_index_by_name = {
         plot_window._central_tab.tabText(index): index
@@ -841,6 +857,8 @@ def test_that_density_tabs_show_log_scale_only_for_valid_gen_kw_values(
     plot_window = PlotWindow(config_file="", ens_path=Path(), parent=None)
     qtbot.addWidget(plot_window)
     plot_window.show()
+    general_options = plot_window._general_options.get_widget()
+    _expand(general_options)
 
     tab_index = next(
         index
@@ -1144,6 +1162,12 @@ def _create_plot_window_for_text_edit(
         return_value=MagicMock(key="some_key", dimensionality=1, metadata={})
     )
     return plot_window
+
+
+def _expand(section: CollapsibleSection) -> None:
+    button = section.findChild(QToolButton)
+    assert button is not None
+    button.setChecked(True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Generalized collapsible widget, allow users to collapse section that can include one or multiple widgets

Only applied to Plot controls initially

Defaults to closed, such that can set higher importance widgets to expanded by default, e.g everest controls
or ensemble selection


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
