### PR TITLE
Add options for statistics to sidebar

### DIFF
--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -58,13 +58,13 @@ from .utils.observation_locations import transform_observation_locations
 from .utils.plot_color_palettes import TABLEAU_10_COLOR_CYCLE
 from .utils.plot_types import ObservationPlotLocations
 from .utils.qt_creator import create_group_box, create_group_layout, create_side_panel
-from .utils.statistics_style import DEFAULT_ENABLED_STATISTICS
 from .widgets.data_type_keys_widget import DataTypeKeysWidget
 from .widgets.everest_control_selection_widget import EverestControlSelectionWidget
 from .widgets.plot_controls import (
     BoxplotOptions,
     EverestControlsPlotOptions,
     GeneralPlotOptions,
+    StatisticsOptions,
 )
 from .widgets.plot_ensemble_selection_widget import EnsembleSelectionWidget
 from .widgets.plot_widget import Plotter, PlotWidget
@@ -301,6 +301,7 @@ class PlotWindow(QMainWindow):
             self._general_options.axisLabelEditRequested.connect(self._edit_axis_label)
             self._general_options.titleEditRequested.connect(self._edit_title)
             self._boxplot_options = BoxplotOptions(self.update_plot)
+            self._statistics_options = StatisticsOptions(self.update_plot)
 
             right_container = QWidget()
             right_layout = create_group_layout(
@@ -310,6 +311,7 @@ class PlotWindow(QMainWindow):
                     self._everest_controls_plot_options.get_widget(),
                     self._everest_controls_group,
                     self._boxplot_options.get_widget(),
+                    self._statistics_options.get_widget(),
                 ]
             )
             right_container.setLayout(right_layout)
@@ -317,6 +319,7 @@ class PlotWindow(QMainWindow):
             self._everest_controls_group.setVisible(False)
             self._everest_controls_plot_options.get_widget().setVisible(False)
             self._boxplot_options.get_widget().setVisible(False)
+            self._statistics_options.get_widget().setVisible(False)
             self._data_type_keys_widget.selectDefault()
 
             splitter = QSplitter(Qt.Orientation.Horizontal)
@@ -384,6 +387,7 @@ class PlotWindow(QMainWindow):
         self._boxplot_options.get_widget().setVisible(
             plot_widget.name in {MISFITS, CROSS_ENSEMBLE_STATISTICS}
         )
+        self._statistics_options.get_widget().setVisible(plot_widget.name == STATISTICS)
         self._general_options.get_widget().setVisible(plot_widget.name != STD_DEV)
 
         is_gradient_plot = plot_widget.name == EVEREST_GRADIENTS_PLOT
@@ -540,9 +544,7 @@ class PlotWindow(QMainWindow):
 
             plot_config = PlotConfig(title=key_def.key)
             if selected_tab == STATISTICS:
-                plot_config.set_statistics_options(
-                    DEFAULT_ENABLED_STATISTICS, fill_bands=False
-                )
+                self._statistics_options.apply_to(plot_config)
             plot_config.set_title(self._titles.get(key_def.key, key_def.key))
             plot_config.set_x_label(self._x_labels.get(key_def.key))
             plot_config.set_y_label(self._y_labels.get(key_def.key))

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -58,6 +58,7 @@ from .utils.observation_locations import transform_observation_locations
 from .utils.plot_color_palettes import TABLEAU_10_COLOR_CYCLE
 from .utils.plot_types import ObservationPlotLocations
 from .utils.qt_creator import create_group_box, create_group_layout, create_side_panel
+from .utils.statistics_style import DEFAULT_ENABLED_STATISTICS
 from .widgets.data_type_keys_widget import DataTypeKeysWidget
 from .widgets.everest_control_selection_widget import EverestControlSelectionWidget
 from .widgets.plot_controls import (
@@ -539,8 +540,8 @@ class PlotWindow(QMainWindow):
 
             plot_config = PlotConfig(title=key_def.key)
             if selected_tab == STATISTICS:
-                plot_config.set_statistics_styles_for_dimensionality(
-                    key_def.dimensionality
+                plot_config.set_statistics_options(
+                    DEFAULT_ENABLED_STATISTICS, fill_bands=False
                 )
             plot_config.set_title(self._titles.get(key_def.key, key_def.key))
             plot_config.set_x_label(self._x_labels.get(key_def.key))

--- a/src/ert/gui/plotting/utils/plot_config.py
+++ b/src/ert/gui/plotting/utils/plot_config.py
@@ -5,6 +5,10 @@ from typing import Any
 
 from .plot_color_palettes import TABLEAU_10_COLOR_CYCLE
 from .plot_style import PlotStyle
+from .statistics_style import (
+    BAND_AREA_STYLE,
+    STATISTICS,
+)
 
 
 class PlotConfig:
@@ -63,12 +67,8 @@ class PlotConfig:
         self._grid_enabled = True
 
         self._statistics_style = {
-            "mean": PlotStyle("Mean", line_style=""),
-            "p50": PlotStyle("P50", line_style=""),
-            "min-max": PlotStyle("Min/Max", line_style=""),
-            "p10-p90": PlotStyle("P10-P90", line_style=""),
-            "p33-p67": PlotStyle("P33-P67", line_style=""),
-            "std": PlotStyle("Std dev", line_style=""),
+            statistic: PlotStyle(style.label, line_style="")
+            for statistic, style in STATISTICS.items()
         }
 
         self._std_dev_factor = 1  # sigma 1 is default std dev
@@ -76,26 +76,19 @@ class PlotConfig:
         self.flip_response_axis = False
         self.flip_observation_axis = False
 
-    def set_statistics_styles_for_dimensionality(self, dimensionality: int) -> None:
-        mean_style = self._statistics_style["mean"]
-        p10p90_style = self._statistics_style["p10-p90"]
-        std_style = self._statistics_style["std"]
-
-        mean_style.line_style = ""
-        mean_style.marker = ""
-        p10p90_style.line_style = ""
-        p10p90_style.marker = ""
-        std_style.line_style = ""
-        std_style.marker = ""
-
-        if dimensionality == 2:
-            mean_style.line_style = "-"
-            p10p90_style.line_style = "--"
-        elif dimensionality == 1:
-            mean_style.line_style = "-"
-            mean_style.marker = "o"
-            std_style.line_style = "--"
-            std_style.marker = "D"
+    def set_statistics_options(
+        self,
+        enabled_statistics: set[str],
+        *,
+        fill_bands: bool,
+    ) -> None:
+        for statistic, style in self._statistics_style.items():
+            if statistic not in enabled_statistics:
+                style.line_style = ""
+            elif fill_bands and STATISTICS[statistic].is_band:
+                style.line_style = BAND_AREA_STYLE
+            else:
+                style.line_style = STATISTICS[statistic].line_style
 
     def get_number_of_colors(self) -> int:
         return len(self._line_color_cycle_colors)

--- a/src/ert/gui/plotting/utils/qt_creator.py
+++ b/src/ert/gui/plotting/utils/qt_creator.py
@@ -5,7 +5,9 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QCheckBox,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -57,3 +59,33 @@ def create_checkbox_with_tooltip(
     checkbox.stateChanged.connect(connection_point)
     log_plot_option_usage_once(checkbox.clicked, logger, name)
     return checkbox
+
+
+def create_spinbox_with_tooltip(
+    name: str,
+    tooltip: str,
+    connection_point: Callable[..., object],
+    *,
+    minimum: int,
+    maximum: int,
+    initial_value: int,
+    logger: Logger,
+) -> QSpinBox:
+    spinbox = QSpinBox()
+    spinbox.setObjectName(f"{name.lower().replace(' ', '_')}_spinbox")
+    spinbox.setToolTip(tooltip)
+    spinbox.setRange(minimum, maximum)
+    spinbox.setValue(initial_value)
+    spinbox.valueChanged.connect(connection_point)
+    log_plot_option_usage_once(spinbox.valueChanged, logger, name)
+    return spinbox
+
+
+def create_labeled_row(label: str, widget: QWidget) -> QWidget:
+    row = QWidget()
+    layout = QHBoxLayout(row)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(QLabel(label))
+    layout.addWidget(widget)
+    layout.addStretch()
+    return row

--- a/src/ert/gui/plotting/utils/statistics_style.py
+++ b/src/ert/gui/plotting/utils/statistics_style.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class StatisticStyle(NamedTuple):
+    label: str
+    line_style: str
+    is_band: bool
+
+
+STATISTICS = {
+    "mean": StatisticStyle("Mean", "-", is_band=False),
+    "p50": StatisticStyle("P50", "--", is_band=False),
+    "std": StatisticStyle("Std dev", ":", is_band=True),
+    "min-max": StatisticStyle("Min/Max", ":", is_band=True),
+    "p10-p90": StatisticStyle("P10-P90", "--", is_band=True),
+    "p33-p67": StatisticStyle("P33-P67", "-.", is_band=True),
+}
+
+BAND_AREA_STYLE = "#"
+
+DEFAULT_ENABLED_STATISTICS = {"mean", "p10-p90"}

--- a/src/ert/gui/plotting/widgets/plot_controls/__init__.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/__init__.py
@@ -3,6 +3,7 @@ from .custom_palette_dialog import CustomPaletteDialog
 from .everest_controls_plot_options import EverestControlsPlotOptions
 from .general_options import GeneralPlotOptions
 from .plot_color_palette_selector import PlotColorPaletteSelector
+from .statistics_options import StatisticsOptions
 
 __all__ = [
     "BoxplotOptions",
@@ -10,4 +11,5 @@ __all__ = [
     "EverestControlsPlotOptions",
     "GeneralPlotOptions",
     "PlotColorPaletteSelector",
+    "StatisticsOptions",
 ]

--- a/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from PyQt6.QtWidgets import QGroupBox
+
+from ert.gui.plotting.utils.qt_creator import (
+    create_checkbox_with_tooltip,
+    create_group_box,
+    create_group_layout,
+    create_labeled_row,
+    create_spinbox_with_tooltip,
+)
+from ert.gui.plotting.utils.statistics_style import (
+    DEFAULT_ENABLED_STATISTICS,
+    STATISTICS,
+)
+
+if TYPE_CHECKING:
+    from ert.gui.plotting.utils import PlotConfig
+
+logger = logging.getLogger(__name__)
+
+
+class StatisticsOptions:
+    """Owns the statistics selection, which persists across keys."""
+
+    def __init__(self, connection_point: Callable[..., object]) -> None:
+        self._toggles = {
+            statistic: create_checkbox_with_tooltip(
+                style.label,
+                f"Show or hide the {style.label} "
+                + ("band" if style.is_band else "line"),
+                connection_point,
+                initial_checked=statistic in DEFAULT_ENABLED_STATISTICS,
+                logger=logger,
+            )
+            for statistic, style in STATISTICS.items()
+        }
+        self._area_toggle = create_checkbox_with_tooltip(
+            "Area",
+            "Draw the standard deviation, min/max and percentile ranges as a "
+            "filled area instead of a pair of lines",
+            connection_point,
+            initial_checked=False,
+            logger=logger,
+        )
+        self._std_dev_factor = create_spinbox_with_tooltip(
+            "Std dev multiplier",
+            "Choose the number of standard deviations to plot",
+            connection_point,
+            minimum=1,
+            maximum=3,
+            initial_value=1,
+            logger=logger,
+        )
+
+        self._statistics_options = create_group_box(
+            "Statistics options",
+            create_group_layout(
+                [
+                    *self._toggles.values(),
+                    self._area_toggle,
+                    create_labeled_row("Std dev multiplier", self._std_dev_factor),
+                ]
+            ),
+        )
+
+    def apply_to(self, plot_config: PlotConfig) -> None:
+        plot_config.set_standard_deviation_factor(self._std_dev_factor.value())
+        plot_config.set_statistics_options(
+            self._enabled_statistics(),
+            fill_bands=self._area_toggle.isChecked(),
+        )
+
+    def _enabled_statistics(self) -> set[str]:
+        return {
+            statistic
+            for statistic, checkbox in self._toggles.items()
+            if checkbox.isChecked()
+        }
+
+    def get_widget(self) -> QGroupBox:
+        return self._statistics_options

--- a/tests/ert/unit_tests/gui/plottery/test_plot_style.py
+++ b/tests/ert/unit_tests/gui/plottery/test_plot_style.py
@@ -1,7 +1,10 @@
 import math
 
+import pytest
+
 from ert.gui.plotting.utils import PlotConfig, PlotStyle
 from ert.gui.plotting.utils.plot_tools import ConditionalAxisFormatter
+from ert.gui.plotting.utils.statistics_style import STATISTICS
 
 
 def test_conditional_axis_formatter():
@@ -205,39 +208,39 @@ def test_plot_config():
     ) != copy_of_plot_config.get_statistics_style("std")
 
 
-def test_that_two_dimensional_keys_draw_mean_and_p10_p90_as_lines():
+def test_that_an_enabled_statistic_gets_its_configured_line_style():
     plot_config = PlotConfig()
-    plot_config.set_statistics_styles_for_dimensionality(1)
 
-    plot_config.set_statistics_styles_for_dimensionality(2)
+    plot_config.set_statistics_options({"mean", "p10-p90"}, fill_bands=False)
+
+    assert plot_config.get_statistics_style("mean").line_style == "-"
+    assert plot_config.get_statistics_style("p10-p90").line_style == "--"
+
+
+def test_that_a_deselected_statistic_has_neither_line_style_nor_marker():
+    plot_config = PlotConfig()
+
+    plot_config.set_statistics_options(set(), fill_bands=False)
 
     mean_style = plot_config.get_statistics_style("mean")
-    assert mean_style.line_style == "-"
+    assert not mean_style.line_style
     assert not mean_style.marker
-
-    p10p90_style = plot_config.get_statistics_style("p10-p90")
-    assert p10p90_style.line_style == "--"
-    assert not p10p90_style.marker
-
-    std_style = plot_config.get_statistics_style("std")
-    assert not std_style.line_style
-    assert not std_style.marker
+    assert not mean_style.is_visible()
 
 
-def test_that_one_dimensional_keys_draw_mean_and_std_with_markers():
+def test_that_filling_bands_draws_selected_band_statistics_as_areas():
     plot_config = PlotConfig()
-    plot_config.set_statistics_styles_for_dimensionality(2)
 
-    plot_config.set_statistics_styles_for_dimensionality(1)
+    plot_config.set_statistics_options({"mean", "p33-p67"}, fill_bands=True)
 
-    mean_style = plot_config.get_statistics_style("mean")
-    assert mean_style.line_style == "-"
-    assert mean_style.marker == "o"
+    assert plot_config.get_statistics_style("p33-p67").line_style == "#"
+    assert plot_config.get_statistics_style("mean").line_style == "-"
 
-    std_style = plot_config.get_statistics_style("std")
-    assert std_style.line_style == "--"
-    assert std_style.marker == "D"
 
-    p10p90_style = plot_config.get_statistics_style("p10-p90")
-    assert not p10p90_style.line_style
-    assert not p10p90_style.marker
+@pytest.mark.parametrize("statistic", sorted(STATISTICS))
+def test_that_every_statistic_is_visible_when_enabled(statistic):
+    plot_config = PlotConfig()
+
+    plot_config.set_statistics_options({statistic}, fill_bands=False)
+
+    assert plot_config.get_statistics_style(statistic).is_visible()

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_statistics_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_statistics_options.py
@@ -1,0 +1,81 @@
+from unittest.mock import Mock
+
+from ert.gui.plotting.utils import PlotConfig
+from ert.gui.plotting.utils.statistics_style import STATISTICS
+from ert.gui.plotting.widgets.plot_controls.statistics_options import StatisticsOptions
+
+
+def test_that_statistics_options_have_expected_default_toggle_states(qtbot):
+    options = StatisticsOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+
+    checked = {
+        statistic
+        for statistic, checkbox in options._toggles.items()
+        if checkbox.isChecked()
+    }
+
+    assert checked == {"mean", "p10-p90"}
+    assert not options._area_toggle.isChecked()
+    assert options._std_dev_factor.value() == 1
+
+
+def test_that_unchecked_statistics_are_hidden_in_the_plot_config(qtbot):
+    options = StatisticsOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+    plot_config = PlotConfig()
+
+    options.apply_to(plot_config)
+
+    for statistic in STATISTICS:
+        style = plot_config.get_statistics_style(statistic)
+        if statistic in {"mean", "p10-p90"}:
+            assert style.is_visible()
+        else:
+            assert not style.is_visible()
+
+
+def test_that_enabling_area_switches_band_statistics_to_a_filled_style(qtbot):
+    options = StatisticsOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+
+    line_config = PlotConfig()
+    options.apply_to(line_config)
+    assert line_config.get_statistics_style("p10-p90").line_style == "--"
+
+    options._area_toggle.setChecked(True)
+    area_config = PlotConfig()
+    options.apply_to(area_config)
+    assert area_config.get_statistics_style("p10-p90").line_style == "#"
+
+
+def test_that_the_std_dev_multiplier_is_applied_to_the_plot_config(qtbot):
+    options = StatisticsOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+    options._std_dev_factor.setValue(3)
+    plot_config = PlotConfig()
+
+    options.apply_to(plot_config)
+
+    assert plot_config.get_standard_deviation_factor() == 3
+
+
+def test_that_toggling_a_statistic_invokes_the_connection_point(qtbot):
+    connection_point = Mock()
+    options = StatisticsOptions(connection_point)
+    qtbot.addWidget(options.get_widget())
+
+    options._toggles["p50"].setChecked(True)
+
+    connection_point.assert_called()
+
+
+def test_that_applying_options_does_not_invoke_the_connection_point(qtbot):
+    connection_point = Mock()
+    options = StatisticsOptions(connection_point)
+    qtbot.addWidget(options.get_widget())
+    connection_point.reset_mock()
+
+    options.apply_to(PlotConfig())
+
+    connection_point.assert_not_called()


### PR DESCRIPTION
**Issue**
Resolves #14030 

**Approach**
Will add a simplified version of statistics controls to the sidebar, with toggles for different lines, e.g p50/p99. 

It also turns out that some of the complications around style defaults and dimensionality was not warranted because 1 dimensional style defaults were in effect never used in the repository. This is simplified in the PR by removing the dimensionality specific styling code. 

Visual changes

Added collapsible statistics panel:

<img width="1130" height="851" alt="image" src="https://github.com/user-attachments/assets/4e8c54fb-6d12-4a9c-b245-bfe8f3a41ef6" />


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
