### PR TITLE
Simplify application of plot control settings

### DIFF
--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -303,7 +303,6 @@ class PlotWindow(QMainWindow):
 
             self._general_options = GeneralPlotOptions(
                 connection_point=self.update_plot,
-                is_everest=self.is_everest,
             )
             self._general_options.axisLabelEditRequested.connect(self._edit_axis_label)
             self._general_options.titleEditRequested.connect(self._edit_title)

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -552,30 +552,10 @@ class PlotWindow(QMainWindow):
 
             plot_config = PlotConfig(title=key_def.key)
             if selected_tab == STATISTICS:
-                self._statistics_options.apply_to(plot_config)
+                self._statistics_options.update_plot_context(plot_config)
             plot_config.set_title(self._titles.get(key_def.key, key_def.key))
             plot_config.set_x_label(self._x_labels.get(key_def.key))
             plot_config.set_y_label(self._y_labels.get(key_def.key))
-            plot_config.set_legend_enabled(self._general_options.legend_checkbox_state)
-            plot_config.set_grid_enabled(self._general_options.grid_checkbox_state)
-            plot_config.set_line_color_cycle(self._general_options.get_color_cycle())
-
-            if not self.is_everest:
-                self._general_options.set_history_visible(history_data_available)
-                self._general_options.set_observations_visible(
-                    key_def.observations and selected_tab != MISFITS
-                )
-                plot_config.set_history_enabled(
-                    self._general_options.history_checkbox_state
-                    and history_data_available
-                )
-                plot_config.set_observations_enabled(
-                    self._general_options.observations_checkbox_state
-                    and key_def.observations
-                )
-                plot_config.set_observations_color(
-                    self._general_options.get_observations_color()
-                )
 
             plot_context = PlotContext(
                 plot_config,
@@ -584,26 +564,17 @@ class PlotWindow(QMainWindow):
                 key,
                 layer,
             )
-            plot_context.by_batch = (
-                self._everest_controls_plot_options.is_batches_selected()
+
+            self._general_options.update_plot_context(
+                plot_context,
+                history_data_available=history_data_available,
+                has_observations=key_def.observations,
+                show_observations=key_def.observations and selected_tab != MISFITS,
+                log_scale_available=log_scale_valid_values
+                and selected_tab in {HISTOGRAM, DISTRIBUTION, GAUSSIAN_KDE},
             )
-
-            plot_context.scatter_plot = self._boxplot_options.scatter_checkbox_state
-            plot_context.box_plot = self._boxplot_options.box_checkbox_state
-            plot_context.mean = self._boxplot_options.mean_checkbox_state
-            log_scale_available = log_scale_valid_values and selected_tab in {
-                HISTOGRAM,
-                DISTRIBUTION,
-                GAUSSIAN_KDE,
-            }
-
-            self._general_options.set_log_visible(log_scale_available)
-
-            plot_context.log_scale = (
-                self._general_options.log_checkbox_state and log_scale_available
-            )
-
-            plot_context.outliers = self._boxplot_options.outliers_checkbox_state
+            self._boxplot_options.update_plot_context(plot_context)
+            self._everest_controls_plot_options.update_plot_context(plot_context)
 
             # Check if key is a history key.
             # If it is, it already has the data it needs.

--- a/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable
 
+from ert.gui.plotting.utils import PlotContext
 from ert.gui.plotting.utils.qt_creator import (
     create_checkbox_with_tooltip,
     create_group_layout,
@@ -73,6 +74,12 @@ class BoxplotOptions:
     @box_checkbox_state.setter
     def box_checkbox_state(self, value: bool) -> None:
         self._toggle_box.setChecked(value)
+
+    def update_plot_context(self, plot_context: PlotContext) -> None:
+        plot_context.scatter_plot = self.scatter_checkbox_state
+        plot_context.box_plot = self.box_checkbox_state
+        plot_context.mean = self.mean_checkbox_state
+        plot_context.outliers = self.outliers_checkbox_state
 
     def get_widget(self) -> CollapsibleSection:
         return self._boxplot_options

--- a/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QRadioButton,
 )
 
+from ert.gui.plotting.utils import PlotContext
 from ert.gui.plotting.utils.logging_utils import log_plot_option_usage_once
 from ert.gui.plotting.utils.qt_creator import (
     create_group_layout,
@@ -44,6 +45,9 @@ class EverestControlsPlotOptions:
 
     def get_widget(self) -> CollapsibleSection:
         return self._display_over_group
+
+    def update_plot_context(self, plot_context: PlotContext) -> None:
+        plot_context.by_batch = self.is_batches_selected()
 
     def is_batches_selected(self) -> bool:
         return self._display_over_batches_radio.isChecked()

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ert.gui.plotting.utils import PlotContext
 from ert.gui.plotting.utils.qt_creator import (
     create_checkbox_with_tooltip,
     create_group_layout,
@@ -36,6 +37,8 @@ class GeneralPlotOptions(QObject):
         is_everest: bool,
     ) -> None:
         super().__init__()
+
+        self._is_everest = is_everest
 
         def create_edit_button(
             name: str,
@@ -155,20 +158,38 @@ class GeneralPlotOptions(QObject):
     def log_checkbox_state(self) -> bool:
         return self._toggle_log_scale.isChecked()
 
-    def set_log_visible(self, visible: bool) -> None:
-        self._toggle_log_scale.setVisible(visible)
+    def update_plot_context(
+        self,
+        plot_context: PlotContext,
+        *,
+        history_data_available: bool,
+        has_observations: bool,
+        show_observations: bool,
+        log_scale_available: bool,
+    ) -> None:
+        plot_config = plot_context.plotConfig()
+        plot_config.set_legend_enabled(self.legend_checkbox_state)
+        plot_config.set_grid_enabled(self.grid_checkbox_state)
+        plot_config.set_line_color_cycle(self.get_color_cycle())
 
-    def set_history_visible(self, visible: bool) -> None:
-        self._toggle_history.setVisible(visible)
+        self._toggle_log_scale.setVisible(log_scale_available)
+        plot_context.log_scale = self.log_checkbox_state and log_scale_available
 
-    def set_observations_visible(self, visible: bool) -> None:
-        self._toggle_observations.setVisible(visible)
+        if self._is_everest:
+            return
+
+        self._toggle_history.setVisible(history_data_available)
+        self._toggle_observations.setVisible(show_observations)
         self._observations_color_edit.setVisible(
-            visible and self._toggle_observations.isChecked()
+            show_observations and self.observations_checkbox_state
         )
-
-    def is_log_visible(self) -> bool:
-        return self._toggle_log_scale.isVisible()
+        plot_config.set_history_enabled(
+            self.history_checkbox_state and history_data_available
+        )
+        plot_config.set_observations_enabled(
+            self.observations_checkbox_state and has_observations
+        )
+        plot_config.set_observations_color(self.get_observations_color())
 
     def get_color_cycle(self) -> list[tuple[str, float]]:
         return self._color_cycle_selector.get_color_cycle()

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -19,6 +19,7 @@ from ert.gui.plotting.utils.qt_creator import (
     create_group_layout,
 )
 from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
+from ert.gui.utils import is_everest_application
 
 from .observation_color import ObservationColorEdit
 from .plot_color_palette_selector import PlotColorPaletteSelector
@@ -33,12 +34,10 @@ class GeneralPlotOptions(QObject):
     def __init__(
         self,
         connection_point: Callable[..., object],
-        *,
-        is_everest: bool,
     ) -> None:
         super().__init__()
 
-        self._is_everest = is_everest
+        self._is_everest = is_everest_application()
 
         def create_edit_button(
             name: str,
@@ -85,7 +84,7 @@ class GeneralPlotOptions(QObject):
             self._toggle_log_scale,
         ]
 
-        if not is_everest:
+        if not self._is_everest:
             self._observations_color_edit = ObservationColorEdit(
                 connection_point=connection_point,
                 observation_checkbox=self._toggle_observations,

--- a/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
@@ -66,7 +66,7 @@ class StatisticsOptions:
             ),
         )
 
-    def apply_to(self, plot_config: PlotConfig) -> None:
+    def update_plot_context(self, plot_config: PlotConfig) -> None:
         plot_config.set_standard_deviation_factor(self._std_dev_factor.value())
         plot_config.set_statistics_options(
             self._enabled_statistics(),

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
@@ -3,7 +3,23 @@ from unittest.mock import Mock
 
 import pytest
 
+from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.widgets.plot_controls.boxplot_options import BoxplotOptions
+
+
+def test_that_boxplot_checkbox_states_are_written_to_the_plot_context(qtbot):
+    options = BoxplotOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+    options.scatter_checkbox_state = True
+    options.box_checkbox_state = False
+    plot_context = PlotContext(PlotConfig(), [], [], "some_key")
+
+    options.update_plot_context(plot_context)
+
+    assert plot_context.scatter_plot is True
+    assert plot_context.box_plot is False
+    assert plot_context.mean is True
+    assert plot_context.outliers is True
 
 
 def test_that_boxplot_options_has_expected_default_checkbox_states(qtbot):

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from PyQt6.QtWidgets import QRadioButton, QToolButton
 
+from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.widgets.plot_controls.everest_controls_plot_options import (
     EverestControlsPlotOptions,
 )
@@ -15,6 +16,17 @@ def test_that_everest_controls_plot_options_initializes_with_expected_default_st
     qtbot.addWidget(options.get_widget())
 
     assert options.is_batches_selected() is True
+
+
+def test_that_the_selected_x_axis_is_written_to_the_plot_context(qtbot):
+    options = EverestControlsPlotOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+    options._display_over_controls_radio.setChecked(True)
+    plot_context = PlotContext(PlotConfig(), [], [], "some_key")
+
+    options.update_plot_context(plot_context)
+
+    assert plot_context.by_batch is False
 
 
 def test_that_toggling_everest_controls_plot_options_invokes_the_connection_point(

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -4,9 +4,32 @@ from unittest.mock import Mock
 import pytest
 from PyQt6.QtWidgets import QCheckBox, QPushButton, QToolButton
 
+from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
 from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 from ert.gui.plotting.widgets.plot_controls.general_options import GeneralPlotOptions
+
+
+def _create_plot_context() -> PlotContext:
+    return PlotContext(PlotConfig(), [], [], "some_key")
+
+
+def _apply_options_to_plot_context(
+    options: GeneralPlotOptions,
+    plot_context: PlotContext,
+    *,
+    history_data_available: bool = False,
+    has_observations: bool = False,
+    show_observations: bool = False,
+    log_scale_available: bool = False,
+) -> None:
+    options.update_plot_context(
+        plot_context,
+        history_data_available=history_data_available,
+        has_observations=has_observations,
+        show_observations=show_observations,
+        log_scale_available=log_scale_available,
+    )
 
 
 def test_that_general_options_has_expected_default_checkbox_states(qtbot):
@@ -82,7 +105,7 @@ def test_that_toggling_a_general_option_logs_sidebar_usage_once(
 
     checkbox = widget.findChild(QCheckBox, checkbox_name)
     if checkbox_name == "log_scale_checkbox":
-        options.set_log_visible(True)
+        checkbox.setVisible(True)
     assert checkbox is not None
     assert checkbox.isVisible()
 
@@ -158,8 +181,13 @@ def test_that_history_and_observations_visibility_can_be_set(
     options.get_widget().show()
     _expand(options.get_widget())
 
-    options.set_history_visible(history_visible)
-    options.set_observations_visible(observations_visible)
+    _apply_options_to_plot_context(
+        options,
+        _create_plot_context(),
+        history_data_available=history_visible,
+        has_observations=observations_visible,
+        show_observations=observations_visible,
+    )
 
     assert options._toggle_history.isVisible() is history_visible
     assert options._toggle_observations.isVisible() is observations_visible
@@ -171,6 +199,83 @@ def test_that_everest_general_options_omit_history_and_observations(qtbot):
     _expand(options.get_widget())
     assert not options._toggle_history.isVisible()
     assert not options._toggle_observations.isVisible()
+
+
+def test_that_legend_grid_and_color_cycle_are_written_to_the_plot_config(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+    options._toggle_grid.setChecked(False)
+    plot_context = _create_plot_context()
+
+    _apply_options_to_plot_context(options, plot_context)
+
+    plot_config = plot_context.plotConfig()
+    assert plot_config.is_legend_enabled()
+    assert not plot_config.is_grid_enabled()
+    assert plot_config.line_color_cycle() == options.get_color_cycle()
+
+
+@pytest.mark.parametrize(
+    ("log_scale_available", "expected_log_scale"),
+    [
+        pytest.param(True, True, id="tab-supports-log-scale"),
+        pytest.param(False, False, id="tab-does-not-support-log-scale"),
+    ],
+)
+def test_that_log_scale_is_applied_only_when_the_current_tab_supports_it(
+    qtbot, log_scale_available, expected_log_scale
+):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+    options._toggle_log_scale.setChecked(True)
+    plot_context = _create_plot_context()
+
+    _apply_options_to_plot_context(
+        options, plot_context, log_scale_available=log_scale_available
+    )
+
+    assert plot_context.log_scale is expected_log_scale
+
+
+def test_that_history_and_observations_stay_disabled_when_the_key_has_neither(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+    plot_context = _create_plot_context()
+
+    _apply_options_to_plot_context(options, plot_context)
+
+    assert not plot_context.plotConfig().is_history_enabled()
+    assert not plot_context.plotConfig().is_observations_enabled()
+
+
+def test_that_observations_stay_enabled_while_their_toggle_is_hidden(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=False)
+    qtbot.addWidget(options.get_widget())
+    options.get_widget().show()
+    plot_context = _create_plot_context()
+
+    _apply_options_to_plot_context(
+        options, plot_context, has_observations=True, show_observations=False
+    )
+
+    assert not options._toggle_observations.isVisible()
+    assert plot_context.plotConfig().is_observations_enabled()
+
+
+def test_that_everest_general_options_leave_history_and_observations_untouched(qtbot):
+    options = GeneralPlotOptions(Mock(), is_everest=True)
+    qtbot.addWidget(options.get_widget())
+    plot_context = _create_plot_context()
+    expected_observations_enabled = plot_context.plotConfig().is_observations_enabled()
+
+    _apply_options_to_plot_context(
+        options, plot_context, has_observations=True, show_observations=True
+    )
+
+    assert (
+        plot_context.plotConfig().is_observations_enabled()
+        is expected_observations_enabled
+    )
 
 
 def test_that_palette_selector_returns_the_correct_color_cycle(qtbot):

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -14,6 +14,14 @@ def _create_plot_context() -> PlotContext:
     return PlotContext(PlotConfig(), [], [], "some_key")
 
 
+@pytest.fixture
+def everest_application(monkeypatch):
+    monkeypatch.setattr(
+        "ert.gui.plotting.widgets.plot_controls.general_options.is_everest_application",
+        lambda: True,
+    )
+
+
 def _apply_options_to_plot_context(
     options: GeneralPlotOptions,
     plot_context: PlotContext,
@@ -33,7 +41,7 @@ def _apply_options_to_plot_context(
 
 
 def test_that_general_options_has_expected_default_checkbox_states(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
 
     assert options.legend_checkbox_state is True
@@ -64,7 +72,7 @@ def test_that_toggling_a_general_option_invokes_the_connection_point(
     checkbox_name,
 ) -> None:
     connection_point = Mock()
-    options = GeneralPlotOptions(connection_point, is_everest=False)
+    options = GeneralPlotOptions(connection_point)
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
@@ -97,7 +105,7 @@ def test_that_toggling_a_general_option_logs_sidebar_usage_once(
     checkbox_name,
     option_name,
 ) -> None:
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
@@ -131,7 +139,7 @@ def test_that_axis_label_button_requests_edit_for_its_axis(
     button_name,
     axis,
 ) -> None:
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
@@ -147,7 +155,7 @@ def test_that_axis_label_button_requests_edit_for_its_axis(
 
 
 def test_that_title_button_requests_title_edit(qtbot) -> None:
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     widget = options.get_widget()
     qtbot.addWidget(widget)
     widget.show()
@@ -176,7 +184,7 @@ def test_that_history_and_observations_visibility_can_be_set(
     history_visible,
     observations_visible,
 ):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     options.get_widget().show()
     _expand(options.get_widget())
@@ -193,8 +201,10 @@ def test_that_history_and_observations_visibility_can_be_set(
     assert options._toggle_observations.isVisible() is observations_visible
 
 
-def test_that_everest_general_options_omit_history_and_observations(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=True)
+def test_that_everest_general_options_omit_history_and_observations(
+    qtbot, everest_application
+):
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     _expand(options.get_widget())
     assert not options._toggle_history.isVisible()
@@ -202,7 +212,7 @@ def test_that_everest_general_options_omit_history_and_observations(qtbot):
 
 
 def test_that_legend_grid_and_color_cycle_are_written_to_the_plot_config(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     options._toggle_grid.setChecked(False)
     plot_context = _create_plot_context()
@@ -225,7 +235,7 @@ def test_that_legend_grid_and_color_cycle_are_written_to_the_plot_config(qtbot):
 def test_that_log_scale_is_applied_only_when_the_current_tab_supports_it(
     qtbot, log_scale_available, expected_log_scale
 ):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     options._toggle_log_scale.setChecked(True)
     plot_context = _create_plot_context()
@@ -238,7 +248,7 @@ def test_that_log_scale_is_applied_only_when_the_current_tab_supports_it(
 
 
 def test_that_history_and_observations_stay_disabled_when_the_key_has_neither(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     plot_context = _create_plot_context()
 
@@ -249,7 +259,7 @@ def test_that_history_and_observations_stay_disabled_when_the_key_has_neither(qt
 
 
 def test_that_observations_stay_enabled_while_their_toggle_is_hidden(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     options.get_widget().show()
     plot_context = _create_plot_context()
@@ -262,8 +272,10 @@ def test_that_observations_stay_enabled_while_their_toggle_is_hidden(qtbot):
     assert plot_context.plotConfig().is_observations_enabled()
 
 
-def test_that_everest_general_options_leave_history_and_observations_untouched(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=True)
+def test_that_everest_general_options_leave_history_and_observations_untouched(
+    qtbot, everest_application
+):
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
     plot_context = _create_plot_context()
     expected_observations_enabled = plot_context.plotConfig().is_observations_enabled()
@@ -279,7 +291,7 @@ def test_that_everest_general_options_leave_history_and_observations_untouched(q
 
 
 def test_that_palette_selector_returns_the_correct_color_cycle(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
 
     selector = options._color_cycle_selector
@@ -290,7 +302,7 @@ def test_that_palette_selector_returns_the_correct_color_cycle(qtbot):
 
 
 def test_that_palette_selector_child_can_be_found(qtbot):
-    options = GeneralPlotOptions(Mock(), is_everest=False)
+    options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
 
     selector = options.get_widget().findChild(

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_statistics_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_statistics_options.py
@@ -25,7 +25,7 @@ def test_that_unchecked_statistics_are_hidden_in_the_plot_config(qtbot):
     qtbot.addWidget(options.get_widget())
     plot_config = PlotConfig()
 
-    options.apply_to(plot_config)
+    options.update_plot_context(plot_config)
 
     for statistic in STATISTICS:
         style = plot_config.get_statistics_style(statistic)
@@ -40,12 +40,12 @@ def test_that_enabling_area_switches_band_statistics_to_a_filled_style(qtbot):
     qtbot.addWidget(options.get_widget())
 
     line_config = PlotConfig()
-    options.apply_to(line_config)
+    options.update_plot_context(line_config)
     assert line_config.get_statistics_style("p10-p90").line_style == "--"
 
     options._area_toggle.setChecked(True)
     area_config = PlotConfig()
-    options.apply_to(area_config)
+    options.update_plot_context(area_config)
     assert area_config.get_statistics_style("p10-p90").line_style == "#"
 
 
@@ -55,7 +55,7 @@ def test_that_the_std_dev_multiplier_is_applied_to_the_plot_config(qtbot):
     options._std_dev_factor.setValue(3)
     plot_config = PlotConfig()
 
-    options.apply_to(plot_config)
+    options.update_plot_context(plot_config)
 
     assert plot_config.get_standard_deviation_factor() == 3
 
@@ -76,6 +76,6 @@ def test_that_applying_options_does_not_invoke_the_connection_point(qtbot):
     qtbot.addWidget(options.get_widget())
     connection_point.reset_mock()
 
-    options.apply_to(PlotConfig())
+    options.update_plot_context(PlotConfig())
 
     connection_point.assert_not_called()


### PR DESCRIPTION
Updating a plot meant reading five widgets from plot_window and deciding, for each one, what its state should mean for the plot config and context. 

**Issue**
Resolves  #14047

**Approach**
Give each control an apply_to method that writes its own state, and let general options record what the current key and tab support through update_availability instead of being told what to hide.

- [X] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [X] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
