### PR TITLE
Replace failing test_invalid_subconfig subtest

### DIFF
--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -136,10 +136,6 @@ def test_extra_key(min_config):
             "unknown job not_a_job",
         ),
         (
-            {"environment": {"simulation_folder": "/usr/bin/unwriteable"}},
-            "User does not have write access to",
-        ),
-        (
             {"environment": {"output_folder": ("super long path" * 300)}},
             "output_folder\n.* File name too long",
         ),
@@ -166,6 +162,28 @@ def test_invalid_subconfig(extra_config, min_config, expected):
         min_config[k] = v
     with pytest.raises(ValidationError, match=expected):
         EverestConfig(**min_config)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "behavior must be looked at. Current code requires all directories on path"
+        "to be unwritable to raise validation error."
+    )
+)
+def test_that_simulation_folder_without_write_access_raises_validation_error(
+    min_config, tmp_path
+):
+    unwritable = tmp_path / "unwritable"
+    unwritable.mkdir()
+    original_mode = unwritable.stat().st_mode
+    unwritable.chmod(0o555)
+
+    try:
+        min_config["environment"] = {"simulation_folder": str(unwritable)}
+        with pytest.raises(ValidationError, match="User does not have write access to"):
+            EverestConfig(**min_config)
+    finally:
+        unwritable.chmod(original_mode)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`test_invalid_subconfig` began failing due to changes in the environment.

Test happened to verify that a validation error is thrown when all directories on the path are unwritable.
1. this is difficult to reproduce in controlled test setup.
2. intuitively one would expect that it is enough for provided directory to be writable, yet check is implemented to verify all directories along the path. Reason for this is unclear.
3. it is unclear if test on purpose used a path with all directories unwritable  or if it was an accident.

As expected behavior is unknown, create a x-failing replacement test for behavior to be verified in the future.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
