### PR TITLE
Fix default color-dialog alpha on macOS

### DIFF
--- a/src/ert/gui/plotting/widgets/plot_controls/color_chooser.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/color_chooser.py
@@ -32,10 +32,11 @@ class ColorBox(QFrame):
 
     @Slot()
     def show_color_dialog(self) -> None:
-        color_dialog = QColorDialog(self._color, self)
+        color_dialog = QColorDialog(self)
         color_dialog.setWindowTitle("Select color")
         color_dialog.setOption(QColorDialog.ColorDialogOption.ShowAlphaChannel)
         color_dialog.setOption(QColorDialog.ColorDialogOption.DontUseNativeDialog)
+        color_dialog.setCurrentColor(self._color)
         color_dialog.accepted.connect(
             lambda: self.colorChanged.emit(color_dialog.selectedColor())
         )


### PR DESCRIPTION
**Issue**
Resolves #14041

**Approach**
The bug occurred because the initial color was passed to QColorDialog before enabling DontUseNativeDialog. On macOS, switching to the non-native dialog afterward reset the alpha channel to 0.

The fix configures the dialog as non-native first and then calls setCurrentColor(). This initializes the final dialog implementation with the complete color, including its existing alpha value, so selecting a new color no longer makes it transparent.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
