### PR TITLE
Include ERT PR title in ert-testdata PR titles

### DIFF
--- a/.github/workflows/push_screenshots.yml
+++ b/.github/workflows/push_screenshots.yml
@@ -35,6 +35,16 @@ jobs:
         echo "pr_number=$(jq -r '.pr_number' artifact/metadata.json)" >> "$GITHUB_OUTPUT"
         echo "outcome=$(jq -r '.outcome' artifact/metadata.json)" >> "$GITHUB_OUTPUT"
 
+    - name: Get ert PR title
+      if: steps.metadata.outputs.outcome == 'failure' && steps.metadata.outputs.pr_number != '0'
+      id: ert-pr-title
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+      run: |
+        ERT_PR_TITLE=$(gh pr view "${PR_NUMBER}" --repo equinor/ert --json title --jq '.title')
+        echo "ert_pr_title=${ERT_PR_TITLE}" >> "$GITHUB_OUTPUT"
+
     - name: Checkout ert-testdata
       if: steps.metadata.outputs.outcome == 'failure'
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -53,6 +63,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.ERTOMATIC_ERT_TESTDATA_TOKEN }}
         PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+        ERT_PR_TITLE: ${{ steps.ert-pr-title.outputs.ert_pr_title }}
       run: |
         BRANCH="update-screenshots-ert-pr-${PR_NUMBER}"
         cd ert-testdata
@@ -74,7 +85,7 @@ jobs:
             --repo equinor/ert-testdata \
             --base main \
             --head "$BRANCH" \
-            --title "Update screenshots for equinor/ert#${PR_NUMBER}" \
+            --title "Update screenshots for ${ERT_PR_TITLE} (equinor/ert#${PR_NUMBER})" \
             --body "Automatically updated screenshot baselines triggered by https://github.com/equinor/ert/pull/${PR_NUMBER}")
           if [ "${PR_NUMBER}" != "0" ]; then
             gh pr comment "${PR_NUMBER}" \


### PR DESCRIPTION
This should make the PR list in ert-testdata more readable

**Issue**
Resolves hard-to-read https://github.com/equinor/ert-testdata/pulls

**Approach**
Include ERT PR title

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
