### PR TITLE
Fix check_writeable_path to validate the target folder itself

### DIFF
--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -306,9 +306,8 @@ def check_writeable_path(path_source: str, config_path: Path) -> None:
     path = as_abs_path(path_source, str(config_path.parent))
     while True:
         if os.path.isdir(path):
-            if os.access(path, os.W_OK | os.X_OK):
-                break
-        elif Path(path).is_file():
+            break
+        if Path(path).is_file():
             raise ValueError(f"{path} is a file, cannot create folders inside it")
         parent = os.path.dirname(path)
         if parent == path:  # ie, if path is root

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -164,12 +164,6 @@ def test_invalid_subconfig(extra_config, min_config, expected):
         EverestConfig(**min_config)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "behavior must be looked at. Current code requires all directories on path"
-        "to be unwritable to raise validation error."
-    )
-)
 def test_that_simulation_folder_without_write_access_raises_validation_error(
     min_config, tmp_path
 ):


### PR DESCRIPTION
**Issue**
Resolves #14056


**Approach**
`check_writeable_path` walks up from the configured path to the lowest existing directory, but the loop only stopped on a directory that was *already writeable*. An existing but unwritable `simulation_folder` therefore did not terminate the walk — it kept climbing to a writeable ancestor and validation passed, so the error only surfaced when every directory on the path was unwritable.

The walk now stops at the first existing directory and the `os.access` check after the loop decides whether to raise. A writeable folder still passes, a non-existent path still falls back to its nearest existing ancestor, and an existing unwritable folder now raises the intended `ValueError`.

This also un-xfails `test_that_simulation_folder_without_write_access_raises_validation_error`, the placeholder added in #14055 for exactly this bug; it fails on `main` and passes with the fix.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

Verified locally: `tests/everest/test_everlint.py` + `tests/everest/test_config_validation.py` — 247 passed (the one failure in `test_config_validation.py` is pre-existing on `main`). Labels left for a maintainer.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
