### PR TITLE
Rename 'run_id' to 'experiment_id' in experiment_server

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -66,13 +66,15 @@ class ExperimentRunnerState:
     start_time_unix: int | None = None
 
 
-_runs: dict[str, ExperimentRunnerState] = {}
+_experiments: dict[str, ExperimentRunnerState] = {}
 
 
-def _get_run(run_id: str) -> ExperimentRunnerState:
-    if run_id not in _runs:
-        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
-    return _runs[run_id]
+def _get_experiment(experiment_id: str) -> ExperimentRunnerState:
+    if experiment_id not in _experiments:
+        raise HTTPException(
+            status_code=404, detail=f"Experiment '{experiment_id}' not found"
+        )
+    return _experiments[experiment_id]
 
 
 def _failed_realizations_messages(
@@ -167,24 +169,24 @@ def get_status() -> PlainTextResponse:
     return PlainTextResponse("EVEREST is running")
 
 
-@router.get(f"/{EverEndpoints.status}/{{run_id}}", dependencies=authenticated)
+@router.get(f"/{EverEndpoints.status}/{{experiment_id}}", dependencies=authenticated)
 def experiment_status(
-    run: Annotated[ExperimentRunnerState, Depends(_get_run)],
+    experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
 ) -> ExperimentStatus:
-    return run.status
+    return experiment.status
 
 
-@router.get("/runs", dependencies=authenticated)
-def runs() -> JSONResponse:
-    return JSONResponse({"run_ids": list(_runs.keys())})
+@router.get("/" + EverEndpoints.experiments, dependencies=authenticated)
+def experiments() -> JSONResponse:
+    return JSONResponse({"experiment_ids": list(_experiments.keys())})
 
 
 @router.post("/" + EverEndpoints.stop, dependencies=authenticated)
 def stop() -> Response:
-    if not _runs:
+    if not _experiments:
         os.kill(os.getpid(), signal.SIGTERM)
-    for run in _runs.values():
-        run.status = ExperimentStatus(
+    for experiment in _experiments.values():
+        experiment.status = ExperimentStatus(
             message="Server stopped by user", status=ExperimentState.stopped
         )
     return Response("Raise STOP flag succeeded. EVEREST initiates shutdown..", 200)
@@ -195,29 +197,29 @@ async def start_experiment(
     request: Request,
     background_tasks: BackgroundTasks,
 ) -> JSONResponse:
-    run_id = str(uuid.uuid4())
-    run_state = ExperimentRunnerState()
-    _runs[run_id] = run_state
+    experiment_id = str(uuid.uuid4())
+    experiment_state = ExperimentRunnerState()
+    _experiments[experiment_id] = experiment_state
     request_data = await request.json()
     # The output of warnings is the task of the user interface, not
     # of everserver. Therefore we suppress them here:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=ConfigWarning)
         config = EverestConfig.with_plugins(request_data)
-    runner = ExperimentRunner(config, run_id)
+    runner = ExperimentRunner(config, experiment_id)
     try:
         background_tasks.add_task(runner.run)
-        run_state.config_path = config.config_path
+        experiment_state.config_path = config.config_path
 
-        run_state.run_path = config.simulation_dir
-        run_state.storage_path = config.output_dir
+        experiment_state.run_path = config.simulation_dir
+        experiment_state.storage_path = config.output_dir
 
         # Assume client and server is always in the same timezone
         # so disregard timestamps
-        run_state.start_time_unix = int(time.time())
-        return JSONResponse({"run_id": run_id})
+        experiment_state.start_time_unix = int(time.time())
+        return JSONResponse({"experiment_id": experiment_id})
     except Exception as e:
-        run_state.status = ExperimentStatus(
+        experiment_state.status = ExperimentStatus(
             status=ExperimentState.failed,
             message=f"Could not start experiment: {e!s}",
         )
@@ -227,44 +229,50 @@ async def start_experiment(
         )
 
 
-@router.get(f"/{EverEndpoints.config_path}/{{run_id}}", dependencies=authenticated)
+@router.get(
+    f"/{EverEndpoints.config_path}/{{experiment_id}}", dependencies=authenticated
+)
 async def config_path(
-    run: Annotated[ExperimentRunnerState, Depends(_get_run)],
+    experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
 ) -> JSONResponse:
-    if run.status.status == ExperimentState.pending:
+    if experiment.status.status == ExperimentState.pending:
         return JSONResponse("No experiment started", status_code=404)
 
     return JSONResponse(
         {
-            "config_path": str(run.config_path),
-            "run_path": str(run.run_path),
-            "storage_path": str(run.storage_path),
+            "config_path": str(experiment.config_path),
+            "run_path": str(experiment.run_path),
+            "storage_path": str(experiment.storage_path),
         },
         status_code=200,
     )
 
 
-@router.get(f"/{EverEndpoints.start_time}/{{run_id}}", dependencies=authenticated)
+@router.get(
+    f"/{EverEndpoints.start_time}/{{experiment_id}}", dependencies=authenticated
+)
 async def start_time(
-    run: Annotated[ExperimentRunnerState, Depends(_get_run)],
+    experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
 ) -> Response:
-    if run.status.status == ExperimentState.pending:
+    if experiment.status.status == ExperimentState.pending:
         return Response("No experiment started", status_code=404)
 
-    return Response(str(run.start_time_unix), status_code=200)
+    return Response(str(experiment.start_time_unix), status_code=200)
 
 
-@router.websocket(f"/{EverEndpoints.events}/{{run_id}}")
-async def websocket_endpoint(websocket: WebSocket, run_id: str) -> None:
+@router.websocket(f"/{EverEndpoints.events}/{{experiment_id}}")
+async def websocket_endpoint(websocket: WebSocket, experiment_id: str) -> None:
     await websocket.accept()
     _check_authentication(websocket.headers.get("Authorization"))
-    if run_id not in _runs:
+    if experiment_id not in _experiments:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
     subscriber_id = str(uuid.uuid4())
     try:
         while True:
-            event = await _get_event(subscriber_id=subscriber_id, run_id=run_id)
+            event = await _get_event(
+                subscriber_id=subscriber_id, experiment_id=experiment_id
+            )
             await websocket.send_json(jsonable_encoder(event))
             if isinstance(event, EndEvent):
                 break
@@ -276,16 +284,16 @@ async def websocket_endpoint(websocket: WebSocket, run_id: str) -> None:
         )
         # Give some time for subscribers to get events
         await asyncio.sleep(5)
-        _runs[run_id].subscribers[subscriber_id].done()
+        _experiments[experiment_id].subscribers[subscriber_id].done()
 
 
-async def _get_event(subscriber_id: str, run_id: str) -> StatusEvents:
+async def _get_event(subscriber_id: str, experiment_id: str) -> StatusEvents:
     """
     The function waits until there is an event available for the subscriber
     and returns the event. If the subscriber is up to date it will
     wait until we wake up the subscriber using notify
     """
-    run = _runs[run_id]
+    run = _experiments[experiment_id]
     if subscriber_id not in run.subscribers:
         run.subscribers[subscriber_id] = Subscriber()
     subscriber = run.subscribers[subscriber_id]
@@ -302,15 +310,15 @@ class ExperimentRunner:
     def __init__(
         self,
         everest_config: EverestConfig,
-        run_id: str,
+        experiment_id: str,
     ) -> None:
         super().__init__()
 
         self._everest_config = everest_config
-        self._run_id = run_id
+        self._experiment_id = experiment_id
 
     async def run(self) -> None:
-        run = _runs[self._run_id]
+        run = _experiments[self._experiment_id]
         status_queue: SimpleQueue[StatusEvents] = SimpleQueue()
         run_model: EverestRunModel | None = None
         try:  # ruff: ignore[too-many-statements-in-try-clause]

--- a/src/ert/gui/experiments/experiment_client.py
+++ b/src/ert/gui/experiments/experiment_client.py
@@ -27,14 +27,14 @@ logger = logging.getLogger(__name__)
 class ExperimentClient:
     def __init__(
         self,
-        run_id: str,
+        experiment_id: str,
         url: str,
         cert_file: str,
         username: str,
         password: str,
         ssl_context: ssl.SSLContext,
     ) -> None:
-        self._run_id = run_id
+        self._experiment_id = experiment_id
         self._url = url
         self._cert = cert_file
         self._username = username
@@ -62,7 +62,9 @@ class ExperimentClient:
 
     @property
     def config(self) -> dict[str, str]:
-        return self._http_get(f"{EverEndpoints.config_path}/{self._run_id}").json()
+        return self._http_get(
+            f"{EverEndpoints.config_path}/{self._experiment_id}"
+        ).json()
 
     @property
     def credentials(self) -> str:
@@ -80,7 +82,7 @@ class ExperimentClient:
             try:  # ruff: ignore[too-many-statements-in-try-clause]
                 with connect(
                     self._url.replace("https://", "wss://")
-                    + f"/{EverEndpoints.events}/{self._run_id}",
+                    + f"/{EverEndpoints.events}/{self._experiment_id}",
                     ssl=self._ssl_context,
                     open_timeout=open_timeout,
                     additional_headers={"Authorization": f"Basic {self.credentials}"},

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -246,7 +246,7 @@ async def run_everest(options: argparse.Namespace) -> None:
         "Starting experiment"
     )
 
-    run_id = start_experiment(
+    experiment_id = start_experiment(
         server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),
         config=options.config,
     )
@@ -262,7 +262,7 @@ async def run_everest(options: argparse.Namespace) -> None:
             name="EVEREST CLI monitor thread",
             args=[
                 ServerConfig.get_server_context_from_conn_info(client.conn_info),
-                run_id,
+                experiment_id,
             ],
             daemon=True,
         )
@@ -274,14 +274,14 @@ async def run_everest(options: argparse.Namespace) -> None:
             server_context=ServerConfig.get_server_context_from_conn_info(
                 client.conn_info
             ),
-            run_id=run_id,
+            experiment_id=experiment_id,
         )
     else:
         run_detached_monitor(
             server_context=ServerConfig.get_server_context_from_conn_info(
                 client.conn_info
             ),
-            run_id=run_id,
+            experiment_id=experiment_id,
         )
 
     msg: str = ""

--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 from ert.services import create_ertserver_client
 from ert.storage import ErtStorageException, ExperimentState
 from everest.config import EverestConfig, ServerConfig
-from everest.detached.client import get_runs
+from everest.detached.client import get_experiments
 from everest.everest_storage import EverestStorage
 
 from .utils import (
@@ -89,8 +89,10 @@ def monitor_everest(options: argparse.Namespace) -> None:
             server_context = ServerConfig.get_server_context_from_conn_info(
                 client.conn_info
             )
-            run_id = get_runs(server_context)[-1]
-            run_detached_monitor(server_context=server_context, run_id=run_id)
+            experiment_id = get_experiments(server_context)[-1]
+            run_detached_monitor(
+                server_context=server_context, experiment_id=experiment_id
+            )
 
             try:
                 experiment_status = get_experiment_status(str(config.storage_dir))

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -416,17 +416,17 @@ class _DetachedMonitor:
 
 def run_detached_monitor(
     server_context: tuple[str, str, tuple[str, str]],
-    run_id: str,
+    experiment_id: str,
 ) -> None:
     monitor = _DetachedMonitor()
-    start_monitor(server_context, callback=monitor.update, run_id=run_id)
+    start_monitor(server_context, callback=monitor.update, experiment_id=experiment_id)
 
 
 def run_empty_detached_monitor(
     server_context: tuple[str, str, tuple[str, str]],
-    run_id: str,
+    experiment_id: str,
 ) -> None:
-    start_monitor(server_context, callback=lambda _: None, run_id=run_id)
+    start_monitor(server_context, callback=lambda _: None, experiment_id=experiment_id)
 
 
 def _read_user_preferences(user_info_path: Path) -> dict[str, dict[str, Any]]:

--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -2,7 +2,7 @@
 
 from .client import (
     PROXY,
-    get_runs,
+    get_experiments,
     server_is_running,
     start_experiment,
     start_monitor,
@@ -14,7 +14,7 @@ from .client import (
 
 __all__ = [
     "PROXY",
-    "get_runs",
+    "get_experiments",
     "server_is_running",
     "start_experiment",
     "start_monitor",

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -74,9 +74,9 @@ def stop_server(
     server_context: tuple[str, str, tuple[str, str]], retries: int = 5
 ) -> bool:
     """Stop server if found and it is running."""
+    url, cert, auth = server_context
     for retry in range(retries):
         try:
-            url, cert, auth = server_context
             stop_endpoint = f"{url}/{EverEndpoints.stop}"
             response = requests.post(
                 stop_endpoint,
@@ -93,25 +93,25 @@ def stop_server(
     return False
 
 
-def get_runs(
+def get_experiments(
     server_context: tuple[str, str, tuple[str, str]],
     retries: int = 5,
 ) -> list[str]:
+    url, cert, auth = server_context
     for retry in range(retries):
         try:
-            url, cert, auth = server_context
             response = requests.get(
-                f"{url}/{EverEndpoints.runs}",
+                f"{url}/{EverEndpoints.experiments}",
                 verify=cert,
                 auth=auth,
                 proxies=PROXY,
             )
             response.raise_for_status()
-            return response.json()["run_ids"]
+            return response.json()["experiment_ids"]
         except Exception:
             logger.debug(traceback.format_exc())
             time.sleep(retry)
-    raise RuntimeError("Failed to get run_ids")
+    raise RuntimeError("Failed to get experiment_ids")
 
 
 def start_experiment(
@@ -119,9 +119,9 @@ def start_experiment(
     config: EverestConfig,
     retries: int = 5,
 ) -> str:
+    url, cert, auth = server_context
     for retry in range(retries):
         try:
-            url, cert, auth = server_context
             start_endpoint = f"{url}/{EverEndpoints.start_experiment}"
             response = requests.post(
                 start_endpoint,
@@ -131,7 +131,7 @@ def start_experiment(
                 json=config.to_dict(),
             )
             response.raise_for_status()
-            return response.json()["run_id"]
+            return response.json()["experiment_id"]
         except Exception:
             logger.debug(traceback.format_exc())
             time.sleep(retry)
@@ -227,7 +227,7 @@ def get_opt_status_from_batch_result_event(
 def start_monitor(
     server_context: tuple[str, str, tuple[str, str]],
     callback: Callable[..., None],
-    run_id: str,
+    experiment_id: str,
     polling_interval: float = 0.1,
 ) -> None:
     """
@@ -243,7 +243,8 @@ def start_monitor(
 
     try:  # ruff: ignore[too-many-statements-in-try-clause]
         with connect(
-            url.replace("https://", "wss://") + f"/{EverEndpoints.events}/{run_id}",
+            url.replace("https://", "wss://")
+            + f"/{EverEndpoints.events}/{experiment_id}",
             ssl=ssl_context,
             open_timeout=30,
             additional_headers={"Authorization": f"Basic {credentials}"},

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -19,7 +19,7 @@ from ert.storage.local_experiment import ExperimentState
 from ert.trace import tracer
 from ert.utils import makedirs_if_needed
 from everest.config import ServerConfig
-from everest.detached import get_runs
+from everest.detached import get_experiments
 from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
     EVEREST,
@@ -181,7 +181,7 @@ def main() -> None:
                 with create_ertserver_client(Path(server_path)) as client:
                     done = False
                     while not done:
-                        run_ids = get_runs(
+                        experiment_ids = get_experiments(
                             ServerConfig.get_server_context_from_conn_info(
                                 client.conn_info
                             )
@@ -189,14 +189,14 @@ def main() -> None:
                         active = [
                             ExperimentStatus(
                                 **client.get(
-                                    f"/experiment_server/{EverEndpoints.status}/{run_id}",
+                                    f"/experiment_server/{EverEndpoints.status}/{experiment_id}",
                                     auth=server.fetch_auth(),
                                 ).json()
                             ).status
                             in {ExperimentState.pending, ExperimentState.running}
-                            for run_id in run_ids
+                            for experiment_id in experiment_ids
                         ]
-                        done = run_ids and not any(active)
+                        done = experiment_ids and not any(active)
                         time.sleep(0.5)
         except ErtServerExit:
             # Server exit, happens on normal shutdown and keyboard interrupt

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -16,7 +16,7 @@ from ert.gui.experiments.experiment_client import ExperimentClient
 from ert.plugins import ErtPluginManager
 from ert.services import create_ertserver_client
 from everest.config import ServerConfig
-from everest.detached import get_runs, wait_for_server
+from everest.detached import get_experiments, wait_for_server
 
 
 class EverestMainWindow(QMainWindow):
@@ -58,7 +58,7 @@ class EverestMainWindow(QMainWindow):
         username, password = auth
 
         client = ExperimentClient(
-            run_id=get_runs(server_context)[-1],
+            experiment_id=get_experiments(server_context)[-1],
             url=url,
             cert_file=cert,
             username=username,

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -31,6 +31,6 @@ class EverEndpoints(StrEnum):
     start_experiment = "start_experiment"
     config_path = "config_path"
     start_time = "start_time_unix"
-    runs = "runs"
+    experiments = "experiments"
     status = "status"
     events = "events"

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -243,11 +243,13 @@ def test_everest_entry_detached_running(
 
 @patch("everest.bin.monitor_script.run_detached_monitor")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
-@patch("everest.bin.monitor_script.get_runs", return_value=["test-run-id"])
+@patch(
+    "everest.bin.monitor_script.get_experiments", return_value=["test-experiment-id"]
+)
 @patch("everest.bin.monitor_script.create_ertserver_client")
 def test_everest_entry_detached_running_monitor(
     monitor_script_client_mock,
-    get_runs_mock,
+    get_experiments_mock,
     get_server_context_from_conn_info_mock,
     start_monitor_mock,
     change_to_tmpdir,
@@ -264,7 +266,7 @@ def test_everest_entry_detached_running_monitor(
     start_monitor_mock.assert_called_once()
     monitor_script_client_mock.assert_called_once()
     get_server_context_from_conn_info_mock.assert_called_once()
-    get_runs_mock.assert_called_once()
+    get_experiments_mock.assert_called_once()
 
 
 @patch("everest.bin.monitor_script.run_detached_monitor")
@@ -333,11 +335,13 @@ def test_exception_raised_when_server_run_fails(
     side_effect=raise_system_error,
 )
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
-@patch("everest.bin.monitor_script.get_runs", return_value="test-run-id")
+@patch(
+    "everest.bin.monitor_script.get_experiments", return_value=["test-experiment-id"]
+)
 @patch("everest.bin.monitor_script.create_ertserver_client")
 def test_exception_raised_when_server_run_fails_monitor(
     monitor_script_client_mock,
-    run_ids_mock,
+    get_experiments_mock,
     get_server_context_from_conn_info_mock,
     start_monitor_mock,
     change_to_tmpdir,

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -18,7 +18,7 @@ from ert.services import create_ertserver_client
 from ert.shared import find_available_socket
 from everest.bin.everest_script import everest_entry
 from everest.config import EverestConfig, ServerConfig
-from everest.detached import get_runs, server_is_running
+from everest.detached import get_experiments, server_is_running
 from everest.strings import EverEndpoints
 from tests.ert.utils import wait_until
 
@@ -44,7 +44,7 @@ def client_server_mock() -> tuple[FastAPI, threading.Thread, ExperimentClient]:
     )
 
     everest_client = ExperimentClient(
-        run_id="test_run_id",
+        experiment_id="test_experiment_id",
         url=server_url,
         cert_file="N/A",
         username="",
@@ -213,7 +213,7 @@ def test_that_multiple_everest_clients_can_connect_to_server(
     monitor_threads = []
     for _ in range(5):
         client = ExperimentClient(
-            run_id=get_runs(server_context)[-1],
+            experiment_id=get_experiments(server_context)[-1],
             url=url,
             cert_file=cert,
             username=username,

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -15,7 +15,10 @@ from starlette.websockets import WebSocketDisconnect
 
 from ert.config import ConfigWarning
 from ert.dark_storage.app import app
-from ert.dark_storage.endpoints.experiment_server import ExperimentRunnerState, _runs
+from ert.dark_storage.endpoints.experiment_server import (
+    ExperimentRunnerState,
+    _experiments,
+)
 from ert.ensemble_evaluator import EndEvent
 from ert.run_models.event import StatusEvents
 from ert.scheduler.event import FinishedEvent
@@ -38,23 +41,23 @@ from everest.strings import (
 
 @pytest.fixture
 def setup_client(monkeypatch):
-    original = dict(_runs)
+    original = dict(_experiments)
 
     def func(events=None):
         events = [EndEvent(failed=False, msg="Complete")] if events is None else events
 
-        _runs.clear()
-        run_id = "test-run-id"
+        _experiments.clear()
+        experiment_id = "experiment_id"
         state = ExperimentRunnerState()
         state.events = cast(list[StatusEvents], events)
-        _runs[run_id] = state
+        _experiments[experiment_id] = state
 
         monkeypatch.setenv("ERT_STORAGE_TOKEN", "password")
-        return TestClient(app), state.subscribers, run_id
+        return TestClient(app), state.subscribers, experiment_id
 
     yield func
-    _runs.clear()
-    _runs.update(original)
+    _experiments.clear()
+    _experiments.update(original)
 
 
 async def wait_for_server_to_complete(config):
@@ -240,9 +243,11 @@ async def test_status_contains_max_runtime_failure(change_to_tmpdir, min_config)
 
 
 def test_websocket_no_authentication(setup_client):
-    client, _, run_id = setup_client()
+    client, _, experiment_id = setup_client()
     with (
-        client.websocket_connect(f"/experiment_server/events/{run_id}") as websocket,
+        client.websocket_connect(
+            f"/experiment_server/events/{experiment_id}"
+        ) as websocket,
         pytest.raises(WebSocketDisconnect) as exception,
     ):
         websocket.receive_json()
@@ -250,11 +255,11 @@ def test_websocket_no_authentication(setup_client):
 
 
 def test_websocket_wrong_password(setup_client):
-    client, _, run_id = setup_client()
+    client, _, experiment_id = setup_client()
     credentials = b64encode(b"username:wrong_password").decode()
     with (
         client.websocket_connect(
-            f"/experiment_server/events/{run_id}",
+            f"/experiment_server/events/{experiment_id}",
             headers={"Authorization": f"Basic {credentials}"},
         ) as websocket,
         pytest.raises(WebSocketDisconnect) as exception,
@@ -265,16 +270,16 @@ def test_websocket_wrong_password(setup_client):
 
 @pytest.mark.flaky(rerun=3)
 def test_websocket_multiple_connections(setup_client):
-    client, subscribers, run_id = setup_client()
+    client, subscribers, experiment_id = setup_client()
     credentials = b64encode(b"username:password").decode()
     with client.websocket_connect(
-        f"/experiment_server/events/{run_id}",
+        f"/experiment_server/events/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     ) as websocket:
         event = websocket.receive_json()
         websocket.close()
     with client.websocket_connect(
-        f"/experiment_server/events/{run_id}",
+        f"/experiment_server/events/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     ) as websocket:
         event_2 = websocket.receive_json()
@@ -283,15 +288,17 @@ def test_websocket_multiple_connections(setup_client):
 
 
 def test_websocket_multiple_connections_one_fails(setup_client):
-    client, subscribers, run_id = setup_client()
+    client, subscribers, experiment_id = setup_client()
     credentials = b64encode(b"username:password").decode()
     with (
-        client.websocket_connect(f"/experiment_server/events/{run_id}") as websocket,
+        client.websocket_connect(
+            f"/experiment_server/events/{experiment_id}"
+        ) as websocket,
         pytest.raises(WebSocketDisconnect),
     ):
         websocket.receive_json()
     with client.websocket_connect(
-        f"/experiment_server/events/{run_id}",
+        f"/experiment_server/events/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     ) as websocket:
         event = websocket.receive_json()
@@ -309,23 +316,23 @@ def test_websocket_multiple_events_in_queue(setup_client):
         TestEvent("event_2"),
         EndEvent(failed=False, msg="Done"),
     ]
-    client, _, run_id = setup_client(expected)
+    client, _, experiment_id = setup_client(expected)
     credentials = b64encode(b"username:password").decode()
     event_msgs = []
     with client.websocket_connect(
-        f"/experiment_server/events/{run_id}",
+        f"/experiment_server/events/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     ) as websocket:
         event_msgs.extend(websocket.receive_json() for _ in expected)
     assert event_msgs == [jsonable_encoder(e) for e in expected]
 
 
-def test_that_multiple_started_experiments_each_receive_distinct_run_ids(
+def test_that_multiple_started_experiments_each_receive_distinct_experiment_ids(
     monkeypatch,
 ):
     monkeypatch.setenv("ERT_STORAGE_TOKEN", "password")
-    original = dict(_runs)
-    _runs.clear()
+    original = dict(_experiments)
+    _experiments.clear()
     try:
         credentials = b64encode(b"username:password").decode()
         auth_headers = {"Authorization": f"Basic {credentials}"}
@@ -350,26 +357,31 @@ def test_that_multiple_started_experiments_each_receive_distinct_run_ids(
                 headers=auth_headers,
             )
         assert r1.status_code == r2.status_code == 200
-        run_id_1 = r1.json()["run_id"]
-        run_id_2 = r2.json()["run_id"]
-        assert run_id_1 != run_id_2
-        runs_response = client.get("/experiment_server/runs", headers=auth_headers)
+        experiment_id_1 = r1.json()["experiment_id"]
+        experiment_id_2 = r2.json()["experiment_id"]
+        assert experiment_id_1 != experiment_id_2
+        runs_response = client.get(
+            "/experiment_server/experiments", headers=auth_headers
+        )
         assert runs_response.status_code == 200
-        assert set(runs_response.json()["run_ids"]) >= {run_id_1, run_id_2}
+        assert set(runs_response.json()["experiment_ids"]) >= {
+            experiment_id_1,
+            experiment_id_2,
+        }
     finally:
-        _runs.clear()
-        _runs.update(original)
+        _experiments.clear()
+        _experiments.update(original)
 
 
 async def test_websocket_no_events_on_connect(setup_client):
     events = []
-    client, subs, run_id = setup_client(events)
+    client, subs, experiment_id = setup_client(events)
     credentials = b64encode(b"username:password").decode()
     result = []
     expected_result = EndEvent(failed=False, msg="Test message")
 
     with client.websocket_connect(
-        f"/experiment_server/events/{run_id}",
+        f"/experiment_server/events/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     ) as websocket:
 
@@ -400,13 +412,13 @@ def test_that_get_status_returns_successfully(setup_client):
 
 
 @pytest.mark.parametrize(
-    ("run_id", "credentials", "expected_status_code", "expected_response"),
+    ("experiment_id", "credentials", "expected_status_code", "expected_response"),
     [
         (
             "1",
             b64encode(b"username:password").decode(),
             404,
-            {"detail": "Run '1' not found"},
+            {"detail": "Experiment '1' not found"},
         ),
         (
             None,
@@ -422,13 +434,13 @@ def test_that_get_status_returns_successfully(setup_client):
         ),
     ],
 )
-def test_that_get_status_by_run_id_endpoint_returns_expected_response(
-    setup_client, run_id, credentials, expected_status_code, expected_response
+def test_that_get_status_by_experiment_id_endpoint_returns_expected_response(
+    setup_client, experiment_id, credentials, expected_status_code, expected_response
 ):
-    client, _, valid_run_id = setup_client()
+    client, _, valid_experiment_id = setup_client()
 
     response = client.get(
-        f"/experiment_server/status/{run_id or valid_run_id}",
+        f"/experiment_server/status/{experiment_id or valid_experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     )
     assert response.status_code == expected_status_code
@@ -438,11 +450,11 @@ def test_that_get_status_by_run_id_endpoint_returns_expected_response(
 def test_that_get_config_path_returns_not_found_for_pending_experiment_state(
     setup_client,
 ):
-    client, _, run_id = setup_client()
+    client, _, experiment_id = setup_client()
     credentials = b64encode(b"username:password").decode()
 
     response = client.get(
-        f"/experiment_server/config_path/{run_id}",
+        f"/experiment_server/config_path/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     )
     assert response.status_code == 404
@@ -452,23 +464,23 @@ def test_that_get_config_path_returns_not_found_for_pending_experiment_state(
 def test_that_get_config_path_returns_successfully_for_running_experiment(
     setup_client,
 ):
-    client, _, run_id = setup_client()
+    client, _, experiment_id = setup_client()
     credentials = b64encode(b"username:password").decode()
 
-    assert run_id in _runs
-    _runs[run_id].status.status = ExperimentState.running
+    assert experiment_id in _experiments
+    _experiments[experiment_id].status.status = ExperimentState.running
     response = client.get(
-        f"/experiment_server/config_path/{run_id}",
+        f"/experiment_server/config_path/{experiment_id}",
         headers={"Authorization": f"Basic {credentials}"},
     )
     assert response.status_code == 200
 
 
 def test_that_experiment_stop_endpoint_returns_successfully(setup_client):
-    client, _, run_id = setup_client()
+    client, _, experiment_id = setup_client()
 
-    assert run_id in _runs
-    assert _runs[run_id].status.status == ExperimentState.pending
+    assert experiment_id in _experiments
+    assert _experiments[experiment_id].status.status == ExperimentState.pending
 
     credentials = b64encode(b"username:password").decode()
 
@@ -481,15 +493,15 @@ def test_that_experiment_stop_endpoint_returns_successfully(setup_client):
     assert response.text == "Raise STOP flag succeeded. EVEREST initiates shutdown.."
 
     # ExperimentState should be updated to 'stopped' after the stop endpoint is called
-    assert _runs[run_id].status.status == ExperimentState.stopped
-    assert _runs[run_id].status.message == "Server stopped by user"
+    assert _experiments[experiment_id].status.status == ExperimentState.stopped
+    assert _experiments[experiment_id].status.message == "Server stopped by user"
 
 
 def test_that_experiment_stop_endpoint_correctly_shuts_down_server(setup_client):
     client, _, _ = setup_client()
 
-    # Clear _runs to force server shutdown when stop endpoint is called
-    _runs.clear()
+    # Clear _experiments to force server shutdown when stop endpoint is called
+    _experiments.clear()
 
     credentials = b64encode(b"username:password").decode()
     previous_handler = getsignal(SIGTERM)

--- a/tests/everest/test_monitor.py
+++ b/tests/everest/test_monitor.py
@@ -170,7 +170,8 @@ def test_failed_jobs_monitor(
     monkeypatch.setattr(everest.detached.client, "ssl", MagicMock())
     partial(everest.detached.start_monitor, polling_interval=0.1)
     run_detached_monitor(
-        ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+        ("some/url", "cert", ("username", "password")),
+        experiment_id="test-experiment-id",
     )
     captured = capsys.readouterr()
     expected = [
@@ -206,7 +207,8 @@ def test_monitor(monkeypatch, full_snapshot_event, snapshot_update_event, capsys
     patched = partial(everest.detached.start_monitor, polling_interval=0.1)
     with patch("everest.bin.utils.start_monitor", patched):
         run_detached_monitor(
-            ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+            ("some/url", "cert", ("username", "password")),
+            experiment_id="test-experiment-id",
         )
     captured = capsys.readouterr()
     expected = [
@@ -237,7 +239,8 @@ def test_forward_model_message_reaches_the_cli(
     monkeypatch.setattr(everest.detached.client, "ssl", MagicMock())
     partial(everest.detached.start_monitor, polling_interval=0.1)
     run_detached_monitor(
-        ("some/url", "cert", ("username", "password")), run_id="test-run-id"
+        ("some/url", "cert", ("username", "password")),
+        experiment_id="test-experiment-id",
     )
     captured = capsys.readouterr()
 


### PR DESCRIPTION
**Issue**
Resolves #13924 


**Approach**
Change occurences of `run_id` to `experiment_id`.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
