### PR TITLE
Use tolerance when comparing seismic data

### DIFF
--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     Literal,
     Self,
     assert_never,
@@ -19,6 +20,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import polars as pl
+import scipy as sp
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from resfo_utilities import InvalidSummaryKeyError, make_summary_key
 
@@ -1002,6 +1004,8 @@ class SeismicObservation(BaseObservation):
     error: float
     boundary_id: int | None = None
 
+    TOLERANCE: ClassVar[float] = 0.1
+
     @staticmethod
     def _load_observations(filepath: Path) -> pd.DataFrame:
         df = pd.read_csv(
@@ -1026,6 +1030,31 @@ class SeismicObservation(BaseObservation):
             )
 
         return df
+
+    @staticmethod
+    def validate_distance_between_observations(
+        observations: Sequence[SeismicObservation], filepath: Path
+    ) -> None:
+        if not observations:
+            return
+        coordinates = [(obs.east, obs.north) for obs in observations]
+        tree = sp.spatial.KDTree(coordinates)
+        too_close_pairs = tree.query_pairs(r=SeismicObservation.TOLERANCE * 2)
+        if too_close_pairs:
+            too_close_coords = [
+                (
+                    (observations[i].east, observations[i].north),
+                    (observations[j].east, observations[j].north),
+                )
+                for i, j in too_close_pairs
+            ]
+            raise ObservationConfigError.with_context(
+                "Seismic observation coordinates with approximate locations "
+                f"{too_close_coords} fall inside of a tolerance radius. "
+                "All seismic observation coordinates must be more than "
+                f"{SeismicObservation.TOLERANCE * 2} m apart.",
+                filepath,
+            )
 
     @classmethod
     def from_obs_dict(
@@ -1090,7 +1119,6 @@ class SeismicObservation(BaseObservation):
             boundary_id = shape_registry.register(boundary)
 
         seismic_observations = []
-        seen_coordinates: set[tuple[np.float32, np.float32]] = set()
         for row in df.itertuples():
             east = validate_float(str(row.X_UTME), "X_UTME")
             north = validate_float(str(row.Y_UTMN), "Y_UTMN")
@@ -1111,18 +1139,6 @@ class SeismicObservation(BaseObservation):
                 )
             )
 
-            coordinates = (
-                np.float32(east),
-                np.float32(north),
-            )
-            if coordinates in seen_coordinates:
-                original_coordinates = (row.X_UTME, row.Y_UTMN)
-                raise ObservationConfigError.with_context(
-                    f"Seismic observation coordinates {original_coordinates} "
-                    "were not unique (after rounding from f64 to f32).",
-                    filepath,
-                )
-            seen_coordinates.add(coordinates)
             seismic_observation = cls(
                 name=name,
                 filepath=filepath,
@@ -1135,6 +1151,7 @@ class SeismicObservation(BaseObservation):
             )
             seismic_observations.append(seismic_observation)
 
+        cls.validate_distance_between_observations(seismic_observations, filepath)
         return seismic_observations
 
 

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Any, ClassVar, Literal, Self
 
+import numpy as np
 import polars as pl
+import scipy as sp
 
 from ert.substitutions import substitute_runpath_name
 
@@ -28,6 +30,8 @@ class SeismicConfig(SimulationResponseConfig):
     name: str = "seismic"
     type: Literal["seismic"] = "seismic"
 
+    TOLERANCE: ClassVar[float] = 0.1
+
     @property
     def expected_input_files(self) -> list[str]:
         return self.input_files
@@ -40,6 +44,28 @@ class SeismicConfig(SimulationResponseConfig):
             "north": pl.Float32,
             "values": pl.Float32,
         }
+
+    @staticmethod
+    def validate_distance_between_responses(df: pl.DataFrame) -> None:
+        easts = df["east"].to_numpy()
+        norths = df["north"].to_numpy()
+        coordinates = np.column_stack([easts, norths])
+        tree = sp.spatial.KDTree(coordinates)
+        too_close_pairs = tree.query_pairs(r=SeismicConfig.TOLERANCE * 2)
+        if too_close_pairs:
+            too_close_coords = [
+                (
+                    (float(easts[i]), float(norths[i])),
+                    (float(easts[j]), float(norths[j])),
+                )
+                for i, j in too_close_pairs
+            ]
+            raise InvalidResponseFile(
+                "Seismic response coordinates with approximate locations "
+                f"{too_close_coords} fall inside of a tolerance radius. All seismic "
+                "response coordinates are expected to be more than "
+                f"{SeismicConfig.TOLERANCE * 2} m apart."
+            )
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         responses = pl.DataFrame(schema=self.response_schema())
@@ -61,22 +87,7 @@ class SeismicConfig(SimulationResponseConfig):
                     "values": csv["OBS"].cast(pl.Float32),
                 }
             )
-            duplicates = (
-                df.group_by(["east", "north"])
-                .agg(pl.len().alias("count"))
-                .filter(pl.col("count") > 1)
-            )
-            duplicates_str = "\n".join(
-                f"  east={d['east']}, north={d['north']}, count={d['count']}"
-                for d in duplicates.to_dicts()
-            )
-            if len(duplicates) > 0:
-                raise InvalidResponseFile(
-                    "Seismic response coordinates were not unique (after rounding "
-                    "from f64 to f32). Approximate locations are:\n"
-                    f"{duplicates_str}"
-                )
-
+            self.validate_distance_between_responses(df)
             responses = pl.concat([responses, df], how="vertical")
         return self._assert_schema(responses, self.response_schema())
 

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -109,3 +109,56 @@ class SeismicConfig(SimulationResponseConfig):
             input_files=files,
             keys=[Path(f).stem for f in files],
         )
+
+    @classmethod
+    def use_observation_locations_in_respective_responses(
+        cls, responses: pl.DataFrame, observations: pl.DataFrame
+    ) -> pl.DataFrame:
+        """Unify response and observation locations.
+
+        Replace the east and north coordinates in the response dataframe with the
+        corresponding coordinates from the observation dataframe, if they are within the
+        tolerance radius. Drop response otherwise. Required to match responses to
+        observations regardless of location precision discrepancies.
+        """
+        candidates = responses.rename(
+            {
+                "east": "east_res",
+                "north": "north_res",
+                "response_key": "response_key_res",
+            }
+        ).join_where(
+            observations.rename(
+                {
+                    "east": "east_obs",
+                    "north": "north_obs",
+                    "response_key": "response_key_obs",
+                }
+            ),
+            pl.col("response_key_res") == pl.col("response_key_obs"),
+            pl.col("east_obs") >= pl.col("east_res") - cls.TOLERANCE,
+            pl.col("east_obs") <= pl.col("east_res") + cls.TOLERANCE,
+            pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
+            pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
+        )
+        matched_on_location = (
+            candidates.filter(
+                (pl.col("east_obs") - pl.col("east_res")).pow(2)
+                + (pl.col("north_obs") - pl.col("north_res")).pow(2)
+                <= cls.TOLERANCE**2
+            )
+        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
+
+        return (
+            responses.join(
+                matched_on_location,
+                left_on=["response_key", "east", "north"],
+                right_on=["response_key_res", "east_res", "north_res"],
+                how="inner",
+            )
+            .with_columns(
+                east=pl.col("east_obs"),
+                north=pl.col("north_obs"),
+            )
+            .drop(["east_obs", "north_obs"])
+        )

--- a/src/ert/gui/tools/manage_experiments/ensemble_widget.py
+++ b/src/ert/gui/tools/manage_experiments/ensemble_widget.py
@@ -29,6 +29,7 @@ from PyQt6.QtWidgets import (
 
 from ert.config.response_config import ResponseConfig
 from ert.config.rft_config import RFTConfig
+from ert.config.seismic_config import SeismicConfig
 from ert.gui.experiments.view.run_status import RunStatusView
 from ert.storage import Ensemble
 from ert.storage.blob_data import BlobType
@@ -317,6 +318,13 @@ class EnsembleWidget(QWidget):
                 return pl.concat(per_realization)
 
             responses = ens.load_responses(response_key, reals_with_responses)
+            if response_type == "seismic":
+                responses = (
+                    SeismicConfig.use_observation_locations_in_respective_responses(
+                        responses, obs
+                    )
+                )
+
             return _filter_by_match_key(responses, None)
 
         response_ds = _load_and_filter_responses()

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -37,6 +37,7 @@ from ert.config.observation_quality_control import (
     qc_seismic_observations,
 )
 from ert.config.rft_config import RFTConfig
+from ert.config.seismic_config import SeismicConfig
 from ert.data import MeasuredData
 from ert.data._measured_data import ObservationError, ResponseError
 from ert.substitutions import substitute_runpath_name
@@ -1028,7 +1029,7 @@ class LocalEnsemble(BaseMode):
 
                 # Filter out responses without observations
                 for col, observed_values in observed_cols.items():
-                    if col != "time":
+                    if col not in {"time", "east", "north"}:
                         responses = responses.filter(
                             pl.col(col).is_in(
                                 observed_values.implode(), nulls_equal=True
@@ -1041,6 +1042,17 @@ class LocalEnsemble(BaseMode):
                     values="values",
                     aggregate_function="mean",
                 )
+                if response_type == "seismic":
+                    pivoted = (
+                        SeismicConfig.use_observation_locations_in_respective_responses(
+                            pivoted, observations
+                        )
+                        # Due to performed validations, all match keys should be unique.
+                        # Calculating 'mean' anyway to assure no ugly error is raised if
+                        # validations are somehow bypassed
+                        .group_by(["response_key", "east", "north"])
+                        .agg(pl.col(str(real)).mean())
+                    )
 
                 if pivoted.is_empty():
                     # There are no responses for this realization,

--- a/tests/ert/defaults_generator.py
+++ b/tests/ert/defaults_generator.py
@@ -1,6 +1,9 @@
 import datetime
 from pathlib import Path
 
+import numpy as np
+import polars as pl
+
 from ert.config._observations import (
     BreakthroughObservation,
     GeneralObservation,
@@ -9,6 +12,7 @@ from ert.config._observations import (
     SummaryObservation,
 )
 from ert.config.parsing.observations_parser import ObservationType
+from ert.config.seismic_config import SeismicConfig
 
 
 def create_general_observation(
@@ -180,7 +184,7 @@ def create_rft_observation_dict(
 
 def create_seismic_observation(
     name: str = "seismic_observation",
-    filepath: Path = Path("obs.csv"),
+    filepath: Path = Path("horizon--amplitude_full_min_depth--20250101_20240101.csv"),
     east: float = 1.0,
     north: float = 1.0,
     value: float = 1.0,
@@ -202,6 +206,25 @@ def create_seismic_observation(
 
 def create_seismic_observation_dict(
     name: str = "seismic_observation",
-    csv: str = "obs.csv",
+    csv: str = "horizon--amplitude_full_min_depth--20250101_20240101.csv",
 ) -> dict:
     return {"type": ObservationType.SEISMIC, "name": name, "CSV": csv}
+
+
+def create_seismic_response(
+    response_key: str = "horizon--amplitude_full_min_depth--20250101_20240101",
+    east: float = 1.0,
+    north: float = 1.0,
+    values: float = 1.1,
+) -> pl.DataFrame:
+    df = pl.DataFrame(
+        {
+            "response_key": [response_key],
+            "east": [np.float32(east)],
+            "north": [np.float32(north)],
+            "values": [np.float32(values)],
+        },
+        schema=SeismicConfig.response_schema(),
+    )
+    SeismicConfig._assert_schema(df, SeismicConfig.response_schema())
+    return df

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -28,7 +28,10 @@ from ert.config.parsing.observations_parser import (
     observations_parser,
 )
 from ert.observation_converters.history_to_summary import convert_history_to_summary
-from tests.ert.defaults_generator import create_seismic_observation
+from tests.ert.defaults_generator import (
+    create_seismic_observation,
+    create_seismic_observation_dict,
+)
 
 observation_contents = stlark.from_lark(observations_parser)
 
@@ -1040,19 +1043,45 @@ def test_that_invalid_value_type_in_seismic_observation_raises_error(
     )
 
 
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_empty_seismic_observation_file_does_not_raise(file_context_token):
+    Path("obs.csv").write_text(
+        dedent(
+            """
+            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+            """
+        ),
+        encoding="utf8",
+    )
+    obs = make_observations(
+        "",
+        [
+            ObservationDict(
+                create_seismic_observation_dict(
+                    csv="obs.csv",
+                ),
+                context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
+            )
+        ],
+        shape_registry=ShapeRegistry(),
+    )
+
+    assert obs == []
+
+
 @pytest.mark.parametrize(
     ("east", "north"),
     [
-        pytest.param([111.11, 111.11], [222.22, 222.22], id="same coordinates"),
+        pytest.param([111.11, 111.11], [222.222, 222.222], id="same coordinates"),
         pytest.param(
-            [111.1111111111111111111111, 111.11111111111111],
-            [222.2222222222222222222222222222222, 222.22222222222223],
-            id="lost precision",
+            [0.0, 0.0],
+            [0.0, 0.19],
+            id="less than double tolerance",
         ),
     ],
 )
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_duplicate_location_in_seismic_observation_raises(
+def test_that_seismic_observation_coordinate_distance_below_tolerance_raises(
     file_context_token, east, north
 ):
 
@@ -1071,11 +1100,9 @@ def test_that_duplicate_location_in_seismic_observation_raises(
             "",
             [
                 ObservationDict(
-                    {
-                        "type": ObservationType.SEISMIC,
-                        "name": "NAME",
-                        "CSV": "obs.csv",
-                    },
+                    create_seismic_observation_dict(
+                        csv="obs.csv",
+                    ),
                     context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
                 )
             ],
@@ -1083,8 +1110,9 @@ def test_that_duplicate_location_in_seismic_observation_raises(
         )
 
     assert (
-        f"Seismic observation coordinates ({east[1]}, {north[1]}) "
-        "were not unique (after rounding from f64 to f32)." in str(err.value)
+        "Seismic observation coordinates with approximate locations "
+        f"[(({east[0]}, {north[0]}), ({east[1]}, {north[1]}))] "
+        "fall inside of a tolerance radius." in str(err.value)
     )
 
 

--- a/tests/ert/unit_tests/config/test_seismic_config.py
+++ b/tests/ert/unit_tests/config/test_seismic_config.py
@@ -110,19 +110,38 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files):
     assert data["values"].to_list() == [1.0, 2.0, 3.0, 4.0]
 
 
+def test_that_empty_seismic_response_file_does_not_raise(mocked_files):
+    key = "horizon--amplitude_full_min_depth--20250101_20240101"
+    name = f"{key}.csv"
+    runpath = "/runpath"
+    simulated_path = runpath + "/" + name
+
+    mocked_files[simulated_path] = dedent(
+        """
+        X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+        """
+    )
+
+    seismic_config = SeismicConfig(
+        input_files=[name],
+        keys=[key],
+    )
+
+    data = seismic_config.read_from_file(runpath, 1, 1)
+    assert data.is_empty()
+
+
 @pytest.mark.parametrize(
     ("east", "north"),
     [
-        pytest.param([111.11, 111.11], [222.22, 222.22], id="same coordinates"),
-        pytest.param(
-            [111.1111111111111111111111, 111.11111111111111],
-            [222.2222222222222222222222222222222, 222.22222222222223],
-            id="lost precision",
-        ),
+        pytest.param([111.25, 111.25], [222.25, 222.25], id="same coordinates"),
+        pytest.param([0.0, 0.0], [0.1953125, 0.0], id="less than double tolerance"),
     ],
 )
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_duplicate_location_in_seismic_response_raises(mocked_files, east, north):
+def test_that_seismic_response_coordinate_distance_below_tolerance_raises(
+    mocked_files, east, north
+):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{key}.csv"
     runpath = "/runpath"
@@ -144,5 +163,8 @@ def test_that_duplicate_location_in_seismic_response_raises(mocked_files, east, 
     with pytest.raises(InvalidResponseFile) as err:
         seismic_config.read_from_file(runpath, 1, 1)
 
-    m = "Seismic response coordinates were not unique (after rounding from f64 to f32)"
-    assert m in str(err.value)
+    assert (
+        "Seismic response coordinates with approximate locations "
+        f"[(({east[0]}, {north[0]}), ({east[1]}, {north[1]}))] "
+        "fall inside of a tolerance radius." in str(err.value)
+    )

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
@@ -21,7 +21,9 @@ from tests.ert.defaults_generator import (
     create_breakthrough_observation_dict,
     create_general_observation_dict,
     create_rft_observation_dict,
+    create_seismic_observation,
     create_seismic_observation_dict,
+    create_seismic_response,
     create_summary_observation_dict,
 )
 from tests.ert.utils import SnapshotBuilder
@@ -493,6 +495,34 @@ def test_that_many_realizations_in_rft_affect_responses_not_observation_tree(
     verify_number_of_visualized_responses()
     observation_widget.setCurrentItem(top.child(1))
     verify_number_of_visualized_responses()
+
+
+def test_that_seismic_observations_use_tolerance_on_response_match(qtbot, storage):
+    observation = create_seismic_observation(east=1.0, north=1.0)
+    response = create_seismic_response(east=1.05, north=1.05)
+
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "SEISMIC": ["dummy.csv"],
+        }
+    )
+    config.observation_declarations.append(observation)
+
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+    ensemble.save_response("seismic", response, 0)
+
+    ensemble_widget = EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    plot = ensemble_widget._figure.get_axes()
+    assert len(plot) == 1
+    assert len(plot[0].collections) == 2
 
 
 @pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")

--- a/tests/ert/unit_tests/storage/test_local_storage.py
+++ b/tests/ert/unit_tests/storage/test_local_storage.py
@@ -34,6 +34,7 @@ from ert.storage.local_storage import _LOCAL_STORAGE_VERSION, LocalStorage
 from ert.storage.mode import ModeError
 from tests.ert.defaults_generator import (
     create_seismic_observation,
+    create_seismic_response,
     create_summary_observation,
 )
 from tests.ert.unit_tests.storage._storage_test_helpers import (
@@ -826,3 +827,101 @@ def test_that_get_observations_and_responses_bounds_seismic_observations(
         assert obs_and_responses["observation_key"].to_list() == [
             "seismic_observation_inside",
         ]
+
+
+def test_that_get_observations_and_responses_compares_seismic_with_tolerance(tmp_path):
+    with open_storage(tmp_path, mode="w") as storage:
+        seismic_config = SeismicConfig()
+
+        seismic_observation1 = create_seismic_observation(
+            name="1_observation_no_matching_response",
+            east=0.5,
+            north=0.5,
+        )
+
+        seismic_observation2 = create_seismic_observation(
+            name="2_observation_with_different_response_key",
+            filepath=Path("wrong_response_key_obs.csv"),
+            east=0.6,
+            north=0.6,
+            value=100.0,
+        )
+
+        seismic_observation3 = create_seismic_observation(
+            name="3_observation_one_matching_response",
+            east=1.5,
+            north=1.5,
+        )
+
+        # Note that two matching responses / two observations sharing a matching
+        # response should be impossible if all validations are completed. Values for
+        # each response key are assured to be outside of the 2 * tolerance distance from
+        # each other, both for responses and observations. Thus within 1 * tolerance
+        # radius there should be a maximum of one match between observation and
+        # response. Below unexpected setups are present to assure function returns a
+        # reasonable result regardless of performed validations.
+        seismic_observation4 = create_seismic_observation(
+            name="4_observation_two_matching_responses",
+            east=2.5,
+            north=2.5,
+        )
+
+        seismic_observation5 = create_seismic_observation(
+            name="5_observation_share_matching_response1",
+            east=3.45,
+            north=3.45,
+        )
+
+        seismic_observation6 = create_seismic_observation(
+            name="6_observation_share_matching_response2",
+            east=3.55,
+            north=3.55,
+        )
+
+        observations = [
+            seismic_observation1,
+            seismic_observation2,
+            seismic_observation3,
+            seismic_observation4,
+            seismic_observation5,
+            seismic_observation6,
+        ]
+
+        experiment = storage.create_experiment(
+            experiment_config={
+                "response_configuration": [seismic_config.model_dump(mode="json")],
+                "observations": [obs.model_dump(mode="json") for obs in observations],
+            }
+        )
+
+        ensemble = storage.create_ensemble(
+            experiment, ensemble_size=1, iteration=0, name="prior"
+        )
+
+        wrong_response_key_response = create_seismic_response(
+            response_key="wrong_response_key_response", east=0.5, north=0.5, values=10.0
+        )
+        response_setup_data = [0.58, 1.57, 2.45, 2.55, 3.5]
+        seismic_response = pl.concat(
+            [
+                create_seismic_response(east=val, north=val, values=val)
+                for val in response_setup_data
+            ]
+        )
+        ensemble.save_response(
+            "seismic", pl.concat([wrong_response_key_response, seismic_response]), 0
+        )
+
+        iens_active_index = np.array([0])
+        active_observations = [obs.name for obs in observations]
+
+        obs_and_responses = ensemble.get_observations_and_responses(
+            active_observations, iens_active_index
+        )
+
+        expected_easts = [0.5, 0.6, 1.5, 2.5, 3.45, 3.55]
+        expected_values = [None, None, 1.57, 2.5, 3.5, 3.5]
+
+        assert obs_and_responses["observation_key"].to_list() == active_observations
+        assert pytest.approx(obs_and_responses["east"].to_list()) == expected_easts
+        assert pytest.approx(obs_and_responses["0"].to_list()) == expected_values


### PR DESCRIPTION
**Issue**
Resolves #13911

**Approach**
Tolerance is added everywhere where I could remember.
`get_observations_and_responses` becomes to large due to number of "ifs", but I am not yet convinced that generalizing it would do more good than bad.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
