### PR TITLE
Add logging for realization status page

### DIFF
--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -117,6 +117,7 @@ class FMStepOverview(QTableView):
     def __init__(self, snapshot_model: SnapshotModel, parent: QWidget | None) -> None:
         super().__init__(parent)
 
+        self._logged_openings: set[str] = set()
         self._fm_step_model = FMStepListProxyModel(self, 0, 0)
         self._fm_step_model.setSourceModel(snapshot_model)
 
@@ -153,6 +154,14 @@ class FMStepOverview(QTableView):
     def set_realization(self, iter_: int, real: int) -> None:
         self._fm_step_model.set_real(iter_, real)
 
+    def _log_first_opening_of(self, opened: str) -> None:
+        if opened in self._logged_openings:
+            return
+        self._logged_openings.add(opened)
+        logger.info(
+            f"{opened.capitalize()} opened for forward model step in experiment status"
+        )
+
     @Slot(QModelIndex)
     def _fm_step_clicked(self, index: QModelIndex) -> None:
         if not index.isValid():
@@ -162,6 +171,7 @@ class FMStepOverview(QTableView):
         if file_dialog and file_dialog.isVisible():
             file_dialog.raise_()
         elif selected_file and file_has_content(selected_file):
+            self._log_first_opening_of(FM_STEP_COLUMNS[index.column()])
             fm_step_name = index.siblingAtColumn(0).data()
             FileDialog(
                 selected_file,
@@ -172,6 +182,7 @@ class FMStepOverview(QTableView):
                 self,
             )
         elif FM_STEP_COLUMNS[index.column()] == ids.ERROR and index.data():
+            self._log_first_opening_of("error message")
             error_dialog = QDialog(self)
             error_dialog.setWindowTitle("Error information")
             layout = QVBoxLayout(error_dialog)

--- a/src/ert/gui/experiments/run_dialog.py
+++ b/src/ert/gui/experiments/run_dialog.py
@@ -116,6 +116,7 @@ class FMStepOverview(QTableView):
     def __init__(self, snapshot_model: SnapshotModel, parent: QWidget | None) -> None:
         super().__init__(parent)
 
+        self._logged_openings: set[str] = set()
         self._fm_step_model = FMStepListProxyModel(self, 0, 0)
         self._fm_step_model.setSourceModel(snapshot_model)
 
@@ -152,6 +153,14 @@ class FMStepOverview(QTableView):
     def set_realization(self, iter_: int, real: int) -> None:
         self._fm_step_model.set_real(iter_, real)
 
+    def _log_first_opening_of(self, opened: str) -> None:
+        if opened in self._logged_openings:
+            return
+        self._logged_openings.add(opened)
+        logger.info(
+            f"{opened.capitalize()} opened for forward model step in experiment status"
+        )
+
     @Slot(QModelIndex)
     def _fm_step_clicked(self, index: QModelIndex) -> None:
         if not index.isValid():
@@ -161,6 +170,7 @@ class FMStepOverview(QTableView):
         if file_dialog and file_dialog.isVisible():
             file_dialog.raise_()
         elif selected_file and file_has_content(selected_file):
+            self._log_first_opening_of(FM_STEP_COLUMNS[index.column()])
             fm_step_name = index.siblingAtColumn(0).data()
             FileDialog(
                 selected_file,
@@ -171,6 +181,7 @@ class FMStepOverview(QTableView):
                 self,
             )
         elif FM_STEP_COLUMNS[index.column()] == ids.ERROR and index.data():
+            self._log_first_opening_of("error message")
             error_dialog = QDialog(self)
             error_dialog.setWindowTitle("Error information")
             layout = QVBoxLayout(error_dialog)

--- a/src/ert/gui/experiments/view/realization.py
+++ b/src/ert/gui/experiments/view/realization.py
@@ -1,3 +1,4 @@
+import logging
 from typing import cast, override
 
 from PyQt6.QtCore import (
@@ -30,7 +31,10 @@ from ert.gui.model.snapshot import (
     MemoryUsageRole,
     RealIens,
 )
+from ert.gui.utils import log_once
 from ert.shared.status.utils import byte_with_unit
+
+logger = logging.getLogger(__name__)
 
 
 class RealizationWidget(QWidget):
@@ -61,6 +65,12 @@ class RealizationWidget(QWidget):
         )
 
         self._real_view.clicked.connect(self._item_clicked)
+
+        log_once(
+            self._real_view.clicked,
+            logger,
+            f"Realization details opened in experiment status for iteration {it}",
+        )
 
         layout = QVBoxLayout()
         layout.addWidget(self._real_view)

--- a/src/ert/gui/experiments/view/realization.py
+++ b/src/ert/gui/experiments/view/realization.py
@@ -1,3 +1,4 @@
+import logging
 from typing import cast, override
 
 from PyQt6.QtCore import (
@@ -32,7 +33,10 @@ from ert.gui.model.snapshot import (
     MemoryUsageRole,
     RealIens,
 )
+from ert.gui.utils import log_once
 from ert.shared.status.utils import byte_with_unit
+
+logger = logging.getLogger(__name__)
 
 
 class RealizationWidget(QWidget):
@@ -72,6 +76,12 @@ class RealizationWidget(QWidget):
         selector_layout = QHBoxLayout()
         selector_layout.addWidget(self._iteration_selector)
         selector_layout.addStretch()
+
+        log_once(
+            self._real_view.clicked,
+            logger,
+            "Realization details opened in experiment status",
+        )
 
         layout = QVBoxLayout()
         layout.addLayout(selector_layout)

--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 from pathlib import Path
 from queue import SimpleQueue
@@ -21,6 +22,7 @@ from pytestqt.qtbot import QtBot
 import ert.run_models
 from _ert.events import EnsembleEvaluationWarning
 from ert.config import ErtConfig
+from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
 from ert.ensemble_evaluator.event import (
     EndEvent,
@@ -28,6 +30,7 @@ from ert.ensemble_evaluator.event import (
     SnapshotUpdateEvent,
     WarningEvent,
 )
+from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
 from ert.gui.ertwidgets.suggestor.suggestor import Suggestor
 from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.experiments.ensemble_experiment_panel import (
@@ -126,6 +129,37 @@ def mock_set_env_key():
     mock = MagicMock()
     with patch("ert.run_models.run_model.RunModel.set_env_key", mock) as _mock:
         yield _mock
+
+
+@pytest.fixture
+def make_dialog_showing_snapshot(qtbot: QtBot):
+    """Build a RunDialog displaying a single finished iteration of the snapshot."""
+
+    def _make(snapshot: EnsembleSnapshot, status_count: dict[str, int]) -> RunDialog:
+        queue: SimpleQueue = SimpleQueue()
+        mock_api = MagicMock()
+        mock_api.experiment_name = "test"
+
+        dialog = RunDialog("Test", mock_api, queue, MagicMock())
+        qtbot.addWidget(dialog)
+        dialog.setup_event_monitoring()
+
+        queue.put(
+            FullSnapshotEvent(
+                snapshot=snapshot,
+                iteration_label="Iter 0",
+                total_iterations=1,
+                progress=0.0,
+                realization_count=sum(status_count.values()),
+                status_count=status_count,
+                iteration=0,
+            )
+        )
+        queue.put(EndEvent(failed=False, msg=""))
+        qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
+        return dialog
+
+    return _make
 
 
 @pytest.fixture
@@ -1189,6 +1223,68 @@ def test_that_runpath_creation_events_add_update_and_remove_tab(qtbot: QtBot) ->
     qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
     assert isinstance(dialog._tab_widget.widget(0), RealizationWidget)
     qtbot.waitUntil(dialog.is_experiment_done, timeout=2000)
+
+
+def test_that_only_user_initiated_realization_selection_is_logged(
+    make_dialog_showing_snapshot, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO)
+    dialog = make_dialog_showing_snapshot(
+        SnapshotBuilder()
+        .add_fm_step(
+            fm_step_id="0",
+            index="0",
+            name="fm_step_0",
+            status=state.FORWARD_MODEL_STATE_START,
+        )
+        .build(["0", "1"], state.REALIZATION_STATE_UNKNOWN),
+        {"Unknown": 2},
+    )
+
+    def realization_log_messages() -> list[str]:
+        return [r.message for r in caplog.records if "Realization details" in r.message]
+
+    realization_widget = dialog._tab_widget.widget(0)
+    assert isinstance(realization_widget, RealizationWidget)
+
+    # Adding the tab selects realization 0 and refreshes the selection.
+    assert realization_log_messages() == []
+
+    index = realization_widget._real_list_model.index(0, 0)
+    realization_widget._real_view.clicked.emit(index)
+    realization_widget._real_view.clicked.emit(index)
+
+    assert realization_log_messages() == [
+        "Realization details opened in experiment status"
+    ]
+
+
+def test_that_each_forward_model_step_detail_type_is_logged_once(
+    make_dialog_showing_snapshot,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO)
+    dialog = make_dialog_showing_snapshot(
+        SnapshotBuilder()
+        .add_fm_step(
+            fm_step_id="0",
+            index="0",
+            name="fm_step_0",
+            status=state.FORWARD_MODEL_STATE_FAILURE,
+        )
+        .build(["0"], state.REALIZATION_STATE_FAILED),
+        {"Failed": 1},
+    )
+
+    overview = dialog._fm_step_overview
+    overview._log_first_opening_of(ids.STDOUT)
+    overview._log_first_opening_of(ids.STDOUT)
+    overview._log_first_opening_of("error message")
+
+    assert [r.message for r in caplog.records if "experiment status" in r.message] == [
+        f"{ids.STDOUT.capitalize()} opened for forward model step in experiment status",
+        "Error message opened for forward model step in experiment status",
+    ]
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
+++ b/tests/ert/unit_tests/gui/experiments/test_run_dialog.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 from pathlib import Path
 from queue import SimpleQueue
@@ -21,6 +22,7 @@ from pytestqt.qtbot import QtBot
 import ert.run_models
 from _ert.events import EnsembleEvaluationWarning
 from ert.config import ErtConfig
+from ert.ensemble_evaluator import identifiers as ids
 from ert.ensemble_evaluator import state
 from ert.ensemble_evaluator.event import (
     EndEvent,
@@ -28,6 +30,7 @@ from ert.ensemble_evaluator.event import (
     SnapshotUpdateEvent,
     WarningEvent,
 )
+from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
 from ert.gui.ertwidgets.suggestor.suggestor import Suggestor
 from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.experiments.ensemble_experiment_panel import (
@@ -41,6 +44,7 @@ from ert.gui.experiments.multiple_data_assimilation_panel import (
 from ert.gui.experiments.view.realization import RealizationWidget
 from ert.gui.experiments.view.runpath_progress_widget import RunpathProgressWidget
 from ert.gui.main import GUILogHandler, _setup_main_window
+from ert.gui.model.snapshot import FM_STEP_COLUMNS
 from ert.gui.tools.file import FileDialog
 from ert.run_models import (
     EnsembleExperiment,
@@ -126,6 +130,37 @@ def mock_set_env_key():
     mock = MagicMock()
     with patch("ert.run_models.run_model.RunModel.set_env_key", mock) as _mock:
         yield _mock
+
+
+@pytest.fixture
+def make_dialog_showing_snapshot(qtbot: QtBot):
+    """Build a RunDialog displaying a single finished iteration of the snapshot."""
+
+    def _make(snapshot: EnsembleSnapshot, status_count: dict[str, int]) -> RunDialog:
+        queue: SimpleQueue = SimpleQueue()
+        mock_api = MagicMock()
+        mock_api.experiment_name = "test"
+
+        dialog = RunDialog("Test", mock_api, queue, MagicMock())
+        qtbot.addWidget(dialog)
+        dialog.setup_event_monitoring()
+
+        queue.put(
+            FullSnapshotEvent(
+                snapshot=snapshot,
+                iteration_label="Iter 0",
+                total_iterations=1,
+                progress=0.0,
+                realization_count=sum(status_count.values()),
+                status_count=status_count,
+                iteration=0,
+            )
+        )
+        queue.put(EndEvent(failed=False, msg=""))
+        qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
+        return dialog
+
+    return _make
 
 
 @pytest.fixture
@@ -1182,6 +1217,91 @@ def test_that_runpath_creation_events_add_update_and_remove_tab(qtbot: QtBot) ->
     qtbot.waitUntil(lambda: dialog._tab_widget.count() == 1, timeout=2000)
     assert isinstance(dialog._tab_widget.widget(0), RealizationWidget)
     qtbot.waitUntil(dialog.is_experiment_done, timeout=2000)
+
+
+def test_that_only_user_initiated_realization_selection_is_logged(
+    make_dialog_showing_snapshot, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO)
+    dialog = make_dialog_showing_snapshot(
+        SnapshotBuilder()
+        .add_fm_step(
+            fm_step_id="0",
+            index="0",
+            name="fm_step_0",
+            status=state.FORWARD_MODEL_STATE_START,
+        )
+        .build(["0", "1"], state.REALIZATION_STATE_UNKNOWN),
+        {"Unknown": 2},
+    )
+
+    def realization_log_messages() -> list[str]:
+        return [r.message for r in caplog.records if "Realization details" in r.message]
+
+    realization_widget = dialog._tab_widget.widget(0)
+    assert isinstance(realization_widget, RealizationWidget)
+
+    # Adding the tab selects realization 0 and refreshes the selection.
+    assert realization_log_messages() == []
+
+    index = realization_widget._real_list_model.index(0, 0)
+    realization_widget._real_view.clicked.emit(index)
+    realization_widget._real_view.clicked.emit(index)
+
+    assert realization_log_messages() == [
+        "Realization details opened in experiment status for iteration 0"
+    ]
+
+
+def test_that_opening_forward_model_step_output_and_error_is_logged_once(
+    make_dialog_showing_snapshot,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caplog.set_level(logging.INFO)
+    stdout_file = tmp_path / "stdout"
+    stdout_file.write_text("output", encoding="utf-8")
+    monkeypatch.setattr(FileDialog, "_init_thread", lambda self: None)
+
+    dialog = make_dialog_showing_snapshot(
+        SnapshotBuilder()
+        .add_fm_step(
+            fm_step_id="0",
+            index="0",
+            name="fm_step_0",
+            status=state.FORWARD_MODEL_STATE_FAILURE,
+            stdout=str(stdout_file),
+            error="boom",
+        )
+        .build(["0"], state.REALIZATION_STATE_FAILED),
+        {"Failed": 1},
+    )
+
+    overview = dialog._fm_step_overview
+    overview.set_realization(0, 0)
+    model = overview.model()
+    assert model is not None
+
+    stdout_index = model.index(0, FM_STEP_COLUMNS.index(ids.STDOUT))
+    overview.clicked.emit(stdout_index)
+    file_dialog = overview.findChild(FileDialog)
+    assert file_dialog is not None
+    file_dialog.close()
+    overview.clicked.emit(stdout_index)
+
+    def close_error_dialog() -> None:
+        modal_dialog = QApplication.activeModalWidget()
+        assert modal_dialog is not None
+        modal_dialog.close()
+
+    QTimer.singleShot(0, close_error_dialog)
+    overview.clicked.emit(model.index(0, FM_STEP_COLUMNS.index(ids.ERROR)))
+
+    assert [r.message for r in caplog.records if "experiment status" in r.message] == [
+        f"{ids.STDOUT.capitalize()} opened for forward model step in experiment status",
+        "Error message opened for forward model step in experiment status",
+    ]
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
**Issue**
Resolves #14094

**Approach**

Log the first time a user opens realization details or a forward model step's stdout/stderr/error, once per dialog, so usage of these views can be measured.

Two mechanisms, depending on whether a suitable signal already exists: RealizationWidget reuses _real_view.clicked via a new log_once helper in utils.py. FMStepOverview logs inline from its click handler, which already branches on column, guarded by a set of logged names.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
