### PR TITLE
Format verbatim text properly in rst docs

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -687,8 +687,8 @@ replacement in the file content and the file name. All the scalar parameters
 available as magic strings.
 
 .. note::
-        In case of GEN_KW prior file contains `a UNIFORM 0 1`, the magic strings is <a>.
-        In case DESIGN_MATRIX contains column `SENSNAME` the magic string is <SENSNAME>.
+        In case the GEN_KW prior file contains ``a UNIFORM 0 1``, the magic strings is ``<a>``.
+        In case DESIGN_MATRIX contains column ``SENSNAME`` the magic string is ``<SENSNAME>``.
 
 *Example:*
 


### PR DESCRIPTION
Prior to this 'a UNIFORM 0 1' was italicized, which means that the 'a' is easily read as an indefinite article and not the parameter a.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
