### PR TITLE
Avoid entering for loop when there are no files

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,6 +41,7 @@ pack-updated-screenshots:
     #!/bin/bash
     staging="updated-screenshots"
     mkdir -p "$staging"
+    shopt -s nullglob
     for test_dir in pytest-mpl_results/*/; do
       # Filenames from pytest-mpl need a lot of massaging in order to
       # reconstruct the directory structure:


### PR DESCRIPTION
Without the nullopt, the wildcard symbol is used as a literal for a directory name.

**Issue**
Resolves erroneous error message in workflows

`cp: cannot stat 'pytest-mpl_results/*//result.png': No such file or directory
`

**Approach**
`shopt`


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
