### PR TITLE
Handle non-image-related errors in screenshot tests

### DIFF
--- a/.github/workflows/push_screenshots.yml
+++ b/.github/workflows/push_screenshots.yml
@@ -44,6 +44,8 @@ jobs:
       run: |
         ERT_PR_TITLE=$(gh pr view "${PR_NUMBER}" --repo equinor/ert --json title --jq '.title')
         echo "ert_pr_title=${ERT_PR_TITLE}" >> "$GITHUB_OUTPUT"
+        ERT_PR_AUTHOR=$(gh pr view "${PR_NUMBER}" --repo equinor/ert --json author --jq '.author.login')
+        echo "ert_pr_author=${ERT_PR_AUTHOR}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ert-testdata
       if: steps.metadata.outputs.outcome == 'failure'
@@ -64,6 +66,7 @@ jobs:
         GH_TOKEN: ${{ secrets.ERTOMATIC_ERT_TESTDATA_TOKEN }}
         PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
         ERT_PR_TITLE: ${{ steps.ert-pr-title.outputs.ert_pr_title }}
+        ERT_PR_AUTHOR: ${{ steps.ert-pr-title.outputs.ert_pr_author }}
       run: |
         BRANCH="update-screenshots-ert-pr-${PR_NUMBER}"
         cd ert-testdata
@@ -86,7 +89,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "Update screenshots for ${ERT_PR_TITLE} (equinor/ert#${PR_NUMBER})" \
-            --body "Automatically updated screenshot baselines triggered by https://github.com/equinor/ert/pull/${PR_NUMBER}")
+            --body "Automatically updated screenshot baselines triggered by https://github.com/equinor/ert/pull/${PR_NUMBER} by @${ERT_PR_AUTHOR}")
           if [ "${PR_NUMBER}" != "0" ]; then
             gh pr comment "${PR_NUMBER}" \
               --repo equinor/ert \

--- a/.github/workflows/push_screenshots.yml
+++ b/.github/workflows/push_screenshots.yml
@@ -90,6 +90,8 @@ jobs:
             --head "$BRANCH" \
             --title "Update screenshots for ${ERT_PR_TITLE} (equinor/ert#${PR_NUMBER})" \
             --body "Automatically updated screenshot baselines triggered by https://github.com/equinor/ert/pull/${PR_NUMBER} by @${ERT_PR_AUTHOR}")
+          gh pr edit "$PR_URL" --repo equinor/ert-testdata --add-assignee "${ERT_PR_AUTHOR}" --add-reviewer "${ERT_PR_AUTHOR}" \
+            || echo "::warning::Could not assign/request review from @${ERT_PR_AUTHOR} on ert-testdata (insufficient access)"
           if [ "${PR_NUMBER}" != "0" ]; then
             gh pr comment "${PR_NUMBER}" \
               --repo equinor/ert \

--- a/.github/workflows/push_screenshots.yml
+++ b/.github/workflows/push_screenshots.yml
@@ -35,8 +35,17 @@ jobs:
         echo "pr_number=$(jq -r '.pr_number' artifact/metadata.json)" >> "$GITHUB_OUTPUT"
         echo "outcome=$(jq -r '.outcome' artifact/metadata.json)" >> "$GITHUB_OUTPUT"
 
+    - name: Check for updated screenshots
+      id: screenshots
+      run: |
+        if find artifact/updated-screenshots -type f -name '*.png' -print -quit | grep -q .; then
+          echo "has_new_screenshots=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_new_screenshots=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Get ert PR title
-      if: steps.metadata.outputs.outcome == 'failure' && steps.metadata.outputs.pr_number != '0'
+      if: steps.metadata.outputs.outcome == 'failure' && steps.screenshots.outputs.has_new_screenshots == 'true' && steps.metadata.outputs.pr_number != '0'
       id: ert-pr-title
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +57,7 @@ jobs:
         echo "ert_pr_author=${ERT_PR_AUTHOR}" >> "$GITHUB_OUTPUT"
 
     - name: Checkout ert-testdata
-      if: steps.metadata.outputs.outcome == 'failure'
+      if: steps.metadata.outputs.outcome == 'failure' && steps.screenshots.outputs.has_new_screenshots == 'true'
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: equinor/ert-testdata
@@ -57,11 +66,11 @@ jobs:
         path: ert-testdata
 
     - name: Copy updated screenshots into ert-testdata
-      if: steps.metadata.outputs.outcome == 'failure'
+      if: steps.metadata.outputs.outcome == 'failure' && steps.screenshots.outputs.has_new_screenshots == 'true'
       run: cp -r artifact/updated-screenshots/. ert-testdata/screenshotbaselines/
 
     - name: Push branch and open PR in ert-testdata
-      if: steps.metadata.outputs.outcome == 'failure'
+      if: steps.metadata.outputs.outcome == 'failure' && steps.screenshots.outputs.has_new_screenshots == 'true'
       env:
         GH_TOKEN: ${{ secrets.ERTOMATIC_ERT_TESTDATA_TOKEN }}
         PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}

--- a/.github/workflows/test_screenshots.yml
+++ b/.github/workflows/test_screenshots.yml
@@ -3,6 +3,9 @@ name: Screenshot tests
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -59,6 +62,14 @@ jobs:
           exit 1
         fi
         echo "Screenshot tests failed due to image diffs; updated screenshots were produced."
+
+    - name: Fail hard if screenshot fails on main branch
+      if: steps.screenshot-tests.outcome == 'failure' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        echo "Screenshot tests produced new/changed images after merge to main."
+        echo "This should not have happened and needs manual intervention."
+        echo "Maybe you forgot to merge a PR in ert-testdata?"
+        exit 1
 
     - name: Prepare artifact
       if: always()

--- a/.github/workflows/test_screenshots.yml
+++ b/.github/workflows/test_screenshots.yml
@@ -50,6 +50,16 @@ jobs:
       if: steps.screenshot-tests.outcome == 'failure'
       run: uv run just pack-updated-screenshots
 
+    - name: Fail on non-screenshot test failures
+      if: steps.screenshot-tests.outcome == 'failure'
+      run: |
+        if [ -z "$(find updated-screenshots -type f 2>/dev/null)" ]; then
+          echo "Screenshot tests failed, but no updated screenshots were produced."
+          echo "This indicates a failure unrelated to image diffs. Failing the job."
+          exit 1
+        fi
+        echo "Screenshot tests failed due to image diffs; updated screenshots were produced."
+
     - name: Prepare artifact
       if: always()
       run: |

--- a/justfile
+++ b/justfile
@@ -57,6 +57,7 @@ pack-updated-screenshots:
       echo "Mapped $full_dotted_name -> $target_dir/$filename"
     done
     [ -d "/tmp/test_docs_screenshots" ] && cp -r /tmp/test_docs_screenshots/* "$staging"
+    echo "Files staged for updated screenshots:"
     find "$staging" -type f -exec ls -l {} +
 
 ert-gui-tests:


### PR DESCRIPTION
**Issue**
Resolves #14029 

If an error occurs in the screenshot-workflow test where there are no new images produced, the following will be highlighed in Github:

<img width="728" height="158" alt="image" src="https://github.com/user-attachments/assets/57ff3543-f919-40e8-a6e8-9536b9ed3d68" />


**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
