### PR TITLE
Fixup error from ed77de3

### DIFF
--- a/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
+++ b/tests/ert/ui_tests/gui/test_plotting_of_snake_oil.py
@@ -34,11 +34,11 @@ from .conftest import get_child, wait_for_child
     params=[
         ("FOPR", STATISTICS, "snake_oil"),
         ("FOPR", ENSEMBLE, "snake_oil"),
-        ("SNAKE_OIL_PARAM:OP1_OCTAVES", CROSS_ENSEMBLE_STATISTICS, "snake_oil"),
+        ("SNAKE_OIL_PARAM_OP1:OP1_OCTAVES", CROSS_ENSEMBLE_STATISTICS, "snake_oil"),
         ("COND", STD_DEV, "heat_equation"),
-        ("SNAKE_OIL_PARAM:OP1_OCTAVES", DISTRIBUTION, "snake_oil"),
-        ("SNAKE_OIL_PARAM:OP1_OCTAVES", GAUSSIAN_KDE, "snake_oil"),
-        ("SNAKE_OIL_PARAM:OP1_OCTAVES", HISTOGRAM, "snake_oil"),
+        ("SNAKE_OIL_PARAM_OP1:OP1_OCTAVES", DISTRIBUTION, "snake_oil"),
+        ("SNAKE_OIL_PARAM_OP1:OP1_OCTAVES", GAUSSIAN_KDE, "snake_oil"),
+        ("SNAKE_OIL_PARAM_OP1:OP1_OCTAVES", HISTOGRAM, "snake_oil"),
         ("SNAKE_OIL_WPR_DIFF@199", ENSEMBLE, "snake_oil"),
     ],
 )


### PR DESCRIPTION
Test failure went un-noticed in https://github.com/equinor/ert/pull/13980 because of bug in workflow file

**Issue**
Resolves missing screenshot update.


**Approach**
:brain:

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
