### PR TITLE
Read RFT cell centers in map coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dev = [
     "sphinxcontrib.datatemplates",
     "json-schema-for-humans",
     "xlsxwriter>=3.2.3",
-    "resfo-utilities[testing]>=0.5.0",
+    "resfo-utilities[testing]>=1.1.0",
 ]
 style = ["pre-commit"]
 types = [

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -172,7 +172,7 @@ class RFTConfig(SimulationResponseConfig):
             else:
                 location_cell_map[location] = WellConnectionCell(
                     (cell[0] + 1, cell[1] + 1, cell[2] + 1),
-                    tuple(grid.cell_corners(*cell).mean(axis=0)),
+                    tuple(grid.cell_corners(*cell, map_coordinates=True).mean(axis=0)),
                 )
         return location_cell_map
 
@@ -341,7 +341,9 @@ class RFTConfig(SimulationResponseConfig):
 
         def _cell_center(i: int, j: int, k: int) -> npt.NDArray[np.float32]:
             try:
-                return grid.cell_corners(i - 1, j - 1, k - 1).mean(axis=0)
+                return grid.cell_corners(
+                    i - 1, j - 1, k - 1, map_coordinates=True
+                ).mean(axis=0)
             except IndexError as err:
                 raise InvalidResponseFile(
                     f"Grid coordinates ({i}, {j}, {k}) are out of bounds "

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -407,6 +407,17 @@ class RFTConfig(SimulationResponseConfig):
                     if prop != "DEPTH" and len(vals) > 0
                 ]
             )
+            if grid.map_axes:
+                transformed = grid.map_axes.transform_grid_points(
+                    np.asarray(df["cell_center"].to_list(), dtype=np.float32)
+                )
+                df = df.with_columns(
+                    pl.Series(
+                        "cell_center",
+                        transformed.tolist(),
+                        dtype=pl.Array(pl.Float32, 3),
+                    )
+                )
             return df.pipe(self._assert_schema, self.response_schema())
         except KeyError as err:
             raise InvalidResponseFile(

--- a/tests/ert/conftest.py
+++ b/tests/ert/conftest.py
@@ -1,4 +1,5 @@
 import fileinput
+import io
 import logging
 import multiprocessing
 import os
@@ -9,11 +10,14 @@ import sys
 import warnings
 from argparse import ArgumentParser
 from importlib.resources import files
+from io import BytesIO, StringIO
 from pathlib import Path
 from textwrap import dedent
 
+import numpy as np
 import polars as pl
 import pytest
+import resfo
 from hypothesis import HealthCheck, settings
 from hypothesis import strategies as st
 from lark import Token
@@ -575,3 +579,76 @@ def file_context_token():
         )
 
     return _file_context_token
+
+
+original_open = open
+original_io_open = io.open
+original_stat = os.stat
+original_pl_read_csv = pl.read_csv
+original_np_loadtxt = np.loadtxt
+
+
+@pytest.fixture
+def mocked_files(mocker):
+    mocked_files = {}
+
+    def _fresh_buffer(data):
+        if isinstance(data, bytes):
+            return BytesIO(data)
+        return StringIO(data)
+
+    def mock_open(*args, **kwargs):
+        path = args[0] if args else kwargs.get("file")
+        data = mocked_files.get(str(path))
+        if data is not None:
+            return _fresh_buffer(data)
+        return original_open(*args, **kwargs)
+
+    def mock_io_open(*args, **kwargs):
+        path = args[0] if args else kwargs.get("file")
+        data = mocked_files.get(str(path))
+        if data is not None:
+            return _fresh_buffer(data)
+        return original_io_open(*args, **kwargs)
+
+    def mock_stat(*args, **kwargs):
+        path = args[0] if args else kwargs.get("path")
+        if str(path) in mocked_files:
+            return os.stat_result([0x777, *([1] * 10)])
+        return original_stat(*args, **kwargs)
+
+    def mock_pl_read_csv(*args, **kwargs):
+        path = args[0] if args else kwargs.get("source")
+        data = mocked_files.get(str(path))
+        if data is not None:
+            new_kwargs = {**kwargs}
+            new_kwargs.pop("source", None)
+            return original_pl_read_csv(_fresh_buffer(data), *args[1:], **new_kwargs)
+        return original_pl_read_csv(*args, **kwargs)
+
+    def mock_np_loadtxt(*args, **kwargs):
+        path = args[0] if args else kwargs.get("fname")
+        data = mocked_files.get(str(path))
+        if data is not None:
+            new_kwargs = {**kwargs}
+            new_kwargs.pop("fname", None)
+            return original_np_loadtxt(_fresh_buffer(data), *args[1:], **new_kwargs)
+        return original_np_loadtxt(*args, **kwargs)
+
+    mocker.patch("builtins.open", mock_open)
+    mocker.patch("io.open", mock_io_open)
+    mocker.patch("os.stat", mock_stat)
+    mocker.patch("polars.read_csv", mock_pl_read_csv)
+    mocker.patch("numpy.loadtxt", mock_np_loadtxt)
+
+    return mocked_files
+
+
+@pytest.fixture
+def mock_resfo_file(mocked_files):
+    def inner(filename, contents):
+        buffer = BytesIO()
+        resfo.write(buffer, contents)
+        mocked_files[filename] = buffer.getvalue()
+
+    return inner

--- a/tests/ert/rft_generator.py
+++ b/tests/ert/rft_generator.py
@@ -46,26 +46,53 @@ def cell_start(date=(1, 1, 2000), ijks=((1, 1, 1), (2, 1, 2)), *args, **kwargs):
     ]
 
 
+def rft_entry(
+    well_name: bytes,
+    date: tuple[int, int, int],
+    ijks: tuple[tuple[int, int, int], ...],
+    **kwargs,
+):
+
+    return [
+        *cell_start(well_name=well_name, date=date, ijks=ijks),
+        *[(k.ljust(8).upper(), float_arr(v)) for k, v in kwargs.items()],
+    ]
+
+
 def pad_to(lst: list[int], target_len: int):
     return np.pad(
         np.array(lst, dtype=np.int32), (0, target_len - len(lst)), mode="constant"
     )
 
 
-def create_egrid(nx, ny, nz, x_width, y_width, layer_height):
+def create_egrid(
+    nx,
+    ny,
+    nz,
+    x_width,
+    y_width,
+    layer_height,
+    *,
+    mapaxes=(0.0, 1.0, 0.0, 0.0, 1.0, 0.0),
+    shift_bottom_plane=(0.0, 0.0),
+):
     """EGrid file contents with nz layers, nx cells in the i direction and ny cells in
     the j direction.
 
     Each cell has width x_width in the i direction and y_width in the j direction and
     height layer_height in the z direction.
+
+    The bottom plane of the grid is shifted by shift_bottom_plane in the i and j
+    directions, respectively, allowing to create a skewed grid.
     """
 
     height = nz * layer_height
     cells_per_layer = nx * ny
 
+    xd, yd = shift_bottom_plane
     coord = np.array(
         [
-            [i * x_width, j * y_width, 0, i * x_width, j * y_width, height]
+            [i * x_width, j * y_width, 0, i * x_width + xd, j * y_width + yd, height]
             for j in range(ny + 1)
             for i in range(nx + 1)
         ],
@@ -82,7 +109,7 @@ def create_egrid(nx, ny, nz, x_width, y_width, layer_height):
     )
     return [
         ("FILEHEAD", pad_to([3, 2007, 0, 0, 0, 0, 1], 100)),
-        ("MAPAXES ", np.array([0.0, 1.0, 0.0, 0.0, 1.0, 0.0], dtype=">f4")),
+        ("MAPAXES ", np.array(mapaxes, dtype=">f4")),
         ("GRIDUNIT", np.array([b"METRES  ", b"        "], dtype="|S8")),
         ("GRIDHEAD", pad_to([1, nx, ny, nz], 100)),
         ("COORD   ", coord.ravel()),

--- a/tests/ert/rft_generator.py
+++ b/tests/ert/rft_generator.py
@@ -52,7 +52,16 @@ def pad_to(lst: list[int], target_len: int):
     )
 
 
-def create_egrid(nx, ny, nz, x_width, y_width, layer_height):
+def create_egrid(
+    nx,
+    ny,
+    nz,
+    x_width,
+    y_width,
+    layer_height,
+    *,
+    mapaxes=(0.0, 1.0, 0.0, 0.0, 1.0, 0.0),
+):
     """EGrid file contents with nz layers, nx cells in the i direction and ny cells in
     the j direction.
 
@@ -82,7 +91,7 @@ def create_egrid(nx, ny, nz, x_width, y_width, layer_height):
     )
     return [
         ("FILEHEAD", pad_to([3, 2007, 0, 0, 0, 0, 1], 100)),
-        ("MAPAXES ", np.array([0.0, 1.0, 0.0, 0.0, 1.0, 0.0], dtype=">f4")),
+        ("MAPAXES ", np.array(mapaxes, dtype=">f4")),
         ("GRIDUNIT", np.array([b"METRES  ", b"        "], dtype="|S8")),
         ("GRIDHEAD", pad_to([1, nx, ny, nz], 100)),
         ("COORD   ", coord.ravel()),

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -367,7 +367,35 @@ def egrid():
     return create_egrid(2, 2, 3, 50.0, 50.0, 1.0)
 
 
-def test_that_locations_are_found_in_corresponding_grid(mock_resfo_file, egrid):
+@pytest.mark.parametrize(
+    ("location", "mapaxes", "expected_center"),
+    [
+        pytest.param(
+            (1.0, 1.0, 1.0),
+            (0.0, 1.0, 0.0, 0.0, 1.0, 0.0),
+            [25.0, 25.0, 0.5],
+            id="without translation and rotation",
+        ),
+        pytest.param(
+            (101.0, 99.0, 1.0),
+            (
+                101.0,
+                100.0,
+                100.0,
+                100.0,
+                100.0,
+                99.0,
+            ),
+            [125.0, 75.0, 0.5],
+            id="with translation and rotation",
+        ),
+    ],
+)
+def test_that_locations_are_found_in_corresponding_grid(
+    mock_resfo_file, location, mapaxes, expected_center
+):
+    egrid = create_egrid(2, 2, 3, 50.0, 50.0, 1.0, mapaxes=mapaxes)
+
     config = ErtConfig.from_dict(
         {
             "ECLBASE": "BASE",
@@ -382,9 +410,9 @@ def test_that_locations_are_found_in_corresponding_grid(mock_resfo_file, egrid):
                         "ERROR": "0.1",
                         "DATE": "2000-01-01",
                         "PROPERTY": "PRESSURE",
-                        "NORTH": 1.0,
-                        "EAST": 1.0,
-                        "TVD": 1.0,
+                        "EAST": location[0],
+                        "NORTH": location[1],
+                        "TVD": location[2],
                     },
                 ],
             ),
@@ -409,9 +437,12 @@ def test_that_locations_are_found_in_corresponding_grid(mock_resfo_file, egrid):
         "/tmp/does_not_exist", 1, 1, observations
     )
 
-    assert data["north"].to_list() == [1.0]
-    assert data["east"].to_list() == [1.0]
-    assert data["tvd"].to_list() == [1.0]
+    assert data["east"].to_list() == [location[0]]
+    assert data["north"].to_list() == [location[1]]
+    assert data["tvd"].to_list() == [location[2]]
+    np.testing.assert_allclose(
+        data["well_connection_cell_center"].to_numpy(), [expected_center]
+    )  # Expects center in map coordinates
 
 
 def test_that_multiple_locations_in_the_same_cell_creates_multiple_rows(
@@ -977,6 +1008,51 @@ def test_that_cell_center_and_cell_zones_are_populated_from_egrid_and_zonemap(
     np.testing.assert_allclose(
         data["cell_center"].to_numpy(), [[25.0, 25.0, 0.5], [25.0, 25.0, 1.5]]
     )
+
+
+@pytest.mark.parametrize(
+    ("mapaxes", "expected_center"),
+    [
+        pytest.param(
+            (0.0, 1.0, 0.0, 0.0, 1.0, 0.0),
+            [25.0, 25.0, 0.5],
+            id="without translation and rotation",
+        ),
+        pytest.param(
+            (101.0, 100.0, 100.0, 100.0, 100.0, 99.0),
+            [125.0, 75.0, 0.5],
+            id="with translation and rotation",
+        ),
+    ],
+)
+def test_that_cell_centers_are_in_map_coordinates(
+    mock_resfo_file, mapaxes, expected_center
+):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        create_egrid(1, 1, 2, 50.0, 50.0, 1.0, mapaxes=mapaxes),
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name=b"WELL",
+                ijks=[(1, 1, 1)],
+            ),
+            ("PRESSURE", float_arr([10.0])),
+            ("DEPTH   ", float_arr([0.5])),
+        ],
+    )
+
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={"WELL": {"2000-01-01": ["PRESSURE"]}},
+    )
+
+    data = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    np.testing.assert_allclose(data["cell_center"].to_numpy(), [expected_center])
 
 
 def _rft_responses_for_approximation(

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1,14 +1,12 @@
 import re
 import warnings
 from datetime import datetime
-from io import BytesIO
 from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
 import polars as pl
 import pytest
-import resfo
 
 from ert.config import (
     CircleShapeConfig,
@@ -37,16 +35,6 @@ def _clear_rft_caches():
     yield
     _read_egrid.cache_clear()
     _get_zonemap.cache_clear()
-
-
-@pytest.fixture
-def mock_resfo_file(mocked_files):
-    def inner(filename, contents):
-        buffer = BytesIO()
-        resfo.write(buffer, contents)
-        mocked_files[filename] = buffer.getvalue()
-
-    return inner
 
 
 def test_that_rfts_match_key_is_well_connection_cell():

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -991,6 +991,39 @@ def test_that_cell_center_and_cell_zones_are_populated_from_egrid_and_zonemap(
     )
 
 
+def test_that_cell_centers_are_in_map_coordinates(mock_resfo_file):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        create_egrid(
+            1, 1, 2, 50.0, 50.0, 1.0, mapaxes=(101.0, 100.0, 100.0, 100.0, 100.0, 99.0)
+        ),
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(
+                date=(1, 1, 2000),
+                well_name=b"WELL",
+                ijks=[(1, 1, 1)],
+            ),
+            ("PRESSURE", float_arr([10.0])),
+            ("DEPTH   ", float_arr([0.5])),
+        ],
+    )
+
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={"WELL": {"2000-01-01": ["PRESSURE"]}},
+    )
+
+    data = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    # The cell center in grid coordinates is (25.0, 25.0, 0.5).
+    # The mapaxes translates by 100 in x and y direction and rotates 90 degrees
+    # making the expected center in map coordinates (125.0, 75.0, 0.5).
+    np.testing.assert_allclose(data["cell_center"].to_numpy(), [[125.0, 75.0, 0.5]])
+
+
 def _rft_responses_for_approximation(
     well: str = "WELL",
     date: str = "2000-01-01",

--- a/tests/ert/unit_tests/conftest.py
+++ b/tests/ert/unit_tests/conftest.py
@@ -1,10 +1,6 @@
-import io
 import os
 import sys
-from io import BytesIO, StringIO
 
-import numpy as np
-import polars as pl
 import pytest
 
 from ert.config import ErtConfig
@@ -26,69 +22,6 @@ def ensure_bin_in_path():
     os.environ["PATH"] = exec_path + os.pathsep + path
     yield
     os.environ["PATH"] = path
-
-
-original_open = open
-original_io_open = io.open
-original_stat = os.stat
-original_pl_read_csv = pl.read_csv
-original_np_loadtxt = np.loadtxt
-
-
-@pytest.fixture
-def mocked_files(mocker):
-    mocked_files = {}
-
-    def _fresh_buffer(data):
-        if isinstance(data, bytes):
-            return BytesIO(data)
-        return StringIO(data)
-
-    def mock_open(*args, **kwargs):
-        path = args[0] if args else kwargs.get("file")
-        data = mocked_files.get(str(path))
-        if data is not None:
-            return _fresh_buffer(data)
-        return original_open(*args, **kwargs)
-
-    def mock_io_open(*args, **kwargs):
-        path = args[0] if args else kwargs.get("file")
-        data = mocked_files.get(str(path))
-        if data is not None:
-            return _fresh_buffer(data)
-        return original_io_open(*args, **kwargs)
-
-    def mock_stat(*args, **kwargs):
-        path = args[0] if args else kwargs.get("path")
-        if str(path) in mocked_files:
-            return os.stat_result([0x777, *([1] * 10)])
-        return original_stat(*args, **kwargs)
-
-    def mock_pl_read_csv(*args, **kwargs):
-        path = args[0] if args else kwargs.get("source")
-        data = mocked_files.get(str(path))
-        if data is not None:
-            new_kwargs = {**kwargs}
-            new_kwargs.pop("source", None)
-            return original_pl_read_csv(_fresh_buffer(data), *args[1:], **new_kwargs)
-        return original_pl_read_csv(*args, **kwargs)
-
-    def mock_np_loadtxt(*args, **kwargs):
-        path = args[0] if args else kwargs.get("fname")
-        data = mocked_files.get(str(path))
-        if data is not None:
-            new_kwargs = {**kwargs}
-            new_kwargs.pop("fname", None)
-            return original_np_loadtxt(_fresh_buffer(data), *args[1:], **new_kwargs)
-        return original_np_loadtxt(*args, **kwargs)
-
-    mocker.patch("builtins.open", mock_open)
-    mocker.patch("io.open", mock_io_open)
-    mocker.patch("os.stat", mock_stat)
-    mocker.patch("polars.read_csv", mock_pl_read_csv)
-    mocker.patch("numpy.loadtxt", mock_np_loadtxt)
-
-    return mocked_files
 
 
 @pytest.fixture

--- a/tests/ert/unit_tests/storage/test_rft_observations_and_responses.py
+++ b/tests/ert/unit_tests/storage/test_rft_observations_and_responses.py
@@ -3,6 +3,7 @@ import logging
 from contextlib import contextmanager
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import hypothesis.strategies as st
@@ -19,6 +20,7 @@ from ert.storage.local_ensemble import (
     _write_responses_to_storage,
 )
 from tests.ert.defaults_generator import create_rft_observation
+from tests.ert.rft_generator import create_egrid, rft_entry
 
 
 def rft_response(
@@ -458,33 +460,80 @@ def test_that_get_observations_and_responses_adds_qc_error_on_rft_mismatch(
         assert obs_and_responses["qc_error_1"].to_list() == [msg, None]
 
 
+def _list_of_tuples_to_dict(keys: list[str], tuples: list[tuple]) -> dict[str, Any]:
+    return dict(zip(keys, zip(*tuples, strict=True), strict=True))
+
+
 @pytest.mark.parametrize(
-    (
-        "approximate_missing_values",
-        "missing_required_columns",
-        "expected_response_values",
-    ),
+    "approximate_missing_values",
     [
-        pytest.param(True, False, [110.0, 310.0], id="interpolate enabled"),
-        pytest.param(False, False, [None, None], id="interpolate disabled"),
-        pytest.param(True, True, [None, None], id="missing required columns"),
+        pytest.param(True, id="interpolate enabled"),
+        pytest.param(False, id="interpolate disabled"),
+    ],
+)
+@pytest.mark.parametrize(
+    "missing_obs_cell_center",
+    [
+        pytest.param(True, id="observation cell center available"),
+        pytest.param(False, id="observation cell center missing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "missing_required_columns",
+    [
+        pytest.param(True, id="missing required columns"),
+        pytest.param(False, id="all required columns present"),
     ],
 )
 def test_that_get_observations_and_responses_interpolates_rft_values(
     tmp_path,
+    mocked_files,
+    mock_resfo_file,
+    missing_obs_cell_center,
     approximate_missing_values,
     missing_required_columns,
-    expected_response_values,
 ):
+    if approximate_missing_values and not missing_required_columns:
+        expected_response_values = (
+            [112.5, 190.0] if missing_obs_cell_center else [100.0, 200.0]
+        )
+    else:
+        expected_response_values = [None, None]
+
+    # fmt: off
+    well_rft = [
+    #        ijks     pressure   depth
+        ( (1, 1, 1),   50.0,   50.0),  # ruff: ignore[whitespace-after-open-bracket, multiple-spaces-after-comma]
+        ( (1, 1, 3),  150.0,  250.0),  # ruff: ignore[whitespace-after-open-bracket, multiple-spaces-after-comma]
+    ]
+    # fmt: on
+
+    well = _list_of_tuples_to_dict(["ijks", "pressure", "depth"], well_rft)
+
     with open_storage(tmp_path, mode="w") as storage:
         rft_config = RFTConfig(
             input_files=["BASE.RFT"],
+            zonemap=Path("zonemap.txt"),
             data_to_read={"WELL": {"2000-01-01": ["PRESSURE"]}},
             approximate_missing_values=approximate_missing_values,
         )
 
-        obs1 = rft_observation(name="RFT_OBS1", value=100.0, tvd=1000.0, zone="zone1")
-        obs2 = rft_observation(name="RFT_OBS2", value=200.0, tvd=2000.0, zone="zone1")
+        obs1 = rft_observation(
+            name="RFT_OBS1",
+            value=100.0,
+            east=345.0,
+            north=155.0,
+            tvd=155.0,
+            zone="zone1",
+        )
+        obs2 = rft_observation(
+            name="RFT_OBS2",
+            value=200.0,
+            east=455.0,
+            north=155.0,
+            tvd=355.0,
+            zone="zone1",
+        )
 
         experiment = storage.create_experiment(
             experiment_config={
@@ -500,34 +549,52 @@ def test_that_get_observations_and_responses_interpolates_rft_values(
             experiment, ensemble_size=1, iteration=0, name="prior"
         )
 
-        date = datetime(2000, 1, 1).date()  # ruff: ignore[call-datetime-without-tzinfo]
+        BASE_PATH = "path/does/not/exist"
+        mock_resfo_file(
+            f"{BASE_PATH}/BASE.EGRID",
+            create_egrid(
+                1,
+                1,
+                4,
+                100,
+                100,
+                100,
+                mapaxes=(100.0, 101.0, 100.0, 100.0, 101.0, 100.0),
+                shift_bottom_plane=(400.0, 0.0),
+            ),
+        )
+        mock_resfo_file(
+            f"{BASE_PATH}/BASE.RFT",
+            [
+                *rft_entry(date=(1, 1, 2000), well_name=b"WELL", **well),
+            ],
+        )
+        mocked_files[f"{BASE_PATH}/zonemap.txt"] = (
+            "1 zone1\n2 zone1\n3 zone1\n4 zone1\n"
+        )
+
+        observations = ensemble.experiment.observations["rft"]
+        assert observations is not None
 
         # If the response is missing the required columns for interpolation,
         # we should skip interpolation and return None, even if interpolation is
         # enabled. The test drops the columns to simulate a legacy response without
         # these columns.
-        drop_columns = ["cell_center", "cell_zones"] if missing_required_columns else []
+        drop_from_response = (
+            ["cell_center", "cell_zones"] if missing_required_columns else []
+        )
+        drop_from_metadata = (
+            ["well_connection_cell_center"] if missing_obs_cell_center else []
+        )
+
         ensemble.save_response(
             "rft",
-            rft_response(
-                well=("WELL", "WELL"),
-                date=(date, date),
-                prop=("PRESSURE", "PRESSURE"),
-                depth=(500.0, 1500.0),
-                values=(50.0, 150.0),
-                well_connection_cell=((10, 10, 10), (10, 10, 12)),
-                cell_center=((100.0, 105.0, 700.0), (100.0, 105.0, 1200.0)),
-                cell_zones=(("zone1",), ("zone1",)),
-            ).drop(drop_columns),
+            rft_config.read_from_file(BASE_PATH, 0, 0).drop(drop_from_response),
             0,
         )
         ensemble.save_observation_location_metadata(
-            location_metadata(
-                east=(100.0, 100.0),
-                north=(105.0, 105.0),
-                tvd=(1000.0, 2000.0),
-                actual_zones=(("zone1",), ("zone1",)),
-                well_connection_cell=((10, 10, 11), (10, 10, 13)),
+            rft_config.obtain_location_metadata(BASE_PATH, 0, 0, observations).drop(
+                drop_from_metadata
             ),
             0,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-03T11:17:43.872957Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1171,7 +1171,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "resdata" },
-    { name = "resfo-utilities", extras = ["testing"], specifier = ">=0.5.0" },
+    { name = "resfo-utilities", extras = ["testing"], specifier = ">=1.1.0" },
     { name = "rust-just" },
     { name = "scikit-image" },
     { name = "sphinx" },
@@ -4465,7 +4465,7 @@ wheels = [
 
 [[package]]
 name = "resfo-utilities"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "natsort" },
@@ -4473,17 +4473,17 @@ dependencies = [
     { name = "resfo" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/bb/37b7ef1d115170108c1613105d6d2f816c9a094f1a7a926316825803e0d4/resfo_utilities-1.0.0.tar.gz", hash = "sha256:60388d538c9cbc1b14bbf047c3fe4e91a5cb6777a08fc92e7e30bbdd01dbdd70", size = 131200, upload-time = "2026-06-29T11:15:10.652Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/07/02c278d7898333c387d6a3093affece37932ce05f85616f88b2182529358/resfo_utilities-1.1.0.tar.gz", hash = "sha256:8db3919e7d0e1e5751a3897df1de1a9cf6e0f8671a7653f0084e8ffcb224f4cb", size = 140558, upload-time = "2026-08-07T11:36:38.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/23/a16c19a6b4a4ce20b513b86710a83832a594196a616bab6ff1af8c9c002d/resfo_utilities-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:89b0ff2bbba592f5ff4cad64b4ea9d37e52f35fae570ecd0668cae685c3c77dd", size = 6655327, upload-time = "2026-06-29T11:14:51.58Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/88/e5a9369f577abe02e3c5b95290816a4a68cc8c22197d842a5c43a95ba37c/resfo_utilities-1.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dbdb005f6aa4791a70be82f770160da79c771cfa6425fc8029d5a974d3427b2", size = 8004625, upload-time = "2026-06-29T11:14:53.223Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/7f/4c0ff0a91bf42dc79fb315d574412cba858086b7de82c85251034b9e994c/resfo_utilities-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:e65e5dab8e5a13d8e6c200ee877d5b3859f1320e39152d93614aafc56ed35709", size = 41035861, upload-time = "2026-06-29T11:14:55.165Z" },
-    { url = "https://files.pythonhosted.org/packages/00/d7/1e3ea7ce5a2316d4b5993f3f754ed42bf8b879a5b4ece449fbd0cb04de2f/resfo_utilities-1.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e306cfbc5f0be106fef3b40596001e945148be48b1ba051b4a54733519c01b7e", size = 6655381, upload-time = "2026-06-29T11:14:57.714Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b8/fd54bef796a8bd815e42ea435b71b90e7d1eac20b89113c52f9d0e5121f1/resfo_utilities-1.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b98a3d0c3ede4d5b0e9bf3d92cdce75c888efef093c76be948933c3fde332b8", size = 8004699, upload-time = "2026-06-29T11:14:59.389Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/06/0bcc7f49614ff8338fe25d164b10d1b31a152a1b7a4131a6c1261090c8a5/resfo_utilities-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:cdbadde135c8ed0d98483319ba9bf7ea150c8b4c39a8cc716ce671547d2c3185", size = 41034060, upload-time = "2026-06-29T11:15:01.646Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d3/9ae110b5202b6bbad0f76ab63d9090994fa9bfcc48721c252f81dfdc314c/resfo_utilities-1.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8eb3ec5444626c7291181080f94e9ed9d3c328a316d239e440ee232b2db9063b", size = 6655653, upload-time = "2026-06-29T11:15:04.394Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/3f7d35fdab9a2c62e3203164ca3fd1e01f078cebfac0d46c4285cecc9b33/resfo_utilities-1.0.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a359ff8eb6be9745adad4a9d67c7f9bb896349f9b18c09c2bd0e4f662df2ad4", size = 8004595, upload-time = "2026-06-29T11:15:05.951Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3b/39e74f6f5c930ace801c6dd3a1f1d545cdb78dd5a743a3ce9d22bc91c8be/resfo_utilities-1.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:c98ed6c306dba110a5395848cdbbf353993386d7db7575f71dcc4629c6e89790", size = 41290050, upload-time = "2026-06-29T11:15:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/86/0da6a252b15eacf8a3a947e69f0e8c59030016c0bfb795d6b059e0f50013/resfo_utilities-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:814634067d72c22f6b9d20a38076c73478a154c8708962444d5a93cf422df8c9", size = 6656304, upload-time = "2026-08-07T11:36:18.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4e/7a34cee4f8388ce00ea6481d7888311ada9414a1f9fdfc99aa3a86798d55/resfo_utilities-1.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c2b00ae16db7bad5fe59eef0a7dd38ff43552b000cfb3cd8f7f8bc08f5cbd4b", size = 8005277, upload-time = "2026-08-07T11:36:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/227f3e745abe1fc63ddb6b56ad006c5d6bfaffef967fb9ac00f0d54ae5de/resfo_utilities-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f1601f97873e745f78ea71dd3012743c204399040aba8c6298656e5c52287ce", size = 41224218, upload-time = "2026-08-07T11:36:22.45Z" },
+    { url = "https://files.pythonhosted.org/packages/83/02/c8a0fca24f81cf309487a647d4ff9cc20d7b06b3252dd9eeb9a3cc6e58ee/resfo_utilities-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:69b358b9a501417e4bf2fcab4d2885092d40cb4459d5e6b35970650296e09698", size = 6656423, upload-time = "2026-08-07T11:36:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/8c21ca2c83b22c3d0e489f8a7fa07380f2c804ce053dd072d143e930922c/resfo_utilities-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c9a2b00f76ae30e4a3b2a0a399da285503c46c75f6012928ec622cde0458725", size = 8005348, upload-time = "2026-08-07T11:36:26.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/56/5cd3cc6fcbd37624275ae040502f96a1e50807257ed61820f33a932d0a6d/resfo_utilities-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:46c9143d01c77fb509dde417fdc3c2b667a972f463e210aaf65e1086419ea4a9", size = 41223559, upload-time = "2026-08-07T11:36:28.761Z" },
+    { url = "https://files.pythonhosted.org/packages/da/2a/5a7900d7106a95d333e5326ccdbeda71c9564b8f790147992d2f76aa27b9/resfo_utilities-1.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0245dec8aecf39dd2361a6148aba8683b8a2358778dee4e50f6712b953e61ae", size = 6656343, upload-time = "2026-08-07T11:36:31.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f0/d3a3c6c6dca2515389ecc46ec597bab76fd90fb0548a5304247cf01a3744/resfo_utilities-1.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9541ff79d8cf2eb002d7ca47417830d13174e8a5104197bce8d3e6efd889f313", size = 8005400, upload-time = "2026-08-07T11:36:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/59/36/694e06e591b55583486ca73a21c9a2814d7fa4171ab3ac52333842d09f45/resfo_utilities-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:46a255df43f558a4f4ef040323219c7853ada3391ac9b66526cff40209607f9f", size = 41486893, upload-time = "2026-08-07T11:36:35.317Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
RFT observations are handled in map coordinates in ERT. Convert response cell centers to the same coordinate system so comparisons and visualization use consistent locations.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
