### PR TITLE
Allow use of wildcards in definition of seismic observations/responses

### DIFF
--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    ClassVar,
     Literal,
     Self,
     assert_never,
@@ -20,12 +19,12 @@ from typing import (
 import numpy as np
 import pandas as pd
 import polars as pl
-import scipy as sp
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from resfo_utilities import InvalidSummaryKeyError, make_summary_key
 
 from ert.validation import rangestring_to_list
 
+from ._reservoir_data_utils import SeismicData
 from ._shapes import CircleShapeConfig, PolygonShapeConfig, ShapeConfig, ShapeRegistry
 from .parsing import (
     ConfigWarning,
@@ -1004,8 +1003,6 @@ class SeismicObservation(BaseObservation):
     error: float
     boundary_id: int | None = None
 
-    TOLERANCE: ClassVar[float] = 0.1
-
     @staticmethod
     def _load_observations(filepath: Path) -> pd.DataFrame:
         df = pd.read_csv(
@@ -1038,8 +1035,7 @@ class SeismicObservation(BaseObservation):
         if not observations:
             return
         coordinates = [(obs.east, obs.north) for obs in observations]
-        tree = sp.spatial.KDTree(coordinates)
-        too_close_pairs = tree.query_pairs(r=SeismicObservation.TOLERANCE * 2)
+        too_close_pairs = SeismicData.get_too_close_coordinate_pairs(coordinates)
         if too_close_pairs:
             too_close_coords = [
                 (
@@ -1052,7 +1048,7 @@ class SeismicObservation(BaseObservation):
                 "Seismic observation coordinates with approximate locations "
                 f"{too_close_coords} fall inside of a tolerance radius. "
                 "All seismic observation coordinates must be more than "
-                f"{SeismicObservation.TOLERANCE * 2} m apart.",
+                f"{SeismicData.TOLERANCE * 2} m apart.",
                 filepath,
             )
 

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -1071,7 +1071,7 @@ class SeismicObservation(BaseObservation):
             shape_registry: ShapeRegistry for storing geometry.
         """
         name = ""
-        filepath: str | Path | None = None
+        filepath: str | None = None
         boundary_filepath: str | Path | None = None
         for key, value in observation_dict.items():
             match key:
@@ -1086,22 +1086,6 @@ class SeismicObservation(BaseObservation):
                 case _:
                     raise _unknown_key_error(str(key), observation_dict.context)
 
-        if filepath is None:
-            raise _missing_value_error(observation_dict.context, "CSV")
-
-        filepath = Path(directory) / filepath
-        if not filepath.exists():
-            raise ObservationConfigError.with_context(
-                f"The CSV file ({filepath.absolute()}) "
-                "does not exist or is not accessible.",
-                filepath,
-            )
-
-        if not name:
-            name = filepath.stem
-
-        df = cls._load_observations(filepath)
-
         boundary_id = None
         if boundary_filepath is not None:
             boundary_filepath = Path(directory) / boundary_filepath
@@ -1113,6 +1097,40 @@ class SeismicObservation(BaseObservation):
                 )
             boundary = PolygonShapeConfig.from_file(str(boundary_filepath))
             boundary_id = shape_registry.register(boundary)
+
+        if filepath is None:
+            raise _missing_value_error(observation_dict.context, "CSV")
+
+        matching_filepaths = SeismicData.resolve_pattern_filepaths(
+            directory,
+            filepath,
+            on_error=lambda msg: ObservationConfigError.with_context(msg, filepath),
+        )
+        seismic_observations_for_filepath: list[Self] = []
+        for matching_filepath in matching_filepaths:
+            seismic_observations_for_filepath.extend(
+                cls._from_filepath(
+                    name=name,
+                    filepath=matching_filepath,
+                    boundary_id=boundary_id,
+                    shape_registry=shape_registry,
+                )
+            )
+        return seismic_observations_for_filepath
+
+    @classmethod
+    def _from_filepath(
+        cls,
+        name: str,
+        filepath: Path,
+        boundary_id: int | None,
+        shape_registry: ShapeRegistry,
+    ) -> list[Self]:
+
+        if not name:
+            name = filepath.stem
+
+        df = cls._load_observations(filepath)
 
         seismic_observations = []
         for row in df.itertuples():

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -1076,7 +1076,7 @@ class SeismicObservation(BaseObservation):
             shape_registry: ShapeRegistry for storing geometry.
         """
         name = ""
-        filepath: str | Path | None = None
+        filepath: str | None = None
         boundary_filepath: str | Path | None = None
 
         if "CSV" in observation_dict and "OBS_FILE" in observation_dict:
@@ -1105,22 +1105,6 @@ class SeismicObservation(BaseObservation):
                 case _:
                     raise _unknown_key_error(str(key), observation_dict.context)
 
-        if filepath is None:
-            raise _missing_value_error(observation_dict.context, "OBS_FILE")
-
-        filepath = Path(directory) / filepath
-        if not filepath.exists():
-            raise ObservationConfigError.with_context(
-                f"The seismic observations file ({filepath.absolute()}) "
-                "does not exist or is not accessible.",
-                filepath,
-            )
-
-        if not name:
-            name = filepath.stem
-
-        df = cls._load_observations(filepath)
-
         boundary_id = None
         if boundary_filepath is not None:
             boundary_filepath = Path(directory) / boundary_filepath
@@ -1132,6 +1116,40 @@ class SeismicObservation(BaseObservation):
                 )
             boundary = PolygonShapeConfig.from_file(str(boundary_filepath))
             boundary_id = shape_registry.register(boundary)
+
+        if filepath is None:
+            raise _missing_value_error(observation_dict.context, "OBS_FILE")
+
+        matching_filepaths = SeismicData.resolve_pattern_filepaths(
+            directory,
+            filepath,
+            on_error=lambda msg: ObservationConfigError.with_context(msg, filepath),
+        )
+        seismic_observations_for_filepath: list[Self] = []
+        for matching_filepath in matching_filepaths:
+            seismic_observations_for_filepath.extend(
+                cls._from_filepath(
+                    name=name,
+                    filepath=matching_filepath,
+                    boundary_id=boundary_id,
+                    shape_registry=shape_registry,
+                )
+            )
+        return seismic_observations_for_filepath
+
+    @classmethod
+    def _from_filepath(
+        cls,
+        name: str,
+        filepath: Path,
+        boundary_id: int | None,
+        shape_registry: ShapeRegistry,
+    ) -> list[Self]:
+
+        if not name:
+            name = filepath.stem
+
+        df = cls._load_observations(filepath)
 
         seismic_observations = []
         for row in df.iter_rows(named=True):

--- a/src/ert/config/_observations.py
+++ b/src/ert/config/_observations.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    ClassVar,
     Literal,
     Self,
     assert_never,
@@ -19,12 +18,12 @@ from typing import (
 
 import numpy as np
 import polars as pl
-import scipy as sp
 from pydantic import BaseModel, ConfigDict, Field, model_serializer
 from resfo_utilities import InvalidSummaryKeyError, make_summary_key
 
 from ert.validation import rangestring_to_list
 
+from ._reservoir_data_utils import SeismicData
 from ._shapes import CircleShapeConfig, PolygonShapeConfig, ShapeConfig, ShapeRegistry
 from .parsing import (
     ConfigWarning,
@@ -999,8 +998,6 @@ class SeismicObservation(BaseObservation):
     error: float
     boundary_id: int | None = None
 
-    TOLERANCE: ClassVar[float] = 0.1
-
     @staticmethod
     def _load_observations(filepath: Path) -> pl.DataFrame:
 
@@ -1043,8 +1040,7 @@ class SeismicObservation(BaseObservation):
         if not observations:
             return
         coordinates = [(obs.east, obs.north) for obs in observations]
-        tree = sp.spatial.KDTree(coordinates)
-        too_close_pairs = tree.query_pairs(r=SeismicObservation.TOLERANCE * 2)
+        too_close_pairs = SeismicData.get_too_close_coordinate_pairs(coordinates)
         if too_close_pairs:
             too_close_coords = [
                 (
@@ -1057,7 +1053,7 @@ class SeismicObservation(BaseObservation):
                 "Seismic observation coordinates with approximate locations "
                 f"{too_close_coords} fall inside of a tolerance radius. "
                 "All seismic observation coordinates must be more than "
-                f"{SeismicObservation.TOLERANCE * 2} m apart.",
+                f"{SeismicData.TOLERANCE * 2} m apart.",
                 filepath,
             )
 

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -1,0 +1,73 @@
+from typing import Any, ClassVar
+
+import polars as pl
+import scipy as sp
+
+
+class SeismicData:
+    TOLERANCE: ClassVar[float] = 0.1
+
+    @classmethod
+    def get_too_close_coordinate_pairs(cls, coordinates: Any) -> set[tuple[int, int]]:
+        """Get pairs of indices of coordinates that are within double tolerance of each
+        other.
+
+        Double tolerance is used to assure that no response and observation are within
+        singular tolerance of each other.
+        """
+
+        tree = sp.spatial.KDTree(coordinates)
+        return tree.query_pairs(r=cls.TOLERANCE * 2)
+
+    @classmethod
+    def use_observation_locations_in_respective_responses(
+        cls, responses: pl.DataFrame, observations: pl.DataFrame
+    ) -> pl.DataFrame:
+        """Unify response and observation locations.
+
+        Replace the east and north coordinates in the response dataframe with the
+        corresponding coordinates from the observation dataframe, if they are within the
+        tolerance radius. Drop response otherwise. Required to match responses to
+        observations regardless of location precision discrepancies.
+        """
+        candidates = responses.rename(
+            {
+                "east": "east_res",
+                "north": "north_res",
+                "response_key": "response_key_res",
+            }
+        ).join_where(
+            observations.rename(
+                {
+                    "east": "east_obs",
+                    "north": "north_obs",
+                    "response_key": "response_key_obs",
+                }
+            ),
+            pl.col("response_key_res") == pl.col("response_key_obs"),
+            pl.col("east_obs") >= pl.col("east_res") - cls.TOLERANCE,
+            pl.col("east_obs") <= pl.col("east_res") + cls.TOLERANCE,
+            pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
+            pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
+        )
+        matched_on_location = (
+            candidates.filter(
+                (pl.col("east_obs") - pl.col("east_res")).pow(2)
+                + (pl.col("north_obs") - pl.col("north_res")).pow(2)
+                <= cls.TOLERANCE**2
+            )
+        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
+
+        return (
+            responses.join(
+                matched_on_location,
+                left_on=["response_key", "east", "north"],
+                right_on=["response_key_res", "east_res", "north_res"],
+                how="inner",
+            )
+            .with_columns(
+                east=pl.col("east_obs"),
+                north=pl.col("north_obs"),
+            )
+            .drop(["east_obs", "north_obs"])
+        )

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -1,4 +1,7 @@
-from collections.abc import Sequence
+import fnmatch
+import re
+from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -83,3 +86,54 @@ class SeismicData:
             )
             .drop(["east_obs", "north_obs"])
         )
+
+    @staticmethod
+    def resolve_pattern_filepaths(
+        basedir: str,
+        pattern: str,
+        on_error: Callable[[str], Exception],
+    ) -> list[Path]:
+        """Resolve all file paths matching a pattern against filenames only.
+
+        The pattern can include a directory path (e.g., "../subdir/obs-*.csv"),
+        but the pattern itself is only matched against the filename component.
+        Literal glob metacharacters (* ?) should be wrapped in brackets: "test[*].csv".
+
+        Args:
+            basedir: Base directory.
+            pattern: Pattern with optional directory path and possible glob-style
+            wildcards in the filename.
+            on_error: Callable to raise a custom exception.
+
+        """
+        pattern_path = Path(pattern)
+        search_dir = Path(basedir) / pattern_path.parent
+        if not search_dir.exists():
+            raise on_error(
+                f"Directory '{search_dir.absolute()}' does not exist "
+                "or is not accessible."
+            )
+
+        filename_pattern = pattern_path.name
+        has_glob = any(char in filename_pattern for char in "*?[")
+        if not has_glob:
+            path = search_dir / filename_pattern
+            if not path.exists():
+                raise on_error(
+                    f"File '{path.absolute()}' does not exist or is not accessible."
+                )
+            return [path]
+
+        compiled_pattern = re.compile(fnmatch.translate(filename_pattern))
+        matching_paths = [
+            path
+            for path in search_dir.iterdir()
+            if path.is_file() and compiled_pattern.fullmatch(path.name)
+        ]
+
+        if not matching_paths:
+            raise on_error(
+                f"No files matching pattern '{filename_pattern}' found "
+                f"in '{search_dir}'"
+            )
+        return sorted(matching_paths)

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -30,6 +30,10 @@ class SeismicData:
         tolerance radius. Drop response otherwise. Required to match responses to
         observations regardless of location precision discrepancies.
         """
+        extra_cols = []
+        if "realization" in responses.columns:
+            extra_cols.append("realization")
+
         candidates = responses.rename(
             {
                 "east": "east_res",
@@ -50,19 +54,23 @@ class SeismicData:
             pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
             pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
         )
+
+        cols = ["response_key_res", "east_res", "north_res", "east_obs", "north_obs"]
         matched_on_location = (
             candidates.filter(
                 (pl.col("east_obs") - pl.col("east_res")).pow(2)
                 + (pl.col("north_obs") - pl.col("north_res")).pow(2)
                 <= cls.TOLERANCE**2
             )
-        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
+        ).select(cols + extra_cols)
 
+        left_on = ["response_key", "east", "north", *extra_cols]
+        right_on = ["response_key_res", "east_res", "north_res", *extra_cols]
         return (
             responses.join(
                 matched_on_location,
-                left_on=["response_key", "east", "north"],
-                right_on=["response_key_res", "east_res", "north_res"],
+                left_on=left_on,
+                right_on=right_on,
                 how="inner",
             )
             .with_columns(

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -1,3 +1,7 @@
+import fnmatch
+import re
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any, ClassVar
 
 import polars as pl
@@ -79,3 +83,54 @@ class SeismicData:
             )
             .drop(["east_obs", "north_obs"])
         )
+
+    @staticmethod
+    def resolve_pattern_filepaths(
+        basedir: str,
+        pattern: str,
+        on_error: Callable[[str], Exception],
+    ) -> list[Path]:
+        """Resolve all file paths matching a pattern against filenames only.
+
+        The pattern can include a directory path (e.g., "../subdir/obs-*.csv"),
+        but the pattern itself is only matched against the filename component.
+        Literal glob metacharacters (* ?) should be wrapped in brackets: "test[*].csv".
+
+        Args:
+            basedir: Base directory.
+            pattern: Pattern with optional directory path and possible glob-style
+            wildcards in the filename.
+            on_error: Callable to raise a custom exception.
+
+        """
+        pattern_path = Path(pattern)
+        search_dir = Path(basedir) / pattern_path.parent
+        if not search_dir.exists():
+            raise on_error(
+                f"Directory '{search_dir.absolute()}' does not exist "
+                "or is not accessible."
+            )
+
+        filename_pattern = pattern_path.name
+        has_glob = any(char in filename_pattern for char in "*?[")
+        if not has_glob:
+            path = search_dir / filename_pattern
+            if not path.exists():
+                raise on_error(
+                    f"File '{path.absolute()}' does not exist or is not accessible."
+                )
+            return [path]
+
+        compiled_pattern = re.compile(fnmatch.translate(filename_pattern))
+        matching_paths = [
+            path
+            for path in search_dir.iterdir()
+            if path.is_file() and compiled_pattern.fullmatch(path.name)
+        ]
+
+        if not matching_paths:
+            raise on_error(
+                f"No files matching pattern '{filename_pattern}' found "
+                f"in '{search_dir}'"
+            )
+        return matching_paths

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -34,6 +34,10 @@ class SeismicData:
         tolerance radius. Drop response otherwise. Required to match responses to
         observations regardless of location precision discrepancies.
         """
+        extra_cols = []
+        if "realization" in responses.columns:
+            extra_cols.append("realization")
+
         candidates = responses.rename(
             {
                 "east": "east_res",
@@ -54,19 +58,23 @@ class SeismicData:
             pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
             pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
         )
+
+        cols = ["response_key_res", "east_res", "north_res", "east_obs", "north_obs"]
         matched_on_location = (
             candidates.filter(
                 (pl.col("east_obs") - pl.col("east_res")).pow(2)
                 + (pl.col("north_obs") - pl.col("north_res")).pow(2)
                 <= cls.TOLERANCE**2
             )
-        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
+        ).select(cols + extra_cols)
 
+        left_on = ["response_key", "east", "north", *extra_cols]
+        right_on = ["response_key_res", "east_res", "north_res", *extra_cols]
         return (
             responses.join(
                 matched_on_location,
-                left_on=["response_key", "east", "north"],
-                right_on=["response_key_res", "east_res", "north_res"],
+                left_on=left_on,
+                right_on=right_on,
                 how="inner",
             )
             .with_columns(

--- a/src/ert/config/_reservoir_data_utils.py
+++ b/src/ert/config/_reservoir_data_utils.py
@@ -1,0 +1,77 @@
+from collections.abc import Sequence
+from typing import ClassVar
+
+import numpy as np
+import polars as pl
+import scipy as sp
+
+
+class SeismicData:
+    TOLERANCE: ClassVar[float] = 0.1
+
+    @classmethod
+    def get_too_close_coordinate_pairs(
+        cls, coordinates: Sequence[tuple[float, float]] | np.ndarray
+    ) -> set[tuple[int, int]]:
+        """Get pairs of indices of coordinates that are within double tolerance of each
+        other.
+
+        Double tolerance is used to assure that no response and observation are within
+        singular tolerance of each other.
+        """
+
+        tree = sp.spatial.KDTree(coordinates)
+        return tree.query_pairs(r=cls.TOLERANCE * 2)
+
+    @classmethod
+    def use_observation_locations_in_respective_responses(
+        cls, responses: pl.DataFrame, observations: pl.DataFrame
+    ) -> pl.DataFrame:
+        """Unify response and observation locations.
+
+        Replace the east and north coordinates in the response dataframe with the
+        corresponding coordinates from the observation dataframe, if they are within the
+        tolerance radius. Drop response otherwise. Required to match responses to
+        observations regardless of location precision discrepancies.
+        """
+        candidates = responses.rename(
+            {
+                "east": "east_res",
+                "north": "north_res",
+                "response_key": "response_key_res",
+            }
+        ).join_where(
+            observations.rename(
+                {
+                    "east": "east_obs",
+                    "north": "north_obs",
+                    "response_key": "response_key_obs",
+                }
+            ),
+            pl.col("response_key_res") == pl.col("response_key_obs"),
+            pl.col("east_obs") >= pl.col("east_res") - cls.TOLERANCE,
+            pl.col("east_obs") <= pl.col("east_res") + cls.TOLERANCE,
+            pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
+            pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
+        )
+        matched_on_location = (
+            candidates.filter(
+                (pl.col("east_obs") - pl.col("east_res")).pow(2)
+                + (pl.col("north_obs") - pl.col("north_res")).pow(2)
+                <= cls.TOLERANCE**2
+            )
+        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
+
+        return (
+            responses.join(
+                matched_on_location,
+                left_on=["response_key", "east", "north"],
+                right_on=["response_key_res", "east_res", "north_res"],
+                how="inner",
+            )
+            .with_columns(
+                east=pl.col("east_obs"),
+                north=pl.col("north_obs"),
+            )
+            .drop(["east_obs", "north_obs"])
+        )

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, ClassVar, Literal, Self
+from typing import Any, Literal, Self
 
 import numpy as np
 import polars as pl
-import scipy as sp
 
+from ert.config._reservoir_data_utils import SeismicData
 from ert.substitutions import substitute_runpath_name
 
 from .parsing import (
@@ -30,8 +30,6 @@ class SeismicConfig(SimulationResponseConfig):
     name: str = "seismic"
     type: Literal["seismic"] = "seismic"
 
-    TOLERANCE: ClassVar[float] = 0.1
-
     @property
     def expected_input_files(self) -> list[str]:
         return self.input_files
@@ -50,8 +48,7 @@ class SeismicConfig(SimulationResponseConfig):
         easts = df["east"].to_numpy()
         norths = df["north"].to_numpy()
         coordinates = np.column_stack([easts, norths])
-        tree = sp.spatial.KDTree(coordinates)
-        too_close_pairs = tree.query_pairs(r=SeismicConfig.TOLERANCE * 2)
+        too_close_pairs = SeismicData.get_too_close_coordinate_pairs(coordinates)
         if too_close_pairs:
             too_close_coords = [
                 (
@@ -64,7 +61,7 @@ class SeismicConfig(SimulationResponseConfig):
                 "Seismic response coordinates with approximate locations "
                 f"{too_close_coords} fall inside of a tolerance radius. All seismic "
                 "response coordinates are expected to be more than "
-                f"{SeismicConfig.TOLERANCE * 2} m apart."
+                f"{SeismicData.TOLERANCE * 2} m apart."
             )
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
@@ -108,57 +105,4 @@ class SeismicConfig(SimulationResponseConfig):
             name="seismic",
             input_files=files,
             keys=[Path(f).stem for f in files],
-        )
-
-    @classmethod
-    def use_observation_locations_in_respective_responses(
-        cls, responses: pl.DataFrame, observations: pl.DataFrame
-    ) -> pl.DataFrame:
-        """Unify response and observation locations.
-
-        Replace the east and north coordinates in the response dataframe with the
-        corresponding coordinates from the observation dataframe, if they are within the
-        tolerance radius. Drop response otherwise. Required to match responses to
-        observations regardless of location precision discrepancies.
-        """
-        candidates = responses.rename(
-            {
-                "east": "east_res",
-                "north": "north_res",
-                "response_key": "response_key_res",
-            }
-        ).join_where(
-            observations.rename(
-                {
-                    "east": "east_obs",
-                    "north": "north_obs",
-                    "response_key": "response_key_obs",
-                }
-            ),
-            pl.col("response_key_res") == pl.col("response_key_obs"),
-            pl.col("east_obs") >= pl.col("east_res") - cls.TOLERANCE,
-            pl.col("east_obs") <= pl.col("east_res") + cls.TOLERANCE,
-            pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
-            pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
-        )
-        matched_on_location = (
-            candidates.filter(
-                (pl.col("east_obs") - pl.col("east_res")).pow(2)
-                + (pl.col("north_obs") - pl.col("north_res")).pow(2)
-                <= cls.TOLERANCE**2
-            )
-        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
-
-        return (
-            responses.join(
-                matched_on_location,
-                left_on=["response_key", "east", "north"],
-                right_on=["response_key_res", "east_res", "north_res"],
-                how="inner",
-            )
-            .with_columns(
-                east=pl.col("east_obs"),
-                north=pl.col("north_obs"),
-            )
-            .drop(["east_obs", "north_obs"])
         )

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -8,7 +8,6 @@ import numpy as np
 import polars as pl
 
 from ert.config._reservoir_data_utils import SeismicData
-from ert.substitutions import substitute_runpath_name
 
 from .parsing import (
     ConfigDict,
@@ -64,15 +63,21 @@ class SeismicConfig(SimulationResponseConfig):
                 f"{SeismicData.TOLERANCE * 2} m apart."
             )
 
+    def _collect_response_filepaths(self, run_path: str) -> list[Path]:
+        filepaths = []
+        for file in self.expected_input_files:
+            filepaths.extend(
+                SeismicData.resolve_pattern_filepaths(
+                    run_path, file, on_error=InvalidResponseFile
+                )
+            )
+        return list(dict.fromkeys(filepaths))
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         responses = pl.DataFrame(schema=self.response_schema())
-        for key, file in zip(self.keys, self.expected_input_files, strict=True):
-            filepath_runpath_relative = substitute_runpath_name(file, iens, iter_)
-            filepath = Path(run_path) / filepath_runpath_relative
-            if not filepath.exists():
-                raise InvalidResponseFile(
-                    f"Expected seismic response file {filepath} does not exist."
-                )
+        filepaths = self._collect_response_filepaths(run_path)
+        keys = [f.stem for f in filepaths]
+        for key, filepath in zip(keys, filepaths, strict=True):
             suffix = filepath.suffix.lower()
             if suffix == ".parquet":
                 data = pl.read_parquet(filepath)
@@ -114,4 +119,5 @@ class SeismicConfig(SimulationResponseConfig):
             name="seismic",
             input_files=files,
             keys=[Path(f).stem for f in files],
+            has_finalized_keys=False,
         )

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, ClassVar, Literal, Self
+from typing import Any, Literal, Self
 
 import numpy as np
 import polars as pl
-import scipy as sp
 
+from ert.config._reservoir_data_utils import SeismicData
 from ert.substitutions import substitute_runpath_name
 
 from .parsing import (
@@ -30,8 +30,6 @@ class SeismicConfig(SimulationResponseConfig):
     name: str = "seismic"
     type: Literal["seismic"] = "seismic"
 
-    TOLERANCE: ClassVar[float] = 0.1
-
     @property
     def expected_input_files(self) -> list[str]:
         return self.input_files
@@ -50,8 +48,7 @@ class SeismicConfig(SimulationResponseConfig):
         easts = df["east"].to_numpy()
         norths = df["north"].to_numpy()
         coordinates = np.column_stack([easts, norths])
-        tree = sp.spatial.KDTree(coordinates)
-        too_close_pairs = tree.query_pairs(r=SeismicConfig.TOLERANCE * 2)
+        too_close_pairs = SeismicData.get_too_close_coordinate_pairs(coordinates)
         if too_close_pairs:
             too_close_coords = [
                 (
@@ -64,7 +61,7 @@ class SeismicConfig(SimulationResponseConfig):
                 "Seismic response coordinates with approximate locations "
                 f"{too_close_coords} fall inside of a tolerance radius. All seismic "
                 "response coordinates are expected to be more than "
-                f"{SeismicConfig.TOLERANCE * 2} m apart."
+                f"{SeismicData.TOLERANCE * 2} m apart."
             )
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
@@ -117,57 +114,4 @@ class SeismicConfig(SimulationResponseConfig):
             name="seismic",
             input_files=files,
             keys=[Path(f).stem for f in files],
-        )
-
-    @classmethod
-    def use_observation_locations_in_respective_responses(
-        cls, responses: pl.DataFrame, observations: pl.DataFrame
-    ) -> pl.DataFrame:
-        """Unify response and observation locations.
-
-        Replace the east and north coordinates in the response dataframe with the
-        corresponding coordinates from the observation dataframe, if they are within the
-        tolerance radius. Drop response otherwise. Required to match responses to
-        observations regardless of location precision discrepancies.
-        """
-        candidates = responses.rename(
-            {
-                "east": "east_res",
-                "north": "north_res",
-                "response_key": "response_key_res",
-            }
-        ).join_where(
-            observations.rename(
-                {
-                    "east": "east_obs",
-                    "north": "north_obs",
-                    "response_key": "response_key_obs",
-                }
-            ),
-            pl.col("response_key_res") == pl.col("response_key_obs"),
-            pl.col("east_obs") >= pl.col("east_res") - cls.TOLERANCE,
-            pl.col("east_obs") <= pl.col("east_res") + cls.TOLERANCE,
-            pl.col("north_obs") >= pl.col("north_res") - cls.TOLERANCE,
-            pl.col("north_obs") <= pl.col("north_res") + cls.TOLERANCE,
-        )
-        matched_on_location = (
-            candidates.filter(
-                (pl.col("east_obs") - pl.col("east_res")).pow(2)
-                + (pl.col("north_obs") - pl.col("north_res")).pow(2)
-                <= cls.TOLERANCE**2
-            )
-        ).select(["response_key_res", "east_res", "north_res", "east_obs", "north_obs"])
-
-        return (
-            responses.join(
-                matched_on_location,
-                left_on=["response_key", "east", "north"],
-                right_on=["response_key_res", "east_res", "north_res"],
-                how="inner",
-            )
-            .with_columns(
-                east=pl.col("east_obs"),
-                north=pl.col("north_obs"),
-            )
-            .drop(["east_obs", "north_obs"])
         )

--- a/src/ert/config/seismic_config.py
+++ b/src/ert/config/seismic_config.py
@@ -8,7 +8,6 @@ import numpy as np
 import polars as pl
 
 from ert.config._reservoir_data_utils import SeismicData
-from ert.substitutions import substitute_runpath_name
 
 from .parsing import (
     ConfigDict,
@@ -64,15 +63,21 @@ class SeismicConfig(SimulationResponseConfig):
                 f"{SeismicData.TOLERANCE * 2} m apart."
             )
 
+    def _collect_response_filepaths(self, run_path: str) -> list[Path]:
+        filepaths = []
+        for file in self.expected_input_files:
+            filepaths.extend(
+                SeismicData.resolve_pattern_filepaths(
+                    run_path, file, on_error=InvalidResponseFile
+                )
+            )
+        return list(dict.fromkeys(filepaths))
+
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         responses = pl.DataFrame(schema=self.response_schema())
-        for key, file in zip(self.keys, self.expected_input_files, strict=True):
-            filepath_runpath_relative = substitute_runpath_name(file, iens, iter_)
-            filepath = Path(run_path) / filepath_runpath_relative
-            if not filepath.exists():
-                raise InvalidResponseFile(
-                    f"Expected seismic response file {filepath} does not exist."
-                )
+        filepaths = self._collect_response_filepaths(run_path)
+        keys = [f.stem for f in filepaths]
+        for key, filepath in zip(keys, filepaths, strict=True):
             csv = pl.read_csv(filepath)
             df = pl.DataFrame(
                 {
@@ -105,4 +110,5 @@ class SeismicConfig(SimulationResponseConfig):
             name="seismic",
             input_files=files,
             keys=[Path(f).stem for f in files],
+            has_finalized_keys=False,
         )

--- a/src/ert/gui/tools/manage_experiments/ensemble_widget.py
+++ b/src/ert/gui/tools/manage_experiments/ensemble_widget.py
@@ -27,9 +27,9 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ert.config._reservoir_data_utils import SeismicData
 from ert.config.response_config import ResponseConfig
 from ert.config.rft_config import RFTConfig
-from ert.config.seismic_config import SeismicConfig
 from ert.gui.experiments.view.run_status import RunStatusView
 from ert.storage import Ensemble
 from ert.storage.blob_data import BlobType
@@ -320,7 +320,7 @@ class EnsembleWidget(QWidget):
             responses = ens.load_responses(response_key, reals_with_responses)
             if response_type == "seismic":
                 responses = (
-                    SeismicConfig.use_observation_locations_in_respective_responses(
+                    SeismicData.use_observation_locations_in_respective_responses(
                         responses, obs
                     )
                 )

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -28,6 +28,7 @@ from ert.config import (
     ParameterConfig,
     SummaryConfig,
 )
+from ert.config._reservoir_data_utils import SeismicData
 from ert.config.field import Field, field_transform
 from ert.config.observation_quality_control import (
     append_to_qc_error,
@@ -36,7 +37,6 @@ from ert.config.observation_quality_control import (
     qc_seismic_observations,
 )
 from ert.config.rft_config import RFTConfig
-from ert.config.seismic_config import SeismicConfig
 from ert.substitutions import substitute_runpath_name
 
 from .blob_data import (
@@ -1048,7 +1048,7 @@ class LocalEnsemble(BaseMode):
                 )
                 if response_type == "seismic":
                     pivoted = (
-                        SeismicConfig.use_observation_locations_in_respective_responses(
+                        SeismicData.use_observation_locations_in_respective_responses(
                             pivoted, observations
                         )
                         # Due to performed validations, all match keys should be unique.

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
+from typing import cast
 
 import hypothesis.extra.lark as stlark
 import pytest
@@ -15,6 +16,7 @@ from ert.config._observations import (
     BreakthroughObservation,
     GeneralObservation,
     RFTObservation,
+    SeismicObservation,
     SummaryObservation,
     make_observations,
 )
@@ -861,10 +863,13 @@ def test_that_seismic_observation_instantiates(file_context_token):
     ]
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_non_existent_seismic_observation_file_raises_error(file_context_token):
+    directory = "dir"
+    Path(directory).mkdir()
     with pytest.raises(ObservationConfigError) as err:
         make_observations(
-            "dir",
+            directory,
             [
                 ObservationDict(
                     {
@@ -878,7 +883,7 @@ def test_that_non_existent_seismic_observation_file_raises_error(file_context_to
             shape_registry=ShapeRegistry(),
         )
 
-    assert "/dir/seismic_observations.csv) does not exist or is not accessible." in str(
+    assert "seismic_observations.csv' does not exist or is not accessible" in str(
         err.value
     )
 
@@ -1116,17 +1121,27 @@ def test_that_seismic_observation_coordinate_distance_below_tolerance_raises(
     )
 
 
-@pytest.mark.usefixtures("use_tmpdir")
-def test_that_seismic_observation_reads_boundary_file(file_context_token):
-    Path("obs.csv").write_text(
-        dedent(
-            """
-            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
-            1.0,1.0,1.0,0.005,1.0
-            """
-        ),
+def default_seismic_file_content() -> str:
+    return dedent(
+        """
+        X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+        1.0,1.0,1.0,0.005,1.0
+        """
+    )
+
+
+def write_default_seismic_file_content(
+    filename="horizon--amplitude_full_min_depth--20250101_20240101.csv",
+):
+    Path(filename).write_text(
+        default_seismic_file_content(),
         encoding="utf8",
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_observation_reads_boundary_file(file_context_token):
+    write_default_seismic_file_content("obs.csv")
     Path("boundary.pol").write_text(
         dedent(
             """
@@ -1185,15 +1200,9 @@ def test_that_non_existent_boundary_seismic_observation_file_raises_error(
 ):
     os.makedirs("directory/right/path", exist_ok=True)
     os.makedirs("directory/wrong/path", exist_ok=True)
-    Path("directory/obs.csv").write_text(
-        dedent(
-            """
-            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
-            1.0,1.0,1.0,0.005,1.0
-            """
-        ),
-        encoding="utf8",
-    )
+
+    write_default_seismic_file_content("directory/obs.csv")
+
     Path("directory/right/path/bound.pol").write_text(
         "Unexpected file location",
         encoding="utf8",
@@ -1219,3 +1228,97 @@ def test_that_non_existent_boundary_seismic_observation_file_raises_error(
         "/directory/wrong/path/bound.pol) does not exist or is not accessible."
         in str(err.value)
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_observation_filenames_can_be_blob_pattern(file_context_token):
+    filename0 = "surface--amplitude_far_mean_depth--20190701_20180101.csv"
+    filename1 = "surface--amplitude_full_min_depth--20190901_20180101.csv"
+    filename2 = "surface--amplitude_full_min_depth--20180701_20180101.csv"
+    filename3 = ".surface--amplitude_full_mean_depth--20190701_20180101.csv.yml"
+
+    directory = "dir1/dir2/.."
+    os.makedirs(directory, exist_ok=True)
+
+    for filename in [filename0, filename1, filename2, filename3]:
+        write_default_seismic_file_content(f"{directory}/{filename}")
+
+    def make_observations_with_pattern(
+        pattern: str, directory: str = directory
+    ) -> list[SeismicObservation]:
+        shape_registry = ShapeRegistry()
+        obs = make_observations(
+            "",
+            [
+                ObservationDict(
+                    {
+                        "type": ObservationType.SEISMIC,
+                        "CSV": f"{directory}/{pattern}",
+                    },
+                    context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
+                )
+            ],
+            shape_registry=shape_registry,
+        )
+        return [cast(SeismicObservation, o) for o in obs]
+
+    p1 = "surface--amplitude_*_*_depth--20190[1-9]01_20180101.csv"
+    obs = make_observations_with_pattern(p1)
+    assert len(obs) == 2
+    assert sorted([o.filepath for o in obs]) == sorted(
+        [
+            Path(f"{directory}/{filename0}"),
+            Path(f"{directory}/{filename1}"),
+        ]
+    )
+
+    p2 = "surface*"
+    obs = make_observations_with_pattern(p2)
+    assert len(obs) == 3
+    assert sorted([o.filepath for o in obs]) == sorted(
+        [
+            Path(f"{directory}/{filename0}"),
+            Path(f"{directory}/{filename1}"),
+            Path(f"{directory}/{filename2}"),
+        ]
+    )
+
+    p3 = p1[:-4]
+    with pytest.raises(ObservationConfigError) as err:
+        make_observations_with_pattern(p3)
+    assert f"No files matching pattern '{p3}' found in '{directory}'" in str(err.value)
+
+    with pytest.raises(ObservationConfigError) as err:
+        make_observations_with_pattern(p1, directory="ufo")
+    assert "ufo' does not exist or is not accessible" in str(err.value)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_filepath_can_have_literal_metacharacters(file_context_token):
+    def make_observations_with_pattern(pattern: str) -> list[SeismicObservation]:
+        shape_registry = ShapeRegistry()
+        obs = make_observations(
+            "",
+            [
+                ObservationDict(
+                    {
+                        "type": ObservationType.SEISMIC,
+                        "CSV": pattern,
+                    },
+                    context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
+                )
+            ],
+            shape_registry=shape_registry,
+        )
+        return [cast(SeismicObservation, o) for o in obs]
+
+    path_with_literal_wildcard = r"test*.csv"
+    path_fitting_to_wildcard = "test123.csv"
+    write_default_seismic_file_content(path_with_literal_wildcard)
+    write_default_seismic_file_content(path_fitting_to_wildcard)
+
+    wildcard_pattern = "test**"
+    literal_pattern = "test[*]*"
+
+    assert len(make_observations_with_pattern(pattern=wildcard_pattern)) == 2
+    assert len(make_observations_with_pattern(pattern=literal_pattern)) == 1

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
+from typing import cast
 
 import hypothesis.extra.lark as stlark
 import polars as pl
@@ -16,6 +17,7 @@ from ert.config._observations import (
     BreakthroughObservation,
     GeneralObservation,
     RFTObservation,
+    SeismicObservation,
     SummaryObservation,
     make_observations,
 )
@@ -862,10 +864,13 @@ def test_that_seismic_observation_instantiates(file_context_token):
     ]
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_non_existent_seismic_observation_file_raises_error(file_context_token):
+    directory = "dir"
+    Path(directory).mkdir()
     with pytest.raises(ObservationConfigError) as err:
         make_observations(
-            "dir",
+            directory,
             [
                 ObservationDict(
                     {
@@ -879,7 +884,7 @@ def test_that_non_existent_seismic_observation_file_raises_error(file_context_to
             shape_registry=ShapeRegistry(),
         )
 
-    assert "/dir/seismic_observations.csv) does not exist or is not accessible." in str(
+    assert "seismic_observations.csv' does not exist or is not accessible" in str(
         err.value
     )
 
@@ -1180,17 +1185,27 @@ def test_that_seismic_observation_coordinate_distance_below_tolerance_raises(
     )
 
 
-@pytest.mark.usefixtures("use_tmpdir")
-def test_that_seismic_observation_reads_boundary_file(file_context_token):
-    Path("obs.csv").write_text(
-        dedent(
-            """
-            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
-            1.0,1.0,1.0,0.005,1.0
-            """
-        ),
+def default_seismic_file_content() -> str:
+    return dedent(
+        """
+        X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+        1.0,1.0,1.0,0.005,1.0
+        """
+    )
+
+
+def write_default_seismic_file_content(
+    filename="horizon--amplitude_full_min_depth--20250101_20240101.csv",
+):
+    Path(filename).write_text(
+        default_seismic_file_content(),
         encoding="utf8",
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_observation_reads_boundary_file(file_context_token):
+    write_default_seismic_file_content("obs.csv")
     Path("boundary.pol").write_text(
         dedent(
             """
@@ -1249,15 +1264,9 @@ def test_that_non_existent_boundary_seismic_observation_file_raises_error(
 ):
     os.makedirs("directory/right/path", exist_ok=True)
     os.makedirs("directory/wrong/path", exist_ok=True)
-    Path("directory/obs.csv").write_text(
-        dedent(
-            """
-            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
-            1.0,1.0,1.0,0.005,1.0
-            """
-        ),
-        encoding="utf8",
-    )
+
+    write_default_seismic_file_content("directory/obs.csv")
+
     Path("directory/right/path/bound.pol").write_text(
         "Unexpected file location",
         encoding="utf8",
@@ -1283,3 +1292,97 @@ def test_that_non_existent_boundary_seismic_observation_file_raises_error(
         "/directory/wrong/path/bound.pol) does not exist or is not accessible."
         in str(err.value)
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_observation_filenames_can_be_glob_pattern(file_context_token):
+    filename0 = "surface--amplitude_far_mean_depth--20190701_20180101.csv"
+    filename1 = "surface--amplitude_full_min_depth--20190901_20180101.csv"
+    filename2 = "surface--amplitude_full_min_depth--20180701_20180101.csv"
+    filename3 = ".surface--amplitude_full_mean_depth--20190701_20180101.csv.yml"
+
+    directory = "dir1/dir2/.."
+    os.makedirs(directory, exist_ok=True)
+
+    for filename in [filename0, filename1, filename2, filename3]:
+        write_default_seismic_file_content(f"{directory}/{filename}")
+
+    def make_observations_with_pattern(
+        pattern: str, directory: str = directory
+    ) -> list[SeismicObservation]:
+        shape_registry = ShapeRegistry()
+        obs = make_observations(
+            "",
+            [
+                ObservationDict(
+                    {
+                        "type": ObservationType.SEISMIC,
+                        "OBS_FILE": f"{directory}/{pattern}",
+                    },
+                    context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
+                )
+            ],
+            shape_registry=shape_registry,
+        )
+        return [cast(SeismicObservation, o) for o in obs]
+
+    p1 = "surface--amplitude_*_*_depth--20190[1-9]01_20180101.csv"
+    obs = make_observations_with_pattern(p1)
+    assert len(obs) == 2
+    assert sorted([o.filepath for o in obs]) == sorted(
+        [
+            Path(f"{directory}/{filename0}"),
+            Path(f"{directory}/{filename1}"),
+        ]
+    )
+
+    p2 = "surface*"
+    obs = make_observations_with_pattern(p2)
+    assert len(obs) == 3
+    assert sorted([o.filepath for o in obs]) == sorted(
+        [
+            Path(f"{directory}/{filename0}"),
+            Path(f"{directory}/{filename1}"),
+            Path(f"{directory}/{filename2}"),
+        ]
+    )
+
+    p3 = p1[:-4]
+    with pytest.raises(ObservationConfigError) as err:
+        make_observations_with_pattern(p3)
+    assert f"No files matching pattern '{p3}' found in '{directory}'" in str(err.value)
+
+    with pytest.raises(ObservationConfigError) as err:
+        make_observations_with_pattern(p1, directory="ufo")
+    assert "ufo' does not exist or is not accessible" in str(err.value)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_filepath_can_have_literal_metacharacters(file_context_token):
+    def make_observations_with_pattern(pattern: str) -> list[SeismicObservation]:
+        shape_registry = ShapeRegistry()
+        obs = make_observations(
+            "",
+            [
+                ObservationDict(
+                    {
+                        "type": ObservationType.SEISMIC,
+                        "OBS_FILE": pattern,
+                    },
+                    context=file_context_token(obs_type="SEISMIC_OBSERVATION"),
+                )
+            ],
+            shape_registry=shape_registry,
+        )
+        return [cast(SeismicObservation, o) for o in obs]
+
+    path_with_literal_wildcard = r"test*.csv"
+    path_fitting_to_wildcard = "test123.csv"
+    write_default_seismic_file_content(path_with_literal_wildcard)
+    write_default_seismic_file_content(path_fitting_to_wildcard)
+
+    wildcard_pattern = "test**"
+    literal_pattern = "test[*]*"
+
+    assert len(make_observations_with_pattern(pattern=wildcard_pattern)) == 2
+    assert len(make_observations_with_pattern(pattern=literal_pattern)) == 1

--- a/tests/ert/unit_tests/config/test_seismic_config.py
+++ b/tests/ert/unit_tests/config/test_seismic_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from textwrap import dedent
 from typing import cast
 
@@ -11,17 +12,16 @@ from ert.config.seismic_config import SeismicConfig
 from tests.ert.defaults_generator import create_seismic_observation_dict
 
 
-def test_that_seismic_observation_response_key_matches_simulated_response_key(
-    mocked_files,
-):
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_observation_response_key_matches_simulated_response_key():
     expected_response_key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{expected_response_key}.csv"
-    runpath = "/runpath"
+    runpath = "runpath"
     obs_path = "share/preprocessed/tables/" + name
     simulated_path_relative_to_runpath = "share/results/tables/" + name
     simulated_path = runpath + "/" + simulated_path_relative_to_runpath
 
-    mocked_files[obs_path] = dedent(
+    obs_content = dedent(
         """
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         100.00,200.00,1.0,0.005,1.0
@@ -29,13 +29,17 @@ def test_that_seismic_observation_response_key_matches_simulated_response_key(
         """
     )
 
-    mocked_files[simulated_path] = dedent(
+    simulated_content = dedent(
         """
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         100.00,200.00,1.1,0.005,1.0
         105.00,205.00,2.2,0.005,1.0
         """
     )
+    Path(obs_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(simulated_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(obs_path).write_text(obs_content, encoding="utf8")
+    Path(simulated_path).write_text(simulated_content, encoding="utf8")
 
     config = ErtConfig.from_dict(
         {
@@ -69,7 +73,7 @@ def test_that_seismic_config_raises_when_reading_from_non_existing_file(tmp_path
         keys=["key"],
     )
     with pytest.raises(InvalidResponseFile):
-        seismic_config.read_from_file(tmp_path / "non-existent-file.csv", 1, 1)
+        seismic_config.read_from_file(tmp_path, 1, 1)
 
 
 def test_that_seismic_config_reads_from_all_input_files(mocked_files):
@@ -77,11 +81,8 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files):
     key2 = "horizon--amplitude_full_mean_depth--20260101_20240101"
     name1 = f"{key1}.csv"
     name2 = f"{key2}.csv"
-    runpath = "/runpath"
-    simulated_path1 = runpath + "/" + name1
-    simulated_path2 = runpath + "/" + name2
 
-    mocked_files[simulated_path1] = dedent(
+    mocked_files[name1] = dedent(
         """
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         100.00,200.00,1.0,0.005,1.0
@@ -89,7 +90,7 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files):
         """
     )
 
-    mocked_files[simulated_path2] = dedent(
+    mocked_files[name2] = dedent(
         """
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         100.00,200.00,3.0,0.005,1.0
@@ -102,7 +103,7 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files):
         keys=[key1, key2],
     )
 
-    data = seismic_config.read_from_file(runpath, 1, 1)
+    data = seismic_config.read_from_file("", 1, 1)
     assert data.shape == (4, 4)
     assert data["response_key"].to_list() == [key1, key1, key2, key2]
     assert data["east"].to_list() == [100.0, 105.0, 100.0, 105.0]
@@ -110,13 +111,52 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files):
     assert data["values"].to_list() == [1.0, 2.0, 3.0, 4.0]
 
 
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_config_supports_blob_pattern():
+    key1 = "horizon1--amplitude_full_mean_depth--20260101_20240101"
+    key2 = "horizon1--amplitude_full_min_depth--20250101_20240101"
+    key3 = "horizon2--amplitude_far_min_depth--20250101_20240101"
+    key4 = "other_horizon--amplitude_full_mean_depth--20260101_20240101"
+
+    runpath = "runpath"
+    Path(runpath).mkdir(parents=True, exist_ok=True)
+
+    for key in [key1, key2, key3, key4]:
+        name = f"{key}.csv"
+        simulated_path = runpath + "/" + name
+        content = dedent(
+            """
+            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+            100.00,200.00,1.0,0.005,1.0
+            """
+        )
+        Path(simulated_path).write_text(
+            content,
+            encoding="utf8",
+        )
+
+    pattern1 = "horizon1--amplitude_full*"
+    pattern2 = "horizon2--amplitude_far*"
+    duplicate_pattern = "horizon*"
+    config = ErtConfig.from_dict(
+        {
+            "SEISMIC": [pattern1, pattern2, duplicate_pattern],
+        }
+    )
+
+    seismic_config = cast(
+        SeismicConfig, config.ensemble_config.response_configs["seismic"]
+    )
+
+    data = seismic_config.read_from_file(runpath, 1, 1)
+    assert sorted(data["response_key"].to_list()) == [key1, key2, key3]
+
+
 def test_that_empty_seismic_response_file_does_not_raise(mocked_files):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{key}.csv"
-    runpath = "/runpath"
-    simulated_path = runpath + "/" + name
 
-    mocked_files[simulated_path] = dedent(
+    mocked_files[name] = dedent(
         """
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         """
@@ -127,7 +167,7 @@ def test_that_empty_seismic_response_file_does_not_raise(mocked_files):
         keys=[key],
     )
 
-    data = seismic_config.read_from_file(runpath, 1, 1)
+    data = seismic_config.read_from_file("", 1, 1)
     assert data.is_empty()
 
 
@@ -144,10 +184,8 @@ def test_that_seismic_response_coordinate_distance_below_tolerance_raises(
 ):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{key}.csv"
-    runpath = "/runpath"
-    simulated_path = runpath + "/" + name
 
-    mocked_files[simulated_path] = dedent(
+    mocked_files[name] = dedent(
         f"""
         X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
         {east[0]},{north[0]},1.0,0.005,1.0
@@ -161,7 +199,7 @@ def test_that_seismic_response_coordinate_distance_below_tolerance_raises(
     )
 
     with pytest.raises(InvalidResponseFile) as err:
-        seismic_config.read_from_file(runpath, 1, 1)
+        seismic_config.read_from_file("", 1, 1)
 
     assert (
         "Seismic response coordinates with approximate locations "

--- a/tests/ert/unit_tests/config/test_seismic_config.py
+++ b/tests/ert/unit_tests/config/test_seismic_config.py
@@ -1,4 +1,5 @@
 from io import BytesIO, StringIO
+from pathlib import Path
 from typing import cast
 
 import polars as pl
@@ -31,13 +32,14 @@ def _mock_seismic_response(
         mocked_files[path] = buf.getvalue()
 
 
+@pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.parametrize("suffix", [".csv", ".parquet"])
 def test_that_seismic_observation_response_key_matches_simulated_response_key(
     mocked_files, suffix
 ):
     expected_response_key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{expected_response_key}{suffix}"
-    runpath = "/runpath"
+    runpath = "runpath"
     obs_path = "share/preprocessed/tables/" + name
     simulated_path_relative_to_runpath = "share/results/tables/" + name
     simulated_path = runpath + "/" + simulated_path_relative_to_runpath
@@ -64,6 +66,16 @@ def test_that_seismic_observation_response_key_matches_simulated_response_key(
 
     _mock_seismic_response(mocked_files, obs_path, obs_frame, suffix)
     _mock_seismic_response(mocked_files, simulated_path, simulated_frame, suffix)
+
+    Path(obs_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(simulated_path).parent.mkdir(parents=True, exist_ok=True)
+
+    if suffix.endswith("parquet"):
+        Path(obs_path).write_bytes(mocked_files[obs_path])
+        Path(simulated_path).write_bytes(mocked_files[simulated_path])
+    else:
+        Path(obs_path).write_text(mocked_files[obs_path], encoding="utf8")
+        Path(simulated_path).write_text(mocked_files[simulated_path], encoding="utf8")
 
     config = ErtConfig.from_dict(
         {
@@ -119,7 +131,7 @@ def test_that_seismic_config_raises_when_reading_from_non_existing_file(tmp_path
         keys=["key"],
     )
     with pytest.raises(InvalidResponseFile):
-        seismic_config.read_from_file(tmp_path / "non-existent-file.csv", 1, 1)
+        seismic_config.read_from_file(tmp_path, 1, 1)
 
 
 @pytest.mark.parametrize("suffix", [".csv", ".parquet"])

--- a/tests/ert/unit_tests/config/test_seismic_config.py
+++ b/tests/ert/unit_tests/config/test_seismic_config.py
@@ -1,5 +1,6 @@
 from io import BytesIO, StringIO
 from pathlib import Path
+from textwrap import dedent
 from typing import cast
 
 import polars as pl
@@ -108,8 +109,7 @@ def test_that_unsupported_seismic_response_file_extension_raises_invalid_respons
 ):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{key}.txt"
-    runpath = "/runpath"
-    mocked_files[f"{runpath}/{name}"] = "irrelevant content"
+    mocked_files[f"{name}"] = "irrelevant content"
 
     seismic_config = SeismicConfig(
         input_files=[name],
@@ -117,10 +117,10 @@ def test_that_unsupported_seismic_response_file_extension_raises_invalid_respons
     )
 
     with pytest.raises(InvalidResponseFile) as err:
-        seismic_config.read_from_file(runpath, 1, 1)
+        seismic_config.read_from_file("", 1, 1)
 
     assert (
-        f"Unsupported seismic response file extension '.txt' for {runpath}/{name}. "
+        f"Unsupported seismic response file extension '.txt' for {name}. "
         "Expected '.csv' or '.parquet'." in str(err.value)
     )
 
@@ -140,7 +140,6 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files, suffix):
     key2 = "horizon--amplitude_full_mean_depth--20260101_20240101"
     name1 = f"{key1}{suffix}"
     name2 = f"{key2}{suffix}"
-    runpath = "/runpath"
 
     frame1 = pl.DataFrame(
         {
@@ -160,15 +159,15 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files, suffix):
             "REGION": [1.0, 1.0],
         }
     )
-    _mock_seismic_response(mocked_files, f"{runpath}/{name1}", frame1, suffix)
-    _mock_seismic_response(mocked_files, f"{runpath}/{name2}", frame2, suffix)
+    _mock_seismic_response(mocked_files, f"{name1}", frame1, suffix)
+    _mock_seismic_response(mocked_files, f"{name2}", frame2, suffix)
 
     seismic_config = SeismicConfig(
         input_files=[name1, name2],
         keys=[key1, key2],
     )
 
-    data = seismic_config.read_from_file(runpath, 1, 1)
+    data = seismic_config.read_from_file("", 1, 1)
     assert data.shape == (4, 4)
     assert data["response_key"].to_list() == [key1, key1, key2, key2]
     assert data["east"].to_list() == [100.0, 105.0, 100.0, 105.0]
@@ -176,11 +175,51 @@ def test_that_seismic_config_reads_from_all_input_files(mocked_files, suffix):
     assert data["values"].to_list() == [1.0, 2.0, 3.0, 4.0]
 
 
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_seismic_config_supports_glob_pattern():
+    key1 = "horizon1--amplitude_full_mean_depth--20260101_20240101"
+    key2 = "horizon1--amplitude_full_min_depth--20250101_20240101"
+    key3 = "horizon2--amplitude_far_min_depth--20250101_20240101"
+    key4 = "other_horizon--amplitude_full_mean_depth--20260101_20240101"
+
+    runpath = "runpath"
+    Path(runpath).mkdir(parents=True, exist_ok=True)
+
+    for key in [key1, key2, key3, key4]:
+        name = f"{key}.csv"
+        simulated_path = runpath + "/" + name
+        content = dedent(
+            """
+            X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+            100.00,200.00,1.0,0.005,1.0
+            """
+        )
+        Path(simulated_path).write_text(
+            content,
+            encoding="utf8",
+        )
+
+    pattern1 = "horizon1--amplitude_full*"
+    pattern2 = "horizon2--amplitude_far*"
+    duplicate_pattern = "horizon*"
+    config = ErtConfig.from_dict(
+        {
+            "SEISMIC": [pattern1, pattern2, duplicate_pattern],
+        }
+    )
+
+    seismic_config = cast(
+        SeismicConfig, config.ensemble_config.response_configs["seismic"]
+    )
+
+    data = seismic_config.read_from_file(runpath, 1, 1)
+    assert sorted(data["response_key"].to_list()) == [key1, key2, key3]
+
+
 @pytest.mark.parametrize("suffix", [".csv", ".parquet"])
 def test_that_empty_seismic_response_file_does_not_raise(mocked_files, suffix):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
     name = f"{key}{suffix}"
-    runpath = "/runpath"
 
     empty = pl.DataFrame(
         schema={
@@ -191,14 +230,14 @@ def test_that_empty_seismic_response_file_does_not_raise(mocked_files, suffix):
             "REGION": pl.Float64,
         }
     )
-    _mock_seismic_response(mocked_files, f"{runpath}/{name}", empty, suffix)
+    _mock_seismic_response(mocked_files, f"{name}", empty, suffix)
 
     seismic_config = SeismicConfig(
         input_files=[name],
         keys=[key],
     )
 
-    data = seismic_config.read_from_file(runpath, 1, 1)
+    data = seismic_config.read_from_file("", 1, 1)
     assert data.is_empty()
 
 
@@ -209,24 +248,19 @@ def test_that_empty_seismic_response_file_does_not_raise(mocked_files, suffix):
         pytest.param([0.0, 0.0], [0.1953125, 0.0], id="less than double tolerance"),
     ],
 )
-@pytest.mark.parametrize("suffix", [".csv", ".parquet"])
 def test_that_seismic_response_coordinate_distance_below_tolerance_raises(
-    mocked_files, east, north, suffix
+    mocked_files, east, north
 ):
     key = "horizon--amplitude_full_min_depth--20250101_20240101"
-    name = f"{key}{suffix}"
-    runpath = "/runpath"
+    name = f"{key}.csv"
 
-    frame = pl.DataFrame(
-        {
-            "X_UTME": east,
-            "Y_UTMN": north,
-            "OBS": [1.0, 2.0],
-            "OBS_ERROR": [0.005, 0.005],
-            "REGION": [1.0, 1.0],
-        }
+    mocked_files[name] = dedent(
+        f"""
+        X_UTME,Y_UTMN,OBS,OBS_ERROR,REGION
+        {east[0]},{north[0]},1.0,0.005,1.0
+        {east[1]},{north[1]},2.0,0.005,1.0
+        """
     )
-    _mock_seismic_response(mocked_files, f"{runpath}/{name}", frame, suffix)
 
     seismic_config = SeismicConfig(
         input_files=[name],
@@ -234,7 +268,7 @@ def test_that_seismic_response_coordinate_distance_below_tolerance_raises(
     )
 
     with pytest.raises(InvalidResponseFile) as err:
-        seismic_config.read_from_file(runpath, 1, 1)
+        seismic_config.read_from_file("", 1, 1)
 
     assert (
         "Seismic response coordinates with approximate locations "

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
@@ -330,6 +330,16 @@ def test_that_approximated_rft_responses_are_visualized_in_ensemble_widget_if_en
         assert len(collections) == 1
 
 
+def verify_number_of_visualized_responses(ensemble_widget, expected_num_responses):
+    plot = ensemble_widget._figure.get_axes()
+    assert len(plot) == 1
+    collections = plot[0].collections
+    assert len(collections) == 2
+    strip_plot_response_collection = collections[-1]
+    displayed_responses = np.asarray(strip_plot_response_collection.get_offsets())
+    assert len(displayed_responses) == expected_num_responses
+
+
 @pytest.mark.filterwarnings("ignore:.*contains a RFT key but no forward model step")
 def test_that_many_realizations_in_rft_affect_responses_not_observation_tree(
     qtbot, storage
@@ -481,37 +491,30 @@ def test_that_many_realizations_in_rft_affect_responses_not_observation_tree(
             f"Expected observation names {expected_children}, but got {children}"
         )
 
-    def verify_number_of_visualized_responses():
-        plot = ensemble_widget._figure.get_axes()
-        assert len(plot) == 1
-        collections = plot[0].collections
-        assert len(collections) == 2
-        strip_plot_response_collection = collections[-1]
-        displayed_responses = np.asarray(strip_plot_response_collection.get_offsets())
-        assert len(displayed_responses) == 1
-
     verify_observation_tree()
     observation_widget.setCurrentItem(top.child(0))
-    verify_number_of_visualized_responses()
+    verify_number_of_visualized_responses(ensemble_widget, expected_num_responses=1)
     observation_widget.setCurrentItem(top.child(1))
-    verify_number_of_visualized_responses()
+    verify_number_of_visualized_responses(ensemble_widget, expected_num_responses=1)
 
 
 def test_that_seismic_observations_use_tolerance_on_response_match(qtbot, storage):
     observation = create_seismic_observation(east=1.0, north=1.0)
-    response = create_seismic_response(east=1.05, north=1.05)
+    response0 = create_seismic_response(east=1.05, north=1.05)
+    response1 = create_seismic_response(east=1.05, north=1.05, values=1.2)
 
     config = ErtConfig.from_dict(
         {
-            "NUM_REALIZATIONS": 1,
+            "NUM_REALIZATIONS": 2,
             "SEISMIC": ["dummy.csv"],
         }
     )
     config.observation_declarations.append(observation)
 
     experiment = create_experiment_from_config(config, storage)
-    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
-    ensemble.save_response("seismic", response, 0)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=2)
+    ensemble.save_response("seismic", response0, 0)
+    ensemble.save_response("seismic", response1, 1)
 
     ensemble_widget = EnsembleWidget()
     ensemble_widget.setEnsemble(ensemble)
@@ -520,9 +523,7 @@ def test_that_seismic_observations_use_tolerance_on_response_match(qtbot, storag
     panels_widget = ensemble_widget._tab_widget
     panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
 
-    plot = ensemble_widget._figure.get_axes()
-    assert len(plot) == 1
-    assert len(plot[0].collections) == 2
+    verify_number_of_visualized_responses(ensemble_widget, expected_num_responses=2)
 
 
 @pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")


### PR DESCRIPTION
**Issue**
Resolves #13913 


**Approach**
It has been confirmed that we want wildcards, not regex.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
