### PR TITLE
Fix building docs via justfile on MacOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -85,7 +85,8 @@ fetch-screenshot-baselines:
     rm -rf .tmp/ert-testdata
     git clone --depth 1 --filter=blob:none --sparse https://github.com/equinor/ert-testdata.git .tmp/ert-testdata
     cd .tmp/ert-testdata && git sparse-checkout set screenshotbaselines
-    cp --recursive .tmp/ert-testdata/screenshotbaselines/. .
+    cp -r .tmp/ert-testdata/screenshotbaselines/. .
+    rm -rf .tmp/ert-testdata
 
 build-ert-docs: fetch-screenshot-baselines
     sphinx-build -n -v -E -W ./docs/ert ./ert_docs


### PR DESCRIPTION
**Issue**
No issue attached. This showed up when working on another issue.


**Approach**
`cp --recursive` does not exist on MacOS so use `cp -r` instead. Also removes temporary folder after extraction of screenshot baselines.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
