### PR TITLE
Fix crash when RESTART used without REFCASE/TIME_MAP

### DIFF
--- a/src/ert/config/observation_config_migrations.py
+++ b/src/ert/config/observation_config_migrations.py
@@ -684,6 +684,18 @@ def _get_restart(
     has_refcase: bool,
 ) -> int:
     if date_dict.restart is not None:
+        if not time_map:
+            raise ObservationConfigError.with_context(
+                f"Missing REFCASE or TIME_MAP for observations: {obs_name}",
+                obs_name,
+            )
+        if date_dict.restart >= len(time_map):
+            raise ObservationConfigError.with_context(
+                f"RESTART {date_dict.restart} for observation {obs_name} is "
+                f"out of range: the REFCASE/TIME_MAP only has "
+                f"{len(time_map)} report step(s).",
+                obs_name,
+            )
         return date_dict.restart
     if not time_map:
         raise ObservationConfigError.with_context(

--- a/tests/ert/unit_tests/config/test_observation_config_migrations.py
+++ b/tests/ert/unit_tests/config/test_observation_config_migrations.py
@@ -18,6 +18,7 @@ from resfo_utilities.testing import (
 from ert.config.observation_config_migrations import (
     remove_refcase_and_time_map_dependence_from_obs_config,
 )
+from ert.config.parsing.observations_parser import ObservationConfigError
 from ert.observation_converters.history_to_summary import convert_history_to_summary
 
 
@@ -549,6 +550,145 @@ SUMMARY_OBSERVATION SUM_OBS_2 {
    ERROR    = 25.0;
    DATE     = 2024-01-31;
    KEY      = WOPRH;
+};
+"""
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_restart_without_refcase_or_time_map_gives_clear_error():
+    """
+    Test that using RESTART without REFCASE or TIME_MAP raises a clear
+    ObservationConfigError instead of crashing with an IndexError.
+    """
+    obs_config_path = Path("observations.txt")
+    obs_config_path.write_text(
+        dedent(
+            """\
+            SUMMARY_OBSERVATION WOPR_OP1_9 {
+                VALUE = 0.1;
+                ERROR = 0.05;
+                RESTART = 9;
+                KEY = WOPR:OP1;
+            };
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = Path("config.ert")
+    config_path.write_text(
+        dedent(
+            """\
+            NUM_REALIZATIONS 1
+            ECLBASE ECLIPSE_CASE
+            OBS_CONFIG observations.txt
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_restart_out_of_range_of_time_map_gives_clear_error():
+    """
+    Test that a RESTART index beyond the length of TIME_MAP raises a clear
+    ObservationConfigError instead of crashing with an IndexError.
+    """
+    Path("time_map.txt").write_text(
+        dedent(
+            """\
+            2020-01-01
+            2020-01-11
+            2020-01-21
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    obs_config_path = Path("observations.txt")
+    obs_config_path.write_text(
+        dedent(
+            """\
+            SUMMARY_OBSERVATION WOPR_OP1_9 {
+                VALUE = 0.1;
+                ERROR = 0.05;
+                RESTART = 9;
+                KEY = WOPR:OP1;
+            };
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = Path("config.ert")
+    config_path.write_text(
+        dedent(
+            """\
+            NUM_REALIZATIONS 1
+            ECLBASE ECLIPSE_CASE
+            TIME_MAP time_map.txt
+            OBS_CONFIG observations.txt
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ObservationConfigError):
+        convert_history_to_summary(str(config_path))
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_restart_with_refcase_present_converts_successfully():
+    """
+    Regression test: RESTART with a valid REFCASE (restart index within
+    range) should convert cleanly, not raise.
+    """
+    smspec, unsmry = create_summary_smspec_unsmry(
+        summary_vectors={"FOPR": [100, 110, 120]},
+        start_date=datetime(2020, 1, 1),  # ruff: ignore[call-datetime-without-tzinfo]
+    )
+    smspec.to_file(Path("REFCASE.SMSPEC"))
+    unsmry.to_file(Path("REFCASE.UNSMRY"))
+
+    obs_config_path = Path("observations.txt")
+    obs_config_path.write_text(
+        dedent(
+            """\
+            SUMMARY_OBSERVATION FOPR_OBS {
+                VALUE = 110.0;
+                ERROR = 5.0;
+                RESTART = 1;
+                KEY = FOPR;
+            };
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    config_path = Path("config.ert")
+    config_path.write_text(
+        dedent(
+            """\
+            NUM_REALIZATIONS 1
+            ECLBASE ECLIPSE_CASE
+            REFCASE REFCASE
+            OBS_CONFIG observations.txt
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Should not raise
+    convert_history_to_summary(str(config_path))
+
+    assert (
+        Path("observations.txt").read_text(encoding="utf-8")
+        == """SUMMARY_OBSERVATION FOPR_OBS {
+   VALUE    = 110.0;
+   ERROR    = 5.0;
+   DATE     = 2020-01-01;
+   KEY      = FOPR;
 };
 """
     )


### PR DESCRIPTION
`ert convert_observations` crashed with an unhandled IndexError when an observation used the RESTART keyword but the ERT config was missing both REFCASE and TIME_MAP. This happened because _get_restart assumed time_map would always be non-empty when computing a restart index, with no validation.

Add explicit checks in _get_restart: raise a clear ObservationConfigError if time_map is empty, or if the given restart index falls outside the range of the time_map, instead of letting the code crash with an opaque IndexError.

Also fix a pre-existing one-line indentation error in _legacy_handle_error_mode, caught by the ruff pre-commit hook while working in this file.

**Issue**
Fixes #14080

**Approach**
Added validation in `_get_restart` to check that `time_map` is non-empty and that the restart index falls within range before indexing into it, raising `ObservationConfigError` with a clear message instead of letting an IndexError propagate. Added three regression tests covering: RESTART without REFCASE/TIME_MAP, RESTART index out of range, and RESTART with a valid REFCASE present (success path, unaffected by the fix).

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [x] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->