### PR TITLE
Bugfix EverestConfig simulation folder validation

### DIFF
--- a/src/everest/config/everest_config.py
+++ b/src/everest/config/everest_config.py
@@ -46,7 +46,6 @@ from everest.config.validation_utils import (
     InstallDataContext,
     check_for_duplicate_names,
     check_path_exists,
-    check_writeable_path,
     unique_items,
     validate_forward_model_configs,
 )
@@ -878,16 +877,6 @@ to read summary data from forward model, do:
             ConfigWarning.deprecation_warn(_WELLS_DEPRECATION)
         return self
 
-    @model_validator(mode="after")
-    def validate_that_environment_sim_folder_is_writeable(self) -> Self:
-        environment = self.environment
-        config_path = self.config_path
-        if environment is None or config_path is None:
-            return self
-
-        check_writeable_path(environment.simulation_folder, Path(config_path))
-        return self
-
     @field_validator("wells")
     @no_type_check
     @classmethod
@@ -944,10 +933,18 @@ to read summary data from forward model, do:
     @field_validator("config_path")
     @no_type_check
     @classmethod
-    def validate_config_path_exists(cls, config_path):
-        expanded_path = os.path.realpath(config_path)
-        if not Path(expanded_path).exists():
-            raise ValueError(f"no such file or directory {expanded_path}")
+    def validate_config_path_exists_and_is_writeable(cls, config_path):
+        """
+        `os.path.exists()` swallows all OSErrors instead returning false.
+        `Path.exists()` only shares this behavior for `>py-3.12`.
+        Replace with `Path.exists()` when we drop support for python 3.12.
+        """
+        path = Path(config_path).resolve()
+        # Will also return False if path is unreachable.
+        if not os.path.exists(path):  # ruff: ignore[os-path-exists]
+            raise ValueError(f"No such file or directory {path!s}")
+        if not os.access(path.parent, os.W_OK | os.X_OK):
+            raise ValueError(f"'{path.parent!s}' is not writeable or executable")
         return config_path
 
     def copy(self) -> "EverestConfig":  # type: ignore

--- a/src/everest/config/validation_utils.py
+++ b/src/everest/config/validation_utils.py
@@ -301,24 +301,6 @@ def check_path_exists(
             raise ValueError(f"No such file or directory {exp_path}")
 
 
-def check_writeable_path(path_source: str, config_path: Path) -> None:
-    # check that the lowest existing folder is writeable
-    path = as_abs_path(path_source, str(config_path.parent))
-    while True:
-        if os.path.isdir(path):
-            if os.access(path, os.W_OK | os.X_OK):
-                break
-        elif Path(path).is_file():
-            raise ValueError(f"{path} is a file, cannot create folders inside it")
-        parent = os.path.dirname(path)
-        if parent == path:  # ie, if path is root
-            break
-        path = parent
-
-    if not os.access(path, os.W_OK | os.X_OK):
-        raise ValueError(f"User does not have write access to {path}")
-
-
 def validate_forward_model_configs(
     forward_model: list[str], install_jobs: list[InstallForwardModelStepConfig]
 ) -> None:

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -383,15 +383,6 @@ def test_that_everest_run_warns_on_nonempty_runpath(
     existing_runpath.cleanup()
 
 
-def test_that_everest_fails_when_runpath_is_a_file():
-    with tempfile.NamedTemporaryFile() as existing_runpath:
-        Path(existing_runpath.name).touch()
-        with pytest.raises(ValueError, match="is a file"):
-            everest_config_with_defaults(
-                environment={"simulation_folder": existing_runpath.name},
-            )
-
-
 @pytest.mark.parametrize(
     ("server_queue_system", "simulator_queue_system"),
     [

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -78,7 +78,7 @@ def test_extra_key(min_config):
         ),
         (
             {"config_path": "does_not_exist"},
-            "no such file or directory .*/does_not_exist",
+            "No such file or directory",
         ),
         (
             {
@@ -86,7 +86,7 @@ def test_extra_key(min_config):
                     {"template": "does_not_exist", "output_file": "not_relevant"}
                 ]
             },
-            "No such file or directory .*/does_not_exist",
+            "No such file or directory",
         ),
         (
             {"model": {"realizations": [-1]}},
@@ -164,26 +164,42 @@ def test_invalid_subconfig(extra_config, min_config, expected):
         EverestConfig(**min_config)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "behavior must be looked at. Current code requires all directories on path"
-        "to be unwritable to raise validation error."
-    )
-)
-def test_that_simulation_folder_without_write_access_raises_validation_error(
+def test_that_config_directory_without_write_access_raises_validation_error(
     min_config, tmp_path
 ):
-    unwritable = tmp_path / "unwritable"
-    unwritable.mkdir()
-    original_mode = unwritable.stat().st_mode
-    unwritable.chmod(0o555)
+    tmp_path.mkdir(exist_ok=True)
+    config_path = tmp_path / "config.yml"
+    config_path.touch()
+    original_mode = tmp_path.stat().st_mode
+    tmp_path.chmod(0o555)
+    min_config["config_path"] = str(config_path)
 
     try:
-        min_config["environment"] = {"simulation_folder": str(unwritable)}
-        with pytest.raises(ValidationError, match="User does not have write access to"):
+        with pytest.raises(ValidationError, match=f"'{tmp_path}' is not writeable"):
             EverestConfig(**min_config)
     finally:
-        unwritable.chmod(original_mode)
+        tmp_path.chmod(original_mode)
+
+
+def test_that_config_directory_parent_without_execute_access_raises_validation_error(
+    min_config, tmp_path
+):
+    tmp_path.mkdir(exist_ok=True)
+    config_path = tmp_path / "sub_dir"
+    config_path.mkdir(exist_ok=True)
+    config_file = config_path / "config.yml"
+    config_file.touch()
+    original_mode = tmp_path.stat().st_mode
+    tmp_path.chmod(0o444)
+    min_config["config_path"] = str(config_file)
+
+    try:
+        with pytest.raises(
+            ValidationError, match=f"No such file or directory {config_file}"
+        ):
+            EverestConfig(**min_config)
+    finally:
+        tmp_path.chmod(original_mode)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #14056 


**Approach**
Previous validation checked every path `<config_dir>/<environment_simulaton_folder>` $\Longrightarrow$ `root` whether it had write and execute access. It required all paths to not be writeable for it to throw an error. New approaches checks `<Config_dir>` access and raises error if it is not writeable or accessible.



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)