### PR TITLE
Ensure Everest exceptions are recorded in the current span

### DIFF
--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -12,11 +12,13 @@ from pathlib import Path
 from textwrap import dedent
 
 import anyio
+from opentelemetry.trace import Status, StatusCode
 
 from _ert.threading import ErtThread
 from ert.config import QueueSystem
 from ert.services import create_ertserver_client
 from ert.storage.local_experiment import ExperimentState
+from ert.trace import trace
 from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import (
@@ -289,7 +291,11 @@ async def run_everest(options: argparse.Namespace) -> None:
     if experiment_status and experiment_status.status == ExperimentState.failed:
         msg = f"EVEREST run failed with: {experiment_status.message or 'Unknown error'}"
         logger.error(msg)
-        raise SystemExit(msg)
+        err = SystemExit(msg)
+        span = trace.get_current_span()
+        span.set_status(Status(StatusCode.ERROR))
+        span.record_exception(err)
+        raise err
     if experiment_status:
         msg = (
             "EVEREST run finished with: "


### PR DESCRIPTION
This should trigger interesting notifications, and makes the behaviour similar to Ert.

**Issue**
Resolves #14138 


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
