### PR TITLE
Output constraint no longer breaks multi-objective everest runs

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -237,7 +237,12 @@ def data_for_response(
                     "batch_id": [batch.iteration for batch, _ in accepted_batches],
                     "accepted": [True] * len(accepted_batches),
                     "improvement_value": [value for _, value in accepted_batches],
-                }
+                },
+                schema={
+                    "batch_id": objective_value_df.schema["batch_id"],
+                    "accepted": pl.Boolean,
+                    "improvement_value": pl.Float64,
+                },
             ),
             on="batch_id",
             how="left",

--- a/src/everest/everest_storage.py
+++ b/src/everest/everest_storage.py
@@ -271,7 +271,7 @@ class EverestStorage:
                         for c in batch_objective_gradient.columns
                         if "constraint" in c.lower()
                     ],
-                ]
+                ].unique(maintain_order=True)
 
                 batch_objective_gradient = batch_objective_gradient.drop(
                     [

--- a/test-data/everest/math_func/config_multiobj_advanced.yml
+++ b/test-data/everest/math_func/config_multiobj_advanced.yml
@@ -1,0 +1,59 @@
+controls:
+  -
+    name: point
+    min: -1.0
+    max: 1.0
+    scaled_range: [-1, 1]
+    initial_guess: 0
+    perturbation_magnitude : 0.01
+    variables:
+        - name: x
+        - name: y
+        - name: z
+
+
+objective_functions:
+  - name: distance_p
+    weight: 0.50
+    scale: 0.6666666667
+  - name: distance_q
+    weight: 0.25
+
+output_constraints:
+  - name: origin_distance
+    lower_bound: -1.0
+
+optimization:
+  algorithm: optpp_q_newton
+  convergence_tolerance: 0.005
+  perturbation_num: 5
+  max_batch_num: 3
+
+install_jobs:
+  -
+    name: distance3
+    executable: jobs/distance3.py
+
+model:
+  realizations: [0]
+
+forward_model:
+  - distance3 --point-file point.json
+              --target 0.5 0.5 0.5
+              --out distance_p
+  - distance3 --point-file point.json
+              --target -1.5 -1.5 0.5
+              --out distance_q
+  - distance3 --point-file point.json
+              --target 0 0 0
+              --out origin_distance
+
+simulator:
+  queue_system:
+    name: local
+
+environment:
+  simulation_folder: sim_output
+  output_folder: everest_output_multiobj_advanced
+  log_level: debug
+  random_seed: 999

--- a/tests/everest/test_everest_storage.py
+++ b/tests/everest/test_everest_storage.py
@@ -111,3 +111,26 @@ def test_everest_data_stored_in_ert_local_storage(
         ]
 
         assert local_storage_params == formatted_control_names
+
+
+@pytest.mark.xdist_group("math_func/config_multiobj_advanced.yml")
+@pytest.mark.slow
+def test_that_constraint_gradients_have_one_row_per_control_with_multiple_objectives(
+    cached_example,
+):
+    config_path, config_file, _, _ = cached_example(
+        "math_func/config_multiobj_advanced.yml"
+    )
+    config = EverestConfig.load_file(Path(config_path) / config_file)
+    experiment = EverestStorage.get_everest_experiment(storage_path=config.storage_dir)
+
+    gradients = [
+        ensemble.batch_constraint_gradient
+        for ensemble in experiment.ensembles
+        if ensemble.batch_constraint_gradient is not None
+    ]
+
+    assert gradients
+    for gradient in gradients:
+        assert gradient.columns == ["batch_id", "control_name", "origin_distance"]
+        assert gradient["control_name"].to_list() == ["point.x", "point.y", "point.z"]


### PR DESCRIPTION
**Issue**
Resolves #14137


**Approach**
🤖🤝🧠  
Avoid duplication of the constraint values prior to the pivot table

Added typing to the response to avoid mismatch


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
