### PR TITLE
Make the overspending warning on CPU clearer

### DIFF
--- a/src/ert/ensemble_evaluator/evaluator.py
+++ b/src/ert/ensemble_evaluator/evaluator.py
@@ -734,8 +734,8 @@ class EnsembleEvaluator:
                     f"while the Ert config has only requested {num_cpu}.\n"
                     f"This means your experiment is consuming more CPU-resources than "
                     f"requested and will slow down other users experiments.\n"
-                    f"We kindly ask you to set "
-                    f"NUM_CPU={ceil(parallelization_obtained)} in your Ert config."
+                    f"We kindly ask you to add \n"
+                    f"NUM_CPU {ceil(parallelization_obtained)}\nto your Ert config."
                 )
                 self.max_parallelism_violation = max(
                     self.max_parallelism_violation,


### PR DESCRIPTION
State exactly which line to add to their ert configs

**Issue**
Resolves ambiguity


**Approach**
:brain:


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
