### PR TITLE
Add endpoint for checking run-path exists

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -13,6 +13,7 @@ from base64 import b64decode
 from queue import SimpleQueue
 from typing import Annotated
 
+import anyio
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -23,6 +24,7 @@ from fastapi import (
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
@@ -67,6 +69,10 @@ class ExperimentRunnerState:
 
 
 _experiments: dict[str, ExperimentRunnerState] = {}
+
+
+class PathsCheckRequest(BaseModel):
+    paths: list[str]
 
 
 def _get_experiment(experiment_id: str) -> ExperimentRunnerState:
@@ -258,6 +264,32 @@ async def start_time(
         return Response("No experiment started", status_code=404)
 
     return Response(str(experiment.start_time_unix), status_code=200)
+
+
+@router.post(f"/{EverEndpoints.runpath}", dependencies=authenticated)
+async def check_runpath_exists(
+    paths: PathsCheckRequest,
+) -> Response:
+    """
+    Check if any of the given paths (iteration directories) exists.
+    Returns a 200 response if at least one path exists, 404 otherwise.
+    """
+    exists = False
+
+    async with anyio.create_task_group() as tg:
+
+        async def _check_path(path: str) -> None:
+            nonlocal exists
+            if await anyio.Path(path).exists():
+                exists = True
+                tg.cancel_scope.cancel()
+
+        for path in paths.paths:
+            tg.start_soon(_check_path, path)
+
+    if exists:
+        return Response("Runpath exists", status_code=200)
+    return Response("Runpath does not exist", status_code=404)
 
 
 @router.websocket(f"/{EverEndpoints.events}/{{experiment_id}}")

--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -175,19 +175,19 @@ def get_status() -> PlainTextResponse:
     return PlainTextResponse("EVEREST is running")
 
 
-@router.get(f"/{EverEndpoints.status}/{{experiment_id}}", dependencies=authenticated)
+@router.get(f"/{EverEndpoints.STATUS}/{{experiment_id}}", dependencies=authenticated)
 def experiment_status(
     experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
 ) -> ExperimentStatus:
     return experiment.status
 
 
-@router.get("/" + EverEndpoints.experiments, dependencies=authenticated)
+@router.get("/" + EverEndpoints.EXPERIMENTS, dependencies=authenticated)
 def experiments() -> JSONResponse:
     return JSONResponse({"experiment_ids": list(_experiments.keys())})
 
 
-@router.post("/" + EverEndpoints.stop, dependencies=authenticated)
+@router.post("/" + EverEndpoints.STOP, dependencies=authenticated)
 def stop() -> Response:
     if not _experiments:
         os.kill(os.getpid(), signal.SIGTERM)
@@ -198,7 +198,7 @@ def stop() -> Response:
     return Response("Raise STOP flag succeeded. EVEREST initiates shutdown..", 200)
 
 
-@router.post("/" + EverEndpoints.start_experiment, dependencies=authenticated)
+@router.post("/" + EverEndpoints.START_EXPERIMENT, dependencies=authenticated)
 async def start_experiment(
     request: Request,
     background_tasks: BackgroundTasks,
@@ -236,7 +236,7 @@ async def start_experiment(
 
 
 @router.get(
-    f"/{EverEndpoints.config_path}/{{experiment_id}}", dependencies=authenticated
+    f"/{EverEndpoints.CONFIG_PATH}/{{experiment_id}}", dependencies=authenticated
 )
 async def config_path(
     experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
@@ -255,7 +255,7 @@ async def config_path(
 
 
 @router.get(
-    f"/{EverEndpoints.start_time}/{{experiment_id}}", dependencies=authenticated
+    f"/{EverEndpoints.START_TIME}/{{experiment_id}}", dependencies=authenticated
 )
 async def start_time(
     experiment: Annotated[ExperimentRunnerState, Depends(_get_experiment)],
@@ -266,7 +266,7 @@ async def start_time(
     return Response(str(experiment.start_time_unix), status_code=200)
 
 
-@router.post(f"/{EverEndpoints.runpath}", dependencies=authenticated)
+@router.post(f"/{EverEndpoints.RUNPATH}", dependencies=authenticated)
 async def check_runpath_exists(
     paths: PathsCheckRequest,
 ) -> Response:
@@ -292,7 +292,7 @@ async def check_runpath_exists(
     return Response("Runpath does not exist", status_code=404)
 
 
-@router.websocket(f"/{EverEndpoints.events}/{{experiment_id}}")
+@router.websocket(f"/{EverEndpoints.EVENTS}/{{experiment_id}}")
 async def websocket_endpoint(websocket: WebSocket, experiment_id: str) -> None:
     await websocket.accept()
     _check_authentication(websocket.headers.get("Authorization"))

--- a/src/ert/gui/experiments/experiment_client.py
+++ b/src/ert/gui/experiments/experiment_client.py
@@ -63,7 +63,7 @@ class ExperimentClient:
     @property
     def config(self) -> dict[str, str]:
         return self._http_get(
-            f"{EverEndpoints.config_path}/{self._experiment_id}"
+            f"{EverEndpoints.CONFIG_PATH}/{self._experiment_id}"
         ).json()
 
     @property
@@ -82,7 +82,7 @@ class ExperimentClient:
             try:  # ruff: ignore[too-many-statements-in-try-clause]
                 with connect(
                     self._url.replace("https://", "wss://")
-                    + f"/{EverEndpoints.events}/{self._experiment_id}",
+                    + f"/{EverEndpoints.EVENTS}/{self._experiment_id}",
                     ssl=self._ssl_context,
                     open_timeout=open_timeout,
                     additional_headers={"Authorization": f"Basic {self.credentials}"},
@@ -133,7 +133,7 @@ class ExperimentClient:
 
     def stop(self) -> None:
         try:
-            response = self._http_post(EverEndpoints.stop)
+            response = self._http_post(EverEndpoints.STOP)
         except requests.exceptions.ConnectionError as e:
             logger.error(
                 "Connection error when cancelling EVEREST "
@@ -154,7 +154,7 @@ class ExperimentClient:
         else:
             logger.error(
                 f"Failed to cancel EVEREST experiment: "
-                f"POST @ {self._url}/{EverEndpoints.stop}, "
+                f"POST @ {self._url}/{EverEndpoints.STOP}, "
                 f"server responded with status {response.status_code}: "
                 f"{HTTPStatus(response.status_code).phrase}"
             )

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -77,7 +77,7 @@ def stop_server(
     url, cert, auth = server_context
     for retry in range(retries):
         try:
-            stop_endpoint = f"{url}/{EverEndpoints.stop}"
+            stop_endpoint = f"{url}/{EverEndpoints.STOP}"
             response = requests.post(
                 stop_endpoint,
                 verify=cert,
@@ -101,7 +101,7 @@ def get_experiments(
     for retry in range(retries):
         try:
             response = requests.get(
-                f"{url}/{EverEndpoints.experiments}",
+                f"{url}/{EverEndpoints.EXPERIMENTS}",
                 verify=cert,
                 auth=auth,
                 proxies=PROXY,
@@ -122,7 +122,7 @@ def start_experiment(
     url, cert, auth = server_context
     for retry in range(retries):
         try:
-            start_endpoint = f"{url}/{EverEndpoints.start_experiment}"
+            start_endpoint = f"{url}/{EverEndpoints.START_EXPERIMENT}"
             response = requests.post(
                 start_endpoint,
                 verify=cert,
@@ -247,7 +247,7 @@ def start_monitor(
     try:  # ruff: ignore[too-many-statements-in-try-clause]
         with connect(
             url.replace("https://", "wss://")
-            + f"/{EverEndpoints.events}/{experiment_id}",
+            + f"/{EverEndpoints.EVENTS}/{experiment_id}",
             ssl=ssl_context,
             open_timeout=30,
             additional_headers={"Authorization": f"Basic {credentials}"},

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -189,7 +189,7 @@ def main() -> None:
                         active = [
                             ExperimentStatus(
                                 **client.get(
-                                    f"/experiment_server/{EverEndpoints.status}/{experiment_id}",
+                                    f"/experiment_server/{EverEndpoints.STATUS}/{experiment_id}",
                                     auth=server.fetch_auth(),
                                 ).json()
                             ).status

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import StrEnum, auto
 
 DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
@@ -27,11 +27,11 @@ STORAGE_DIR = "simulation_results"
 
 
 class EverEndpoints(StrEnum):
-    stop = "stop"
-    start_experiment = "start_experiment"
-    config_path = "config_path"
-    start_time = "start_time_unix"
-    experiments = "experiments"
-    status = "status"
-    events = "events"
-    runpath = "runpath"
+    STOP = auto()
+    START_EXPERIMENT = auto()
+    CONFIG_PATH = auto()
+    START_TIME = auto()
+    EXPERIMENTS = auto()
+    STATUS = auto()
+    EVENTS = auto()
+    RUNPATH = auto()

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -34,3 +34,4 @@ class EverEndpoints(StrEnum):
     experiments = "experiments"
     status = "status"
     events = "events"
+    runpath = "runpath"

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -93,7 +93,7 @@ def test_that_stop_invokes_correct_endpoint(
 ):
     server_app, server_thread, client, wait_until_alive = client_server_mock
 
-    @server_app.post(f"/{EverEndpoints.stop}")
+    @server_app.post(f"/{EverEndpoints.STOP}")
     def stop():
         return Response("STOP..", 200)
 
@@ -113,7 +113,7 @@ def test_that_stop_errors_on_non_ok_httpcode(
 ):
     server_app, server_thread, client, wait_until_alive = client_server_mock
 
-    @server_app.post(f"/{EverEndpoints.stop}")
+    @server_app.post(f"/{EverEndpoints.STOP}")
     def stop():
         return Response("STOP..", 505)
 


### PR DESCRIPTION
**Issue**
Resolves #13928 


**Approach**
A generic endpoint which takes a list of paths and checks if any exists similar to how `run_path` is checked in `run_model.py`.
https://github.com/equinor/ert/blob/57d74dbb2e594b945a4245440efac594edecbb41/src/ert/run_models/run_model.py#L774-L782

**Performance considerations**
Checks concurrently using `anyio` task groups and returns early on find, cancelling other tasks.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)