### PR TITLE
Fix warning about missing response bug

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from collections import defaultdict
-from copy import copy
 from dataclasses import InitVar, dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -295,26 +294,17 @@ class RFTConfig(SimulationResponseConfig):
             for well, time_dict in self.data_to_read.items()
             for time in time_dict
         }
-        well_times_with_response = {(well, time.isoformat()) for well, time in rft_data}
-
-        well_times_to_warn: set[tuple[str, str]] = well_times - well_times_with_response
-
-        # Given well / time wildcard, only warn if there are no responses for
-        # the corresponding well / time value
-        wells_with_responses = {well for well, time in well_times_with_response}
-        times_with_responses = {time for well, time in well_times_with_response}
-        for well, time in copy(well_times_to_warn):
-            if well == "*" and time in times_with_responses:
-                well_times_to_warn.remove((well, time))
-            if time == "*" and well in wells_with_responses:
-                well_times_to_warn.remove((well, time))
-
-        # Only warn about wildcard well and time if there are no responses
-        if (wildcard_well_time := ("*", "*")) in well_times and len(
-            well_times_with_response
-        ) > 0:
-            well_times_to_warn.remove(wildcard_well_time)
-
+        well_times_with_response = {
+            f"{well}:{time.isoformat()}" for well, time in rft_data
+        }
+        well_times_to_warn: set[tuple[str, str]] = {
+            (well, time)
+            for well, time in well_times
+            if not fnmatch.filter(
+                well_times_with_response,
+                f"{well}:{time}",
+            )
+        }
         formatted_items = [
             f"{well=} : {time=}" for well, time in sorted(well_times_to_warn)
         ]

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import logging
 from typing import Any, Literal
 
@@ -33,7 +34,9 @@ class SummaryConfig(SimulationResponseConfig):
     def _warn_about_missing_summary_responses(
         self, response_keys: list[str], filename: str
     ) -> None:
-        keys_missing_responses = sorted(set(self.keys) - set(response_keys) - {"*"})
+        keys_missing_responses = [
+            key for key in self.keys if not fnmatch.filter(response_keys, key)
+        ]
         _warn_about_missing_responses(keys_missing_responses, "key(s)", filename)
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1539,17 +1539,88 @@ def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_ab
     assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
-def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(
-    setup_mock_resfo_file,
-):
+def _collect_rft_response_warnings(
+    well: str, time: str
+) -> list[warnings.WarningMessage]:
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={
-            "*": {"*": ["PRESSURE", "SWAT"]},
+            well: {time: ["PRESSURE", "SWAT"]},
         },
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
-            "error", PostExperimentWarning
-        )
+    with warnings.catch_warnings(record=True) as w:
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    return w
+
+
+def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="*", time="*")
+
+    no_warnings = len(warnings) == 0
+    assert no_warnings
+
+
+def test_that_partly_wildcard_well_name_with_response_does_not_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="WE*", time="*")
+
+    no_warnings = len(warnings) == 0
+    assert no_warnings
+
+
+def test_that_partly_wildcard_times_with_response_does_not_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="*", time="2000*")
+
+    no_warnings = len(warnings) == 0
+    assert no_warnings
+
+
+def test_that_well_with_multiple_wildcard_with_response_does_not_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="W*L*", time="*")
+
+    no_warnings = len(warnings) == 0
+    assert no_warnings
+
+
+def test_that_well_and_time_with_multiple_wildcard_with_response_does_not_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="W*L*", time="2*00*01")
+
+    no_warnings = len(warnings) == 0
+    assert no_warnings
+
+
+def test_that_time_with_partial_wildcard_without_response_at_time_does_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="WELL", time="1999*")
+
+    does_warn = len(warnings) > 0
+    assert does_warn
+
+
+def test_that_well_with_partial_wildcard_without_response_does_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="NOT_A_W*", time="*")
+
+    does_warn = len(warnings) > 0
+    assert does_warn
+
+
+def test_that_well_and_time_with_partial_wildcard_without_response_does_warn(
+    setup_mock_resfo_file,
+):
+    warnings = _collect_rft_response_warnings(well="NOT_A_W*", time="1999*")
+
+    does_warn = len(warnings) > 0
+    assert does_warn

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
@@ -269,3 +270,78 @@ def test_that_when_not_finding_response_obs_keys_raises_warning(monkeypatch):
         WWCT:OP1"""
     )
     assert warning == expected_warning
+
+
+def _collect_summary_response_warnings(
+    response_key: str, simulated_response_key: str
+) -> list[warnings.WarningMessage]:
+    summary_config = SummaryConfig(keys=[response_key])
+    with warnings.catch_warnings(record=True) as w:
+        summary_config._warn_about_missing_summary_responses(
+            response_keys=[simulated_response_key], filename="foo"
+        )
+    return w
+
+
+def test_that_key_with_wildcard_with_response_is_not_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="WGOR*", simulated_response_key="WGOR:OP1"
+    )
+
+    no_warnings = len(w) == 0
+    assert no_warnings
+
+
+def test_that_key_with_multiple_wildcards_with_responses_is_not_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="W*:OP*", simulated_response_key="WGOR:OP1"
+    )
+
+    no_warnings = len(w) == 0
+    assert no_warnings
+
+
+def test_that_identical_key_containing_wildcard_with_response_is_not_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="W*OPR:OP1", simulated_response_key="WOPR:OP1"
+    )
+
+    no_warnings = len(w) == 0
+    assert no_warnings
+
+
+def test_that_key_with_partial_wildcard_without_response_is_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="F*", simulated_response_key="WOPR:OP1"
+    )
+
+    did_warn = len(w) > 0
+    assert did_warn
+
+
+def test_that_keys_with_preceding_wildcard_without_responses_is_not_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="*OP1", simulated_response_key="WOPR:OP1"
+    )
+
+    no_warnings = len(w) == 0
+    assert no_warnings
+
+
+def test_that_key_with_multiple_wildcards_without_response_is_warned_about():
+    w = _collect_summary_response_warnings(
+        response_key="W*OR:OP*", simulated_response_key="WOPR:OP1"
+    )
+
+    did_warn = len(w) > 0
+    assert did_warn
+
+
+def test_that_wildcard_key_without_response_is_warned_about():
+    summary_config = SummaryConfig(keys=["*"])
+    with warnings.catch_warnings(record=True) as w:
+        summary_config._warn_about_missing_summary_responses(
+            response_keys=[], filename="foo"
+        )
+    did_warn = len(w) > 0
+    assert did_warn


### PR DESCRIPTION
The bug was that wildcards were not handled correctly.

Only complete wildcards were handled in the original implementation.

This bugfix contains utilization of fntools to match wildcards in substrings to avoid manual implementation to try to cope with this.

Tested by running drogon with stable (where bug was reported) -> see warnings -> komodoenv version 24.0 with cherry picked bugfix -> rerun drogon -> see no warnings


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
