### PR TITLE
Fix assignee/reviewer requests in push_screenshots workflow

### DIFF
--- a/.github/workflows/push_screenshots.yml
+++ b/.github/workflows/push_screenshots.yml
@@ -99,8 +99,21 @@ jobs:
             --head "$BRANCH" \
             --title "Update screenshots for ${ERT_PR_TITLE} (equinor/ert#${PR_NUMBER})" \
             --body "Automatically updated screenshot baselines triggered by https://github.com/equinor/ert/pull/${PR_NUMBER} by @${ERT_PR_AUTHOR}")
-          gh pr edit "$PR_URL" --repo equinor/ert-testdata --add-assignee "${ERT_PR_AUTHOR}" --add-reviewer "${ERT_PR_AUTHOR}" \
-            || echo "::warning::Could not assign/request review from @${ERT_PR_AUTHOR} on ert-testdata (insufficient access)"
+          TESTDATA_PR_NUMBER="${PR_URL##*/}"
+          set +e
+          ASSIGNEE_ERR=$(gh api --method POST "repos/equinor/ert-testdata/issues/${TESTDATA_PR_NUMBER}/assignees" \
+            -f "assignees[]=${ERT_PR_AUTHOR}" 2>&1 > /dev/null)
+          ASSIGNEE_STATUS=$?
+          REVIEWER_ERR=$(gh api --method POST "repos/equinor/ert-testdata/pulls/${TESTDATA_PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${ERT_PR_AUTHOR}" 2>&1 > /dev/null)
+          REVIEWER_STATUS=$?
+          set -e
+          if [ "$ASSIGNEE_STATUS" -ne 0 ]; then
+            echo "::warning::Could not assign @${ERT_PR_AUTHOR} on ert-testdata (exit code ${ASSIGNEE_STATUS}): ${ASSIGNEE_ERR}"
+          fi
+          if [ "$REVIEWER_STATUS" -ne 0 ]; then
+            echo "::warning::Could not request review from @${ERT_PR_AUTHOR} on ert-testdata (exit code ${REVIEWER_STATUS}): ${REVIEWER_ERR}"
+          fi
           if [ "${PR_NUMBER}" != "0" ]; then
             gh pr comment "${PR_NUMBER}" \
               --repo equinor/ert \


### PR DESCRIPTION
"gh pr edit --add-assignee/--add-reviewer" always fetches editable PR options (labels/projects/teams) via a GraphQL query that requires the "read:org" token scope. ERTOMATIC_ERT_TESTDATA_TOKEN only has the "repo" scope, so the command failed unconditionally, regardless of whether the PR author actually had write access to ert-testdata.

Replace it with direct REST API calls (assignees and requested_reviewers endpoints), which only need the "repo" scope. On failure, surface the real exit code and error/response body instead of assuming "insufficient access", since the failure could have other causes.

**Issue**
Resolves maybe the failure to assign @eilskra in https://github.com/equinor/ert/actions/runs/31606799800


**Approach**
Let the robots attack. 🤖 🤖 🤖 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
