### PR TITLE
Catch warnings more explicitly in tests

### DIFF
--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -3,6 +3,7 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+from warnings import WarningMessage
 
 import numpy as np
 import polars as pl
@@ -1539,19 +1540,22 @@ def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_ab
     assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
 
 
-def _collect_rft_response_warnings(
-    well: str, time: str
-) -> list[warnings.WarningMessage]:
+def _collect_rft_response_warnings(well: str, time: str) -> list[WarningMessage]:
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={
             well: {time: ["PRESSURE", "SWAT"]},
         },
     )
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as ws:
         rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
 
-    return w
+    return [
+        w
+        for w in ws
+        if issubclass(w.category, PostExperimentWarning)
+        and "Could not find response" in str(w.message)
+    ]
 
 
 def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
+from warnings import WarningMessage
 
 import hypothesis.strategies as st
 import polars as pl
@@ -274,13 +275,18 @@ def test_that_when_not_finding_response_obs_keys_raises_warning(monkeypatch):
 
 def _collect_summary_response_warnings(
     response_key: str, simulated_response_key: str
-) -> list[warnings.WarningMessage]:
+) -> list[WarningMessage]:
     summary_config = SummaryConfig(keys=[response_key])
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as ws:
         summary_config._warn_about_missing_summary_responses(
             response_keys=[simulated_response_key], filename="foo"
         )
-    return w
+    return [
+        w
+        for w in ws
+        if issubclass(w.category, PostExperimentWarning)
+        and "Could not find response" in str(w.message)
+    ]
 
 
 def test_that_key_with_wildcard_with_response_is_not_warned_about():


### PR DESCRIPTION
Should any other warnings be raised within the units being tested the tests will start failing. This will catch the right warnings more explicitly.
