### PR TITLE
Allow dynamic messages in log_once method

### DIFF
--- a/src/ert/gui/utils.py
+++ b/src/ert/gui/utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 
 from PyQt6.QtCore import pyqtBoundSignal
 from PyQt6.QtWidgets import QApplication
@@ -37,13 +38,17 @@ def truncate_experiment_name(name: str) -> str:
 def log_once(
     signal: pyqtBoundSignal,
     logger: logging.Logger,
-    message: str,
+    message: str | Callable[[], str],
     level: int = logging.INFO,
 ) -> None:
-    """Log a message the first time a signal is emitted, then disconnect."""
+    """Log once when the signal is first emitted.
+
+    Callable messages are evaluated when the signal is emitted.
+    """
 
     def log_and_disconnect(*_signal_args: object) -> None:
-        logger.log(level, message)
+        resolved_message = message if isinstance(message, str) else message()
+        logger.log(level, resolved_message)
         signal.disconnect(log_and_disconnect)
 
     signal.connect(log_and_disconnect)

--- a/tests/ert/unit_tests/gui/test_gui_utils.py
+++ b/tests/ert/unit_tests/gui/test_gui_utils.py
@@ -1,11 +1,20 @@
+import logging
+
 import pytest
+from PyQt6.QtCore import QObject
+from PyQt6.QtCore import pyqtSignal as Signal
 
 from ert.gui.utils import (
     LONGEST_DEFAULT_EXPERIMENT_NAME,
+    log_once,
     truncate_dropdown_item,
     truncate_experiment_name,
     truncate_string,
 )
+
+
+class SignalEmitter(QObject):
+    emitted = Signal()
 
 
 @pytest.mark.parametrize(
@@ -69,3 +78,23 @@ def test_that_truncate_dropdown_item_truncates_to_100_characters(
         assert len(truncatedItem) == 100
     else:
         assert len(truncatedItem) == len(dropdown_item)
+
+
+def test_that_log_once_evaluates_message_factory_on_first_signal_emission(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO)
+    emitter = SignalEmitter()
+    iteration = 0
+
+    log_once(
+        emitter.emitted,
+        logging.getLogger(__name__),
+        lambda: f"Iteration {iteration} selected",
+    )
+
+    iteration = 1
+    emitter.emitted.emit()
+    emitter.emitted.emit()
+
+    assert [record.message for record in caplog.records] == ["Iteration 1 selected"]


### PR DESCRIPTION
F-strings are evaluated when the signal connection is registered. This can leave the logged message with outdated state when the signal is emitted.

Accept message-producing callables so dynamic messages can be evaluated on the first signal emission.

This is relevant for #14089 

**Issue**
Resolves #14171 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
