### PR TITLE
Rename `Restart run` mda gui label to `Select prior`

### DIFF
--- a/docs/ert/getting_started/howto/esmda_restart.rst
+++ b/docs/ert/getting_started/howto/esmda_restart.rst
@@ -13,8 +13,8 @@ One solution is to restart from ``default_2`` which is straightforward in ERT.
 
 **Steps to Restart from `default_2`:**
 
-1. Check the "Restart run" checkbox.
-2. Use the "Restart from" drop-down list to select the ensemble you wish to restart from.
+1. Check the "Select prior" checkbox.
+2. Use the "Run from" drop-down list to select the ensemble you wish to restart from.
     In this example, you'll pick ``default_2``.
 3. Click "Run Experiment".
     This creates a new ensemble which by default is called ``default_2_3``.

--- a/docs/ert/getting_started/updating_parameters/update_parameters.rst
+++ b/docs/ert/getting_started/updating_parameters/update_parameters.rst
@@ -51,7 +51,7 @@ Run data assimilation
 
 Because we do not have any ensembles with parameters and no responses, the `Ensemble` drop down in `Evaluate ensemble` is
 now empty. To start data assimilation, navigate to the `Multiple Data Assimilation` experiment mode, and check: `Select prior`,
-then select `prior` in the `Run from prior` dropdown and start the experiment. This means that we do not have to rerun the
+then select `prior` in the `Run from` dropdown and start the experiment. This means that we do not have to rerun the
 prior, and we are able to evaluate coverage of the prior without running multiple iterations of ES-MDA first.
 
 .. image:: fig/restart_es_mda.gif

--- a/docs/ert/getting_started/updating_parameters/update_parameters.rst
+++ b/docs/ert/getting_started/updating_parameters/update_parameters.rst
@@ -50,8 +50,8 @@ Run data assimilation
 =====================
 
 Because we do not have any ensembles with parameters and no responses, the `Ensemble` drop down in `Evaluate ensemble` is
-now empty. To start data assimilation, navigate to the `Multiple Data Assimilation` experiment mode, and check: `Restart run`,
-then select `prior` in the `Restart from` dropdown and start the experiment. This means that we do not have to rerun the
+now empty. To start data assimilation, navigate to the `Multiple Data Assimilation` experiment mode, and check: `Select prior`,
+then select `prior` in the `Run from prior` dropdown and start the experiment. This means that we do not have to rerun the
 prior, and we are able to evaluate coverage of the prior without running multiple iterations of ES-MDA first.
 
 .. image:: fig/restart_es_mda.gif

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -202,12 +202,12 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
 
         self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))
         self._ensemble_selector.setEnabled(False)
-        layout.addRow("Restart run:", self._restart_box)
+        layout.addRow("Select prior:", self._restart_box)
 
         self._ensemble_selector.ensemble_populated.connect(self.restart_run_toggled)
         self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
         self._ensemble_selector.currentIndexChanged.connect(self.update_experiment_name)
-        layout.addRow("Restart from:", self._ensemble_selector)
+        layout.addRow("Run from prior:", self._ensemble_selector)
 
         self._experiment_name_field.getValidationSupport().validationChanged.connect(
             self.experiment_configuration_changed

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -209,7 +209,7 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         self._ensemble_selector.ensemble_populated.connect(self.select_prior_toggled)
         self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
         self._ensemble_selector.currentIndexChanged.connect(self.update_experiment_name)
-        layout.addRow("Run from prior:", self._ensemble_selector)
+        layout.addRow("Run from:", self._ensemble_selector)
 
         self._experiment_name_field.getValidationSupport().validationChanged.connect(
             self.experiment_configuration_changed

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -62,7 +62,7 @@ class Arguments:
     target_ensemble: str
     realizations: str
     weights: str
-    restart_run: bool
+    select_prior: bool
     prior_ensemble_id: str  # UUID not serializable in json
     experiment_name: str
 
@@ -195,16 +195,18 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
         layout.addRow("Active realizations:", self._active_realizations_field)
         self._active_realizations_field.setObjectName("active_realizations_box")
 
-        self._restart_box = QCheckBox("")
-        self._restart_box.setObjectName("restart_checkbox_esmda")
-        self._restart_box.toggled.connect(self.restart_run_toggled)
-        self._restart_box.toggled.connect(self.update_experiment_edit)
+        self._select_prior_box = QCheckBox("")
+        self._select_prior_box.setObjectName("select_prior_checkbox_esmda")
+        self._select_prior_box.toggled.connect(self.select_prior_toggled)
+        self._select_prior_box.toggled.connect(self.update_experiment_edit)
 
-        self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))
+        self._select_prior_box.setEnabled(
+            bool(self._ensemble_selector._ensemble_list())
+        )
         self._ensemble_selector.setEnabled(False)
-        layout.addRow("Select prior:", self._restart_box)
+        layout.addRow("Select prior:", self._select_prior_box)
 
-        self._ensemble_selector.ensemble_populated.connect(self.restart_run_toggled)
+        self._ensemble_selector.ensemble_populated.connect(self.select_prior_toggled)
         self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
         self._ensemble_selector.currentIndexChanged.connect(self.update_experiment_name)
         layout.addRow("Run from prior:", self._ensemble_selector)
@@ -286,16 +288,18 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
 
     def _evaluate_weights_box_enabled(self) -> None:
         self._relative_iteration_weights_box.setEnabled(
-            not self._restart_box.isChecked()
+            not self._select_prior_box.isChecked()
             or (
                 self._ensemble_selector.selected_ensemble is not None
                 and not self._ensemble_selector.selected_ensemble.relative_weights
             )
         )
 
-    def restart_run_toggled(self) -> None:
-        self._restart_box.setEnabled(bool(self._ensemble_selector._ensemble_list()))
-        self._ensemble_selector.setEnabled(self._restart_box.isChecked())
+    def select_prior_toggled(self) -> None:
+        self._select_prior_box.setEnabled(
+            bool(self._ensemble_selector._ensemble_list())
+        )
+        self._ensemble_selector.setEnabled(self._select_prior_box.isChecked())
 
         self._relative_iteration_weights_box.setText(
             (
@@ -303,12 +307,12 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
                 and self._ensemble_selector.selected_ensemble.relative_weights
             )
             or self._configured_weights
-            if self._restart_box.isChecked()
+            if self._select_prior_box.isChecked()
             else self._configured_weights
         )
         self._weights_source = self._relative_iteration_weights_box.text()
         self._update_weights_mismatch_warning()
-        if self._restart_box.isChecked():
+        if self._select_prior_box.isChecked():
             self._active_realizations_field.setValidator(
                 self._previous_ensemble_realizations_validator
             )
@@ -418,11 +422,11 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
             target_ensemble=self._target_ensemble_format_model.getValue(),  # type: ignore
             realizations=self._active_realizations_field.text(),
             weights=self.weights,
-            restart_run=self._restart_box.isChecked(),
+            select_prior=self._select_prior_box.isChecked(),
             prior_ensemble_id=(
                 str(self._ensemble_selector.selected_ensemble.id)
                 if self._ensemble_selector.selected_ensemble is not None
-                and self._restart_box.isChecked()
+                and self._select_prior_box.isChecked()
                 else ""
             ),
             experiment_name=self._experiment_name_field.get_text,

--- a/src/ert/run_models/model_factory.py
+++ b/src/ert/run_models/model_factory.py
@@ -463,18 +463,18 @@ def _determine_restart_info(args: Namespace) -> tuple[bool, str | None]:
 
     Returns
     -------
-    A tuple containing the restart_run flag and the ensemble
+    A tuple containing the select_prior flag and the ensemble
     to run from.
     """
     if hasattr(args, "restart_ensemble_id"):
         # When running from CLI
-        restart_run = args.restart_ensemble_id is not None
+        select_prior = args.restart_ensemble_id is not None
         prior_ensemble = args.restart_ensemble_id or ""
     else:
         # When running from GUI
-        restart_run = args.restart_run
+        select_prior = args.select_prior
         prior_ensemble = args.prior_ensemble_id
-    return restart_run, prior_ensemble
+    return select_prior, prior_ensemble
 
 
 def _setup_multiple_data_assimilation(
@@ -483,7 +483,7 @@ def _setup_multiple_data_assimilation(
     update_settings: ObservationSettings,
     status_queue: SimpleQueue[StatusEvents],
 ) -> MultipleDataAssimilation:
-    restart_run, prior_ensemble = _determine_restart_info(args)
+    select_prior, prior_ensemble = _determine_restart_info(args)
     active_realizations = _get_and_validate_active_realizations_list(args, config)
     validate_minimum_realizations(config, active_realizations)
     if sum(active_realizations) < 2:
@@ -492,7 +492,7 @@ def _setup_multiple_data_assimilation(
         )
 
     parameter_configs, design_matrix = _merge_parameters(
-        design_matrix=None if restart_run else config.analysis_config.design_matrix,
+        design_matrix=None if select_prior else config.analysis_config.design_matrix,
         parameter_configs=config.ensemble_config.parameter_configuration,
         require_updateable_param=True,
     )
@@ -502,7 +502,7 @@ def _setup_multiple_data_assimilation(
         active_realizations=active_realizations,
         target_ensemble=_iterative_ensemble_format(args),
         arg_weights=args.weights,
-        restart_run=restart_run,
+        select_prior=select_prior,
         prior_ensemble_id=prior_ensemble,
         minimum_required_realizations=config.analysis_config.minimum_required_realizations,
         experiment_name=args.experiment_name,

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -49,7 +49,7 @@ class MultipleDataAssimilation(
         self._parsed_weights = self.parse_weights(self.analysis_settings.weights)
         start_iteration = 0
         total_iterations = len(self._parsed_weights) + 1
-        if self.restart_run:
+        if self.select_prior:
             if not self.prior_ensemble_id:
                 raise ValueError("For restart run, prior ensemble must be set")
             start_iteration = (
@@ -93,7 +93,7 @@ class MultipleDataAssimilation(
             raise ErtRunError("ESMDA does not support restart")
 
         target_experiment = None
-        if self.restart_run:
+        if self.select_prior:
             id_ = self.prior_ensemble_id
             assert id_ is not None
 

--- a/src/ert/run_models/run_model_configs.py
+++ b/src/ert/run_models/run_model_configs.py
@@ -320,7 +320,7 @@ class MultipleDataAssimilationConfig(
     InitialEnsembleRunModelConfig, UpdateRunModelConfig
 ):
     experiment_type: ExperimentType = ExperimentType.ES_MDA
-    restart_run: bool
+    select_prior: bool
     prior_ensemble_id: str | None
     arg_weights: str | None = Field(default=None, exclude=True)
 
@@ -337,7 +337,7 @@ class MultipleDataAssimilationConfig(
             **self._initial_ensemble_experiment_config(),
             **self._update_experiment_config(),
             **self._common_fields(),
-            "restart_run": self.restart_run,
+            "select_prior": self.select_prior,
             "prior_ensemble_id": self.prior_ensemble_id,
             "experiment_type": ExperimentType.ES_MDA,
         }

--- a/src/ert/storage/local_experiment.py
+++ b/src/ert/storage/local_experiment.py
@@ -117,7 +117,7 @@ class ExperimentConfig(TypedDict, total=False):
     ensemble_id: str
 
     # ESMDA
-    restart_run: bool
+    select_prior: bool
     prior_ensemble_id: str | None
 
     # Everest

--- a/tests/ert/ui_tests/cli/test_restarting_esmda.py
+++ b/tests/ert/ui_tests/cli/test_restarting_esmda.py
@@ -225,7 +225,7 @@ def _build_esmda_restart_model(prior_ensemble_id: str):
             realizations=None,
             target_ensemble="iter-<ITER>",
             weights="1,1",
-            restart_run=True,
+            select_prior=True,
             prior_ensemble_id=prior_ensemble_id,
             experiment_name="restart-experiment",
         ),

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -736,7 +736,7 @@ def test_right_click_plot_button_opens_external_plotter(qtbot, use_tmpdir, monke
     gui.close()
 
 
-def test_that_es_mda_restart_run_box_is_disabled_when_there_are_no_valid_cases(
+def test_that_es_mda_select_prior_box_is_disabled_when_there_are_no_valid_cases(
     qtbot, opened_main_window_minimal_realizations, run_experiment
 ):
     gui = opened_main_window_minimal_realizations
@@ -751,7 +751,9 @@ def test_that_es_mda_restart_run_box_is_disabled_when_there_are_no_valid_cases(
     es_mda_panel = get_child(gui, QWidget, name="ES_MDA_panel")
     assert es_mda_panel
 
-    restart_button = get_child(es_mda_panel, QCheckBox, name="restart_checkbox_esmda")
+    restart_button = get_child(
+        es_mda_panel, QCheckBox, name="select_prior_checkbox_esmda"
+    )
     ensemble_selector = get_child(es_mda_panel, EnsembleSelector)
 
     assert restart_button

--- a/tests/ert/ui_tests/gui/test_restart_esmda.py
+++ b/tests/ert/ui_tests/gui/test_restart_esmda.py
@@ -21,10 +21,12 @@ def test_restart_esmda(ensemble_experiment_has_run_no_failure, qtbot):
 
     es_mda_panel = gui.findChild(QWidget, name="ES_MDA_panel")
     assert es_mda_panel
-    restart_checkbox = es_mda_panel.findChild(QCheckBox, name="restart_checkbox_esmda")
-    assert restart_checkbox
-    restart_checkbox.click()
-    assert restart_checkbox.isChecked()
+    select_prior_checkbox = es_mda_panel.findChild(
+        QCheckBox, name="select_prior_checkbox_esmda"
+    )
+    assert select_prior_checkbox
+    select_prior_checkbox.click()
+    assert select_prior_checkbox.isChecked()
 
     es_mda_panel._ensemble_selector.setCurrentText("iter-0")
     assert es_mda_panel._ensemble_selector.selected_ensemble.name == "iter-0"
@@ -72,12 +74,14 @@ def test_that_esmda_active_realizations_are_set_only_when_restart_is_checked(
     active_reals = es_mda_panel.findChild(StringBox, "active_realizations_box")
     assert active_reals.text() == "0-9"
 
-    restart_checkbox = es_mda_panel.findChild(QCheckBox, name="restart_checkbox_esmda")
-    assert restart_checkbox
-    assert not restart_checkbox.isChecked()
-    restart_checkbox.click()
+    select_prior_checkbox = es_mda_panel.findChild(
+        QCheckBox, name="select_prior_checkbox_esmda"
+    )
+    assert select_prior_checkbox
+    assert not select_prior_checkbox.isChecked()
+    select_prior_checkbox.click()
     assert active_reals.text() == "0-1"
-    restart_checkbox.click()
+    select_prior_checkbox.click()
     assert active_reals.text() == "0-9"
 
 
@@ -117,11 +121,13 @@ def test_custom_weights_stored_and_retrieved_from_metadata_esmda(
         == "Total progress 100% — Experiment completed."
     )
     assert wsb.text() == default_weights
-    restart_checkbox = es_mda_panel.findChild(QCheckBox, name="restart_checkbox_esmda")
-    assert restart_checkbox
-    assert not restart_checkbox.isChecked()
-    restart_checkbox.click()
+    select_prior_checkbox = es_mda_panel.findChild(
+        QCheckBox, name="select_prior_checkbox_esmda"
+    )
+    assert select_prior_checkbox
+    assert not select_prior_checkbox.isChecked()
+    select_prior_checkbox.click()
     # selecting restart will trigger reading of metadata.json containing custom weights
-    assert restart_checkbox.isChecked()
+    assert select_prior_checkbox.isChecked()
     assert not wsb.isEnabled()
     assert wsb.text() == custom_weights

--- a/tests/ert/unit_tests/cli/test_model_hook_order.py
+++ b/tests/ert/unit_tests/cli/test_model_hook_order.py
@@ -75,7 +75,7 @@ def patch_run_model(monkeypatch):
             MultipleDataAssimilation,
             {
                 "target_ensemble": "ens%d",
-                "restart_run": False,
+                "select_prior": False,
                 "prior_ensemble_id": "N/A",
             },
             EXPECTED_CALL_ORDER_WITH_ONE_UPDATE,

--- a/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
+++ b/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
@@ -58,9 +58,9 @@ def test_that_active_realizations_selector_validates_with_ensemble_size_from_con
     assert realization_selector.isValid()
     assert realization_selector.get_text == "0-1, 3, 5-6"
     assert not ensemble_selector.isEnabled()
-    restart_checkbox = panel.findChild(QCheckBox, "restart_checkbox_esmda")
-    assert not restart_checkbox.isEnabled()
-    assert not restart_checkbox.isChecked()
+    select_prior_checkbox = panel.findChild(QCheckBox, "select_prior_checkbox_esmda")
+    assert not select_prior_checkbox.isEnabled()
+    assert not select_prior_checkbox.isChecked()
     assert panel.isConfigurationValid()
 
 
@@ -108,11 +108,11 @@ def test_that_active_realizations_selector_validates_with_with_realizations_from
     assert realization_selector.text() == "0-19"
     assert panel.isConfigurationValid()
     assert not ensemble_selector.isEnabled()
-    restart_checkbox = panel.findChild(QCheckBox, "restart_checkbox_esmda")
-    assert restart_checkbox.isEnabled()
-    assert not restart_checkbox.isChecked()
-    restart_checkbox.click()
-    assert restart_checkbox.isChecked()
+    select_prior_checkbox = panel.findChild(QCheckBox, "select_prior_checkbox_esmda")
+    assert select_prior_checkbox.isEnabled()
+    assert not select_prior_checkbox.isChecked()
+    select_prior_checkbox.click()
+    assert select_prior_checkbox.isChecked()
     assert ensemble_selector.isEnabled()
     assert ensemble_selector.currentText() == "mock_experiment : mock_ensemble"
     assert realization_selector.text() == "0-2, 5"
@@ -120,12 +120,12 @@ def test_that_active_realizations_selector_validates_with_with_realizations_from
     # We try rerunning from a realization that failed previously
     realization_selector.setText("0-2, 4-5")
     assert not panel.isConfigurationValid()
-    restart_checkbox.setChecked(False)
+    select_prior_checkbox.setChecked(False)
     assert realization_selector.text() == "0-19"
     assert panel.isConfigurationValid()
 
 
-def test_that_multiple_data_assimilation_panel_sets_active_realizations_to_initial_active_realizations_when_restart_run_toggled(  # ruff: ignore[line-too-long]
+def test_that_multiple_data_assimilation_panel_sets_active_realizations_to_initial_active_realizations_when_select_prior_toggled(  # ruff: ignore[line-too-long]
     qtbot,
 ):
     active_realizations = [True, True, False, True, True]
@@ -142,7 +142,7 @@ def test_that_multiple_data_assimilation_panel_sets_active_realizations_to_initi
         config_num_realization=2,
     )
     assert mda_panel._active_realizations_field.text() == active_realizations_string
-    mda_panel.restart_run_toggled()
+    mda_panel.select_prior_toggled()
     assert mda_panel._active_realizations_field.text() == active_realizations_string
 
 

--- a/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
+++ b/tests/ert/unit_tests/gui/experiments/test_multiple_data_assimilation_panel.py
@@ -36,7 +36,7 @@ def test_that_active_realizations_selector_validates_with_ensemble_size_from_con
 ) -> None:
     """This is a test that makes sure the realization selector autofills and
     validates with the num_realizations from config/designmatrix, and the autofilled
-    configuration is valid. It also makes sure the restart run button is disabled if
+    configuration is valid. It also makes sure the "Select prior" button is disabled if
     there are no previous experiments/ensembles in storage
     """
     active_realizations = [True, True, False, True, False, True, True]

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/heat_equationconfig.ert/config.json
@@ -598,6 +598,6 @@
     }
   },
   "experiment_type": "Multiple Data Assimilation",
-  "restart_run": false,
+  "select_prior": false,
   "prior_ensemble_id": null
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/poly_examplepoly.ert/poly.json
@@ -305,6 +305,6 @@
     "shapes": {}
   },
   "experiment_type": "Multiple Data Assimilation",
-  "restart_run": false,
+  "select_prior": false,
   "prior_ensemble_id": null
 }

--- a/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
+++ b/tests/ert/unit_tests/run_models/snapshots/test_experiment_serialization/test_that_dumped_esmda_matches_snapshot/snake_oilsnake_oil.ert/snake_oil.json
@@ -461,6 +461,6 @@
     "shapes": {}
   },
   "experiment_type": "Multiple Data Assimilation",
-  "restart_run": false,
+  "select_prior": false,
   "prior_ensemble_id": null
 }

--- a/tests/ert/unit_tests/run_models/test_experiment_serialization.py
+++ b/tests/ert/unit_tests/run_models/test_experiment_serialization.py
@@ -409,7 +409,7 @@ def multidass(_):
     # Note: this does not test restart runs, it may be
     # better to test that separately
     return {
-        "restart_run": False,
+        "select_prior": False,
         "prior_ensemble_id": None,
     }
 
@@ -877,7 +877,7 @@ def test_that_dumped_esmda_matches_snapshot(
             realizations="1,2",
             target_ensemble="iter-<ITER>",
             weights="4, 2, 1",
-            restart_run=False,
+            select_prior=False,
             prior_ensemble_id=None,
             experiment_name="es-mda",
         ),

--- a/tests/ert/unit_tests/run_models/test_model_factory.py
+++ b/tests/ert/unit_tests/run_models/test_model_factory.py
@@ -70,7 +70,7 @@ def test_that_the_model_warns_when_active_realizations_less_min_realizations(
                 target_ensemble="target",
                 experiment_name="experiment",
                 num_iterations=1,
-                restart_run=False,
+                select_prior=False,
                 prior_ensemble_id="",
                 weights="2,3",
             ),
@@ -199,7 +199,7 @@ def test_that_setup_multiple_data_assimilation_uses_the_arguments_from_the_cli(
             realizations="0-4,8",
             weights="6,4,2",
             target_ensemble="test_case_%d",
-            restart_run=False,
+            select_prior=False,
             prior_ensemble_id="b272fe09-83ac-4744-b667-9a0a5415420b",
             experiment_name="My-experiment",
             starting_iteration=0,
@@ -216,7 +216,7 @@ def test_that_setup_multiple_data_assimilation_uses_the_arguments_from_the_cli(
     )
     assert model.target_ensemble == "test_case_%d"
     assert model.prior_ensemble_id == "b272fe09-83ac-4744-b667-9a0a5415420b"
-    assert model.restart_run is False
+    assert model.select_prior is False
 
 
 @pytest.mark.filterwarnings("ignore:MIN_REALIZATIONS")
@@ -235,7 +235,7 @@ def test_that_setup_multiple_data_assimilation_uses_config_weights_when_cli_omit
             realizations="0-4,8",
             target_ensemble="test_case_%d",
             weights=None,
-            restart_run=False,
+            select_prior=False,
             prior_ensemble_id="b272fe09-83ac-4744-b667-9a0a5415420b",
             experiment_name="My-experiment",
             starting_iteration=0,
@@ -281,7 +281,7 @@ def test_multiple_data_assimilation_restart_paths(
         realizations="0,1",
         weights="6,4,2",
         target_ensemble="restart_case_%d",
-        restart_run=True,
+        select_prior=True,
         prior_ensemble_id=str(uuid1()),
         experiment_name="just_assimilatin",
     )
@@ -319,7 +319,7 @@ def test_num_realizations_specified_incorrectly_raises(analysis_mode):
         realizations="0",
         weights="6,4,2",
         target_ensemble="restart_case_%d",
-        restart_run=True,
+        select_prior=True,
         prior_ensemble_id=str(uuid1()),
         experiment_name=None,
     )
@@ -393,7 +393,7 @@ def test_that_setting_up_experiment_with_update_step_raises_config_validation_er
     ones specified in the gui) and all active realization in the 'config', meaning we
     are referring to two different active realizations.
     """
-    args = MagicMock(realizations="0", restart_run=False, prior_ensemble_id="")
+    args = MagicMock(realizations="0", select_prior=False, prior_ensemble_id="")
     config = MagicMock()
     config.active_realizations = [True] * 10
     config.analysis_config = MagicMock(minimum_required_realizations=1)


### PR DESCRIPTION
**Issue**
Resolves #11920 


**Approach**
Rename GUI labels related to reruns to something more understandable, as well as updating related variables to match new name.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [x] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
