### PR TITLE
Match wildcards for missing RFT response property warnings

### DIFF
--- a/src/ert/config/response_config.py
+++ b/src/ert/config/response_config.py
@@ -15,7 +15,7 @@ _RESPONSE_WARNING_LIMIT = 5
 
 def _warn_about_missing_responses(
     missing_items: list[str],
-    item_label: Literal["key(s)", "well(s) at time(s)"],
+    response_type: Literal["summary", "RFT"],
     filename: str,
 ) -> None:
     if not missing_items:
@@ -24,7 +24,7 @@ def _warn_about_missing_responses(
     num_excess = len(missing_items) - _RESPONSE_WARNING_LIMIT
 
     warning = (
-        f"Could not find responses for {item_label} in '{filename}':\n"
+        f"Could not find responses for {response_type} key(s) in '{filename}':\n"
         + "\n".join(missing_items[:_RESPONSE_WARNING_LIMIT])
         + (f"\n... and {num_excess} other missing responses" if num_excess > 0 else "")
     )

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -289,27 +289,36 @@ class RFTConfig(SimulationResponseConfig):
         rft_data: dict[tuple[WellName, datetime.date], RFTConfig.ValidRFTEntry],
         rft_filename: str,
     ) -> None:
-        well_times = {
-            (well, time)
-            for well, time_dict in self.data_to_read.items()
-            for time in time_dict
-        }
-        well_times_with_response = {
-            f"{well}:{time.isoformat()}" for well, time in rft_data
-        }
-        well_times_to_warn: set[tuple[str, str]] = {
-            (well, time)
-            for well, time in well_times
-            if not fnmatch.filter(
-                well_times_with_response,
-                f"{well}:{time}",
-            )
-        }
-        formatted_items = [
-            f"{well=} : {time=}" for well, time in sorted(well_times_to_warn)
+        missing_response_properties = defaultdict(list)
+        for well, time_dict in self.data_to_read.items():
+            for time in time_dict:
+                expected_properties = set(time_dict[time])
+                # Find all well-time tuples matching expected well-time pattern
+                well_time_tuple_matches = [
+                    t
+                    for t in rft_data
+                    if fnmatch.fnmatch(t[0], well)
+                    and fnmatch.fnmatch(t[1].isoformat(), time)
+                ]
+                # Find all properties matching expected property patterns
+                property_matches = set()
+                for well_time in well_time_tuple_matches:
+                    properties_in_response = rft_data[well_time].property_values.keys()
+                    property_matches |= {
+                        exp_prop
+                        for exp_prop in expected_properties
+                        if fnmatch.filter(properties_in_response, exp_prop)
+                    }
+
+                for missing_property in expected_properties - property_matches:
+                    missing_response_properties[well, time].append(missing_property)
+
+        formatted_missing_rft_responses = [
+            f"well='{well}' : time='{time}' : properties={sorted(properties)}"
+            for (well, time), properties in missing_response_properties.items()
         ]
         _warn_about_missing_responses(
-            formatted_items, "well(s) at time(s)", rft_filename
+            sorted(formatted_missing_rft_responses), "RFT", rft_filename
         )
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:

--- a/src/ert/config/summary_config.py
+++ b/src/ert/config/summary_config.py
@@ -37,7 +37,7 @@ class SummaryConfig(SimulationResponseConfig):
         keys_missing_responses = [
             key for key in self.keys if not fnmatch.filter(response_keys, key)
         ]
-        _warn_about_missing_responses(keys_missing_responses, "key(s)", filename)
+        _warn_about_missing_responses(keys_missing_responses, "summary", filename)
 
     def read_from_file(self, run_path: str, iens: int, iter_: int) -> pl.DataFrame:
         filename = substitute_runpath_name(self.input_files[0], iens, iter_)

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1447,9 +1447,10 @@ def _collect_rft_response_warnings(
     ]
 
 
-def test_that_no_wildcard_rft_key_with_response_doesnt_warn(
+def test_that_simple_rft_key_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):
+    """Simple means a RFT key not containing any wildcards in this context"""
     warnings_ = _collect_rft_response_warnings(
         wells=[_MOCK_RESFO_RFT_WELL],
         times=[_MOCK_RESFO_RFT_TIME],

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -85,9 +85,7 @@ def test_that_match_key_dict_expr_fits_match_key():
     assert response2["response_dict"].to_list() == ["well_connection_cell=None"]
 
 
-@pytest.mark.filterwarnings(
-    r"ignore:Could not find responses for well\(s\) at time\(s\)"
-)
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
 def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo_file):
     mock_resfo_file("/tmp/does_not_exist/BASE.RFT", [])
     rft_config = RFTConfig(
@@ -787,9 +785,7 @@ def test_that_missing_egrid_with_locations_raises_invalid_response_file(
         rft_config.obtain_location_metadata("/tmp/does_not_exist", 1, 1, observations)
 
 
-@pytest.mark.filterwarnings(
-    r"ignore:Could not find responses for well\(s\) at time\(s\)"
-)
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
 def test_that_missing_egrid_without_locations_raises_invalid_response_file(
     mock_resfo_file,
 ):
@@ -897,9 +893,7 @@ def test_that_non_matching_wells_are_ignored_silently(mock_resfo_file, egrid):
     ]
 
 
-@pytest.mark.filterwarnings(
-    r"ignore:Could not find responses for well\(s\) at time\(s\)"
-)
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
 def test_that_wildcard_well_with_specific_date_matches_all_wells(
     mock_resfo_file, egrid
 ):

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1558,6 +1558,29 @@ def test_that_all_wildcard_rft_key_doesnt_warn(
     assert no_warnings
 
 
+def test_that_all_wildcard_rft_key_warns_given_no_responses_at_all(
+    mock_resfo_file, egrid
+):
+    mock_resfo_file(
+        _MOCK_RESFO_DIR + "/BASE.RFT",
+        [],
+    )
+    mock_resfo_file(
+        _MOCK_RESFO_DIR + "/BASE.EGRID",
+        egrid,
+    )
+    warnings_ = _collect_rft_response_warnings(
+        wells=["*"],
+        times=["*"],
+        property_lists=[["*"]],
+    )
+    warning_message = str(warnings_.pop().message)
+    assert warning_message == (
+        "Could not find responses for RFT key(s) in 'BASE.RFT':\n"
+        "well='*' : time='*' : properties=['*']"
+    )
+
+
 def test_that_properties_without_response_warns_while_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 from datetime import datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, cast
 from warnings import WarningMessage
@@ -1354,66 +1355,42 @@ def test_that_approximate_missing_rft_values_keyword_sets_interpolation_to_true_
     assert rft_config.approximate_missing_values is expected_setting
 
 
-@pytest.fixture(name="setup_mock_resfo_file")
+_MOCK_RESFO_DIR = "/tmp/does_not_exist"
+_MOCK_RESFO_RFT_WELL = "WELL"
+_MOCK_RESFO_RFT_TIME = "2000-01-01"
+_MOCK_RESFO_RFT_TIME2 = "2000-02-01"
+
+_RFT_PROP_LENGTH = 8
+
+
+class _RFT_PROPERTY(StrEnum):
+    PRESSURE = "PRESSURE"
+    SWAT = "SWAT"
+    SGAS = "SGAS"
+    DEPTH = "DEPTH"
+
+
+@pytest.fixture
 def setup_mock_resfo_file(mock_resfo_file, egrid):
     mock_resfo_file(
-        "/tmp/does_not_exist/BASE.RFT",
+        _MOCK_RESFO_DIR + "/BASE.RFT",
         [
-            *cell_start(date=(1, 1, 2000), well_name="WELL"),
-            ("PRESSURE", float_arr([100.0, 200.0])),
-            ("SWAT    ", float_arr([0.1, 0.2])),
-            ("SGAS    ", float_arr([0.3, 0.4])),
-            ("DEPTH   ", float_arr([20.0, 30.0])),
-            *cell_start(date=(1, 2, 2000), well_name="WELL"),
-            ("PRESSURE", float_arr([101.0, 201.0])),
-            ("SWAT    ", float_arr([0.01, 0.01])),
-            ("SGAS    ", float_arr([0.01, 0.01])),
-            ("DEPTH   ", float_arr([21.0, 31.0])),
+            *cell_start(date=(1, 1, 2000), well_name=_MOCK_RESFO_RFT_WELL),
+            (_RFT_PROPERTY.PRESSURE.ljust(_RFT_PROP_LENGTH), float_arr([100.0, 200.0])),
+            (_RFT_PROPERTY.SWAT.ljust(_RFT_PROP_LENGTH), float_arr([0.1, 0.2])),
+            (_RFT_PROPERTY.SGAS.ljust(_RFT_PROP_LENGTH), float_arr([0.3, 0.4])),
+            (_RFT_PROPERTY.DEPTH.ljust(_RFT_PROP_LENGTH), float_arr([20.0, 30.0])),
+            *cell_start(date=(1, 2, 2000), well_name=_MOCK_RESFO_RFT_WELL),
+            (_RFT_PROPERTY.PRESSURE.ljust(_RFT_PROP_LENGTH), float_arr([101.0, 201.0])),
+            (_RFT_PROPERTY.SWAT.ljust(_RFT_PROP_LENGTH), float_arr([0.01, 0.01])),
+            (_RFT_PROPERTY.SGAS.ljust(_RFT_PROP_LENGTH), float_arr([0.01, 0.01])),
+            (_RFT_PROPERTY.DEPTH.ljust(_RFT_PROP_LENGTH), float_arr([21.0, 31.0])),
         ],
     )
     mock_resfo_file(
-        "/tmp/does_not_exist/BASE.EGRID",
+        _MOCK_RESFO_DIR + "/BASE.EGRID",
         egrid,
     )
-
-
-def test_that_missing_response_for_rft_well_raises_warning(setup_mock_resfo_file):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "NOT_A_WELL": {"2000-01-01": ["PRESSURE", "SWAT"]},
-            "WELL": {"2000-01-01": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-    expected_warnings = [
-        "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
-        "well='NOT_A_WELL' : time='2000-01-01'",
-    ]
-    assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
-
-
-def test_that_one_existing_and_one_missing_rft_response_warns_about_the_one_missing(
-    setup_mock_resfo_file,
-):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "WELL": {
-                "4000-01-01": ["PRESSURE", "SWAT"],
-                "2000-01-01": ["PRESSURE", "SWAT"],
-            },
-        },
-    )
-    with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-    expected_warnings = [
-        "Could not find responses for well(s) at time(s) in 'BASE.RFT':",
-        "well='WELL' : time='4000-01-01'",
-    ]
-    assert any(all(m in str(w) for m in expected_warnings) for w in warnings)
 
 
 def test_that_many_missing_response_warnings_are_truncated(setup_mock_resfo_file):
@@ -1421,14 +1398,12 @@ def test_that_many_missing_response_warnings_are_truncated(setup_mock_resfo_file
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
         data_to_read={
-            "WELL": {
-                f"400{n}-01-01": ["PRESSURE", "SWAT"]
-                for n in range(num_missing_responses)
-            }
+            f"WELL_{n}": {"2000-01-01": ["PRESSURE", "SWAT"]}
+            for n in range(num_missing_responses)
         },
     )
     with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+        rft_config.read_from_file(_MOCK_RESFO_DIR, 1, 1)
     warning_msg = next(
         str(w.message) for w in warnings if "Could not find responses" in str(w.message)
     )
@@ -1442,113 +1417,27 @@ def test_that_many_missing_response_warnings_are_truncated(setup_mock_resfo_file
     assert excess_warnings == num_missing_responses - _RESPONSE_WARNING_LIMIT
 
 
-def test_that_wildcard_wells_are_not_warned_about(setup_mock_resfo_file):
+def _collect_rft_response_warnings(
+    wells: list[str], times: list[str], property_lists: list[list[str]]
+) -> list[WarningMessage]:
+    """Sets up data_to_read with all possible combinations of wells, times and
+    property_lists, runs RFTConfig.read_from_file, and returns all captures
+    PostExperimentWarnings
+    """
+    data_to_read = {}
+    for well in wells:
+        for time in times:
+            for property_list in property_lists:
+                if well in data_to_read:
+                    data_to_read[well] |= {time: property_list}
+                else:
+                    data_to_read |= {well: {time: property_list}}
     rft_config = RFTConfig(
         input_files=["BASE.RFT"],
-        data_to_read={
-            "*": {"2000-01-01": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
-            "error", PostExperimentWarning
-        )
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-
-def test_that_wildcard_times_are_not_warned_about_given_any_well_response(
-    setup_mock_resfo_file,
-):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "WELL": {"*": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter(  # Asserts no PostExperimentWarnings were raised
-            "error", PostExperimentWarning
-        )
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-
-def test_that_wildcard_times_are_warned_about_given_no_well_response(
-    setup_mock_resfo_file,
-):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "DIFFERENT_WELL": {"*": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-    expected_warnings = [
-        "Could not find responses for well(s) at time(s)",
-        "well='DIFFERENT_WELL' : time='*'",
-    ]
-    # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
-
-
-def test_that_wildcard_wells_are_warned_about_given_no_time_response(
-    setup_mock_resfo_file,
-):
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "*": {"2010-10-10": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-    expected_warnings = [
-        "Could not find responses for well(s) at time(s)",
-        "well='*' : time='2010-10-10'",
-    ]
-    # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
-
-
-def test_that_wildcard_well_with_wildcard_time_without_any_response_is_warned_about(
-    mock_resfo_file, egrid
-):
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.RFT",
-        [],
-    )
-    mock_resfo_file(
-        "/tmp/does_not_exist/BASE.EGRID",
-        egrid,
-    )
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            "*": {"*": ["PRESSURE", "SWAT"]},
-        },
-    )
-    with pytest.warns(PostExperimentWarning) as warnings:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
-
-    expected_warnings = [
-        "Could not find responses for well(s) at time(s)",
-        "well='*' : time='*'",
-    ]
-    # Assert one warning contains all expected warnings
-    assert any(all(e_w in str(w) for e_w in expected_warnings) for w in warnings)
-
-
-def _collect_rft_response_warnings(well: str, time: str) -> list[WarningMessage]:
-    rft_config = RFTConfig(
-        input_files=["BASE.RFT"],
-        data_to_read={
-            well: {time: ["PRESSURE", "SWAT"]},
-        },
+        data_to_read=data_to_read,
     )
     with warnings.catch_warnings(record=True) as ws:
-        rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+        rft_config.read_from_file(_MOCK_RESFO_DIR, 1, 1)
 
     return [
         w
@@ -1558,73 +1447,182 @@ def _collect_rft_response_warnings(well: str, time: str) -> list[WarningMessage]
     ]
 
 
-def test_that_wildcard_well_with_wildcard_time_with_any_response_is_not_warned_about(
+def test_that_no_wildcard_rft_key_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="*", time="*")
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    no_warnings = len(warnings) == 0
+    no_warnings = len(warnings_) == 0
     assert no_warnings
 
 
-def test_that_partly_wildcard_well_name_with_response_does_not_warn(
+def test_that_wildcard_rft_well_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="WE*", time="*")
+    wildcard_well = _MOCK_RESFO_RFT_WELL[:2] + "*"  # "WE*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[wildcard_well],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    no_warnings = len(warnings) == 0
+    no_warnings = len(warnings_) == 0
     assert no_warnings
 
 
-def test_that_partly_wildcard_times_with_response_does_not_warn(
+def test_that_wildcard_rft_well_without_response_warns(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="*", time="2000*")
+    wildcard_well = "FOO*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[wildcard_well],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    no_warnings = len(warnings) == 0
+    did_warn = len(warnings_) == 1
+    assert did_warn
+
+
+def test_that_wildcard_rft_time_with_response_doesnt_warn(
+    setup_mock_resfo_file,
+):
+    wildcard_time = _MOCK_RESFO_RFT_TIME[:4] + "*"  # "2000*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[wildcard_time],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
+
+    no_warnings = len(warnings_) == 0
     assert no_warnings
 
 
-def test_that_well_with_multiple_wildcard_with_response_does_not_warn(
+def test_that_wildcard_rft_time_without_response_warns(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="W*L*", time="*")
+    wildcard_time = "1970*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[wildcard_time],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    no_warnings = len(warnings) == 0
+    did_warn = len(warnings_) == 1
+    assert did_warn
+
+
+def test_that_wildcard_rft_property_with_response_doesnt_warn(
+    setup_mock_resfo_file,
+):
+    wildcard_property = _RFT_PROPERTY.PRESSURE[:2] + "*"  # "PR*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[wildcard_property]],
+    )
+
+    no_warnings = len(warnings_) == 0
     assert no_warnings
 
 
-def test_that_well_and_time_with_multiple_wildcard_with_response_does_not_warn(
+def test_that_wildcard_rft_property_without_response_warns(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="W*L*", time="2*00*01")
+    wildcard_property = "FOO*"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE, wildcard_property]],
+    )
 
-    no_warnings = len(warnings) == 0
+    did_warn = len(warnings_) > 0
+    assert did_warn
+
+
+def test_that_all_wildcard_rft_key_doesnt_warn(
+    setup_mock_resfo_file,
+):
+    warnings_ = _collect_rft_response_warnings(
+        wells=["*"],
+        times=["*"],
+        property_lists=[["*"]],
+    )
+
+    no_warnings = len(warnings_) == 0
     assert no_warnings
 
 
-def test_that_time_with_partial_wildcard_without_response_at_time_does_warn(
+def test_that_properties_without_response_warns_while_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="WELL", time="1999*")
+    foo = "Foo"
+    bar = "Bar"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE, foo, _RFT_PROPERTY.SGAS, bar]],
+    )
 
-    does_warn = len(warnings) > 0
-    assert does_warn
+    warning_message = str(warnings_.pop().message)
+    assert warning_message == (
+        "Could not find responses for RFT key(s) in 'BASE.RFT':\n"
+        f"well='WELL' : time='2000-01-01' : properties=['{bar}', '{foo}']"
+    )
 
 
-def test_that_well_with_partial_wildcard_without_response_does_warn(
+def test_that_times_without_response_warns_while_with_response_doesnt_warn(
     setup_mock_resfo_file,
 ):
-    warnings = _collect_rft_response_warnings(well="NOT_A_W*", time="*")
+    foo_time = "1970-01-01"
+    bar_time = "2050-01-01"
+    warnings_ = _collect_rft_response_warnings(
+        wells=[_MOCK_RESFO_RFT_WELL],
+        times=[_MOCK_RESFO_RFT_TIME, foo_time, _MOCK_RESFO_RFT_TIME2, bar_time],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    does_warn = len(warnings) > 0
-    assert does_warn
+    warning_message = str(warnings_.pop().message)
+    assert warning_message == (
+        "Could not find responses for RFT key(s) in 'BASE.RFT':\n"
+        f"well='WELL' : time='{foo_time}' : properties=['{_RFT_PROPERTY.PRESSURE}']\n"
+        f"well='WELL' : time='{bar_time}' : properties=['{_RFT_PROPERTY.PRESSURE}']"
+    )
 
 
-def test_that_well_and_time_with_partial_wildcard_without_response_does_warn(
-    setup_mock_resfo_file,
+def test_that_wildcard_wells_with_any_response_doesnt_warn(
+    setup_mock_resfo_file, egrid, mock_resfo_file
 ):
-    warnings = _collect_rft_response_warnings(well="NOT_A_W*", time="1999*")
+    foo_well = "WALL"
+    shared_well_pattern = "W*"
+    mock_resfo_file(
+        _MOCK_RESFO_DIR + "/BASE.RFT",
+        [
+            *cell_start(date=(1, 1, 2000), well_name=_MOCK_RESFO_RFT_WELL),
+            ("PRESSURE", float_arr([100.0, 200.0])),
+            ("SWAT    ", float_arr([0.1, 0.2])),
+            ("SGAS    ", float_arr([0.3, 0.4])),
+            ("DEPTH   ", float_arr([20.0, 30.0])),
+            *cell_start(date=(1, 2, 2000), well_name=foo_well),
+            ("PRESSURE", float_arr([101.0, 201.0])),
+            ("SWAT    ", float_arr([0.01, 0.01])),
+            ("SGAS    ", float_arr([0.01, 0.01])),
+            ("DEPTH   ", float_arr([21.0, 31.0])),
+        ],
+    )
+    mock_resfo_file(
+        _MOCK_RESFO_DIR + "/BASE.EGRID",
+        egrid,
+    )
+    warnings_ = _collect_rft_response_warnings(
+        wells=[shared_well_pattern],
+        times=[_MOCK_RESFO_RFT_TIME],
+        property_lists=[[_RFT_PROPERTY.PRESSURE]],
+    )
 
-    does_warn = len(warnings) > 0
-    assert does_warn
+    no_warnings = len(warnings_) == 0
+    assert no_warnings

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -28,7 +28,7 @@ from ert.warnings import PostExperimentWarning
 @given(summaries(summary_keys=st.just(["WOPR:OP1"])))
 @pytest.mark.usefixtures("use_tmpdir")
 @pytest.mark.slow
-@pytest.mark.filterwarnings(r"ignore:Could not find responses for key\(s\)")
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
 def test_that_reading_empty_summaries_returns_empty_df_with_column_schema(wopr_summary):
     smspec, unsmry = wopr_summary
     smspec.to_file("CASE.SMSPEC")

--- a/tests/ert/unit_tests/config/test_summary_config.py
+++ b/tests/ert/unit_tests/config/test_summary_config.py
@@ -266,7 +266,7 @@ def test_that_when_not_finding_response_obs_keys_raises_warning(monkeypatch):
     )
     expected_warning = dedent(
         """\
-        Could not find responses for key(s) in 'CASE':
+        Could not find responses for summary key(s) in 'CASE':
         WOPR:OP2
         WWCT:OP1"""
     )

--- a/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
+++ b/tests/ert/unit_tests/dark_storage/test_dark_storage_state.py
@@ -21,7 +21,7 @@ def escape(s):
     return quote(quote(quote(s, safe="")))
 
 
-@pytest.mark.filterwarnings(r"ignore:Could not find responses for key\(s\)")
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
 class DarkStorageStateTest(StatefulStorageTest):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
The old implementation assumed it was enough to look for responses matching RFT well and time, however, this leaves the user with little information of which property was not found given existing well and time.

That would mean the user would get the warning "Did not find response for <WELL> <TIME>" When indeed there was responses, just not for the property.