### PR TITLE
Rename `Restart run` mda gui label to `Select prior`

### DIFF
--- a/src/ert/storage/local_storage.py
+++ b/src/ert/storage/local_storage.py
@@ -31,7 +31,7 @@ from .realization_storage_state import RealizationStorageState
 
 logger = logging.getLogger(__name__)
 
-_LOCAL_STORAGE_VERSION = 37
+_LOCAL_STORAGE_VERSION = 38
 
 
 def open_storage(
@@ -642,6 +642,7 @@ class LocalStorage(BaseMode):
             to35,
             to36,
             to37,
+            to38,
         )
 
         try:  # ruff: ignore[too-many-statements-in-try-clause]
@@ -708,6 +709,7 @@ class LocalStorage(BaseMode):
                     34: to35,
                     35: to36,
                     36: to37,
+                    37: to38,
                 }
                 for from_version in range(version, _LOCAL_STORAGE_VERSION):
                     migrations[from_version].migrate(self.path)

--- a/src/ert/storage/migration/to38.py
+++ b/src/ert/storage/migration/to38.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+info = "Rename 'restart_run' Multiple Data Assimilation class key to 'select_prior'"
+
+
+def _rename_restart_run_mda_key_to_select_prior(path: Path) -> None:
+    experiments_dir = path / "experiments"
+    if not experiments_dir.exists():
+        return
+
+    for exp_dir in experiments_dir.iterdir():
+        if not exp_dir.is_dir():
+            continue
+
+        index_file = exp_dir / "index.json"
+        if not index_file.exists():
+            continue
+
+        index_data = json.loads(index_file.read_text(encoding="utf-8"))
+        experiment_data = index_data.get("experiment", {})
+
+        experiment_type = experiment_data.get("experiment_type", "")
+        if experiment_type != "Multiple Data Assimilation":
+            continue
+
+        experiment_data["select_prior"] = experiment_data.pop("restart_run")
+
+        index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
+
+
+def migrate(path: Path) -> None:
+    _rename_restart_run_mda_key_to_select_prior(path)

--- a/tests/ert/unit_tests/storage/migration/test_to38.py
+++ b/tests/ert/unit_tests/storage/migration/test_to38.py
@@ -1,0 +1,101 @@
+import json
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import assume, given, settings
+
+from ert.storage.migration.to38 import migrate
+
+_OLD_KEY = "restart_run"
+_NEW_KEY = "select_prior"
+_MDA_EXP_TYPE = "Multiple Data Assimilation"
+
+
+def migrate_and_load_updated_experiment(tmp_path, original_experiment_data):
+    root = tmp_path / "project"
+    root.mkdir()
+
+    exp_path = root / "experiments" / "exp1"
+    exp_path.mkdir(parents=True)
+
+    index_data = {
+        "id": "exp-id",
+        "name": "exp1",
+        "ensembles": [],
+        "experiment": {
+            **original_experiment_data,
+        },
+    }
+    (exp_path / "index.json").write_text(json.dumps(index_data), encoding="utf-8")
+
+    migrate(root)
+
+    updated = json.loads((exp_path / "index.json").read_text(encoding="utf-8"))
+    return updated["experiment"]
+
+
+def test_that_restart_run_key_not_present_in_migrated_experiment(tmp_path):
+
+    original_experiment_data = {
+        "experiment_type": _MDA_EXP_TYPE,
+        _OLD_KEY: True,
+    }
+
+    migrated_experiment = migrate_and_load_updated_experiment(
+        tmp_path, original_experiment_data
+    )
+
+    assert _OLD_KEY not in migrated_experiment
+
+
+def test_that_select_prior_key_is_present_in_migrated_experiment(tmp_path):
+
+    original_experiment_data = {
+        "experiment_type": _MDA_EXP_TYPE,
+        _OLD_KEY: True,
+    }
+
+    migrated_experiment = migrate_and_load_updated_experiment(
+        tmp_path, original_experiment_data
+    )
+
+    assert _NEW_KEY in migrated_experiment
+
+
+@pytest.mark.parametrize("original_value", [True, False])
+def test_that_new_key_value_is_equal_to_old_key_value(tmp_path, original_value):
+
+    original_experiment_data = {
+        "experiment_type": _MDA_EXP_TYPE,
+        _OLD_KEY: original_value,
+    }
+
+    migrated_experiment = migrate_and_load_updated_experiment(
+        tmp_path, original_experiment_data
+    )
+
+    assert migrated_experiment[_NEW_KEY] == original_value
+
+
+@given(non_mda_experiment_type=st.text())
+@settings(max_examples=10)
+def test_that_non_mda_experiment_type_is_not_migrated(
+    tmp_path_factory, non_mda_experiment_type
+):
+
+    # to avoid hypothesis tmp_path fixture error
+    tmp_path = tmp_path_factory.mktemp("arbitrary")
+
+    assume(non_mda_experiment_type != _MDA_EXP_TYPE)
+
+    original_experiment_data = {
+        "experiment_type": non_mda_experiment_type,
+        _OLD_KEY: True,
+    }
+
+    migrated_experiment = migrate_and_load_updated_experiment(
+        tmp_path, original_experiment_data
+    )
+
+    assert _OLD_KEY in migrated_experiment
+    assert _NEW_KEY not in migrated_experiment


### PR DESCRIPTION
**Issue**
Resolves #11920


**Approach**
See #14175.
Forgot to make migration and tests which is reason for reopen and new PR.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [x] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
