### PR TITLE
Allow both E and F states for a killed OpenPBS job

### DIFF
--- a/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
+++ b/tests/ert/unit_tests/scheduler/test_openpbs_driver.py
@@ -658,7 +658,10 @@ async def test_that_queue_system_can_kill_before_scheduler_with_negative_padding
     stdout_content: dict[str, dict] = json.loads(stdout.decode(errors="ignore"))
     job = stdout_content.get("Jobs", {}).get(job_id, {})
     assert job is not None, "Job not found in qstat output"
-    assert job.get("job_state") == "F", "The job was not marked as failed"
+    job_state = job.get("job_state")
+    assert job_state in {"E", "F"}, (
+        f"Expected job state to be 'E' (exiting) or 'F' (failed), got {job_state}"
+    )
     assert job.get("Resource_List", {}).get("walltime") == "00:00:00", (
         "Wall time was not propagated correctly"
     )


### PR DESCRIPTION
E is a transitional state, and it will later progress to F when the queue system is done with it. In this test we pick up either E or F depending on star alignment.

**Issue**
Resolves #14142 


**Approach**
🧠 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
