### PR TITLE
Fix Qt race condition when repainting

### DIFF
--- a/src/ert/gui/plotting/widgets/collapsible_section.py
+++ b/src/ert/gui/plotting/widgets/collapsible_section.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QSizePolicy,
     QToolButton,
@@ -47,7 +47,7 @@ class CollapsibleSection(QWidget):
         self._toggle_button.setArrowType(
             Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow
         )
-        self._content_widget.setVisible(checked)
+        QTimer.singleShot(0, lambda: self._content_widget.setVisible(checked))
 
     def set_title(self, title: str) -> None:
         self._toggle_button.setText(title)

--- a/src/ert/gui/plotting/widgets/plot_side_panel.py
+++ b/src/ert/gui/plotting/widgets/plot_side_panel.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import QSize, Qt
+from PyQt6.QtCore import QSize, Qt, QTimer
 from PyQt6.QtWidgets import (
     QWIDGETSIZE_MAX,
     QDockWidget,
@@ -113,11 +113,17 @@ class PlotSidePanel(QDockWidget):
         )
 
         if expanded:
-            self.setMinimumWidth(self._min_expanded_width)
-            self.setMaximumWidth(QWIDGETSIZE_MAX)
-            self._main_window.resizeDocks(
-                [self], [self._expanded_width], Qt.Orientation.Horizontal
-            )
+
+            def _expand() -> None:
+                self.setMinimumWidth(self._min_expanded_width)
+                self.setMaximumWidth(QWIDGETSIZE_MAX)
+                self._main_window.resizeDocks(
+                    [self], [self._expanded_width], Qt.Orientation.Horizontal
+                )
+
+            QTimer.singleShot(0, _expand)
         else:
-            # Collapsed width is button + slight padding
-            self.setFixedWidth(self._toggle_button.sizeHint().width() + 8)
+            QTimer.singleShot(
+                0,
+                lambda: self.setFixedWidth(self._toggle_button.sizeHint().width() + 8),
+            )

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_plot_side_panel.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_plot_side_panel.py
@@ -40,23 +40,27 @@ def test_that_collapsing_hides_content_but_keeps_toggle_button_visible(main_wind
     assert side_panel._toggle_button.isVisibleTo(side_panel.titleBarWidget())
 
 
-def test_that_collapsing_fixes_width_to_toggle_button_width(main_window):
+def test_that_collapsing_fixes_width_to_toggle_button_width(
+    qtbot: QtBot, main_window: QMainWindow
+) -> None:
     side_panel = make_side_panel(main_window)
 
     side_panel._toggle_button.setChecked(False)
 
     expected = side_panel._toggle_button.sizeHint().width() + 8
-    assert side_panel.minimumWidth() == expected
+    qtbot.waitUntil(lambda: side_panel.minimumWidth() == expected)
     assert side_panel.maximumWidth() == expected
 
 
-def test_that_expanding_restores_minimum_width_and_unbounded_maximum(main_window):
+def test_that_expanding_restores_minimum_width_and_unbounded_maximum(
+    qtbot: QtBot, main_window: QMainWindow
+) -> None:
     side_panel = make_side_panel(main_window)
 
     side_panel._toggle_button.setChecked(False)
     side_panel._toggle_button.setChecked(True)
 
-    assert side_panel.minimumWidth() == MIN_WIDTH
+    qtbot.waitUntil(lambda: side_panel.minimumWidth() == MIN_WIDTH)
     assert side_panel.maximumWidth() == QWIDGETSIZE_MAX
 
 


### PR DESCRIPTION
**Issue**
Resolves #14192 


**Approach**
Delaying repainting of widgets by moving them to end of the event queue.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
