### PR TITLE
Improve seismic misfit plot

### DIFF
--- a/src/ert/gui/plotting/ert_plots/misfits.py
+++ b/src/ert/gui/plotting/ert_plots/misfits.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Literal, cast
 import numpy as np
 import pandas as pd
 import polars as pl
-from matplotlib.lines import Line2D
 
 from ert.gui.plotting.shared_plots.generic_boxplot_with_scatter import (
     generate_legend_items,
@@ -320,96 +319,38 @@ class MisfitsPlot:
         axes.set_ylim(y_min, y_max)
         axes.axhline(0.0, color="black", linewidth=0.5, alpha=0.5)
 
-        config = plot_context.plotConfig()
         for position, ens_key in zip(positions, plotted_keys, strict=True):
             color = color_map[ens_key]
             values = ensemble_misfits[ens_key]
-            axes.boxplot(
+            generate_plots(
+                plot_context,
+                axes,
                 [values],
-                positions=[position],
-                widths=box_width,
-                whis=(LOWER_PERCENTILE_FOR_WHISKERS, UPPER_PERCENTILE_FOR_WHISKERS),
-                patch_artist=True,
-                showfliers=True,
-                boxprops={
-                    "facecolor": color,
-                    "alpha": 0.8,
-                    "edgecolor": color,
-                    "linewidth": 0.7,
-                },
-                whiskerprops={
-                    "color": color,
-                    "alpha": 1,
-                    "linewidth": 1,
-                    "linestyle": "--",
-                },
-                capprops={
-                    "color": color,
-                    "alpha": 1,
-                    "linewidth": 2,
-                    "linestyle": "--",
-                },
-                medianprops={"color": "black", "linewidth": 1, "alpha": 1},
-                flierprops={
-                    "marker": "o",
-                    "alpha": 1,
-                    "markeredgewidth": 0.3 + (0.4 * (1 - box_width)),
-                    "markeredgecolor": color,
-                    "markerfacecolor": "none",
-                },
+                [position],
+                box_width,
+                color,
+                LOWER_PERCENTILE_FOR_WHISKERS,
+                UPPER_PERCENTILE_FOR_WHISKERS,
+                legend_label=ens_key[0],
             )
-            axes.plot(
-                position,
-                float(np.nanmean(values)),
-                "D",
-                markersize=4,
-                color="black",
-                zorder=3,
-            )
-            median_val = float(np.nanmedian(values))
-            axes.annotate(
-                f"{median_val:.3g}",
-                xy=(position + box_width / 2, median_val),
-                xytext=(4, 0),
-                textcoords="offset points",
-                va="center",
-                ha="left",
-                fontsize=10,
-                color="black",
-                zorder=4,
-            )
+            if plot_context.box_plot:
+                median_val = float(np.nanmedian(values))
+                axes.annotate(
+                    f"{median_val:.3g}",
+                    xy=(position + box_width / 2, median_val),
+                    xytext=(4, 0),
+                    textcoords="offset points",
+                    va="center",
+                    ha="left",
+                    fontsize=10,
+                    color="black",
+                    zorder=4,
+                )
 
-        config.add_legend_item(
-            "Median", Line2D([0], [0], color="black", linewidth=0.9, alpha=1)
-        )
-        config.add_legend_item(
-            f"Whiskers ({LOWER_PERCENTILE_FOR_WHISKERS}-"
-            f"{UPPER_PERCENTILE_FOR_WHISKERS} %)",
-            Line2D([0], [0], color="black", linewidth=2, linestyle="--", alpha=1),
-        )
-        config.add_legend_item(
-            "Outliers",
-            Line2D(
-                [0],
-                [0],
-                marker="o",
-                color="none",
-                markeredgecolor="black",
-                markerfacecolor="none",
-                markersize=6,
-                alpha=1,
-            ),
-        )
-        config.add_legend_item(
-            "Mean",
-            Line2D(
-                [0],
-                [0],
-                marker="D",
-                linestyle="None",
-                color="black",
-                markersize=4,
-            ),
+        generate_legend_items(
+            plot_context,
+            LOWER_PERCENTILE_FOR_WHISKERS,
+            UPPER_PERCENTILE_FOR_WHISKERS,
         )
 
         axes.set_xlim(-0.5, len(plotted_keys) - 0.5)

--- a/src/ert/gui/plotting/ert_plots/misfits.py
+++ b/src/ert/gui/plotting/ert_plots/misfits.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Literal, cast
 import numpy as np
 import pandas as pd
 import polars as pl
+from matplotlib.lines import Line2D
 
 from ert.gui.plotting.shared_plots.generic_boxplot_with_scatter import (
     generate_legend_items,
@@ -158,7 +159,14 @@ class MisfitsPlot:
                 plot_context,
             )
 
-        elif response_type in {"gen_data", "rft", "seismic"}:
+        elif response_type == "seismic":
+            self._plot_seismic_mean_misfits(
+                figure,
+                data_with_misfits,
+                plot_context,
+            )
+
+        elif response_type in {"gen_data", "rft"}:
             self._plot_misfits(
                 figure,
                 data_with_misfits,
@@ -269,4 +277,154 @@ class MisfitsPlot:
             axes,
             default_x_label="",
             default_y_label="Value",
+        )
+
+    def _plot_seismic_mean_misfits(
+        self,
+        figure: Figure,
+        data_with_misfits: dict[tuple[str, str], pl.DataFrame],
+        plot_context: PlotContext,
+    ) -> None:
+        plot_context.plot_type = PlotType.BOX
+
+        sorted_ensemble_keys = sorted(data_with_misfits.keys())
+        color_map = self._map_ensembles_to_colours(
+            sorted_ensemble_keys, plot_context.plotConfig().line_color_cycle()
+        )
+
+        # Average observation-point misfits within each realization. Each box then
+        # represents the ensemble distribution of mean misfits across realizations.
+        ensemble_misfits: dict[tuple[str, str], npt.NDArray[np.float64]] = {}
+        for ens_key in sorted_ensemble_keys:
+            df = data_with_misfits[ens_key]
+            if df.is_empty():
+                continue
+            ensemble_misfits[ens_key] = (
+                df.group_by("Realization")
+                .agg(pl.col("misfit").mean())
+                .get_column("misfit")
+                .to_numpy()
+            )
+
+        plotted_keys = list(ensemble_misfits.keys())
+        ensemble_names = [k[0] for k in plotted_keys]
+        positions = list(range(len(plotted_keys)))
+        box_width = 0.6
+
+        all_misfits = pl.DataFrame(
+            {"misfit": np.concatenate(list(ensemble_misfits.values()))}
+        )
+        y_min, y_max = self._compute_misfits_padded_minmax(all_misfits, 0.05)
+
+        axes = figure.add_subplot(111)
+        axes.set_ylim(y_min, y_max)
+        axes.axhline(0.0, color="black", linewidth=0.5, alpha=0.5)
+
+        config = plot_context.plotConfig()
+        for position, ens_key in zip(positions, plotted_keys, strict=True):
+            color = color_map[ens_key]
+            values = ensemble_misfits[ens_key]
+            axes.boxplot(
+                [values],
+                positions=[position],
+                widths=box_width,
+                whis=(LOWER_PERCENTILE_FOR_WHISKERS, UPPER_PERCENTILE_FOR_WHISKERS),
+                patch_artist=True,
+                showfliers=True,
+                boxprops={
+                    "facecolor": color,
+                    "alpha": 0.8,
+                    "edgecolor": color,
+                    "linewidth": 0.7,
+                },
+                whiskerprops={
+                    "color": color,
+                    "alpha": 1,
+                    "linewidth": 1,
+                    "linestyle": "--",
+                },
+                capprops={
+                    "color": color,
+                    "alpha": 1,
+                    "linewidth": 2,
+                    "linestyle": "--",
+                },
+                medianprops={"color": "black", "linewidth": 1, "alpha": 1},
+                flierprops={
+                    "marker": "o",
+                    "alpha": 1,
+                    "markeredgewidth": 0.3 + (0.4 * (1 - box_width)),
+                    "markeredgecolor": color,
+                    "markerfacecolor": "none",
+                },
+            )
+            axes.plot(
+                position,
+                float(np.nanmean(values)),
+                "D",
+                markersize=4,
+                color="black",
+                zorder=3,
+            )
+            median_val = float(np.nanmedian(values))
+            axes.annotate(
+                f"{median_val:.3g}",
+                xy=(position + box_width / 2, median_val),
+                xytext=(4, 0),
+                textcoords="offset points",
+                va="center",
+                ha="left",
+                fontsize=10,
+                color="black",
+                zorder=4,
+            )
+
+        config.add_legend_item(
+            "Median", Line2D([0], [0], color="black", linewidth=0.9, alpha=1)
+        )
+        config.add_legend_item(
+            f"Whiskers ({LOWER_PERCENTILE_FOR_WHISKERS}-"
+            f"{UPPER_PERCENTILE_FOR_WHISKERS} %)",
+            Line2D([0], [0], color="black", linewidth=2, linestyle="--", alpha=1),
+        )
+        config.add_legend_item(
+            "Outliers",
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="none",
+                markeredgecolor="black",
+                markerfacecolor="none",
+                markersize=6,
+                alpha=1,
+            ),
+        )
+        config.add_legend_item(
+            "Mean",
+            Line2D(
+                [0],
+                [0],
+                marker="D",
+                linestyle="None",
+                color="black",
+                markersize=4,
+            ),
+        )
+
+        axes.set_xlim(-0.5, len(plotted_keys) - 0.5)
+        axes.set_xticks(positions, labels=ensemble_names)
+
+        plot_context.plotConfig().set_title(
+            f"{plot_context.key()} (Mean signed Chi-squared misfit per ensemble)"
+            if plot_context.plotConfig().is_unnamed()
+            else f"{plot_context.plotConfig().title()} (Signed Chi-squared)"
+        )
+
+        PlotTools.finalize_plot(
+            plot_context,
+            figure,
+            axes,
+            default_x_label="Ensemble name",
+            default_y_label="Mean signed Chi-squared misfit",
         )

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -627,8 +627,6 @@ class PlotWindow(QMainWindow):
                 plot_context.flip_observation_axis = True
 
             if key_def.response is not None and key_def.response.type == "seismic":
-                plot_context.setXLabel("Cumulative euclidean distance to the point")
-                plot_context.setYLabel(make_seismic_y_label(key))
                 plot_context.deactivate_date_support()
 
             for untransposed_data in ensemble_to_data_map.values():

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -766,12 +766,18 @@ class PlotWindow(QMainWindow):
             else f"Select up to {max_selected} ensembles"
         )
 
+        is_observed_seismic = (
+            key_def.observations
+            and key_def.response is not None
+            and key_def.response.type == "seismic"
+        )
         available_widgets = [
             widget
             for widget in self._plot_widgets
             if widget._plotter.dimensionality == key_def.dimensionality
             and (key_def.observations or not widget._plotter.requires_observations)
             and not is_everest_specific_widget
+            and (not is_observed_seismic or widget.name == MISFITS)
         ]
 
         def everest_data_origin_check(origin: list[str]) -> bool:

--- a/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfits_plot.py
+++ b/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfits_plot.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from itertools import starmap
 
 import pandas as pd
 import polars as pl
@@ -11,28 +12,61 @@ from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
 from ert.gui.plotting.utils import PlotConfig, PlotContext
 
 
-def test_that_misfits_plot_is_empty_when_observations_are_missing():
-    ensemble = EnsembleObject(
-        "ensemble",
-        "ensemble",
-        False,
-        "experiment",
-        "2026-01-01T00:00:00",
-    )
-    plot_context = PlotContext(
-        PlotConfig(),
-        ensembles=[ensemble],
-        ensembles_color_indexes=[0],
-        key="FOPR",
-        layer=None,
-    )
-    key_def = PlotApiKeyDefinition(
-        "FOPR",
-        index_type=None,
-        metadata={"data_origin": "summary"},
-        observations=True,
-        dimensionality=2,
-    )
+@pytest.fixture
+def make_ensemble():
+    def _make(name: str, id_: str | None = None) -> EnsembleObject:
+        return EnsembleObject(
+            name,
+            id_ if id_ is not None else name,
+            False,
+            "experiment",
+            "2026-01-01T00:00:00",
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_plot_context():
+    def _make(
+        ensembles: list[EnsembleObject],
+        *,
+        key: str = "FOPR",
+        plot_config: PlotConfig | None = None,
+    ) -> PlotContext:
+        return PlotContext(
+            plot_config if plot_config is not None else PlotConfig(),
+            ensembles=ensembles,
+            ensembles_color_indexes=list(range(len(ensembles))),
+            key=key,
+            layer=None,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_key_def():
+    def _make(
+        *, key: str = "FOPR", data_origin: str = "summary"
+    ) -> PlotApiKeyDefinition:
+        return PlotApiKeyDefinition(
+            key,
+            index_type=None,
+            metadata={"data_origin": data_origin},
+            observations=True,
+            dimensionality=2,
+        )
+
+    return _make
+
+
+def test_that_misfits_plot_is_empty_when_observations_are_missing(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensemble = make_ensemble("ensemble")
+    plot_context = make_plot_context([ensemble])
+    key_def = make_key_def()
     figure = Figure()
 
     MisfitsPlot().plot(
@@ -116,43 +150,54 @@ def test_that_misfit_conversion_for_summary_converts_to_equivalent_long_polars_d
     assert_frame_equal(result_df, expected_df)
 
 
-def test_that_misfits_plot_is_empty_when_no_misfit_data_is_available():
-    ensemble = EnsembleObject(
-        "ensemble",
-        "ensemble",
-        False,
-        "experiment",
-        "2026-01-01T00:00:00",
-    )
-    plot_context = PlotContext(
-        PlotConfig(),
-        ensembles=[ensemble],
-        ensembles_color_indexes=[0],
-        key="FOPR",
-        layer=None,
-    )
-    key_def = PlotApiKeyDefinition(
-        "FOPR",
-        index_type=None,
-        metadata={"data_origin": "summary"},
-        observations=True,
-        dimensionality=2,
-    )
+@pytest.mark.parametrize(
+    ("data_origin", "key", "ensemble_specs", "ensemble_frames", "observation_data"),
+    [
+        pytest.param(
+            "summary",
+            "FOPR",
+            [("ensemble",)],
+            [{"2023-01-01": [12.0]}],
+            {0: [1.0, 10.0, "2023-01-02"]},
+            id="summary_key_index_mismatch",
+        ),
+        pytest.param(
+            "seismic",
+            "SEISMIC_KEY",
+            [
+                ("ensemble_empty_1", "ensemble_empty_id_1"),
+                ("ensemble_empty_2", "ensemble_empty_id_2"),
+            ],
+            [{"99": [1.0], "100": [2.0]}, {"99": [3.0], "100": [4.0]}],
+            {0: [10.0, 100.0, "0"], 1: [10.0, 200.0, "5"]},
+            id="seismic_key_index_mismatch_all_ensembles",
+        ),
+    ],
+)
+def test_that_misfits_plot_is_empty_when_no_misfit_data_is_available(
+    data_origin,
+    key,
+    ensemble_specs,
+    ensemble_frames,
+    observation_data,
+    make_ensemble,
+    make_plot_context,
+    make_key_def,
+):
+    ensembles = list(starmap(make_ensemble, ensemble_specs))
+    plot_context = make_plot_context(ensembles, key=key)
+    key_def = make_key_def(key=key, data_origin=data_origin)
     figure = Figure()
 
     MisfitsPlot().plot(
         figure,
         plot_context,
         {
-            ensemble: pd.DataFrame(
-                {"2023-01-01": [12.0]},
-                index=pd.Index([0], name="Realization"),
-            )
+            ensemble: pd.DataFrame(frame, index=pd.Index([0], name="Realization"))
+            for ensemble, frame in zip(ensembles, ensemble_frames, strict=True)
         },
         observation_data=pd.DataFrame(
-            data={
-                0: [1.0, 10.0, "2023-01-02"],
-            },
+            data=observation_data,
             index=["STD", "OBS", "key_index"],
         ),
         std_dev_images={},
@@ -224,30 +269,14 @@ def test_that_misfit_conversion_for_gen_data_converts_to_equivalent_long_polars_
     assert_frame_equal(result_df, expected_df)
 
 
-def test_that_box_and_scatter_plot_is_being_plotted_for_summary_data():
-    ensemble = EnsembleObject(
-        "ensemble",
-        "ensemble",
-        False,
-        "experiment",
-        "2026-01-01T00:00:00",
-    )
-    plot_context = PlotContext(
-        PlotConfig(),
-        ensembles=[ensemble],
-        ensembles_color_indexes=[0],
-        key="FOPR",
-        layer=None,
-    )
+def test_that_box_and_scatter_plot_is_being_plotted_for_summary_data(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensemble = make_ensemble("ensemble")
+    plot_context = make_plot_context([ensemble])
     plot_context.scatter_plot = True  # box is true by default
 
-    key_def = PlotApiKeyDefinition(
-        "FOPR",
-        index_type=None,
-        metadata={"data_origin": "summary"},
-        observations=True,
-        dimensionality=2,
-    )
+    key_def = make_key_def()
     figure = Figure()
 
     MisfitsPlot().plot(
@@ -277,31 +306,15 @@ def test_that_box_and_scatter_plot_is_being_plotted_for_summary_data():
     assert len(axes.patches) == 3  # 2 boxes + background patch
 
 
-def test_that_mean_gets_plotted_for_summary_data_when_enabled():
-    ensemble = EnsembleObject(
-        "ensemble",
-        "ensemble",
-        False,
-        "experiment",
-        "2026-01-01T00:00:00",
-    )
-    plot_context = PlotContext(
-        PlotConfig(),
-        ensembles=[ensemble],
-        ensembles_color_indexes=[0],
-        key="FOPR",
-        layer=None,
-    )
+def test_that_mean_gets_plotted_for_summary_data_when_enabled(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensemble = make_ensemble("ensemble")
+    plot_context = make_plot_context([ensemble])
     plot_context.box_plot = False
     plot_context.mean = True
 
-    key_def = PlotApiKeyDefinition(
-        "FOPR",
-        index_type=None,
-        metadata={"data_origin": "summary"},
-        observations=True,
-        dimensionality=2,
-    )
+    key_def = make_key_def()
     figure = Figure()
 
     MisfitsPlot().plot(
@@ -332,38 +345,22 @@ def test_that_mean_gets_plotted_for_summary_data_when_enabled():
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_that_legend_items_for_summary_data_is_toggleable(enabled):
+def test_that_legend_items_for_summary_data_is_toggleable(
+    enabled, make_ensemble, make_plot_context, make_key_def
+):
     legend_items = [
         "Mean",
         "Median",
         "Outliers",
         "Scatter points",
     ]
-    ensemble = EnsembleObject(
-        "ensemble",
-        "ensemble",
-        False,
-        "experiment",
-        "2026-01-01T00:00:00",
-    )
-    plot_context = PlotContext(
-        PlotConfig(),
-        ensembles=[ensemble],
-        ensembles_color_indexes=[0],
-        key="FOPR",
-        layer=None,
-    )
+    ensemble = make_ensemble("ensemble")
+    plot_context = make_plot_context([ensemble])
     plot_context.mean = enabled
     plot_context.scatter_plot = enabled
     plot_context.box_plot = enabled
 
-    key_def = PlotApiKeyDefinition(
-        "FOPR",
-        index_type=None,
-        metadata={"data_origin": "summary"},
-        observations=True,
-        dimensionality=2,
-    )
+    key_def = make_key_def()
     figure = Figure()
 
     MisfitsPlot().plot(
@@ -415,3 +412,180 @@ def test_that_misfit_conversion_for_seismic_casts_key_index_to_int32():
 
     result_df = result["ens1", "id1"]
     assert result_df["key_index"].dtype == pl.Int32
+
+
+def test_that_seismic_misfit_plot_draws_one_box_per_ensemble_with_ensemble_name(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensembles = [
+        make_ensemble("ensemble_a", "ensemble_id_a"),
+        make_ensemble("ensemble_b", "ensemble_id_b"),
+    ]
+    plot_context = make_plot_context(
+        ensembles, key="SEISMIC_KEY", plot_config=PlotConfig(title=None)
+    )
+    key_def = make_key_def(key="SEISMIC_KEY", data_origin="seismic")
+    figure = Figure()
+
+    MisfitsPlot().plot(
+        figure,
+        plot_context,
+        {
+            ensembles[0]: pd.DataFrame(
+                {"0": [110.0], "5": [180.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+            ensembles[1]: pd.DataFrame(
+                {"0": [90.0], "5": [220.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+        },
+        observation_data=pd.DataFrame(
+            data={
+                0: [10.0, 100.0, "0"],
+                1: [10.0, 200.0, "5"],
+            },
+            index=["STD", "OBS", "key_index"],
+        ),
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    assert len(figure.axes) == 1
+    axes = figure.axes[0]
+    xtick_labels = [t.get_text() for t in axes.get_xticklabels()]
+    assert xtick_labels == ["ensemble_a", "ensemble_b"]
+    # One box patch per ensemble (no per-timestep background shading here).
+    assert len(axes.patches) == 2
+    assert axes.get_xlabel() == "Ensemble name"
+    assert axes.get_ylabel() == "Mean signed Chi-squared misfit"
+    assert "Mean signed Chi-squared misfit per ensemble" in axes.get_title()
+
+
+def test_that_seismic_misfit_plot_annotates_median_to_each_box_when_box_plot_enabled(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensembles = [
+        make_ensemble("ensemble_a", "ensemble_id_a"),
+        make_ensemble("ensemble_b", "ensemble_id_b"),
+    ]
+    plot_context = make_plot_context(ensembles, key="SEISMIC_KEY")
+    plot_context.box_plot = True
+
+    key_def = make_key_def(key="SEISMIC_KEY", data_origin="seismic")
+    figure = Figure()
+
+    MisfitsPlot().plot(
+        figure,
+        plot_context,
+        {
+            ensembles[0]: pd.DataFrame(
+                {"0": [110.0], "5": [180.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+            ensembles[1]: pd.DataFrame(
+                {"0": [90.0], "5": [220.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+        },
+        observation_data=pd.DataFrame(
+            data={
+                0: [10.0, 100.0, "0"],
+                1: [10.0, 200.0, "5"],
+            },
+            index=["STD", "OBS", "key_index"],
+        ),
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    axes = figure.axes[0]
+    annotation_texts = sorted(t.get_text() for t in axes.texts)
+    assert annotation_texts == ["-1.5", "1.5"]
+
+
+def test_that_seismic_misfit_plot_omits_median_annotations_when_box_plot_disabled(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensemble = make_ensemble("ensemble", "ensemble_id")
+    plot_context = make_plot_context([ensemble], key="SEISMIC_KEY")
+    plot_context.box_plot = False
+    plot_context.scatter_plot = True
+
+    key_def = make_key_def(key="SEISMIC_KEY", data_origin="seismic")
+    figure = Figure()
+
+    MisfitsPlot().plot(
+        figure,
+        plot_context,
+        {
+            ensemble: pd.DataFrame(
+                {"0": [110.0], "5": [180.0]},
+                index=pd.Index([0], name="Realization"),
+            )
+        },
+        observation_data=pd.DataFrame(
+            data={
+                0: [10.0, 100.0, "0"],
+                1: [10.0, 200.0, "5"],
+            },
+            index=["STD", "OBS", "key_index"],
+        ),
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    axes = figure.axes[0]
+    assert len(axes.texts) == 0
+
+
+def test_that_seismic_misfit_plot_skips_ensembles_with_no_misfit_data(
+    make_ensemble, make_plot_context, make_key_def
+):
+    ensembles = [
+        make_ensemble("ensemble", "ensemble_id"),
+        make_ensemble("ensemble_empty", "ensemble_empty_id"),
+    ]
+    plot_context = make_plot_context(
+        ensembles, key="SEISMIC_KEY", plot_config=PlotConfig(title=None)
+    )
+    key_def = make_key_def(key="SEISMIC_KEY", data_origin="seismic")
+
+    figure = Figure()
+
+    MisfitsPlot().plot(
+        figure,
+        plot_context,
+        {
+            ensembles[0]: pd.DataFrame(
+                {"0": [110.0], "5": [180.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+            ensembles[1]: pd.DataFrame(
+                {"99": [1.0], "100": [2.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+        },
+        observation_data=pd.DataFrame(
+            data={
+                0: [10.0, 100.0, "0"],
+                1: [10.0, 200.0, "5"],
+            },
+            index=["STD", "OBS", "key_index"],
+        ),
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    assert len(figure.axes) == 1
+    assert all(
+        text.get_text() != "No misfit data available" for text in figure.axes[0].texts
+    )
+    xtick_labels = [tick.get_text() for tick in figure.axes[0].get_xticklabels()]
+    assert xtick_labels == ["ensemble"]
+    assert len(figure.axes[0].patches) == 1
+    assert figure.axes[0].get_xlim() == (-0.5, 0.5)


### PR DESCRIPTION
**Issue**
Resolves #14198

**Approach**
Disabled all tabs for seismic plots but the misfit plot.
Then adjusted the misfit plot as described in the linked issue

Before:
<img width="1475" height="824" alt="Screenshot 2026-08-17 at 14 43 19" src="https://github.com/user-attachments/assets/967ed0d9-960f-42c1-a50b-16dcb3af1e67" />


After:
<img width="1475" height="824" alt="image" src="https://github.com/user-attachments/assets/a8b3281b-e8db-4107-9263-645289ce70e6" />


After fixup:
<img width="1475" height="824" alt="image" src="https://github.com/user-attachments/assets/5fa81eb3-30fc-4612-bb83-3debc09f0e16" />




- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
