### PR TITLE
Disable param updating experiments when design matrix

### DIFF
--- a/src/ert/gui/experiments/ensemble_experiment_panel.py
+++ b/src/ert/gui/experiments/ensemble_experiment_panel.py
@@ -133,6 +133,10 @@ class EnsembleExperimentPanel(ExperimentConfigPanel):
 
         self.notifier.ertChanged.connect(self._update_experiment_name_placeholder)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return False
+
     @override
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/experiments/ensemble_information_filter_panel.py
+++ b/src/ert/gui/experiments/ensemble_information_filter_panel.py
@@ -165,6 +165,10 @@ class EnsembleInformationFilterPanel(ExperimentConfigPanel):
 
         self.notifier.ertChanged.connect(self._update_experiment_name_placeholder)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return True
+
     @override
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/experiments/ensemble_smoother_panel.py
+++ b/src/ert/gui/experiments/ensemble_smoother_panel.py
@@ -147,6 +147,10 @@ class EnsembleSmootherPanel(ExperimentConfigPanel):
 
         self.notifier.ertChanged.connect(self._update_experiment_name_placeholder)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return True
+
     @override
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/experiments/evaluate_ensemble_panel.py
+++ b/src/ert/gui/experiments/evaluate_ensemble_panel.py
@@ -94,6 +94,10 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         )
         self._ensemble_selector.currentIndexChanged.connect(self._realizations_from_fs)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return False
+
     @override
     def isConfigurationValid(self) -> bool:
         return (

--- a/src/ert/gui/experiments/experiment_config_panel.py
+++ b/src/ert/gui/experiments/experiment_config_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from PyQt6.QtCore import pyqtSignal as Signal
@@ -17,6 +18,10 @@ class ExperimentConfigPanel(QWidget):
         super().__init__()
         self.setContentsMargins(10, 10, 10, 10)
         self.__run_model = run_model
+
+    @property
+    @abstractmethod
+    def requires_updatable_parameters(self) -> bool: ...
 
     def get_experiment_type(self) -> type[RunModel]:
         return self.__run_model

--- a/src/ert/gui/experiments/experiment_panel.py
+++ b/src/ert/gui/experiments/experiment_panel.py
@@ -91,6 +91,8 @@ class ExperimentPanel(QWidget):
         run_path = config.runpath_config.runpath_format_string
         self._config_file = config_file
 
+        self._parameters_updatable = self._is_parameters_updatable()
+
         self.setObjectName("experiment_panel")
         layout = QVBoxLayout()
 
@@ -182,7 +184,6 @@ class ExperimentPanel(QWidget):
                 run_path,
                 notifier,
             ),
-            True,
         )
 
         active_realizations = config.active_realizations
@@ -196,19 +197,10 @@ class ExperimentPanel(QWidget):
                 run_path,
                 notifier,
             ),
-            True,
         )
         self.addExperimentConfigPanel(
             EvaluateEnsemblePanel(run_path, notifier),
-            True,
         )
-
-        merged_parameters = config.parameter_configurations_with_design_matrix
-        updatable_parameters_exist = any(
-            p.update_strategy is not None for p in merged_parameters
-        )
-        observations_exist = bool(config.observation_declarations)
-        experiment_model_enabled = updatable_parameters_exist and observations_exist
 
         self.addExperimentConfigPanel(
             MultipleDataAssimilationPanel(
@@ -219,7 +211,6 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             EnsembleSmootherPanel(
@@ -230,7 +221,6 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             EnsembleInformationFilterPanel(
@@ -241,11 +231,9 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             ManualUpdatePanel(run_path, notifier, analysis_config),
-            experiment_model_enabled,
         )
 
         self.configuration_summary = SummaryPanel(config)
@@ -253,9 +241,20 @@ class ExperimentPanel(QWidget):
 
         self.setLayout(layout)
 
-    def addExperimentConfigPanel(
-        self, panel: ExperimentConfigPanel, mode_enabled: bool
-    ) -> None:
+    def _is_parameters_updatable(self) -> bool:
+        merged_params = self.config.parameter_configurations_with_design_matrix
+        updatable_parameters_exist = any(
+            p.update_strategy is not None for p in merged_params
+        )
+        observations_exist = bool(self.config.observation_declarations)
+        return updatable_parameters_exist and observations_exist
+
+    def _is_panel_enabled(self, requires_updatable_parameters: bool) -> bool:
+        if requires_updatable_parameters:
+            return self._parameters_updatable
+        return True
+
+    def addExperimentConfigPanel(self, panel: ExperimentConfigPanel) -> None:
         assert isinstance(panel, ExperimentConfigPanel)
         self._experiment_stack.addWidget(panel)
         experiment_type = panel.get_experiment_type()
@@ -266,7 +265,7 @@ class ExperimentPanel(QWidget):
             experiment_type.group(),
         )
 
-        if not mode_enabled:
+        if not self._is_panel_enabled(panel.requires_updatable_parameters):
             item_count = self._experiment_type_combo.count() - 1
             model = self._experiment_type_combo.model()
             assert isinstance(model, QStandardItemModel)

--- a/src/ert/gui/experiments/experiment_panel.py
+++ b/src/ert/gui/experiments/experiment_panel.py
@@ -203,10 +203,12 @@ class ExperimentPanel(QWidget):
             True,
         )
 
-        experiment_type_valid = any(
-            p.update_strategy is not None
-            for p in config.ensemble_config.parameter_configs.values()
-        ) and bool(config.observation_declarations)
+        merged_parameters = config.parameter_configurations_with_design_matrix
+        updatable_parameters_exist = any(
+            p.update_strategy is not None for p in merged_parameters
+        )
+        observations_exist = bool(config.observation_declarations)
+        experiment_model_enabled = updatable_parameters_exist and observations_exist
 
         self.addExperimentConfigPanel(
             MultipleDataAssimilationPanel(
@@ -217,7 +219,7 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_type_valid,
+            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             EnsembleSmootherPanel(
@@ -228,7 +230,7 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_type_valid,
+            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             EnsembleInformationFilterPanel(
@@ -239,11 +241,11 @@ class ExperimentPanel(QWidget):
                 active_realizations,
                 config_num_realization,
             ),
-            experiment_type_valid,
+            experiment_model_enabled,
         )
         self.addExperimentConfigPanel(
             ManualUpdatePanel(run_path, notifier, analysis_config),
-            experiment_type_valid,
+            experiment_model_enabled,
         )
 
         self.configuration_summary = SummaryPanel(config)

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -182,6 +182,10 @@ class ManualUpdatePanel(ExperimentConfigPanel):
                     parent=self,
                 ).show()
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return True
+
     @override
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/experiments/multiple_data_assimilation_panel.py
+++ b/src/ert/gui/experiments/multiple_data_assimilation_panel.py
@@ -244,6 +244,10 @@ class MultipleDataAssimilationPanel(ExperimentConfigPanel):
 
         self.notifier.ertChanged.connect(self._update_experiment_name_placeholder)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return True
+
     @override
     @Slot(QWidget)
     def experimentTypeChanged(self, w: QWidget) -> None:

--- a/src/ert/gui/experiments/single_test_run_panel.py
+++ b/src/ert/gui/experiments/single_test_run_panel.py
@@ -59,6 +59,10 @@ class SingleTestRunPanel(ExperimentConfigPanel):
 
         self.setLayout(layout)
 
+    @property
+    def requires_updatable_parameters(self) -> bool:
+        return False
+
     @override
     def get_experiment_arguments(self) -> Arguments:
         return Arguments(TEST_RUN_MODE, "ensemble", "single_test_run")

--- a/tests/ert/unit_tests/gui/experiments/test_experiment_panel.py
+++ b/tests/ert/unit_tests/gui/experiments/test_experiment_panel.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock, patch
+
+from tests.ert.ui_tests.gui.conftest import ExperimentPanel
+
+
+@patch.object(ExperimentPanel, "__init__", lambda *args, **kwargs: None)
+def test_is_parameters_updatable():
+    panel = ExperimentPanel.__new__(ExperimentPanel)
+    panel.config = Mock()
+    mock_param = Mock()
+
+    mock_param.update_strategy = "some_strategy"
+    panel.config.parameter_configurations_with_design_matrix = [mock_param]
+    panel.config.observation_declarations = ["obs1"]
+    assert panel._is_parameters_updatable() is True
+
+    mock_param.update_strategy = None
+    assert panel._is_parameters_updatable() is False
+
+    mock_param.update_strategy = "some_strategy"
+    panel.config.observation_declarations = []
+    assert panel._is_parameters_updatable() is False
+
+
+@patch.object(ExperimentPanel, "__init__", lambda *args, **kwargs: None)
+def test_is_panel_enabled():
+    panel = ExperimentPanel.__new__(ExperimentPanel)
+    panel._parameters_updatable = True
+
+    assert panel._is_panel_enabled(requires_updatable_parameters=True) is True
+    assert panel._is_panel_enabled(requires_updatable_parameters=False) is True
+
+    panel._parameters_updatable = False
+    assert panel._is_panel_enabled(requires_updatable_parameters=True) is False
+    assert panel._is_panel_enabled(requires_updatable_parameters=False) is True


### PR DESCRIPTION
**Issue**
Resolves #14139 


**Approach**
When design matrix is set, parameters are explicit and it should not be possible to run experiment types that updates parameters.
For this case, the parameter updating experiment types are now disabled in the main experiment drop down menu.

Original state:
<img width="1280" height="709" alt="Screenshot 2026-08-19 at 09 34 29" src="https://github.com/user-attachments/assets/1668caeb-75c1-423d-83d8-4005e7cd5dd6" />

State after disabling updating experiment types when design matrix present:
<img width="1280" height="783" alt="Screenshot 2026-08-19 at 09 36 20" src="https://github.com/user-attachments/assets/d5b87831-942f-4f88-9dc3-5c9404b1b70d" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
