### PR TITLE
Default plot controls to expanded

### DIFF
--- a/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/boxplot_options.py
@@ -10,6 +10,8 @@ from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_EXPANDED_STATE = True
+
 
 class BoxplotOptions:
     def __init__(self, connection_point: Callable[..., object]) -> None:
@@ -41,6 +43,7 @@ class BoxplotOptions:
                     self._toggle_outliers,
                 ]
             ),
+            expanded=DEFAULT_EXPANDED_STATE,
         )
 
     @property

--- a/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/everest_controls_plot_options.py
@@ -15,6 +15,8 @@ from ert.gui.utils import log_once
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_EXPANDED_STATE = True
+
 
 class EverestControlsPlotOptions:
     def __init__(self, connection_point: Callable[..., object]) -> None:
@@ -41,6 +43,7 @@ class EverestControlsPlotOptions:
                     self._display_over_controls_radio,
                 ]
             ),
+            expanded=DEFAULT_EXPANDED_STATE,
         )
 
     def get_widget(self) -> CollapsibleSection:

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -26,6 +26,8 @@ from .plot_color_palette_selector import PlotColorPaletteSelector
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_EXPANDED_STATE = True
+
 
 class GeneralPlotOptions(QObject):
     axisLabelEditRequested = Signal(str)
@@ -112,6 +114,7 @@ class GeneralPlotOptions(QObject):
         self._general_options = CollapsibleSection(
             "General options",
             create_group_layout(widgets),
+            expanded=DEFAULT_EXPANDED_STATE,
         )
         self._general_options.setObjectName("general_options")
 

--- a/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/statistics_options.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_EXPANDED_STATE = True
+
 
 class StatisticsOptions:
     """Owns the statistics selection, which persists across keys."""
@@ -64,6 +66,7 @@ class StatisticsOptions:
                     create_labeled_row("Std dev multiplier", self._std_dev_factor),
                 ]
             ),
+            expanded=DEFAULT_EXPANDED_STATE,
         )
 
     def update_plot_context(self, plot_config: PlotConfig) -> None:

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_boxplot_options.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock
 import pytest
 
 from ert.gui.plotting.utils import PlotConfig, PlotContext
-from ert.gui.plotting.widgets.plot_controls.boxplot_options import BoxplotOptions
+from ert.gui.plotting.widgets.plot_controls.boxplot_options import (
+    DEFAULT_EXPANDED_STATE,
+    BoxplotOptions,
+)
 
 
 def test_that_boxplot_checkbox_states_are_written_to_the_plot_context(qtbot):
@@ -22,7 +25,7 @@ def test_that_boxplot_checkbox_states_are_written_to_the_plot_context(qtbot):
     assert plot_context.outliers is True
 
 
-def test_that_boxplot_options_has_expected_default_checkbox_states(qtbot):
+def test_that_boxplot_options_has_expected_default_states(qtbot):
     options = BoxplotOptions(Mock())
     qtbot.addWidget(options.get_widget())
 
@@ -30,6 +33,8 @@ def test_that_boxplot_options_has_expected_default_checkbox_states(qtbot):
     assert options.outliers_checkbox_state is True
     assert options.box_checkbox_state is True
     assert options.scatter_checkbox_state is False
+
+    assert options.get_widget()._toggle_button.isChecked() is DEFAULT_EXPANDED_STATE
 
 
 def test_that_setting_boxplot_option_state_updates_underlying_checkbox(qtbot):
@@ -81,10 +86,3 @@ def test_that_toggling_a_boxplot_option_logs_sidebar_usage_once(
 
         checkbox.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
-
-
-def test_that_boxplot_options_defaults_to_collapsed_state(qtbot):
-    options = BoxplotOptions(Mock())
-    qtbot.addWidget(options.get_widget())
-
-    assert not options.get_widget()._toggle_button.isChecked()

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_everest_controls_plot_options.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import QRadioButton, QToolButton
 
 from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.widgets.plot_controls.everest_controls_plot_options import (
+    DEFAULT_EXPANDED_STATE,
     EverestControlsPlotOptions,
 )
 
@@ -16,6 +17,7 @@ def test_that_everest_controls_plot_options_initializes_with_expected_default_st
     qtbot.addWidget(options.get_widget())
 
     assert options.is_batches_selected() is True
+    assert options.get_widget()._toggle_button.isChecked() is DEFAULT_EXPANDED_STATE
 
 
 def test_that_the_selected_x_axis_is_written_to_the_plot_context(qtbot):
@@ -64,10 +66,3 @@ def test_that_selecting_x_axis_display_option_logs_sidebar_usage_once(qtbot, cap
 
         batches_radio.click()
         assert [r.getMessage() for r in caplog.records].count(expected_message) == 1
-
-
-def test_that_everest_controls_plot_options_defaults_to_collapsed_state(qtbot):
-    options = EverestControlsPlotOptions(Mock())
-    qtbot.addWidget(options.get_widget())
-
-    assert not options.get_widget()._toggle_button.isChecked()

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -7,7 +7,10 @@ from PyQt6.QtWidgets import QCheckBox, QPushButton, QToolButton
 from ert.gui.plotting.utils import PlotConfig, PlotContext
 from ert.gui.plotting.utils.plot_color_palettes import PALETTES_WITH_DESCRIPTIONS
 from ert.gui.plotting.widgets.collapsible_section import CollapsibleSection
-from ert.gui.plotting.widgets.plot_controls.general_options import GeneralPlotOptions
+from ert.gui.plotting.widgets.plot_controls.general_options import (
+    DEFAULT_EXPANDED_STATE,
+    GeneralPlotOptions,
+)
 
 
 def _create_plot_context() -> PlotContext:
@@ -40,7 +43,7 @@ def _apply_options_to_plot_context(
     )
 
 
-def test_that_general_options_has_expected_default_checkbox_states(qtbot):
+def test_that_general_options_has_expected_default_states(qtbot):
     options = GeneralPlotOptions(Mock())
     qtbot.addWidget(options.get_widget())
 
@@ -49,6 +52,7 @@ def test_that_general_options_has_expected_default_checkbox_states(qtbot):
     assert options.history_checkbox_state is True
     assert options.observations_checkbox_state is True
     assert options.log_checkbox_state is False
+    assert options.get_widget()._toggle_button.isChecked() is DEFAULT_EXPANDED_STATE
 
 
 def _expand(section: CollapsibleSection) -> None:


### PR DESCRIPTION
To make it easier for users to find the new functionalities, all options should default to open
Later, when the functionality has been established, the less important functionality can be collapsed

**Approach**
Added `DEFAULT_EXPANDED_STATE` and updated tests to use this, so that we can more easily change this in the future without having to update tests


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
