### PR TITLE
Remove guard against multiple flow threads

### DIFF
--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -354,11 +354,6 @@ class Flow(ForwardModelStepPlugin):
                 "Do not supply --np as an option to FLOW, "
                 "set NUM_CPU in the Ert config instead."
             )
-        if "--threads" in self.private_args.get("<OPTS>", ""):
-            raise ForwardModelStepValidationError(
-                "Do not supply --threads as an option to FLOW, "
-                "set NUM_CPU in the Ert config instead."
-            )
 
         available_versions = _available_flow_versions(
             env_vars=fm_json["environment"] or {}

--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -374,13 +374,13 @@ class Flow(ForwardModelStepPlugin):
 
     FORWARD_MODEL FLOW(<ECLBASE>, <VERSION>=xxx, <OPTS>="--ignore-errors")
 
-The :code:`OPTS` argument is optional and can be removed. :code:`ECLBASE` can
-also be defaulted. Multiple options can be supplied by separating them
-with a space.
+The :code:`OPTS` argument is optional and can be skipped. :code:`ECLBASE` can
+also be defaulted. Multiple options in :code:`OPTS` can be supplied by
+separating them with a space.
 
-ERT will be able to run the flow simulator if there is a binary named
-:code:`flow` or the wrapper :code:`flowrun` in the users :code:`$PATH`
-environment variable.
+ERT will be able to run the flow simulator if there is an executable named
+:code:`flow` or :code:`flowrun` found in the user's :code:`$PATH` environment
+variable.
 
 If :code:`flowrun` is found, it will take precedence, and then it will be
 possible to select the version of flow to use by setting :code:`<VERSION>`.

--- a/tests/ert/unit_tests/config/test_forward_model.py
+++ b/tests/ert/unit_tests/config/test_forward_model.py
@@ -600,15 +600,6 @@ def test_that_flow_fm_gives_error_on_np_in_opts(plugins_ert_config):
         )
 
 
-def test_that_flow_fm_gives_error_on_threads_in_opts(plugins_ert_config):
-    with pytest.raises(
-        ConfigValidationError, match=r".*Do not supply --threads as an option to FLOW*"
-    ):
-        plugins_ert_config.from_file_contents(
-            'NUM_REALIZATIONS 1\nFORWARD_MODEL FLOW(<OPTS>="--threads=2")\n'
-        )
-
-
 @pytest.mark.parametrize("fm_step_name", ["ECLIPSE100", "ECLIPSE300", "FLOW"])
 def test_that_reservoir_simulator_fm_rejects_unknown_keyword(
     plugins_ert_config, fm_step_name


### PR DESCRIPTION
Such a guard should be local site configuration, not enforced for ert as a whole.

Flow threads are lightweight IO helper threads, and local conditions determine whether they should be used or not.

**Issue**
Relates to https://github.com/equinor/scout/issues/1640

**Approach**
✂️ 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
