### PR TITLE
Constrain ensemble widget observations by response key

### DIFF
--- a/src/ert/gui/tools/manage_experiments/ensemble_widget.py
+++ b/src/ert/gui/tools/manage_experiments/ensemble_widget.py
@@ -414,7 +414,8 @@ class EnsembleWidget(QWidget):
                         root.setData(0, Qt.ItemDataRole.UserRole, response_type)
 
                     obs_ds = obs_ds_for_type.filter(
-                        pl.col("observation_key").eq(obs_key)
+                        (pl.col("observation_key").eq(obs_key))
+                        & (pl.col("response_key").eq(response_key))
                     ).unique()
 
                     for observation_data in obs_ds.iter_slices(n_rows=1):

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensemble_widget.py
@@ -559,6 +559,46 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
 
 
 @pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
+def test_that_observations_in_the_tree_are_constrained_by_response_key(qtbot, storage):
+    name = "obs"
+    key1 = "key1"
+    key2 = "key2"
+    date1 = "2000-01-01"
+    date2 = "2123-12-15"
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "SUMMARY": ["*"],
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    create_summary_observation_dict(name=name, key=key1, date=date1),
+                    create_summary_observation_dict(name=name, key=key2, date=date2),
+                ],
+            ),
+        }
+    )
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    ensemble_widget = EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    observation_widget = ensemble_widget.findChild(QTreeWidget)
+    assert observation_widget.topLevelItemCount() == 2
+
+    for i in range(observation_widget.topLevelItemCount()):
+        top = observation_widget.topLevelItem(i)
+        assert top is not None
+        assert top.childCount() == 1
+
+
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 @pytest.mark.parametrize(
     ("observations", "expected_name_order"),
     [


### PR DESCRIPTION
Discovered during random seismic setup, where all observations are given the same name (in order to not pollute main view).

Test screenshots.
Before:
<img width="200" height="161" alt="image" src="https://github.com/user-attachments/assets/61759bb2-0399-4292-8091-150b498da3bc" />

After:
<img width="184" height="128" alt="image" src="https://github.com/user-attachments/assets/15fb1304-dba9-4c2e-b560-6f98f215d013" />


And I still do not understand why we want for some reason to backport every single bug to the previous release, but alright.

---

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
