### PR TITLE
Remove global current ensemble signal from EnsembleSelector

### DIFF
--- a/src/ert/gui/ertnotifier.py
+++ b/src/ert/gui/ertnotifier.py
@@ -13,7 +13,6 @@ class ErtNotifier(QObject):
     ertChanged = Signal()
     experiment_started = Signal()
     experiment_ended = Signal()
-    current_ensemble_changed = Signal(object, name="currentEnsembleChanged")
 
     def __init__(self) -> None:
         QObject.__init__(self)
@@ -78,17 +77,11 @@ class ErtNotifier(QObject):
 
         self.ertChanged.emit()
 
-    @Slot(object)
+    @Slot(str)
     def set_storage(self, storage_path: str) -> None:
         self._storage = open_storage(storage_path, mode="r")
         self._storage_path = storage_path
         self.emitErtChange()
-
-    @Slot(object)
-    def set_current_ensemble_id(self, ensemble_id: UUID | None = None) -> None:
-        if ensemble_id != self._current_ensemble_id:
-            self._current_ensemble_id = ensemble_id
-            self.current_ensemble_changed.emit(ensemble_id)
 
     @Slot(bool)
     def set_is_experiment_running(self, is_running: bool) -> None:

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSignal as Signal
@@ -11,12 +10,9 @@ from PyQt6.QtWidgets import QComboBox
 from ert.config import ErrorInfo
 from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.utils import truncate_dropdown_item
-from ert.storage import RealizationStorageState
+from ert.storage import Ensemble, RealizationStorageState
 
 from .suggestor import Suggestor
-
-if TYPE_CHECKING:
-    from ert.storage import Ensemble
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +29,7 @@ class EnsembleSelector(QComboBox):
     """
 
     ensemble_populated = Signal()
+    ensemble_selected = Signal(Ensemble)
 
     def __init__(
         self,
@@ -48,6 +45,7 @@ class EnsembleSelector(QComboBox):
         self.setEnabled(False)
 
         notifier.ertChanged.connect(self.populate)
+        self.currentIndexChanged.connect(self._on_current_index_changed)
 
         if notifier.is_storage_available:
             self.populate()
@@ -60,6 +58,11 @@ class EnsembleSelector(QComboBox):
             )
         except KeyError:
             return None
+
+    def _on_current_index_changed(self, _: int) -> None:
+        ensemble = self.selected_ensemble
+        if ensemble:
+            self.ensemble_selected.emit(ensemble)
 
     def populate(self) -> None:
         block = self.blockSignals(True)

--- a/src/ert/gui/ertwidgets/ensembleselector.py
+++ b/src/ert/gui/ertwidgets/ensembleselector.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSignal as Signal
@@ -27,9 +26,6 @@ class EnsembleSelector(QComboBox):
     Parameters
     ----------
     notifier: ErtNotifier
-    update_ert: bool, optional
-        If True, changing the selection in this combo box will update the
-        current ensemble in ERT.
     filters: iterable of callables, optional
         An iterable of "or" filter functions to apply to the ensemble list. If
         provided, only ensembles that pass at least one filter will be shown.
@@ -42,29 +38,14 @@ class EnsembleSelector(QComboBox):
         self,
         notifier: ErtNotifier,
         *,
-        update_ert: bool = True,
         filters: Iterable[Callable[[Iterable[Ensemble]], Iterable[Ensemble]]] = (),
     ) -> None:
         super().__init__()
+
         self.notifier = notifier
-
-        # If true current ensemble of ert will be changed
-        self._update_ert = update_ert
-
         self._or_filters = filters
-
         self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
-
         self.setEnabled(False)
-
-        if update_ert:
-            # Update ERT when this combo box is changed
-            self.currentIndexChanged.connect(self._on_current_index_changed)
-
-            # Update this combo box when ERT is changed
-            notifier.current_ensemble_changed.connect(
-                self._on_global_current_ensemble_changed
-            )
 
         notifier.ertChanged.connect(self.populate)
 
@@ -139,9 +120,3 @@ class EnsembleSelector(QComboBox):
             ),
             reverse=True,
         )
-
-    def _on_current_index_changed(self, index: int) -> None:
-        self.notifier.set_current_ensemble_id(UUID(self.itemData(index)))
-
-    def _on_global_current_ensemble_changed(self, data: UUID | None) -> None:
-        self.setCurrentIndex(max(self.findData(str(data), Qt.ItemDataRole.UserRole), 0))

--- a/src/ert/gui/ertwidgets/models/targetensemblemodel.py
+++ b/src/ert/gui/ertwidgets/models/targetensemblemodel.py
@@ -1,4 +1,4 @@
-from typing import Any, override
+from typing import override
 
 from ert.config import AnalysisConfig
 from ert.gui.ertnotifier import ErtNotifier
@@ -16,8 +16,7 @@ class TargetEnsembleModel(ValueModel):
         self.notifier = notifier
         self._custom = False
         super().__init__(self.getDefaultValue())
-        notifier.ertChanged.connect(self.on_current_ensemble_changed)
-        notifier.current_ensemble_changed.connect(self.on_current_ensemble_changed)
+        notifier.ertChanged.connect(self._on_current_ensemble_changed)
 
     @override
     def setValue(self, value: str | None) -> None:
@@ -32,6 +31,6 @@ class TargetEnsembleModel(ValueModel):
     def getDefaultValue(self) -> str | None:
         return "iter-%d"
 
-    def on_current_ensemble_changed(self, *args: Any) -> None:
+    def _on_current_ensemble_changed(self) -> None:
         if not self._custom:
             super().setValue(self.getDefaultValue())

--- a/src/ert/gui/experiments/evaluate_ensemble_panel.py
+++ b/src/ert/gui/experiments/evaluate_ensemble_panel.py
@@ -35,7 +35,6 @@ class Arguments:
 
 class EvaluateEnsemblePanel(ExperimentConfigPanel):
     def __init__(self, run_path: str, notifier: ErtNotifier) -> None:
-        self.notifier = notifier
         super().__init__(EvaluateEnsemble)
         self.setObjectName("Evaluate_parameters_panel")
 
@@ -45,9 +44,7 @@ class EvaluateEnsemblePanel(ExperimentConfigPanel):
         def show_only_no_children_filter(
             ensembles: Iterable[Ensemble],
         ) -> Iterable[Ensemble]:
-            parents = [
-                ens.parent for ens in self.notifier.storage.ensembles if ens.parent
-            ]
+            parents = [ens.parent for ens in notifier.storage.ensembles if ens.parent]
             return (ensemble for ensemble in ensembles if ensemble.id not in parents)
 
         # Filter out any ensembles which have children.

--- a/src/ert/gui/experiments/manual_update_panel.py
+++ b/src/ert/gui/experiments/manual_update_panel.py
@@ -46,7 +46,6 @@ class ManualUpdatePanel(ExperimentConfigPanel):
         notifier: ErtNotifier,
         analysis_config: AnalysisConfig,
     ) -> None:
-        self.notifier = notifier
         super().__init__(ManualUpdate)
         self.setObjectName("Manual_update_panel")
 

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -42,6 +42,9 @@ class LoadResultsPanel(QWidget):
 
         layout = QFormLayout()
 
+        self._ensemble_selector = EnsembleSelector(self._notifier)
+        self._ensemble_selector.ensemble_selected.connect(self.refresh)
+
         self._run_path_text = TextBox(TextModel(self._read_current_run_path()))
         self._run_path_text.setFixedHeight(80)
         self._run_path_text.setValidator(StringDefinition(required=["<IENS>"]))
@@ -53,8 +56,8 @@ class LoadResultsPanel(QWidget):
 
         self.help_iter_lbl = QLabel("<ITER> will be replaced by: 0")
         self.help_iens_lbl = QLabel("<IENS> will be replaced by %")
+
         layout.addRow("Load data from run path: ", self._run_path_text)
-        self._ensemble_selector = EnsembleSelector(self._notifier)
         layout.addRow("", self.help_iens_lbl)
         layout.addRow("", self.help_iter_lbl)
         layout.addRow("Load into ensemble:", self._ensemble_selector)
@@ -84,10 +87,12 @@ class LoadResultsPanel(QWidget):
         self.help_iter_lbl.setVisible("<ITER>" in self._run_path_text.get_text)
 
     def _read_current_run_path(self) -> str:
-        current_ensemble = self._notifier.current_ensemble_name
         run_path = self._resolved_run_path
-        run_path = run_path.replace("<ERTCASE>", current_ensemble)
-        return run_path.replace("<ERT-CASE>", current_ensemble)
+        if self._ensemble_selector.selected_ensemble:
+            current_ensemble = self._ensemble_selector.selected_ensemble.name
+            run_path = run_path.replace("<ERTCASE>", current_ensemble)
+            run_path = run_path.replace("<ERT-CASE>", current_ensemble)
+        return run_path
 
     def is_configuration_valid(self) -> bool:
         return (

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -30,7 +30,7 @@ class LoadResultsPanel(QWidget):
 
         self.setMinimumWidth(500)
         self.setMinimumHeight(200)
-        self._dynamic = False
+
         self._notifier = notifier
 
         self._resolved_run_path = str(
@@ -42,23 +42,22 @@ class LoadResultsPanel(QWidget):
 
         layout = QFormLayout()
 
-        self._run_path_text = TextBox(TextModel(self.readCurrentRunPath()))
+        self._run_path_text = TextBox(TextModel(self._read_current_run_path()))
         self._run_path_text.setFixedHeight(80)
         self._run_path_text.setValidator(StringDefinition(required=["<IENS>"]))
         self._run_path_text.setObjectName("run_path_edit_lrm")
         self._run_path_text.getValidationSupport().validationChanged.connect(
             self.panelConfigurationChanged
         )
-        self._run_path_text.textChanged.connect(self.text_change)
+        self._run_path_text.textChanged.connect(self._text_change)
 
-        self.help_iter_lbl = QLabel("<ITER> will be replace by: 0")
-        self.help_iens_lbl = QLabel("<IENS> will be replace by %")
+        self.help_iter_lbl = QLabel("<ITER> will be replaced by: 0")
+        self.help_iens_lbl = QLabel("<IENS> will be replaced by %")
         layout.addRow("Load data from run path: ", self._run_path_text)
-        ensemble_selector = EnsembleSelector(self._notifier)
+        self._ensemble_selector = EnsembleSelector(self._notifier)
         layout.addRow("", self.help_iens_lbl)
         layout.addRow("", self.help_iter_lbl)
-        layout.addRow("Load into ensemble:", ensemble_selector)
-        self._ensemble_selector = ensemble_selector
+        layout.addRow("Load into ensemble:", self._ensemble_selector)
 
         ensemble_size = config.runpath_config.num_realizations
         self._active_realizations_model = ActiveRealizationsModel(ensemble_size)
@@ -66,11 +65,11 @@ class LoadResultsPanel(QWidget):
             self._active_realizations_model,  # type: ignore
             "load_results_manually/Realizations",
         )
-        self._active_realizations_field.textChanged.connect(self.text_change)
+        self._active_realizations_field.textChanged.connect(self._text_change)
         self._active_realizations_field.setValidator(RangeStringArgument(ensemble_size))
         self._active_realizations_field.setObjectName("active_realizations_lrm")
         self.help_iens_lbl.setText(
-            f"<IENS> will be replace by {self._active_realizations_field.get_text}"
+            f"<IENS> will be replaced by {self._active_realizations_field.get_text}"
         )
         layout.addRow("Realizations to load:", self._active_realizations_field)
 
@@ -79,18 +78,18 @@ class LoadResultsPanel(QWidget):
         )
         self.setLayout(layout)
 
-    def text_change(self) -> None:
+    def _text_change(self) -> None:
         active_realizations = self._active_realizations_field.get_text
         self.help_iens_lbl.setText(f"<IENS> will be replace by {active_realizations}")
         self.help_iter_lbl.setVisible("<ITER>" in self._run_path_text.get_text)
 
-    def readCurrentRunPath(self) -> str:
+    def _read_current_run_path(self) -> str:
         current_ensemble = self._notifier.current_ensemble_name
         run_path = self._resolved_run_path
         run_path = run_path.replace("<ERTCASE>", current_ensemble)
         return run_path.replace("<ERT-CASE>", current_ensemble)
 
-    def isConfigurationValid(self) -> bool:
+    def is_configuration_valid(self) -> bool:
         return (
             self._active_realizations_field.isValid() and self._run_path_text.isValid()
         )
@@ -104,9 +103,9 @@ class LoadResultsPanel(QWidget):
         messages: list[str] = []
         loaded: int = 0
         with captured_logs(messages), self._notifier.write_storage() as write_storage:
-            if self._notifier.current_ensemble is not None:
+            if self._ensemble_selector.selected_ensemble:
                 write_ensemble = write_storage.get_ensemble(
-                    self._notifier.current_ensemble.id
+                    self._ensemble_selector.selected_ensemble.id
                 )
                 loaded = load_parameters_and_responses_from_runpath(
                     run_path_format=self._run_path_text.get_text,
@@ -144,5 +143,5 @@ class LoadResultsPanel(QWidget):
         return loaded
 
     def refresh(self) -> None:
-        self._run_path_text.setText(self.readCurrentRunPath())
+        self._run_path_text.setText(self._read_current_run_path())
         self._run_path_text.refresh()

--- a/src/ert/gui/tools/load_results/load_results_tool.py
+++ b/src/ert/gui/tools/load_results/load_results_tool.py
@@ -27,14 +27,14 @@ class LoadResultsTool(Tool):
         if self._import_widget is None:
             self._import_widget = LoadResultsPanel(self._config, self._notifier)
             self._import_widget.panelConfigurationChanged.connect(
-                self.validationStatusChanged
+                self._validation_status_changed
             )
             self._dialog = ClosableDialog(
                 "Load results manually",
                 self._import_widget,
                 self.parent(),  # type: ignore
             )
-            self._loadButton = self._dialog.addButton("Load", self.load)
+            self._loadButton = self._dialog.addButton("Load", self._load)
             self._dialog.setObjectName("load_results_manually_tool")
 
         else:
@@ -46,7 +46,7 @@ class LoadResultsTool(Tool):
         assert self._dialog is not None
         self._dialog.exec()
 
-    def load(self, _: Any) -> None:
+    def _load(self, _: Any) -> None:
         logger.info("Gui utility: LoadResults tool was used")
         assert self._dialog is not None
         assert self._import_widget is not None
@@ -54,10 +54,11 @@ class LoadResultsTool(Tool):
         self._dialog.toggleButton(caption="Load", enabled=False)
         self._import_widget.load()
         self._dialog.accept()
+        self._dialog.enableCloseButton()
 
-    def validationStatusChanged(self) -> None:
+    def _validation_status_changed(self) -> None:
         assert self._dialog is not None
         assert self._import_widget is not None
         self._dialog.toggleButton(
-            caption="Load", enabled=self._import_widget.isConfigurationValid()
+            caption="Load", enabled=self._import_widget.is_configuration_valid()
         )

--- a/src/ert/gui/tools/manage_experiments/storage_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_widget.py
@@ -205,7 +205,7 @@ class StorageWidget(QWidget):
                     response_configuration = (
                         self._ert_config.ensemble_config.response_configuration
                     )
-                    ensemble = storage.create_experiment(
+                    storage.create_experiment(
                         experiment_config={
                             "parameter_configuration": [
                                 c.model_dump(mode="json")
@@ -232,7 +232,6 @@ class StorageWidget(QWidget):
                         iteration=create_experiment_dialog.iteration,
                     )
 
-                self._notifier.set_current_ensemble_id(ensemble.id)
             except OSError as err:
                 logger.error(str(err))
                 Suggestor(

--- a/src/ert/gui/tools/workflows/run_workflow_widget.py
+++ b/src/ert/gui/tools/workflows/run_workflow_widget.py
@@ -50,7 +50,7 @@ class RunWorkflowWidget(QWidget):
 
         layout.addRow("Workflow", self._workflow_combo)
 
-        self.source_ensemble_selector = EnsembleSelector(notifier, update_ert=False)
+        self.source_ensemble_selector = EnsembleSelector(notifier)
         layout.addRow("Ensemble", self.source_ensemble_selector)
 
         self.run_button = QToolButton()

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -476,8 +476,6 @@ def test_that_the_manage_experiments_tool_can_be_used(esmda_has_run, qtbot):
     create_widget = get_child(storage_widget, AddWidget)
     qtbot.mouseClick(create_widget.addButton, Qt.MouseButton.LeftButton)
 
-    assert experiments_panel.notifier.current_ensemble.iteration == 42
-
     # Go to the "initialize from scratch" panel
     experiments_panel.setCurrentIndex(1)
     current_tab = experiments_panel.currentWidget()

--- a/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
+++ b/tests/ert/ui_tests/gui/test_manage_experiments_tool.py
@@ -82,7 +82,6 @@ def test_design_matrix_in_manage_experiments_panel(
     ensemble = notifier.storage.get_experiment_by_name(
         "my-experiment"
     ).get_ensemble_by_name("my-design")
-    notifier.set_current_ensemble_id(ensemble.id)
     assert all(
         RealizationStorageState.UNDEFINED in s for s in ensemble.get_ensemble_state()
     )
@@ -155,7 +154,6 @@ def test_init_prior(qtbot):
             RealizationStorageState.UNDEFINED in s
             for s in ensemble.get_ensemble_state()
         )
-    notifier.set_current_ensemble_id(ensemble.id)
 
     tool = ManageExperimentsPanel(
         config, notifier, config.runpath_config.num_realizations
@@ -181,7 +179,7 @@ def test_that_init_updates_the_info_tab(qtbot):
     ensemble_config = config.ensemble_config
 
     with notifier.write_storage() as storage:
-        ensemble = storage.create_experiment(
+        storage.create_experiment(
             experiment_config={
                 "parameter_configuration": [
                     pc.model_dump(mode="json")
@@ -200,7 +198,6 @@ def test_that_init_updates_the_info_tab(qtbot):
         ).create_ensemble(
             ensemble_size=config.runpath_config.num_realizations, name="default"
         )
-    notifier.set_current_ensemble_id(ensemble.id)
 
     tool = ManageExperimentsPanel(
         config, notifier, config.runpath_config.num_realizations

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -53,44 +53,6 @@ def test_current_ensemble(qtbot, notifier, storage):
     assert widget.currentData() == str(ensemble.id)
 
 
-def test_changing_ensemble(qtbot, notifier, storage):
-    ensemble_a = storage.create_experiment().create_ensemble(
-        name="default_a", ensemble_size=1
-    )
-    ensemble_b = storage.create_experiment().create_ensemble(
-        name="default_b", ensemble_size=1
-    )
-
-    notifier.set_storage(str(storage.path))
-    notifier.set_current_ensemble_id(ensemble_a.id)
-    widget_a = EnsembleSelector(notifier)
-    widget_b = EnsembleSelector(notifier)
-    qtbot.addWidget(widget_a)
-    qtbot.addWidget(widget_b)
-
-    assert widget_a.count() == 2
-    assert widget_b.count() == 2
-
-    # Latest ensemble is selected in both
-    assert widget_a.currentData() == str(ensemble_b.id)
-    assert widget_b.currentData() == str(ensemble_b.id)
-
-    # Second ensemble is selected via signal, widgets do not change'
-    # selections
-    notifier.set_current_ensemble_id(ensemble_b.id)
-    assert widget_a.currentData() == str(ensemble_b.id)
-    assert widget_b.currentData() == str(ensemble_b.id)
-
-    # Changing back to first ensemble via widget sets the global current_ensemble
-    qtbot.keyClicks(
-        widget_a,
-        widget_a.itemText(widget_a.findData(str(ensemble_a.id))),
-    )
-    assert notifier.current_ensemble.id == ensemble_a.id
-    assert widget_a.currentData() == str(ensemble_a.id)
-    assert widget_b.currentData() == str(ensemble_a.id)
-
-
 def test_ensembles_are_sorted_failed_first_then_by_start_time(storage):
     ensemble_a = storage.create_experiment().create_ensemble(
         name="default_a", ensemble_size=1

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -67,6 +67,36 @@ def test_that_ensemble_selector_is_populated_regardless_of_storage_creation_orde
     assert widget.currentData() == str(ensemble.id)
 
 
+def test_that_changing_one_selector_leaves_other_selectors_and_notifier_unchanged(
+    qtbot, notifier, storage
+):
+    ensemble_a = storage.create_experiment().create_ensemble(
+        name="default_a", ensemble_size=1
+    )
+    ensemble_b = storage.create_experiment().create_ensemble(
+        name="default_b", ensemble_size=1
+    )
+    notifier.set_storage(str(storage.path))
+
+    widget_a = EnsembleSelector(notifier)
+    widget_b = EnsembleSelector(notifier)
+    qtbot.addWidget(widget_a)
+    qtbot.addWidget(widget_b)
+
+    widget_b_selection = widget_b.selected_ensemble
+    notifier_selection = notifier.current_ensemble
+
+    # Select the ensemble in widget_a that is not currently selected
+    assert widget_a.selected_ensemble is not None
+    other = ensemble_a if widget_a.selected_ensemble.id == ensemble_b.id else ensemble_b
+    widget_a.setCurrentIndex(widget_a.findData(str(other.id)))
+
+    assert widget_a.selected_ensemble is not None
+    assert widget_a.selected_ensemble.id == other.id
+    assert widget_b.selected_ensemble == widget_b_selection
+    assert notifier.current_ensemble == notifier_selection
+
+
 def test_ensembles_are_sorted_failed_first_then_by_start_time(storage):
     ensemble_a = storage.create_experiment().create_ensemble(
         name="default_a", ensemble_size=1

--- a/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_ensembleselector.py
@@ -24,14 +24,29 @@ def notifier():
     return ErtNotifier()
 
 
-def test_empty(qtbot, notifier):
+@pytest.fixture
+def storage_with_three_ensembles(storage, notifier):
+    ensemble_a = storage.create_experiment().create_ensemble(name="a", ensemble_size=1)
+    ensemble_b = storage.create_experiment().create_ensemble(
+        name="b", ensemble_size=1, prior_ensemble=ensemble_a
+    )
+    storage.create_experiment().create_ensemble(
+        name="c", ensemble_size=1, prior_ensemble=ensemble_b
+    )
+
+    notifier.set_storage(str(storage.path))
+
+
+def test_that_ensemble_selector_is_empty_when_no_storage_is_set(qtbot, notifier):
     widget = EnsembleSelector(notifier)
     qtbot.addWidget(widget)
 
     assert widget.count() == 0
 
 
-def test_current_ensemble(qtbot, notifier, storage):
+def test_that_ensemble_selector_is_populated_regardless_of_storage_creation_order(
+    qtbot, notifier, storage
+):
     ensemble = storage.create_experiment().create_ensemble(
         name="default", ensemble_size=1
     )
@@ -42,7 +57,6 @@ def test_current_ensemble(qtbot, notifier, storage):
     assert widget.count() == 0
 
     notifier.set_storage(str(storage.path))
-    notifier.set_current_ensemble_id(ensemble.id)
     assert widget.count() == 1
     assert widget.currentData() == str(ensemble.id)
 
@@ -69,19 +83,6 @@ def test_ensembles_are_sorted_failed_first_then_by_start_time(storage):
         ensemble_c,
         ensemble_a,
     ]
-
-
-@pytest.fixture
-def storage_with_three_ensembles(storage, notifier):
-    ensemble_a = storage.create_experiment().create_ensemble(name="a", ensemble_size=1)
-    ensemble_b = storage.create_experiment().create_ensemble(
-        name="b", ensemble_size=1, prior_ensemble=ensemble_a
-    )
-    storage.create_experiment().create_ensemble(
-        name="c", ensemble_size=1, prior_ensemble=ensemble_b
-    )
-
-    notifier.set_storage(str(storage.path))
 
 
 def test_that_when_filters_are_not_provided_then_all_ensembles_are_selected(


### PR DESCRIPTION
The EnsembleSelector no longer mutates or listens to the notifier's global current ensemble. The update_ert option and the associated signal wiring are removed, and consumers now read the selection directly from the widget. Panels that only kept a notifier reference for this behavior are updated accordingly + some minor maintenance

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
