### PR TITLE
Constrain ensemble widget obs by response key

### DIFF
--- a/src/ert/gui/tools/manage_experiments/storage_info_widget.py
+++ b/src/ert/gui/tools/manage_experiments/storage_info_widget.py
@@ -501,7 +501,8 @@ class _EnsembleWidget(QWidget):
                         root.setData(0, Qt.ItemDataRole.UserRole, response_type)
 
                     obs_ds = obs_ds_for_type.filter(
-                        pl.col("observation_key").eq(obs_key)
+                        (pl.col("observation_key").eq(obs_key))
+                        & (pl.col("response_key").eq(response_key))
                     ).unique()
 
                     for observation_data in obs_ds.iter_slices(n_rows=1):

--- a/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_storage_info_widget.py
@@ -563,6 +563,60 @@ def test_that_both_observations_with_same_data_are_displayed(qtbot, storage):
 
 
 @pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
+def test_that_observations_in_the_tree_are_constrained_by_response_key(qtbot, storage):
+    name = "obs"
+    key1 = "key1"
+    key2 = "key2"
+    date1 = "2000-01-01"
+    date2 = "2123-12-15"
+    config = ErtConfig.from_dict(
+        {
+            "NUM_REALIZATIONS": 1,
+            "ECLBASE": "BASE",
+            "SUMMARY": ["*"],
+            "OBS_CONFIG": (
+                "obs_config",
+                [
+                    {
+                        "type": ObservationType.SUMMARY,
+                        "name": name,
+                        "KEY": key1,
+                        "DATE": date1,
+                        "VALUE": 1.0,
+                        "ERROR": 1.0,
+                    },
+                    {
+                        "type": ObservationType.SUMMARY,
+                        "name": name,
+                        "KEY": key2,
+                        "DATE": date2,
+                        "VALUE": 1.0,
+                        "ERROR": 1.0,
+                    },
+                ],
+            ),
+        }
+    )
+    experiment = create_experiment_from_config(config, storage)
+    ensemble = experiment.create_ensemble(name="default", ensemble_size=1)
+
+    ensemble_widget = _EnsembleWidget()
+    ensemble_widget.setEnsemble(ensemble)
+    qtbot.addWidget(ensemble_widget)
+
+    panels_widget = ensemble_widget._tab_widget
+    panels_widget.setCurrentIndex(_EnsembleWidgetTabs.OBSERVATIONS_TAB)
+
+    observation_widget = ensemble_widget.findChild(QTreeWidget)
+    assert observation_widget.topLevelItemCount() == 2
+
+    for i in range(observation_widget.topLevelItemCount()):
+        top = observation_widget.topLevelItem(i)
+        assert top is not None
+        assert top.childCount() == 1
+
+
+@pytest.mark.filterwarnings("ignore:.*contains a SUMMARY key but no forward model step")
 @pytest.mark.parametrize(
     ("observations", "expected_name_order"),
     [


### PR DESCRIPTION
Due to lack of constrain by response key (but with existing constrain by observation name) all observations with the same name were displayed under all response keys.

(cherry picked from commit fa78658c447c63dcc09fced4c3624dd51943b0e0)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
