### PR TITLE
Merge `everest.log` and `forward_model.log` log output files with `everserver.log`

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -44,7 +44,6 @@ from everest.detached.everserver import (
     ExperimentStatus,
 )
 from everest.strings import (
-    EXPERIMENT_SERVER,
     OPT_FAILURE_ALL_REALIZATIONS,
     OPT_FAILURE_REALIZATIONS,
     EverEndpoints,
@@ -130,7 +129,7 @@ def _get_optimization_status(
             status_ = ExperimentState.failed
             messages = _failed_realizations_messages(events, exit_code)
             for msg in messages:
-                logging.getLogger(EXPERIMENT_SERVER).error(msg)
+                logging.getLogger(__name__).error(msg)
             return status_, "\n".join(messages)
         case EverestExitCode.COMPLETED:
             return ExperimentState.completed, "Optimization completed."
@@ -154,7 +153,7 @@ def verify_auth(
     request: Request,
     credentials: Annotated[HTTPBasicCredentials, Depends(HTTPBasic())],
 ) -> None:
-    logging.getLogger(EXPERIMENT_SERVER).debug(
+    logging.getLogger(__name__).debug(
         f"{request.scope['path']} entered from "
         f"{request.client.host if request.client else 'unknown host'} "
         f"with HTTP {request.method}"
@@ -224,7 +223,7 @@ async def start_experiment(
             status=ExperimentState.failed,
             message=f"Could not start experiment: {e!s}",
         )
-        logging.getLogger(EXPERIMENT_SERVER).exception(e)
+        logging.getLogger(__name__).exception(e)
         return JSONResponse(
             {"error": f"Could not start experiment: {e!s}"}, status_code=501
         )
@@ -304,9 +303,9 @@ async def websocket_endpoint(websocket: WebSocket, experiment_id: str) -> None:
             if isinstance(event, EndEvent):
                 break
     except Exception as e:
-        logging.getLogger(EXPERIMENT_SERVER).exception(str(e))
+        logging.getLogger(__name__).exception(str(e))
     finally:
-        logging.getLogger(EXPERIMENT_SERVER).info(
+        logging.getLogger(__name__).info(
             f"Subscriber {subscriber_id} done. Closing websocket"
         )
         # Give some time for subscribers to get events
@@ -399,9 +398,9 @@ class ExperimentRunner:
                 status=exp_status,
             )
         except UserCancelled as e:
-            logging.getLogger(EXPERIMENT_SERVER).info(f"User cancelled: {e}")
+            logging.getLogger(__name__).info(f"User cancelled: {e}")
         except Exception as e:
-            logging.getLogger(EXPERIMENT_SERVER).exception(e)
+            logging.getLogger(__name__).exception(e)
             run.status = ExperimentStatus(
                 message=f"Exception: {e}\n{traceback.format_exc()}",
                 status=ExperimentState.failed,
@@ -410,7 +409,7 @@ class ExperimentRunner:
             if run_model and run_model._experiment:
                 run_model._experiment.status = run.status
 
-            logging.getLogger(EXPERIMENT_SERVER).info(
+            logging.getLogger(__name__).info(
                 f"ExperimentRunner done. Items left in queue: {status_queue.qsize()}"
             )
 

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -319,10 +319,24 @@ class ErtPluginManager(pluggy.PluginManager):
         self.hook.legacy_ertscript_workflow(config=config)
         return config
 
-    def add_logging_handle_to_root(self, logger: logging.Logger) -> None:
+    def add_logging_handle_to_root(
+        self, logger: logging.Logger
+    ) -> list[logging.Handler]:
         handles = self.hook.add_log_handle_to_root()
+        # Loggers configured with propagate=False never forward their records
+        # to the root logger's handlers, so the plugin handles must be
+        # attached directly to them as well.
+        non_propagating_loggers = [
+            existing_logger
+            for existing_logger in logging.Logger.manager.loggerDict.values()
+            if isinstance(existing_logger, logging.Logger)
+            and not existing_logger.propagate
+        ]
         for handle in handles:
             logger.addHandler(handle)
+            for non_propagating_logger in non_propagating_loggers:
+                non_propagating_logger.addHandler(handle)
+        return handles
 
     def get_ip_address(self) -> str:
         ip_address: list[str] = self.hook.get_ip_address()

--- a/src/ert/plugins/plugin_manager.py
+++ b/src/ert/plugins/plugin_manager.py
@@ -77,6 +77,8 @@ class ErtPluginManager(pluggy.PluginManager):
             for plugin in plugins:
                 self.register(plugin)
 
+        self._log_handles: list[logging.Handler] | None = None
+
     def __str__(self) -> str:
         self_str = "ERT Plugin manager:\n"
         for plugin in self.get_plugins():
@@ -322,7 +324,10 @@ class ErtPluginManager(pluggy.PluginManager):
     def add_logging_handle_to_root(
         self, logger: logging.Logger
     ) -> list[logging.Handler]:
-        handles = self.hook.add_log_handle_to_root()
+        # Avoid duplicate loggers
+        if self._log_handles is None:
+            self._log_handles = self.hook.add_log_handle_to_root()
+        handles = self._log_handles
         # Loggers configured with propagate=False never forward their records
         # to the root logger's handlers, so the plugin handles must be
         # attached directly to them as well.

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -201,8 +201,8 @@ def run_server(
     os.environ["ERT_STORAGE_ENS_PATH"] = str(args.project.absolute())
     config = (
         # uvicorn.Config() resets the logging config (overriding additional
-        # handlers added to loggers like e.g. the ert_azurelogger handler
-        # added through the plugin system
+        # handlers added to loggers through the plugin system, e.g. log
+        # handlers registered by external logging plugins)
         uvicorn.Config(DARK_STORAGE_APP, **config_args)
         if uvicorn_config is None
         else uvicorn_config

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -22,9 +22,6 @@ from everest.config import ServerConfig
 from everest.detached import get_experiments
 from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
-    EVEREST,
-    EVERSERVER,
-    EXPERIMENT_SERVER,
     OPTIMIZATION_LOG_DIR,
     EverEndpoints,
 )
@@ -67,17 +64,7 @@ def _configure_loggers(
                 for logger_name, logger_config in ert_loggers.items()
                 if logger_config.get("level") == "WARNING"
             },
-            EVERSERVER: {
-                "handlers": ["endpoint_log"],
-                "level": logging_level,
-                "propagate": False,
-            },
-            EXPERIMENT_SERVER: {
-                "handlers": ["endpoint_log"],
-                "level": logging_level,
-                "propagate": False,
-            },
-            EVEREST: {
+            "everest": {
                 "handlers": ["everest_log"],
                 "level": logging_level,
                 "propagate": False,
@@ -169,7 +156,7 @@ def main() -> None:
                 output_file=log_file.name,
             )
 
-            logging.getLogger(EVERSERVER).info("Everserver starting ...")
+            logging.getLogger(__name__).info("Everserver starting ...")
             logger.info(version_info())
             logger.info(f"Output directory: {output_dir}")
             # Starting the server
@@ -200,9 +187,9 @@ def main() -> None:
                         time.sleep(0.5)
         except ErtServerExit:
             # Server exit, happens on normal shutdown and keyboard interrupt
-            logging.getLogger(EVERSERVER).info("Everserver stopped by user")
+            logging.getLogger(__name__).info("Everserver stopped by user")
         except Exception as e:
-            logging.getLogger(EVERSERVER).exception(e)
+            logging.getLogger(__name__).exception(e)
 
 
 if __name__ == "__main__":

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 def _configure_loggers(
     log_dir: Path, logging_level: int, output_file: str | None
-) -> None:
+) -> list[logging.Handler]:
     def make_handler_config(path: Path, log_level: int) -> dict[str, Any]:
         makedirs_if_needed(path.parent)
         return {
@@ -47,42 +47,23 @@ def _configure_loggers(
         "version": 1,
         "disable_existing_loggers": False,
         "handlers": {
-            "endpoint_log": make_handler_config(
+            "everserver_log": make_handler_config(
                 log_dir / "everserver.log", logging_level
             ),
-            "everest_log": make_handler_config(log_dir / "everest.log", logging_level),
             "ropt_log": make_handler_config(log_dir / "ropt.log", logging_level),
-            "forward_models_log": make_handler_config(
-                log_dir / "forward_models.log", logging_level
-            ),
         },
         "loggers": {
-            "root": {"handlers": ["endpoint_log"], "level": logging_level},
+            "root": {"handlers": ["everserver_log"], "level": logging_level},
             "uvicorn": {"level": logging.WARNING},
             **{
                 logger_name: {"level": logging.WARNING}
                 for logger_name, logger_config in ert_loggers.items()
                 if logger_config.get("level") == "WARNING"
             },
-            "everest": {
-                "handlers": ["everest_log"],
-                "level": logging_level,
-                "propagate": False,
-            },
             "ropt": {
                 "handlers": ["ropt_log"],
                 "level": logging_level,
                 "propagate": False,
-            },
-            "forward_models": {
-                "handlers": ["forward_models_log"],
-                "level": logging_level,
-                "propagate": False,
-            },
-            "ert.scheduler.job": {
-                "handlers": ["forward_models_log"],
-                "propagate": False,
-                "level": logging_level,
             },
         },
         "formatters": {
@@ -101,8 +82,10 @@ def _configure_loggers(
     logging.config.dictConfig(logging_config)
 
     plugin_manager = ErtPluginManager()
-    plugin_manager.add_logging_handle_to_root(logging.getLogger())
+    plugin_log_handles = plugin_manager.add_logging_handle_to_root(logging.getLogger())
     plugin_manager.add_span_processor_to_trace_provider()
+
+    return plugin_log_handles
 
 
 def get_trace_context():
@@ -149,8 +132,9 @@ def main() -> None:
         tracer.start_as_current_span("everest.everserver", context=ctx),
         NamedTemporaryFile() as log_file,
     ):
+        plugin_log_handles: list[logging.Handler] = []
         try:  # ruff: ignore[too-many-statements-in-try-clause]
-            _configure_loggers(
+            plugin_log_handles = _configure_loggers(
                 log_dir=Path(output_dir) / OPTIMIZATION_LOG_DIR,
                 logging_level=options.logging_level,
                 output_file=log_file.name,
@@ -190,6 +174,15 @@ def main() -> None:
             logging.getLogger(__name__).info("Everserver stopped by user")
         except Exception as e:
             logging.getLogger(__name__).exception(e)
+        finally:
+            # Explicitly flush plugin-provided log handlers (e.g. one sending
+            # logs to a remote monitoring backend) since process shutdown may
+            # not reliably trigger their internal batched-export flush via
+            # atexit.
+            for handle in plugin_log_handles:
+                force_flush = getattr(handle, "force_flush", None)
+                if callable(force_flush):
+                    force_flush()
 
 
 if __name__ == "__main__":

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -4,9 +4,6 @@ DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 
 EVEREST = "everest"
-EVERSERVER = "everserver"
-EXPERIMENT_SERVER = "experiment_server"
-
 NAME = "name"
 
 OPTIMIZATION_OUTPUT_DIR = "optimization_output"

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -241,6 +241,27 @@ def test_that_add_logging_handle_returns_the_handles(tmpdir):
         assert isinstance(handles[0], logging.FileHandler)
 
 
+def test_that_add_logging_handle_to_root_is_idempotent(tmpdir):
+    """Calling add_logging_handle_to_root more than once on the same plugin
+    manager instance must not create new handler instances or attach
+    duplicate handlers to the root logger.
+    """
+    with tmpdir.as_cwd():
+        root_logger = logging.getLogger()
+        pre_existing_handlers = list(root_logger.handlers)
+        pm = ErtPluginManager(plugins=[dummy_plugins])
+        first_handles = pm.add_logging_handle_to_root(root_logger)
+        second_handles = pm.add_logging_handle_to_root(root_logger)
+
+        assert first_handles == second_handles
+        added_handlers = [
+            handler
+            for handler in root_logger.handlers
+            if handler not in pre_existing_handlers
+        ]
+        assert added_handlers == first_handles
+
+
 def test_that_non_propagating_loggers_also_receive_plugin_log_handles(tmpdir):
     """A logger configured with propagate=False never forwards its records to
     the root logger's handlers. Since add_logging_handle_to_root is meant to

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -218,6 +218,54 @@ def test_add_logging_handle(tmpdir):
         )
 
 
+def test_that_add_logging_handle_returns_the_handles(tmpdir):
+    with tmpdir.as_cwd():
+        pm = ErtPluginManager(plugins=[dummy_plugins])
+        handles = pm.add_logging_handle_to_root(logging.getLogger())
+        assert len(handles) == 1
+        assert isinstance(handles[0], logging.FileHandler)
+
+
+def test_that_non_propagating_loggers_also_receive_plugin_log_handles(tmpdir):
+    """A logger configured with propagate=False never forwards its records to
+    the root logger's handlers. Since add_logging_handle_to_root is meant to
+    make plugin-provided handlers (e.g. a remote log exporter) see every log
+    record regardless of which logger emitted it, such loggers must have the
+    plugin handles attached directly.
+    """
+    with tmpdir.as_cwd():
+        non_propagating_logger = logging.getLogger(
+            "test_non_propagating_logger_receives_plugin_handles"
+        )
+        non_propagating_logger.propagate = False
+        non_propagating_logger.setLevel(logging.DEBUG)
+        try:
+            pm = ErtPluginManager(plugins=[dummy_plugins])
+            pm.add_logging_handle_to_root(logging.getLogger())
+            non_propagating_logger.critical("I should also end up in spam.log")
+            assert "I should also end up in spam.log" in Path("spam.log").read_text(
+                encoding="utf-8"
+            )
+        finally:
+            non_propagating_logger.handlers.clear()
+            non_propagating_logger.propagate = True
+
+
+def test_that_propagating_loggers_are_not_directly_attached_by_plugin_handles(tmpdir):
+    """Loggers with the default propagate=True already forward their records
+    to the root logger, so attaching plugin handles directly to them as well
+    would cause duplicate log entries.
+    """
+    with tmpdir.as_cwd():
+        propagating_logger = logging.getLogger(
+            "test_propagating_logger_is_not_directly_attached"
+        )
+        assert propagating_logger.propagate
+        pm = ErtPluginManager(plugins=[dummy_plugins])
+        pm.add_logging_handle_to_root(logging.getLogger())
+        assert propagating_logger.handlers == []
+
+
 def test_add_span_processor():
     pm = ErtPluginManager(plugins=[dummy_plugins])
     pm.add_span_processor_to_trace_provider()

--- a/tests/ert/unit_tests/plugins/test_plugin_manager.py
+++ b/tests/ert/unit_tests/plugins/test_plugin_manager.py
@@ -11,6 +11,21 @@ from tests.ert.unit_tests.plugins import dummy_plugins
 from tests.ert.unit_tests.plugins.dummy_plugins import PLUGIN_IP_ADDRESS, DummyFMStep
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_root_logger_handlers():
+    """Ensure handlers are detached and closed after each test so file
+    descriptors are not leaked and later tests don't unexpectedly write
+    to files opened by earlier tests.
+    """
+    root_logger = logging.getLogger()
+    pre_existing_handlers = list(root_logger.handlers)
+    yield
+    for handler in list(root_logger.handlers):
+        if handler not in pre_existing_handlers:
+            root_logger.removeHandler(handler)
+            handler.close()
+
+
 def test_no_plugins():
     pm = ErtPluginManager(plugins=[ert.plugins.hook_implementations])
     assert pm.get_help_links() == {"GitHub page": "https://github.com/equinor/ert"}

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -48,24 +48,16 @@ def test_logging_setup(copy_math_func_test_data_to_tmp):
     everest_output_path = Path.cwd() / "everest_output"
     everest_logs_dir_path = Path(everest_config.log_dir)
     everserver_log_path = everest_logs_dir_path / "everserver.log"
-    everest_log_path = everest_logs_dir_path / "everest.log"
-    forward_model_log_path = everest_logs_dir_path / "forward_models.log"
 
     assert everest_output_path.exists()
     assert everest_logs_dir_path.exists()
-    assert forward_model_log_path.exists()
-    assert everest_log_path.exists()
     assert everserver_log_path.exists()
 
-    assert (
-        "everest.detached.everserver INFO: Output directory:"
-        in everest_log_path.read_text(encoding="utf-8")
-    )
-    assert "Process exited with status code 1" in forward_model_log_path.read_text(
-        encoding="utf-8"
-    )
-
     endpoint_logs = everserver_log_path.read_text(encoding="utf-8")
+
+    assert "everest.detached.everserver INFO: Output directory:" in endpoint_logs
+    assert "Process exited with status code 1" in endpoint_logs
+
     # Avoid cases where optimization finished before we get a chance to check that
     # the everest server has started
     if endpoint_logs:


### PR DESCRIPTION
This PR will remove some output log files and have the output sent into `everserver.log` instead.
This will also cause the logs to be propagated elsewhere should a plugin do so.

Affected log files: `everest.log` & `forward_models.log`
Stop using hardcoded loggers, and rely on `__name__` instead.

⚠️ This change will have all custom loggers propagate to external logging regardless of `propagate = False` set.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
