### PR TITLE
Fix crash when RFT has no matching properties

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -376,37 +376,40 @@ class RFTConfig(SimulationResponseConfig):
         get_cell_column = _get_cell_center()
         get_cell_zone = _get_cell_zone()
         try:
-            df = pl.concat(
-                [
-                    pl.DataFrame(
-                        {
-                            "response_key": [f"{well}:{time.isoformat()}:{prop}"],
-                            "well": [well],
-                            "date": [time.isoformat()],
-                            "property": [prop],
-                            "time": [time],
-                            "depth": [rft_data[well, time].property_values["DEPTH"]],
-                            "values": [vals],
-                            "well_connection_cell": pl.Series(
-                                [rft_data[well, time].well_connection_cells.tolist()],
-                                dtype=pl.List(pl.Array(pl.Int64, 3)),
-                            ),
-                        }
-                    )
-                    .explode(
-                        "depth",
-                        "values",
-                        "well_connection_cell",
-                        empty_as_null=False,
-                    )
-                    .with_columns(
-                        get_cell_column.alias("cell_center"),
-                        get_cell_zone.alias("cell_zones"),
-                    )
-                    for (well, time), inner_dict in rft_data.items()
-                    for prop, vals in inner_dict.property_values.items()
-                    if prop != "DEPTH" and len(vals) > 0
-                ]
+            dfs = [
+                pl.DataFrame(
+                    {
+                        "response_key": [f"{well}:{time.isoformat()}:{prop}"],
+                        "well": [well],
+                        "date": [time.isoformat()],
+                        "property": [prop],
+                        "time": [time],
+                        "depth": [rft_data[well, time].property_values["DEPTH"]],
+                        "values": [vals],
+                        "well_connection_cell": pl.Series(
+                            [rft_data[well, time].well_connection_cells.tolist()],
+                            dtype=pl.List(pl.Array(pl.Int64, 3)),
+                        ),
+                    }
+                )
+                .explode(
+                    "depth",
+                    "values",
+                    "well_connection_cell",
+                    empty_as_null=False,
+                )
+                .with_columns(
+                    get_cell_column.alias("cell_center"),
+                    get_cell_zone.alias("cell_zones"),
+                )
+                for (well, time), inner_dict in rft_data.items()
+                for prop, vals in inner_dict.property_values.items()
+                if prop != "DEPTH" and len(vals) > 0
+            ]
+            df = (
+                pl.concat(dfs)
+                if len(dfs) > 0
+                else pl.DataFrame(schema=self.response_schema())
             )
             return df.pipe(self._assert_schema, self.response_schema())
         except KeyError as err:

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -109,6 +109,34 @@ def test_that_rft_with_no_matching_well_and_dates_returns_empty_frame(mock_resfo
     }
 
 
+@pytest.mark.filterwarnings(r"ignore:Could not find responses")
+def test_that_rft_with_no_matching_properties_returns_empty_frame(
+    mock_resfo_file, egrid
+):
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.RFT",
+        [
+            *cell_start(date=(1, 1, 2000), well_name="WELL"),
+            ("PRESSURE", float_arr([100.0, 200.0])),
+            ("SWAT    ", float_arr([0.1, 0.2])),
+            ("SGAS    ", float_arr([0.3, 0.4])),
+            ("DEPTH   ", float_arr([20.0, 30.0])),
+        ],
+    )
+    mock_resfo_file(
+        "/tmp/does_not_exist/BASE.EGRID",
+        egrid,
+    )
+    rft_config = RFTConfig(
+        input_files=["BASE.RFT"],
+        data_to_read={"WELL": {"2000-01-01": ["FOO"]}},
+    )
+    df = rft_config.read_from_file("/tmp/does_not_exist", 1, 1)
+
+    assert df.is_empty()
+    assert df.schema == RFTConfig.response_schema()
+
+
 def test_that_rft_with_empty_data_to_read_returns_empty_df(mock_resfo_file):
     mock_resfo_file("/tmp/does_not_exist/BASE.RFT", [])
     rft_config = RFTConfig(input_files=["BASE.RFT"], data_to_read={})


### PR DESCRIPTION
**Issue**
Resolves #14177 


**Approach**
 - Added regression test
 - Fixed the bug

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
