### PR TITLE
Derive seismic response from observations

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -17,6 +17,7 @@ from numpy.random import SeedSequence
 from pydantic import BaseModel, Field, model_validator
 from pydantic import ValidationError as PydanticValidationError
 
+from ert.config.seismic_config import SeismicConfig
 from ert.substitutions import Substitutions
 
 from ._design_matrix_validator import DesignMatrixValidator
@@ -25,6 +26,7 @@ from ._observations import (
     GeneralObservation,
     Observation,
     RFTObservation,
+    SeismicObservation,
     SummaryObservation,
     make_observations,
 )
@@ -1250,6 +1252,7 @@ class ErtConfig(BaseModel):
 
             cls_config.derive_rft_response_input_from_observations(config_dict)
             cls_config.derive_breakthrough_response_input_from_observations()
+            cls_config.derive_seismic_response_input_from_observations()
 
             cls_config.random_seed_generator.user_defined_seed = config_dict.get(
                 ConfigKeys.RANDOM_SEED
@@ -1311,6 +1314,23 @@ class ErtConfig(BaseModel):
                 thresholds=[o.threshold for o in bt_obs],
                 observed_dates=[o.date for o in bt_obs],
             )
+
+    def derive_seismic_response_input_from_observations(self) -> None:
+        observations = self.observation_declarations
+        ensemble_config = self.ensemble_config
+
+        seismic_obs = [o for o in observations if isinstance(o, SeismicObservation)]
+
+        if "seismic" not in ensemble_config.response_configs and seismic_obs:
+            default_dir = Path("share/results/tables")
+            response_files = list(
+                dict.fromkeys(str(default_dir / o.filepath.name) for o in seismic_obs)
+            )
+            seismic_config = SeismicConfig.from_config_dict(
+                {ConfigKeys.SEISMIC: response_files}
+            )
+            assert seismic_config is not None
+            ensemble_config.response_configs["seismic"] = seismic_config
 
     @classmethod
     def _create_list_of_forward_model_steps_to_run(

--- a/tests/ert/defaults_generator.py
+++ b/tests/ert/defaults_generator.py
@@ -242,3 +242,15 @@ def create_seismic_response(
     )
     SeismicConfig._assert_schema(df, SeismicConfig.response_schema())
     return df
+
+
+def seismic_file_content() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "X_UTME": [100.0, 110.0, 120.0],
+            "Y_UTMN": [200.0, 210.0, 220.0],
+            "OBS": [1.0, 1.1, 1.2],
+            "OBS_ERROR": [0.005, 0.005, 0.005],
+            "REGION": [1.0, 1.0, 1.0],
+        }
+    )

--- a/tests/ert/unit_tests/config/test_observations.py
+++ b/tests/ert/unit_tests/config/test_observations.py
@@ -32,13 +32,16 @@ from ert.config.parsing.observations_parser import (
     ObservationType,
 )
 from ert.config.rft_config import RFTConfig
+from ert.config.seismic_config import SeismicConfig
 from ert.gui.plotting.ert_plots.observations import _plotObservations
 from ert.gui.plotting.utils import PlotConfig
 from ert.observation_converters.history_to_summary import convert_history_to_summary
 from tests.ert.defaults_generator import (
     create_breakthrough_observation_dict,
     create_rft_observation_dict,
+    create_seismic_observation_dict,
     create_summary_observation_dict,
+    seismic_file_content,
 )
 
 pytestmark = pytest.mark.filterwarnings("ignore:Config contains a SUMMARY key")
@@ -2501,3 +2504,70 @@ def test_that_seismic_observation_reports_missing_obs_file_key(file_context_toke
                 ),
             }
         )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_config_derives_seismic_response_when_no_response_entry_exists():
+    name1 = "horizon--amplitude_full_mean_depth--20250101_20240101.csv"
+    name2 = "horizon--amplitude_full_min_depth--20250101_20240101.parquet"
+    pattern2 = "*.parquet"
+
+    obs_dir = Path("share/preprocessed/tables")
+    obs_dir.mkdir(parents=True, exist_ok=True)
+
+    path1 = obs_dir / name1
+    seismic_file_content().write_csv(path1)
+    path2 = obs_dir / name2
+    seismic_file_content().write_parquet(path2)
+    pattern_path2 = obs_dir / pattern2
+
+    config = ErtConfig.from_dict(
+        {
+            "OBS_CONFIG": (
+                "obsconf",
+                [
+                    create_seismic_observation_dict(obs_file=str(path1)),
+                    create_seismic_observation_dict(obs_file=str(pattern_path2)),
+                ],
+            ),
+        }
+    )
+
+    seismic_config = cast(
+        SeismicConfig, config.ensemble_config.response_configs["seismic"]
+    )
+    assert seismic_config.input_files == [
+        f"share/results/tables/{name1}",
+        f"share/results/tables/{name2}",
+    ]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_config_does_not_derive_seismic_response_when_response_entry_exists():
+    obs_path = "horizon--amplitude_full_mean_depth--20250101_20240101.parquet"
+    seismic_file_content().write_parquet(obs_path)
+
+    name1 = (
+        "share/results/tables/horizon--amplitude_full_mean_depth--20250101_20240101.csv"
+    )
+    name2 = (
+        "share/results/tables/horizon--amplitude_full_min_depth--20250101_20240101.csv"
+    )
+
+    config = ErtConfig.from_dict(
+        {
+            "SEISMIC": [
+                name1,
+                name2,
+            ],
+            "OBS_CONFIG": (
+                "obsconf",
+                [create_seismic_observation_dict(obs_file=obs_path)],
+            ),
+        }
+    )
+
+    seismic_config = cast(
+        SeismicConfig, config.ensemble_config.response_configs["seismic"]
+    )
+    assert seismic_config.input_files == [name1, name2]


### PR DESCRIPTION
**Issue**
Resolves #13912 


**Approach**
If no response entries are explicitly provided, responses would be searched for in the default directory `share/results/tables` with names corresponding to provided observations.

If those default assumptions do not hold, users should be expected to provide `SEISMIC` keyword.

I am not fully sure users would need this feature, but decided to add it before the meeting, for easier feedback.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
