### PR TITLE
Fix schema key in improvement_df

### DIFF
--- a/src/ert/dark_storage/endpoints/responses.py
+++ b/src/ert/dark_storage/endpoints/responses.py
@@ -245,7 +245,7 @@ def data_for_response(
                 },
                 schema={
                     "batch_id": objective_value_df.schema["batch_id"],
-                    "accepted": pl.Boolean,
+                    "is_improvement": pl.Boolean,
                     "improvement_value": pl.Float64,
                 },
             ),


### PR DESCRIPTION
The schema added in 8cb63476 was cherry-picked from main, where the column has been renamed to "accepted". On version-24.0 the df still uses "is_improvement", so polars rejected the mismatch with "the given column-schema names do not match the data dictionary"

**Issue**
Resolves #14251


**Approach**
Schema now matches `df`-format and using column name `is_improvement`

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
