### PR TITLE
Fix APPROXIMATE_MISSING_RFT_VALUES validation

### DIFF
--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -1275,8 +1275,8 @@ class ErtConfig(BaseModel):
                 input_files=[summary_file_base_name],
                 data_to_read={},
                 zonemap=self.zonemap,
-                approximate_missing_values=config_dict.get(
-                    ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False
+                approximate_missing_values=bool(
+                    config_dict.get(ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False)
                 ),
             )
 

--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -747,8 +747,8 @@ class RFTConfig(SimulationResponseConfig):
                 keys=keys,
                 data_to_read=data_to_read,
                 zonemap=config_dict.get(ConfigKeys.ZONEMAP),
-                approximate_missing_values=config_dict.get(
-                    ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False
+                approximate_missing_values=bool(
+                    config_dict.get(ConfigKeys.APPROXIMATE_MISSING_RFT_VALUES, False)
                 ),
             )
 

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -3,7 +3,8 @@ import warnings
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, cast
+from textwrap import dedent
+from typing import cast
 from warnings import WarningMessage
 
 import numpy as np
@@ -1320,29 +1321,38 @@ def test_rft_value_approximation(
 
 
 @pytest.mark.parametrize(
-    ("approximate_missing_rft_values", "expected_setting"),
-    [(None, False), (False, False), (True, True)],
+    ("approximate_missing_rft_values_config", "expected_setting"),
+    [(None, False), ("FALSE", False), ("TRUE", True)],
 )
 @pytest.mark.parametrize(
     ("rft_response_config", "rft_obs_config"),
     [(False, True), (True, False), (True, True)],
 )
 def test_that_approximate_missing_rft_values_keyword_sets_interpolation_to_true_on_rft_config(  # ruff: ignore[line-too-long]
-    approximate_missing_rft_values,
+    approximate_missing_rft_values_config,
     expected_setting,
     rft_response_config,
     rft_obs_config,
 ):
-    config_dict: dict[str, Any] = {"ECLBASE": "BASE"}
-    if approximate_missing_rft_values is not None:
-        config_dict["APPROXIMATE_MISSING_RFT_VALUES"] = approximate_missing_rft_values
-    if rft_response_config:
-        config_dict["RFT"] = [{"WELL": "*", "DATE": "*", "PROPERTIES": "*"}]
+    rft_keyword = "RFT WELL:* DATE:* PROPERTIES:*" if rft_response_config else ""
+    approximate_keyword = (
+        f"APPROXIMATE_MISSING_RFT_VALUES {approximate_missing_rft_values_config}"
+        if approximate_missing_rft_values_config is not None
+        else ""
+    )
+    config_dict = ErtConfig._config_dict_from_contents(
+        dedent(
+            f"""\
+            NUM_REALIZATIONS 1
+            ECLBASE BASE
+            {rft_keyword}
+            {approximate_keyword}
+            """
+        ),
+        "./config.ert",
+    )
     if rft_obs_config:
-        config_dict["OBS_CONFIG"] = (
-            "obsconf",
-            [create_rft_observation_dict()],
-        )
+        config_dict["OBS_CONFIG"] = ("obsconf", [create_rft_observation_dict()])
 
     config = ErtConfig.from_dict(config_dict)
     rft_config = cast(RFTConfig, config.ensemble_config.response_configs["rft"])


### PR DESCRIPTION
The APPROXIMATE_MISSING_RFT_VALUES keyword raised a ConfigValidationError instead of being accepted.

**Approach**
Added regression test
Fixed the bug


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
