### PR TITLE
Improve load results manually Qt dialogue

### DIFF
--- a/src/ert/gui/ertwidgets/textbox.py
+++ b/src/ert/gui/ertwidgets/textbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from PyQt6.QtCore import QSize
 from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QTextEdit
 
@@ -115,3 +116,13 @@ class TextBox(QTextEdit):
 
     def refresh(self) -> None:
         self.validateString()
+
+    def sizeHint(self) -> QSize:
+        hint = super().sizeHint()
+        if self._preferred_height is not None:
+            hint.setHeight(self._preferred_height)
+        return hint
+
+    def setPreferredHeightInLines(self, lines: float) -> None:
+        self._preferred_height = round(self.fontMetrics().height() * lines)
+        self.updateGeometry()

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -33,7 +33,7 @@ class LoadResultsPanel(QWidget):
 
         self._notifier = notifier
 
-        self._resolved_run_path = str(
+        self._resolved_runpath = str(
             Path(config.runpath_config.runpath_format_string).resolve()
         )
 
@@ -45,19 +45,19 @@ class LoadResultsPanel(QWidget):
         self._ensemble_selector = EnsembleSelector(self._notifier)
         self._ensemble_selector.ensemble_selected.connect(self.refresh)
 
-        self._run_path_text = TextBox(TextModel(self._read_current_run_path()))
-        self._run_path_text.setFixedHeight(80)
-        self._run_path_text.setValidator(StringDefinition(required=["<IENS>"]))
-        self._run_path_text.setObjectName("run_path_edit_lrm")
-        self._run_path_text.getValidationSupport().validationChanged.connect(
+        self._runpath_text = TextBox(TextModel(self._read_current_runpath()))
+        self._runpath_text.setFixedHeight(80)
+        self._runpath_text.setValidator(StringDefinition(required=["<IENS>"]))
+        self._runpath_text.setObjectName("runpath_edit_lrm")
+        self._runpath_text.getValidationSupport().validationChanged.connect(
             self.panelConfigurationChanged
         )
-        self._run_path_text.textChanged.connect(self._text_change)
+        self._runpath_text.textChanged.connect(self._text_change)
 
         self.help_iter_lbl = QLabel("<ITER> will be replaced by: 0")
         self.help_iens_lbl = QLabel("<IENS> will be replaced by %")
 
-        layout.addRow("Load data from run path: ", self._run_path_text)
+        layout.addRow("Load data from run path: ", self._runpath_text)
         layout.addRow("", self.help_iens_lbl)
         layout.addRow("", self.help_iter_lbl)
         layout.addRow("Load into ensemble:", self._ensemble_selector)
@@ -84,19 +84,19 @@ class LoadResultsPanel(QWidget):
     def _text_change(self) -> None:
         active_realizations = self._active_realizations_field.get_text
         self.help_iens_lbl.setText(f"<IENS> will be replace by {active_realizations}")
-        self.help_iter_lbl.setVisible("<ITER>" in self._run_path_text.get_text)
+        self.help_iter_lbl.setVisible("<ITER>" in self._runpath_text.get_text)
 
-    def _read_current_run_path(self) -> str:
-        run_path = self._resolved_run_path
+    def _read_current_runpath(self) -> str:
+        runpath = self._resolved_runpath
         if self._ensemble_selector.selected_ensemble:
             current_ensemble = self._ensemble_selector.selected_ensemble.name
-            run_path = run_path.replace("<ERTCASE>", current_ensemble)
-            run_path = run_path.replace("<ERT-CASE>", current_ensemble)
-        return run_path
+            runpath = runpath.replace("<ERTCASE>", current_ensemble)
+            runpath = runpath.replace("<ERT-CASE>", current_ensemble)
+        return runpath
 
     def is_configuration_valid(self) -> bool:
         return (
-            self._active_realizations_field.isValid() and self._run_path_text.isValid()
+            self._active_realizations_field.isValid() and self._runpath_text.isValid()
         )
 
     def load(self) -> int:
@@ -113,7 +113,7 @@ class LoadResultsPanel(QWidget):
                     self._ensemble_selector.selected_ensemble.id
                 )
                 loaded = load_parameters_and_responses_from_runpath(
-                    run_path_format=self._run_path_text.get_text,
+                    run_path_format=self._runpath_text.get_text,
                     ensemble=write_ensemble,
                     active_realizations=active_realizations,
                 )
@@ -148,5 +148,5 @@ class LoadResultsPanel(QWidget):
         return loaded
 
     def refresh(self) -> None:
-        self._run_path_text.setText(self._read_current_run_path())
-        self._run_path_text.refresh()
+        self._runpath_text.setText(self._read_current_runpath())
+        self._runpath_text.refresh()

--- a/src/ert/gui/tools/load_results/load_results_panel.py
+++ b/src/ert/gui/tools/load_results/load_results_panel.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtCore import pyqtSignal as Signal
-from PyQt6.QtWidgets import QFormLayout, QLabel, QMessageBox, QWidget
+from PyQt6.QtWidgets import (
+    QFormLayout,
+    QLabel,
+    QMessageBox,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ert.config import ErtConfig, WarningInfo
 from ert.gui.ertnotifier import ErtNotifier
@@ -28,8 +35,7 @@ class LoadResultsPanel(QWidget):
     def __init__(self, config: ErtConfig, notifier: ErtNotifier) -> None:
         QWidget.__init__(self)
 
-        self.setMinimumWidth(500)
-        self.setMinimumHeight(200)
+        self.setMinimumWidth(600)
 
         self._notifier = notifier
 
@@ -40,27 +46,41 @@ class LoadResultsPanel(QWidget):
         self.setWindowTitle("Load results manually")
         self.activateWindow()
 
-        layout = QFormLayout()
+        expanding_form = QFormLayout()
+        runpath_label_text = "Enter runpath to load results from: "
+        runpath_label = QLabel(runpath_label_text)
 
         self._ensemble_selector = EnsembleSelector(self._notifier)
         self._ensemble_selector.ensemble_selected.connect(self.refresh)
 
-        self._runpath_text = TextBox(TextModel(self._read_current_runpath()))
-        self._runpath_text.setFixedHeight(80)
-        self._runpath_text.setValidator(StringDefinition(required=["<IENS>"]))
-        self._runpath_text.setObjectName("runpath_edit_lrm")
-        self._runpath_text.getValidationSupport().validationChanged.connect(
+        self._runpath_textbox = TextBox(TextModel(self._read_current_runpath()))
+        self._runpath_textbox.setPreferredHeightInLines(3)
+        self._runpath_textbox.setMinimumHeight(10)
+        self._runpath_textbox.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+        self._runpath_textbox.setValidator(StringDefinition(required=["<IENS>"]))
+        self._runpath_textbox.setObjectName("runpath_edit_lrm")
+        self._runpath_textbox.getValidationSupport().validationChanged.connect(
             self.panelConfigurationChanged
         )
-        self._runpath_text.textChanged.connect(self._text_change)
+        self._runpath_textbox.textChanged.connect(self._text_change)
 
-        self.help_iter_lbl = QLabel("<ITER> will be replaced by: 0")
+        expanding_form.addRow(runpath_label, self._runpath_textbox)
+
+        fixed_form = QFormLayout()
+        label_width = runpath_label.sizeHint().width()
+
+        def make_qlabel(text: str) -> QLabel:
+            """Propagate width of upper left label to other labels"""
+            label = QLabel(text)
+            label.setMinimumWidth(label_width)
+            return label
+
         self.help_iens_lbl = QLabel("<IENS> will be replaced by %")
 
-        layout.addRow("Load data from run path: ", self._runpath_text)
-        layout.addRow("", self.help_iens_lbl)
-        layout.addRow("", self.help_iter_lbl)
-        layout.addRow("Load into ensemble:", self._ensemble_selector)
+        fixed_form.addRow(make_qlabel(""), self.help_iens_lbl)
+        fixed_form.addRow(make_qlabel("Load into ensemble:"), self._ensemble_selector)
 
         ensemble_size = config.runpath_config.num_realizations
         self._active_realizations_model = ActiveRealizationsModel(ensemble_size)
@@ -74,17 +94,22 @@ class LoadResultsPanel(QWidget):
         self.help_iens_lbl.setText(
             f"<IENS> will be replaced by {self._active_realizations_field.get_text}"
         )
-        layout.addRow("Realizations to load:", self._active_realizations_field)
+        fixed_form.addRow(
+            make_qlabel("Realizations to load:"), self._active_realizations_field
+        )
 
         self._active_realizations_field.getValidationSupport().validationChanged.connect(
             self.panelConfigurationChanged
         )
+
+        layout = QVBoxLayout()
+        layout.addLayout(expanding_form, 1)
+        layout.addLayout(fixed_form, 0)
         self.setLayout(layout)
 
     def _text_change(self) -> None:
         active_realizations = self._active_realizations_field.get_text
-        self.help_iens_lbl.setText(f"<IENS> will be replace by {active_realizations}")
-        self.help_iter_lbl.setVisible("<ITER>" in self._runpath_text.get_text)
+        self.help_iens_lbl.setText(f"<IENS> will be replaced by {active_realizations}")
 
     def _read_current_runpath(self) -> str:
         runpath = self._resolved_runpath
@@ -92,11 +117,12 @@ class LoadResultsPanel(QWidget):
             current_ensemble = self._ensemble_selector.selected_ensemble.name
             runpath = runpath.replace("<ERTCASE>", current_ensemble)
             runpath = runpath.replace("<ERT-CASE>", current_ensemble)
-        return runpath
+        return runpath.replace("<ITER>", "0")
 
     def is_configuration_valid(self) -> bool:
         return (
-            self._active_realizations_field.isValid() and self._runpath_text.isValid()
+            self._active_realizations_field.isValid()
+            and self._runpath_textbox.isValid()
         )
 
     def load(self) -> int:
@@ -113,7 +139,7 @@ class LoadResultsPanel(QWidget):
                     self._ensemble_selector.selected_ensemble.id
                 )
                 loaded = load_parameters_and_responses_from_runpath(
-                    run_path_format=self._runpath_text.get_text,
+                    run_path_format=self._runpath_textbox.get_text,
                     ensemble=write_ensemble,
                     active_realizations=active_realizations,
                 )
@@ -148,5 +174,5 @@ class LoadResultsPanel(QWidget):
         return loaded
 
     def refresh(self) -> None:
-        self._runpath_text.setText(self._read_current_runpath())
-        self._runpath_text.refresh()
+        self._runpath_textbox.setText(self._read_current_runpath())
+        self._runpath_textbox.refresh()

--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -11,12 +11,13 @@ from pytestqt.qtbot import QtBot
 from skimage import io, transform
 from skimage.metrics import structural_similarity as ssim
 
-from ert.gui.ertwidgets import CopyableLabel
+from ert.gui.ertwidgets import ClosableDialog, CopyableLabel, TextBox
 from ert.gui.experiments import ExperimentPanel, RunDialog
 from ert.gui.experiments.single_test_run_panel import SingleTestRunPanel
 from ert.gui.experiments.view import RealizationWidget
 from ert.gui.experiments.view.disk_space_widget import DiskSpaceWidget
 from ert.gui.plotting.widgets import DataTypeKeysWidget, EnsembleSelectionWidget
+from ert.gui.tools.load_results import LoadResultsPanel
 from ert.run_models import EnsembleExperiment, EnsembleSmoother, RunModel
 from ert.services import ErtServerController
 from ert.storage import open_storage
@@ -136,6 +137,7 @@ PNGS_TESTED_FOR_CHANGE = [
     "docs/ert/getting_started/configuration/poly_new/with_observations/coeff_b.png",
     "docs/ert/getting_started/configuration/poly_new/with_observations/coeff_c.png",
     "docs/ert/getting_started/configuration/poly_new/with_more_observations/coeff_b.png",
+    "docs/ert/getting_started/load_results_manually.png",
 ]
 
 FIXED_RANDOM_SEED = 11223344
@@ -148,6 +150,7 @@ PLOT_OBS_PNG_THRESHOLD = 0.9999
 PLOTS_PNG_THRESHOLD = 0.9999
 POLY_PLOT_PNG_THRESHOLD = 0.9999
 SIMULATIONS_PNG_THRESHOLD = 0.9999
+LOAD_RESULTS_MANUALLY_PNG_THRESHOLD = 0.9999
 
 
 class ExampleFolders(StrEnum):
@@ -214,8 +217,10 @@ class GuiEvaluator:
         self.gui = gui
         self.qtbot = qtbot
 
-    def compare_img_with_gui(self, img_name: str, threshold: float = 0.99) -> None:
-        temp_image_path: Path = self.qtbot.screenshot(self.gui)
+    def compare_img_with_gui(
+        self, img_name: str, threshold: float = 0.99, widget: QWidget | None = None
+    ) -> None:
+        temp_image_path: Path = self.qtbot.screenshot(widget or self.gui)
         new_img: np.ndarray = io.imread(temp_image_path, as_gray=True)
 
         image_path = self.example_folder / img_name
@@ -424,6 +429,36 @@ def test_that_poly_new_with_results_screenshots_are_up_to_date(
         set_data_type_selection_index(data_type_widget, 1)
 
         gui_evaluator.compare_img_with_gui("plots.png", PLOTS_PNG_THRESHOLD)
+
+    assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
+
+
+@pytest.mark.screenshot_test
+def test_that_load_results_manually_screenshot_is_up_to_date(
+    qtbot, source_root: Path, ensemble_experiment_has_run_no_failure
+):
+    example_folder = Path("docs/ert/getting_started")
+    gui = ensemble_experiment_has_run_no_failure
+
+    gui_evaluator = GuiEvaluator(source_root, example_folder, gui, qtbot)
+
+    def handle_load_results_dialog() -> None:
+        dialog = wait_for_child(gui, qtbot, ClosableDialog)
+        panel = get_child(dialog, LoadResultsPanel)
+
+        run_path_edit = get_child(panel, TextBox, name="runpath_edit_lrm")
+        current_directory = str(Path.cwd())
+        run_path_edit.setText(run_path_edit.get_text.replace(current_directory, "."))
+
+        gui_evaluator.compare_img_with_gui(
+            "load_results_manually.png",
+            LOAD_RESULTS_MANUALLY_PNG_THRESHOLD,
+            widget=dialog,
+        )
+        dialog.close()
+
+    QTimer.singleShot(500, handle_load_results_dialog)
+    gui.load_results_tool.trigger()
 
     assert not gui_evaluator.gui_change_detected(), gui_evaluator.change_report()
 

--- a/tests/ert/ui_tests/gui/test_load_results_manually.py
+++ b/tests/ert/ui_tests/gui/test_load_results_manually.py
@@ -21,9 +21,9 @@ def test_validation(ensemble_experiment_has_run_no_failure, qtbot):
 
         load_button = get_child(panel.parent(), QPushButton, name="Load")
 
-        run_path_edit = get_child(panel, TextBox, name="run_path_edit_lrm")
-        assert run_path_edit.isEnabled()
-        valid_text = run_path_edit.get_text
+        runpath_edit = get_child(panel, TextBox, name="runpath_edit_lrm")
+        assert runpath_edit.isEnabled()
+        valid_text = runpath_edit.get_text
         assert "<IENS>" in valid_text
 
         active_realizations = get_child(
@@ -38,9 +38,9 @@ def test_validation(ensemble_experiment_has_run_no_failure, qtbot):
         active_realizations.setText(default_value_active_reals)
         assert load_button.isEnabled()
 
-        run_path_edit.setText(valid_text.replace("<IENS>", "<IES>"))
+        runpath_edit.setText(valid_text.replace("<IENS>", "<IES>"))
         assert not load_button.isEnabled()
-        run_path_edit.setText(valid_text)
+        runpath_edit.setText(valid_text)
         assert load_button.isEnabled()
 
         dialog.close()


### PR DESCRIPTION
**Issue**
Resolves #14210 

Also in the direction of #14257 

**Approach**
do-it

Added a screenshot-test even though this is not (yet?) part of the documentation. 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
