### PR TITLE
Replace create_ertserver_client with ErtClient

### DIFF
--- a/src/ert/services/ert_client.py
+++ b/src/ert/services/ert_client.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from .shared_client import Methods, SharedClient
+from .shared_client import ErtClientConnectionInfo, Methods, SharedClient
 
 DEFAULT_TIMEOUT = 120
 DEFAULT_CACHE_SIZE = 256
@@ -123,6 +123,10 @@ class ErtClient:
     @property
     def client(self) -> SharedClient:
         return self._client
+
+    @property
+    def conn_info(self) -> ErtClientConnectionInfo:
+        return self._client.conn_info
 
     def clear_cache(self) -> None:
         with self._cache_lock:

--- a/src/everest/bin/everest_script.py
+++ b/src/everest/bin/everest_script.py
@@ -16,7 +16,7 @@ from opentelemetry.trace import Status, StatusCode
 
 from _ert.threading import ErtThread
 from ert.config import QueueSystem
-from ert.services import create_ertserver_client
+from ert.services.ert_client import ErtClient
 from ert.storage.local_experiment import ExperimentState
 from ert.trace import trace
 from ert.utils import makedirs_if_needed
@@ -164,8 +164,9 @@ def _build_args_parser() -> argparse.ArgumentParser:
 async def run_everest(options: argparse.Namespace) -> None:
 
     try:
-        create_ertserver_client(
-            Path(ServerConfig.get_session_dir(options.config.output_dir)), timeout=1
+        ErtClient.get_client(
+            Path(ServerConfig.get_session_dir(options.config.output_dir)),
+            connect_timeout=1,
         )
         server_running = True
     except TimeoutError:
@@ -227,7 +228,7 @@ async def run_everest(options: argparse.Namespace) -> None:
     print("Waiting for server ...")
     logger.debug("Waiting for response from everserver")
     wait_start_time: float = time.monotonic()
-    client = create_ertserver_client(
+    client = ErtClient.get_client(
         Path(ServerConfig.get_session_dir(options.config.output_dir))
     )
     wait_for_server(client, timeout=600)

--- a/src/everest/bin/kill_script.py
+++ b/src/everest/bin/kill_script.py
@@ -12,7 +12,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from ert.services import create_ertserver_client
+from ert.services.ert_client import ErtClient
 from everest.bin.utils import setup_logging
 from everest.config import EverestConfig, ServerConfig
 from everest.detached import stop_server, wait_for_server_to_stop
@@ -74,8 +74,9 @@ def _handle_keyboard_interrupt(signal: int, _: Any, *, after: bool = False) -> N
 
 def kill_everest(options: argparse.Namespace) -> None:
     try:
-        client = create_ertserver_client(
-            Path(ServerConfig.get_session_dir(options.config.output_dir)), timeout=1
+        client = ErtClient.get_client(
+            Path(ServerConfig.get_session_dir(options.config.output_dir)),
+            connect_timeout=1,
         )
         server_context = ServerConfig.get_server_context_from_conn_info(
             client.conn_info

--- a/src/everest/bin/monitor_script.py
+++ b/src/everest/bin/monitor_script.py
@@ -7,7 +7,7 @@ from functools import partial
 from pathlib import Path
 from textwrap import dedent
 
-from ert.services import create_ertserver_client
+from ert.services.ert_client import ErtClient
 from ert.storage import ErtStorageException, ExperimentState
 from everest.config import EverestConfig, ServerConfig
 from everest.detached.client import get_experiments
@@ -78,31 +78,25 @@ def _build_args_parser() -> argparse.ArgumentParser:
 def monitor_everest(options: argparse.Namespace) -> None:
     config: EverestConfig = options.config
     try:  # ruff: ignore[too-many-statements-in-try-clause]
-        with create_ertserver_client(
-            Path(ServerConfig.get_session_dir(config.output_dir)), timeout=1
-        ) as client:
-            server_context = ServerConfig.get_server_context_from_conn_info(
-                client.conn_info
-            )
-            experiment_id = get_experiments(server_context)[-1]
-            run_detached_monitor(
-                server_context=server_context, experiment_id=experiment_id
-            )
+        client = ErtClient.get_client(
+            Path(ServerConfig.get_session_dir(config.output_dir)), connect_timeout=1
+        )
+        server_context = ServerConfig.get_server_context_from_conn_info(
+            client.conn_info
+        )
+        experiment_id = get_experiments(server_context)[-1]
+        run_detached_monitor(server_context=server_context, experiment_id=experiment_id)
 
-            try:
-                experiment_status = get_experiment_status(str(config.storage_dir))
-                if (
-                    experiment_status
-                    and experiment_status.status == ExperimentState.failed
-                ):
-                    raise SystemExit(experiment_status.message or "Optimization failed")
-                if experiment_status:
-                    print(
-                        experiment_status.message
-                        or "Optimization completed successfully"
-                    )
-            except ErtStorageException as err:
-                print(f"Error reading experiment status: {err}")
+        try:
+            experiment_status = get_experiment_status(str(config.storage_dir))
+            if experiment_status and experiment_status.status == ExperimentState.failed:
+                raise SystemExit(experiment_status.message or "Optimization failed")
+            if experiment_status:
+                print(
+                    experiment_status.message or "Optimization completed successfully"
+                )
+        except ErtStorageException as err:
+            print(f"Error reading experiment status: {err}")
 
     except TimeoutError:
         try:  # ruff: ignore[too-many-statements-in-try-clause]

--- a/src/everest/bin/utils.py
+++ b/src/everest/bin/utils.py
@@ -24,7 +24,7 @@ from ert.ensemble_evaluator import (
 from ert.ensemble_evaluator.event import EndEvent
 from ert.logging import LOGGING_CONFIG
 from ert.plugins.plugin_manager import ErtPluginManager
-from ert.services import create_ertserver_client
+from ert.services.ert_client import ErtClient
 from ert.storage import (
     ExperimentStatus,
     open_storage,
@@ -106,7 +106,7 @@ def handle_keyboard_interrupt(signum: int, _: Any, options: argparse.Namespace) 
             "The optimization will be stopped and the program will exit..."
         )
         try:
-            client = create_ertserver_client(
+            client = ErtClient.get_client(
                 Path(ServerConfig.get_session_dir(options.config.output_dir))
             )
             server_context = ServerConfig.get_server_context_from_conn_info(

--- a/src/everest/detached/client.py
+++ b/src/everest/detached/client.py
@@ -18,7 +18,7 @@ from ert.run_models.event import EverestBatchResultEvent, status_event_from_json
 from ert.scheduler import create_driver
 from ert.scheduler.driver import Driver, FailedSubmit
 from ert.scheduler.event import StartedEvent
-from ert.services.shared_client import Client
+from ert.services.ert_client import ErtClient
 from ert.trace import get_traceparent
 from everest.config import EverestConfig, ServerConfig
 from everest.strings import (
@@ -142,7 +142,7 @@ def extract_errors_from_file(path: str) -> list[str]:
     return re.findall(r"(Error \w+.*)", Path(path).read_text(encoding="utf-8"))
 
 
-def wait_for_server(client: Client, timeout: float) -> None:
+def wait_for_server(api: ErtClient, timeout: float) -> None:
     """
     Waits until the everest server has started. Polls
     for server availability until timeout (measured in seconds).
@@ -156,7 +156,7 @@ def wait_for_server(client: Client, timeout: float) -> None:
     wait_start_time: float = time.monotonic()
     while time.monotonic() - wait_start_time <= timeout:
         if server_is_running(
-            *ServerConfig.get_server_context_from_conn_info(client.conn_info)
+            *ServerConfig.get_server_context_from_conn_info(api.conn_info)
         ):
             return
         until_timeout = max(0, timeout - (time.monotonic() - wait_start_time))

--- a/src/everest/detached/everserver.py
+++ b/src/everest/detached/everserver.py
@@ -13,7 +13,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 from ert.logging import LOGGING_CONFIG
 from ert.plugins.plugin_manager import ErtPluginManager
-from ert.services import ErtServerController, ErtServerExit, create_ertserver_client
+from ert.services import ErtClient, ErtServerController, ErtServerExit
 from ert.storage import ExperimentStatus
 from ert.storage.local_experiment import ExperimentState
 from ert.trace import tracer
@@ -23,7 +23,6 @@ from everest.detached import get_experiments
 from everest.strings import (
     DEFAULT_LOGGING_FORMAT,
     OPTIMIZATION_LOG_DIR,
-    EverEndpoints,
 )
 from everest.util import version_info
 
@@ -149,26 +148,21 @@ def main() -> None:
                 timeout=240, project=Path(server_path), logging_config=log_file.name
             ) as server:
                 server.fetch_connection_info()
-                with create_ertserver_client(Path(server_path)) as client:
-                    done = False
-                    while not done:
-                        experiment_ids = get_experiments(
-                            ServerConfig.get_server_context_from_conn_info(
-                                client.conn_info
-                            )
-                        )
-                        active = [
-                            ExperimentStatus(
-                                **client.get(
-                                    f"/experiment_server/{EverEndpoints.STATUS}/{experiment_id}",
-                                    auth=server.fetch_auth(),
-                                ).json()
-                            ).status
-                            in {ExperimentState.pending, ExperimentState.running}
-                            for experiment_id in experiment_ids
-                        ]
-                        done = experiment_ids and not any(active)
-                        time.sleep(0.5)
+                client = ErtClient.get_client(Path(server_path))
+                done = False
+                while not done:
+                    experiment_ids = get_experiments(
+                        ServerConfig.get_server_context_from_conn_info(client.conn_info)
+                    )
+                    active = [
+                        ExperimentStatus(
+                            **client.experiment_status(experiment_id)
+                        ).status
+                        in {ExperimentState.pending, ExperimentState.running}
+                        for experiment_id in experiment_ids
+                    ]
+                    done = experiment_ids and not any(active)
+                    time.sleep(0.5)
         except ErtServerExit:
             # Server exit, happens on normal shutdown and keyboard interrupt
             logging.getLogger(__name__).info("Everserver stopped by user")

--- a/src/everest/gui/main_window.py
+++ b/src/everest/gui/main_window.py
@@ -14,7 +14,7 @@ from ert.gui.ertnotifier import ErtNotifier
 from ert.gui.experiments import RunDialog
 from ert.gui.experiments.experiment_client import ExperimentClient
 from ert.plugins import ErtPluginManager
-from ert.services import create_ertserver_client
+from ert.services.ert_client import ErtClient
 from everest.config import ServerConfig
 from everest.detached import get_experiments, wait_for_server
 
@@ -43,13 +43,13 @@ class EverestMainWindow(QMainWindow):
         self.setCentralWidget(self.central_widget)
 
     def run(self) -> None:
-        storage_client = create_ertserver_client(
+        client = ErtClient.get_client(
             Path(ServerConfig.get_session_dir(self.output_dir))
         )
-        wait_for_server(storage_client, 60)
+        wait_for_server(client, 60)
 
         server_context = ServerConfig.get_server_context_from_conn_info(
-            storage_client.conn_info
+            client.conn_info
         )
         url, cert, auth = server_context
 
@@ -57,7 +57,7 @@ class EverestMainWindow(QMainWindow):
         ssl_context.load_verify_locations(cafile=cert)
         username, password = auth
 
-        client = ExperimentClient(
+        exp_client = ExperimentClient(
             experiment_id=get_experiments(server_context)[-1],
             url=url,
             cert_file=cert,
@@ -66,13 +66,15 @@ class EverestMainWindow(QMainWindow):
             ssl_context=ssl_context,
         )
 
-        config = client.config
+        config = exp_client.config
         title = Path(config["config_path"]).name
         self.setWindowTitle(f"EVEREST - {title}")
 
-        run_model_api = client.create_run_model_api()
-        event_queue, event_monitor_thread = client.setup_event_queue_from_ws_endpoint(
-            refresh_interval=0.02, open_timeout=40, websocket_recv_timeout=1.0
+        run_model_api = exp_client.create_run_model_api()
+        event_queue, event_monitor_thread = (
+            exp_client.setup_event_queue_from_ws_endpoint(
+                refresh_interval=0.02, open_timeout=40, websocket_recv_timeout=1.0
+            )
         )
 
         run_dialog = RunDialog(

--- a/tests/ert/ui_tests/gui/conftest.py
+++ b/tests/ert/ui_tests/gui/conftest.py
@@ -51,6 +51,7 @@ def setup_svg_search_path():
 @pytest.fixture(autouse=True)
 def reset_ert_api_client():
     # The client is process-wide and bound to one project, but each test has its own.
+    SharedClient.close_client()
     yield
     SharedClient.close_client()
 

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -18,12 +18,22 @@ from ert.plugins import ErtRuntimePlugins, get_site_plugins
 from ert.run_models import StatusEvents
 from ert.run_models.event import status_event_from_json, status_event_to_json
 from ert.run_models.everest_run_model import EverestRunModel
+from ert.services import SharedClient
 from everest.config import (
     EverestConfig,
 )
 from everest.config.control_config import ControlConfig
 from everest.detached import everserver
 from tests.everest.utils import MIN_CONFIG, get_optimal_result, relpath
+
+
+@pytest.fixture(autouse=True)
+def reset_ert_api_client():
+    # The client is process-wide and bound to one project, but each test has its own.
+    # Background threads may rebind it after teardown, so reset on the way in too.
+    SharedClient.close_client()
+    yield
+    SharedClient.close_client()
 
 
 @pytest.fixture

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -26,13 +26,13 @@ def raise_system_error(*args, **kwargs):
 @patch("everest.bin.everest_script.start_server")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch(
-    "everest.bin.everest_script.create_ertserver_client",
-    side_effect=[TimeoutError(), MagicMock()],
+    "everest.bin.everest_script.ErtClient",
+    **{"get_client.side_effect": [TimeoutError(), MagicMock()]},
 )
 @patch("everest.bin.everest_script.start_experiment")
 def test_everest_entry_debug(
     start_experiment_mock,
-    everest_script_client_mock,
+    everest_script_api_mock,
     get_server_context_from_conn_info_mock,
     start_server_mock,
     wait_for_server_mock,
@@ -60,7 +60,7 @@ def test_everest_entry_debug(
     wait_for_server_mock.assert_called_once()
     start_monitor_mock.assert_called_once()
     start_experiment_mock.assert_called_once()
-    assert everest_script_client_mock.call_count == 2
+    assert everest_script_api_mock.get_client.call_count == 2
     assert get_server_context_from_conn_info_mock.call_count == 2
 
     # the config file itself is dumped at DEBUG level
@@ -75,13 +75,13 @@ def test_everest_entry_debug(
 @patch("everest.bin.everest_script.start_server")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch(
-    "everest.bin.everest_script.create_ertserver_client",
-    side_effect=[TimeoutError(), MagicMock()],
+    "everest.bin.everest_script.ErtClient",
+    **{"get_client.side_effect": [TimeoutError(), MagicMock()]},
 )
 @patch("everest.bin.everest_script.start_experiment")
 def test_everest_entry(
     start_experiment_mock,
-    everest_script_client_mock,
+    everest_script_api_mock,
     get_server_context_from_conn_info_mock,
     start_server_mock,
     wait_for_server_mock,
@@ -98,7 +98,7 @@ def test_everest_entry(
     wait_for_server_mock.assert_called_once()
     start_monitor_mock.assert_called_once()
     start_experiment_mock.assert_called_once()
-    assert everest_script_client_mock.call_count == 2
+    assert everest_script_api_mock.get_client.call_count == 2
     assert get_server_context_from_conn_info_mock.call_count == 2
 
 
@@ -108,18 +108,23 @@ def test_everest_entry(
 @patch("everest.bin.everest_script.start_experiment")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch(
-    "everest.bin.everest_script.create_ertserver_client",
-    side_effect=[
-        TimeoutError(),
-        MagicMock(),
-        TimeoutError(),
-        MagicMock(),
-    ],
+    "everest.bin.everest_script.ErtClient",
+    **{
+        "get_client.side_effect": [
+            TimeoutError(),
+            MagicMock(),
+            TimeoutError(),
+            MagicMock(),
+        ]
+    },
 )
-@patch("everest.bin.kill_script.create_ertserver_client", side_effect=TimeoutError())
+@patch(
+    "everest.bin.kill_script.ErtClient",
+    **{"get_client.side_effect": TimeoutError()},
+)
 def test_everest_entry_detached_already_run(
-    kill_script_client_mock,
-    everest_script_client_mock,
+    kill_script_api_mock,
+    everest_script_api_mock,
     get_server_context_from_conn_info_mock,
     start_experiment_mock,
     start_server_mock,
@@ -140,7 +145,7 @@ def test_everest_entry_detached_already_run(
     start_server_mock.assert_called_once()
     start_monitor_mock.assert_called_once()
     start_experiment_mock.assert_called_once()
-    assert everest_script_client_mock.call_count == 2
+    assert everest_script_api_mock.get_client.call_count == 2
 
     start_server_mock.reset_mock()
     start_monitor_mock.reset_mock()
@@ -148,15 +153,15 @@ def test_everest_entry_detached_already_run(
 
     # stopping the server has no effect (not running)
     kill_entry(["config.yml"])
-    assert everest_script_client_mock.call_count == 2
-    assert kill_script_client_mock.call_count == 1
+    assert everest_script_api_mock.get_client.call_count == 2
+    assert kill_script_api_mock.get_client.call_count == 1
 
     # run again, should start a new run like above
     everest_entry(["config.yml"])
     start_server_mock.assert_called_once()
     start_monitor_mock.assert_called_once()
     start_experiment_mock.assert_called_once()
-    assert everest_script_client_mock.call_count == 4
+    assert everest_script_api_mock.get_client.call_count == 4
 
 
 @patch("everest.bin.monitor_script.run_detached_monitor")
@@ -164,11 +169,14 @@ def test_everest_entry_detached_already_run(
     "everest.bin.monitor_script.get_experiment_status",
     return_value=ExperimentStatus(status=ExperimentState.completed, message=""),
 )
-@patch("everest.bin.monitor_script.create_ertserver_client", side_effect=TimeoutError())
+@patch(
+    "everest.bin.monitor_script.ErtClient",
+    **{"get_client.side_effect": TimeoutError()},
+)
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 def test_everest_entry_detached_already_run_monitor(
     get_server_context_from_conn_info_mock,
-    monitor_script_client_mock,
+    monitor_script_api_mock,
     get_experiment_status_mock,
     start_monitor_mock,
     change_to_tmpdir,
@@ -184,26 +192,26 @@ def test_everest_entry_detached_already_run_monitor(
     start_monitor_mock.assert_not_called()
     get_experiment_status_mock.assert_called()
     get_server_context_from_conn_info_mock.assert_not_called()
-    monitor_script_client_mock.assert_called_once()
+    monitor_script_api_mock.get_client.assert_called_once()
 
 
-@patch("everest.bin.everest_script.create_ertserver_client")
+@patch("everest.bin.everest_script.ErtClient")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch("everest.bin.everest_script.run_detached_monitor")
 @patch("everest.bin.everest_script.wait_for_server")
 @patch("everest.bin.everest_script.start_server")
 @patch("everest.bin.kill_script.stop_server", return_value=True)
 @patch("everest.bin.kill_script.wait_for_server_to_stop")
-@patch("everest.bin.kill_script.create_ertserver_client")
+@patch("everest.bin.kill_script.ErtClient")
 def test_everest_entry_detached_running(
-    kill_client_mock,
+    kill_api_mock,
     wait_for_server_to_stop_mock,
     stop_server_mock,
     start_server_mock,
     wait_for_server_mock,
     start_monitor_mock,
     get_server_context_from_conn_info_mock,
-    kill_script_client_mock,
+    everest_script_api_mock,
     change_to_tmpdir,
 ):
     """Test everest detached, optimization is running"""
@@ -220,16 +228,16 @@ def test_everest_entry_detached_running(
     start_server_mock.assert_not_called()
     start_monitor_mock.assert_not_called()
     wait_for_server_mock.assert_not_called()
-    kill_script_client_mock.assert_called_once()
-    kill_script_client_mock.reset_mock()
+    everest_script_api_mock.get_client.assert_called_once()
+    everest_script_api_mock.reset_mock()
     get_server_context_from_conn_info_mock.assert_not_called()
 
     # stop the server
     kill_entry(["config.yml"])
     stop_server_mock.assert_called_once()
     wait_for_server_to_stop_mock.assert_called_once()
-    kill_client_mock.assert_called_once()
-    kill_client_mock.reset_mock()
+    kill_api_mock.get_client.assert_called_once()
+    kill_api_mock.reset_mock()
     get_server_context_from_conn_info_mock.assert_called_once()
     wait_for_server_mock.assert_not_called()
 
@@ -237,7 +245,7 @@ def test_everest_entry_detached_running(
     assert "everest kill" in out.getvalue()
     assert "everest monitor" in out.getvalue()
     everest_entry(["config.yml"])
-    kill_script_client_mock.assert_called_once()
+    everest_script_api_mock.get_client.assert_called_once()
     start_server_mock.assert_not_called()
 
 
@@ -246,9 +254,9 @@ def test_everest_entry_detached_running(
 @patch(
     "everest.bin.monitor_script.get_experiments", return_value=["test-experiment-id"]
 )
-@patch("everest.bin.monitor_script.create_ertserver_client")
+@patch("everest.bin.monitor_script.ErtClient")
 def test_everest_entry_detached_running_monitor(
-    monitor_script_client_mock,
+    monitor_script_api_mock,
     get_experiments_mock,
     get_server_context_from_conn_info_mock,
     start_monitor_mock,
@@ -264,7 +272,7 @@ def test_everest_entry_detached_running_monitor(
     with capture_streams():
         monitor_entry(["config.yml"])
     start_monitor_mock.assert_called_once()
-    monitor_script_client_mock.assert_called_once()
+    monitor_script_api_mock.get_client.assert_called_once()
     get_server_context_from_conn_info_mock.assert_called_once()
     get_experiments_mock.assert_called_once()
 
@@ -275,9 +283,12 @@ def test_everest_entry_detached_running_monitor(
     return_value=ExperimentStatus(status=ExperimentState.completed),
 )
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
-@patch("everest.bin.monitor_script.create_ertserver_client", side_effect=TimeoutError())
+@patch(
+    "everest.bin.monitor_script.ErtClient",
+    **{"get_client.side_effect": TimeoutError()},
+)
 def test_everest_entry_monitor_already_run(
-    monitor_script_client_mock,
+    monitor_script_api_mock,
     get_server_context_from_conn_info_mock,
     get_experiment_status_mock,
     start_monitor_mock,
@@ -292,7 +303,7 @@ def test_everest_entry_monitor_already_run(
     assert "Optimization already completed." in out.getvalue()
     start_monitor_mock.assert_not_called()
     get_experiment_status_mock.assert_called()
-    monitor_script_client_mock.assert_called_once()
+    monitor_script_api_mock.get_client.assert_called_once()
     get_server_context_from_conn_info_mock.assert_not_called()
 
 
@@ -310,11 +321,11 @@ def mock_ssl(monkeypatch):
 @patch("everest.bin.everest_script.start_experiment")
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch(
-    "everest.bin.everest_script.create_ertserver_client",
-    side_effect=[TimeoutError(), MagicMock()],
+    "everest.bin.everest_script.ErtClient",
+    **{"get_client.side_effect": [TimeoutError(), MagicMock()]},
 )
 def test_exception_raised_when_server_run_fails(
-    everest_script_client_mock,
+    everest_script_api_mock,
     get_server_context_from_conn_info_mock,
     start_experiment_mock,
     start_server_mock,
@@ -338,9 +349,9 @@ def test_exception_raised_when_server_run_fails(
 @patch(
     "everest.bin.monitor_script.get_experiments", return_value=["test-experiment-id"]
 )
-@patch("everest.bin.monitor_script.create_ertserver_client")
+@patch("everest.bin.monitor_script.ErtClient")
 def test_exception_raised_when_server_run_fails_monitor(
-    monitor_script_client_mock,
+    monitor_script_api_mock,
     get_experiments_mock,
     get_server_context_from_conn_info_mock,
     start_monitor_mock,
@@ -406,8 +417,8 @@ def test_that_run_everest_prints_where_it_runs(
 
     with (
         patch(
-            "everest.bin.everest_script.create_ertserver_client",
-            side_effect=[TimeoutError(), MagicMock()],
+            "everest.bin.everest_script.ErtClient",
+            **{"get_client.side_effect": [TimeoutError(), MagicMock()]},
         ),
         patch(
             "everest.config.ServerConfig.get_server_context_from_conn_info",

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from ruamel.yaml import YAML
 
+from ert.services import SharedClient
 from ert.storage import ExperimentState
 from everest import __version__ as everest_version
 from everest.bin.main import start_everest
@@ -80,6 +81,10 @@ def test_everest_entry_run(cached_example):
     assert optimal.controls["point.z"] == pytest.approx(0.5, abs=0.05)
 
     assert optimal.objectives["distance"] == pytest.approx(0.0, abs=0.0005)
+
+    # `everest run` and `everest monitor` are separate processes in real usage, so
+    # drop the client that `run` bound to the now-stopped server.
+    SharedClient.close_client()
 
     with capture_streams():
         start_everest(["everest", "monitor", config_file])

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -23,7 +23,7 @@ from ert.config.queue_config import (
 )
 from ert.plugins import ErtRuntimePlugins
 from ert.scheduler.event import FinishedEvent
-from ert.services import create_ertserver_client
+from ert.services import ErtClient
 from ert.services.shared_client import ErtClientConnectionInfo
 from ert.utils import makedirs_if_needed
 from everest.config import EverestConfig
@@ -60,11 +60,11 @@ async def test_https_requests(change_to_tmpdir):
     makedirs_if_needed(Path(everest_config.output_dir), roll_if_exists=True)
     await start_server(everest_config, logging_level=logging.INFO)
 
-    session = create_ertserver_client(
+    client = ErtClient.get_client(
         Path(ServerConfig.get_session_dir(everest_config.output_dir)), 240
     )
-    wait_for_server(session, 240)
-    url, cert, auth = ServerConfig.get_server_context_from_conn_info(session.conn_info)
+    wait_for_server(client, 240)
+    url, cert, auth = ServerConfig.get_server_context_from_conn_info(client.conn_info)
     result = requests.get(url, verify=cert, auth=auth, proxies=PROXY)  # ruff: ignore[blocking-http-call-in-async-function]
     assert result.status_code == 200  # Request has succeeded
 
@@ -82,9 +82,9 @@ async def test_https_requests(change_to_tmpdir):
 
     # Test stopping server
     assert server_is_running(
-        *ServerConfig.get_server_context_from_conn_info(session.conn_info)
+        *ServerConfig.get_server_context_from_conn_info(client.conn_info)
     )
-    server_context = ServerConfig.get_server_context_from_conn_info(session.conn_info)
+    server_context = ServerConfig.get_server_context_from_conn_info(client.conn_info)
     if stop_server(server_context):
         wait_for_server_to_stop(server_context, 240)
         assert not server_is_running(*server_context)

--- a/tests/everest/test_everest_client.py
+++ b/tests/everest/test_everest_client.py
@@ -14,7 +14,7 @@ from starlette.responses import Response
 
 from ert.gui.experiments.experiment_client import ExperimentClient
 from ert.run_models.event import EverestBatchResultEvent, EverestStatusEvent
-from ert.services import create_ertserver_client
+from ert.services import ErtClient, SharedClient
 from ert.shared import find_available_socket
 from everest.bin.everest_script import everest_entry
 from everest.config import EverestConfig, ServerConfig
@@ -175,6 +175,7 @@ def test_that_multiple_everest_clients_can_connect_to_server(
     path, config_file, _, server_events_list = cached_example(
         "math_func/config_minimal.yml"
     )
+    SharedClient.close_client()
 
     config_path = Path(path) / config_file
     config_content = yaml.safe_load(config_path.read_text(encoding="utf-8"))
@@ -191,18 +192,21 @@ def test_that_multiple_everest_clients_can_connect_to_server(
     )
 
     everest_main_thread.start()
-    client = create_ertserver_client(
-        Path(ServerConfig.get_session_dir(ever_config.output_dir))
-    )
+    session_dir = Path(ServerConfig.get_session_dir(ever_config.output_dir))
 
-    def everserver_is_running():
+    def everserver_is_running() -> bool:
+        try:
+            api = ErtClient.get_client(session_dir, connect_timeout=1)
+        except TimeoutError:
+            return False
         return server_is_running(
-            *ServerConfig.get_server_context_from_conn_info(client.conn_info)
+            *ServerConfig.get_server_context_from_conn_info(api.conn_info)
         )
 
     wait_until(everserver_is_running, interval=1, timeout=300)
 
-    server_context = ServerConfig.get_server_context_from_conn_info(client.conn_info)
+    api = ErtClient.get_client(session_dir)
+    server_context = ServerConfig.get_server_context_from_conn_info(api.conn_info)
     url, cert, auth = server_context
 
     ssl_context = ssl.create_default_context()

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -27,8 +27,8 @@ def test_that_one_experiment_creates_one_ensemble_per_batch(cached_example):
 
 
 @patch(
-    "everest.bin.everest_script.create_ertserver_client",
-    side_effect=[TimeoutError(), MagicMock()],
+    "everest.bin.everest_script.ErtClient",
+    **{"get_client.side_effect": [TimeoutError(), MagicMock()]},
 )
 @patch("everest.config.ServerConfig.get_server_context_from_conn_info")
 @patch("everest.bin.everest_script.run_detached_monitor")

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -22,7 +22,7 @@ from ert.dark_storage.endpoints.experiment_server import (
 from ert.ensemble_evaluator import EndEvent
 from ert.run_models.event import StatusEvents
 from ert.scheduler.event import FinishedEvent
-from ert.services import create_ertserver_client
+from ert.services import ErtClient
 from ert.storage import ExperimentState
 from everest.bin.utils import get_experiment_status
 from everest.config import EverestConfig, ServerConfig
@@ -70,12 +70,10 @@ async def wait_for_server_to_complete(config):
                 return
 
     driver = await start_server(config, logging.DEBUG)
-    client = create_ertserver_client(
-        Path(ServerConfig.get_session_dir(config.output_dir))
-    )
-    wait_for_server(client, 120)
+    api = ErtClient.get_client(Path(ServerConfig.get_session_dir(config.output_dir)))
+    wait_for_server(api, 120)
     start_experiment(
-        server_context=ServerConfig.get_server_context_from_conn_info(client.conn_info),
+        server_context=ServerConfig.get_server_context_from_conn_info(api.conn_info),
         config=config,
     )
     await server_running()


### PR DESCRIPTION
**Issue**
Resolves #14244


**Approach**
This PR simply changes all occurenses of `create_ertserver_client` with the new clients initialization. Tests are also updated accordingly.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>