### PR TITLE
Fix illegal transition crash on experiment terminate

### DIFF
--- a/src/_ert/forward_model_runner/reporting/event.py
+++ b/src/_ert/forward_model_runner/reporting/event.py
@@ -34,7 +34,10 @@ from _ert.forward_model_runner.reporting.message import (
     Running,
     Start,
 )
-from _ert.forward_model_runner.reporting.statemachine import StateMachine
+from _ert.forward_model_runner.reporting.statemachine import (
+    StateMachine,
+    TransitionError,
+)
 from _ert.threading import ErtThread
 
 logger = logging.getLogger(__name__)
@@ -107,7 +110,16 @@ class Event(Reporter):
 
     def stop(self, exited_event: Exited | None = None) -> None:
         if exited_event:
-            self._statemachine.transition(exited_event)
+            try:
+                self._statemachine.transition(exited_event)
+            except TransitionError:
+                # A SIGTERM (e.g. from terminating the experiment) can arrive
+                # after all steps have completed, when reporting an Exited event
+                # is no longer legal. Skip it and shut down cleanly.
+                logger.warning(
+                    "Ignoring Exited event on stop; "
+                    "forward model already past the running state"
+                )
         self._event_queue.put(Event._sentinel)
         self._done.set()
         if self._event_publisher_thread.is_alive():

--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -13,6 +13,7 @@ from _ert.forward_model_runner.client import ClientConnectionError
 from _ert.forward_model_runner.forward_model_step import ForwardModelStep
 from _ert.forward_model_runner.reporting import Event
 from _ert.forward_model_runner.reporting.message import (
+    Checksum,
     Exited,
     Finish,
     Init,
@@ -150,6 +151,20 @@ def test_report_inconsistent_events():
         TransitionError, match=r"Illegal transition None -> \(MessageType<Finish>,\)"
     ):
         reporter.report(Finish())
+
+
+def test_that_stop_with_exited_event_after_checksum_does_not_raise():
+    fmstep1 = ForwardModelStep(
+        {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
+    )
+    with MockZMQServer() as mock_server:
+        reporter = Event(evaluator_url=mock_server.uri)
+        reporter.report(Init([fmstep1], 1, 19, ens_id="ens_id", real_id=0))
+        reporter.report(Start(fmstep1))
+        reporter.report(Running(fmstep1, ProcessTreeStatus(max_rss=100, rss=10)))
+        reporter.report(Checksum(checksum_dict={}, run_path="."))
+
+        reporter.stop(exited_event=Exited(fmstep1, exit_code=1))
 
 
 def test_report_with_failed_reporter_but_finished_jobs():

--- a/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_event_reporter.py
@@ -153,7 +153,7 @@ def test_report_inconsistent_events():
         reporter.report(Finish())
 
 
-def test_that_stop_with_exited_event_after_checksum_does_not_raise():
+def test_that_stop_with_exited_event_after_checksum_does_not_raise(caplog):
     fmstep1 = ForwardModelStep(
         {"name": "fmstep1", "stdout": "stdout", "stderr": "stderr"}, 0
     )
@@ -165,6 +165,8 @@ def test_that_stop_with_exited_event_after_checksum_does_not_raise():
         reporter.report(Checksum(checksum_dict={}, run_path="."))
 
         reporter.stop(exited_event=Exited(fmstep1, exit_code=1))
+
+    assert "Ignoring Exited event on stop" in caplog.text
 
 
 def test_report_with_failed_reporter_but_finished_jobs():


### PR DESCRIPTION
A SIGTERM from terminating an experiment can arrive after the forward model has passed the running state (e.g. during checksum reporting). The sigterm handler's Exited transition was then illegal and raised TransitionError inside the signal handler, crashing fm_dispatch.

Make Event.stop tolerate an illegal Exited transition and shut down cleanly instead.

**Issue**
Resolves #14204


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
