### PR TITLE
Skip RFT approximation for points outside the grid

### DIFF
--- a/src/ert/config/rft_config.py
+++ b/src/ert/config/rft_config.py
@@ -538,6 +538,16 @@ class RFTConfig(SimulationResponseConfig):
             how="anti",
         )
 
+        # Only attempt to approximate missing values for observations that have a
+        # well connection cell since currently observations and responses are matched
+        # based on well connection cell.
+        # Responses could be approximated for observations without a
+        # well connection cell based on its utm coordinates, however this will require
+        # a fallback mechanism to match responses to observations when
+        # the well_connection_cell is None.
+        observations_with_missing_response = observations_with_missing_response.filter(
+            pl.col("well_connection_cell").is_not_null()
+        )
         if observations_with_missing_response.is_empty():
             return responses
 

--- a/tests/ert/unit_tests/config/test_rft_config.py
+++ b/tests/ert/unit_tests/config/test_rft_config.py
@@ -1138,8 +1138,8 @@ def _rft_observation_for_approximation(
     east: float = 5.0,
     north: float = 5.0,
     tvd: float = 15.0,
-    well_connection_cell: tuple[int, int, int] = (1, 1, 3),
-    well_connection_cell_center: tuple[float, float, float] = (5.0, 5.0, 25.0),
+    well_connection_cell: tuple[int, int, int] | None = (1, 1, 3),
+    well_connection_cell_center: tuple[float, float, float] | None = (5.0, 5.0, 25.0),
     zone: str | None = "zone1",
 ) -> pl.DataFrame:
     def _make_dataframe(prop: str) -> pl.DataFrame:
@@ -1311,6 +1311,16 @@ def _expected_approximated_values(
                 "available. I.e. no zonemap file."
             ),
         ),
+        pytest.param(
+            _rft_responses_for_approximation(),
+            _rft_observation_for_approximation(
+                tvd=25.0,
+                well_connection_cell=None,  # <= observation is outside the grid
+                well_connection_cell_center=None,  # <= observation is outside the grid
+            ),
+            None,
+            id=("Test that approximation is not done when observation is outside grid"),
+        ),
     ],
 )
 def test_rft_value_approximation(
@@ -1322,9 +1332,15 @@ def test_rft_value_approximation(
         responses=rft_responses, observations=rft_observations
     )
 
-    approximated_values = responses_with_approximations.filter(
-        pl.col("well_connection_cell") == [1, 1, 3]  # The cell of the observation
-    ).collect()
+    # rechunk before the anti-join: polars raises a PanicException on multi-chunk
+    # frames when a join on Array columns yields an empty result.
+    # See: https://github.com/pola-rs/polars/issues/29093
+    rft_responses = rft_responses.collect()
+    approximated_values = (
+        responses_with_approximations.collect()
+        .rechunk()
+        .join(rft_responses, on=rft_responses.columns, how="anti")
+    )
 
     assert dict(
         zip(


### PR DESCRIPTION
Observations whose location falls outside the grid have well_connection_cell and well_connection_cell_center None. Attempting to calculate an approximated response for a point with coordinates None would raise a TypeError. Since responses and observations are matched on well_connection_cell, an approximated response would not be matched to any observation. Approximation is therefore skipped for such points.

**Issue**
Resolves #14267 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [x] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
