### PR TITLE
Revert: using non-localizated observations in distance based localiza…

### DIFF
--- a/src/ert/analysis/_update_strategies/_distance.py
+++ b/src/ert/analysis/_update_strategies/_distance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from datetime import timedelta
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
 
     from ._protocol import ObservationContext
 
+logger = logging.getLogger(__name__)
+
 
 class DistanceLocalizationUpdate:
     """Distance-based localization for Field and Surface parameters."""
@@ -46,32 +49,42 @@ class DistanceLocalizationUpdate:
         self._obs_loc: ObservationLocations | None = None
         self._smoother: LocalizedESMDA | None = None
         self._ensemble_size: int = 0
-        self._num_obs: int = 0
-        self._location_mask: npt.NDArray[np.bool_] | None = None
 
     def prepare(self, obs_context: ObservationContext) -> None:
+        if obs_context.observation_locations is None:
+            raise RuntimeError(
+                "Distance localization requires observation_locations in context"
+            )
         self._obs_loc = obs_context.observation_locations
         self._ensemble_size = obs_context.ensemble_size
-        self._num_obs = obs_context.num_observations
 
-        if self._obs_loc is None:
-            self._location_mask = np.zeros(self._num_obs, dtype=bool)
-        else:
-            self._location_mask = self._obs_loc.location_mask
+        mask = self._obs_loc.location_mask
+        responses = obs_context.responses[mask, :]
+        obs_values = obs_context.observation_values[mask]
+        obs_errors = obs_context.observation_errors[mask]
+        observation_perturbations = obs_context.observation_perturbations[mask, :]
+        excluded_observations = obs_context.num_observations - obs_values.shape[0]
+        if excluded_observations:
+            logger.info(
+                "Distance localization excluded %d observations without location data; "
+                "%d observations with locations will be assimilated",
+                excluded_observations,
+                obs_values.shape[0],
+            )
 
         self._smoother = LocalizedESMDA(
-            covariance=obs_context.observation_errors**2,
-            observations=obs_context.observation_values,
+            covariance=obs_errors**2,
+            observations=obs_values,
             alpha=1,
             # Observation perturbations are supplied explicitly below, so no
             # smoother RNG is used.
             seed=None,
         )
         self._smoother.prepare_assimilation(
-            Y=obs_context.responses,
+            Y=responses,
             truncation=self._enkf_truncation,
             overwrite=False,
-            observation_perturbations=obs_context.observation_perturbations,
+            observation_perturbations=observation_perturbations,
         )
 
     def update(
@@ -80,12 +93,13 @@ class DistanceLocalizationUpdate:
         param_config: ParameterConfig,
         non_zero_variance_mask: npt.NDArray[np.bool_],
     ) -> npt.NDArray[np.floating]:
-        if self._smoother is None or self._location_mask is None:
+        if self._obs_loc is None or self._smoother is None:
             raise RuntimeError("prepare() must be called before update()")
 
         num_params = param_ensemble.shape[0]
-        num_located_obs = int(np.count_nonzero(self._location_mask))
-        batch_size = calculate_localization_batch_size(num_params, self._num_obs)
+        batch_size = calculate_localization_batch_size(
+            num_params, self._obs_loc.xpos.shape[0]
+        )
         batches = split_by_batch_size(np.arange(0, num_params), batch_size)
         num_batches = len(batches)
 
@@ -95,8 +109,7 @@ class DistanceLocalizationUpdate:
                 msg=f"Updating {param_config.name} ({param_config.type.upper()}) "
                 f"using distance-based localization, "
                 f"{num_params} parameters, "
-                f"{self._num_obs} observations "
-                f"({num_located_obs} with locations), "
+                f"{self._obs_loc.xpos.shape[0]} observations, "
                 f"{self._ensemble_size} realizations"
                 f"{batch_info}"
             )
@@ -125,18 +138,6 @@ class DistanceLocalizationUpdate:
 
         return result
 
-    def _full_localization_matrix(
-        self,
-        num_params: int,
-        located_rho: npt.NDArray[np.floating] | None,
-    ) -> npt.NDArray[np.floating]:
-        assert self._location_mask is not None
-
-        rho = np.ones((num_params, self._num_obs), dtype=np.float32)
-        if located_rho is not None:
-            rho[:, self._location_mask] = located_rho.astype(np.float32, copy=False)
-        return rho
-
     def _update_field(
         self,
         param_ensemble: npt.NDArray[np.floating],
@@ -144,19 +145,8 @@ class DistanceLocalizationUpdate:
         batches: list[npt.NDArray[np.int_]],
         non_zero_variance_mask: npt.NDArray[np.bool_],
     ) -> npt.NDArray[np.floating]:
-        assert self._smoother is not None
-        assert self._location_mask is not None
-
-        # No located observations; use global assimilation
-        if not self._location_mask.any():
-            X = param_ensemble[non_zero_variance_mask]
-            param_ensemble[non_zero_variance_mask] = self._smoother.assimilate_batch(
-                X=X,
-                overwrite=True,
-            )
-            return param_ensemble
-
         assert self._obs_loc is not None
+        assert self._smoother is not None
 
         ertbox = param_config.ertbox_params
         if ertbox.xinc is None:
@@ -193,7 +183,7 @@ class DistanceLocalizationUpdate:
             obs_perp_range=self._obs_loc.main_range,
             obs_anisotropy_angle=ellipse_rotation,
             axis_orientation=ertbox.axis_orientation,
-        )
+        ).astype(np.float32, copy=False)
 
         rho_2d = rho_matrix.reshape(ertbox.nx * ertbox.ny, -1)
 
@@ -202,9 +192,7 @@ class DistanceLocalizationUpdate:
             if update_idx.size == 0:
                 continue
             xy_idx = update_idx // ertbox.nz
-            rho_batch = self._full_localization_matrix(
-                len(update_idx), rho_2d[xy_idx, :]
-            )
+            rho_batch = rho_2d[xy_idx, :]
 
             def localization_callback(
                 K: npt.NDArray[np.floating],
@@ -228,19 +216,8 @@ class DistanceLocalizationUpdate:
         batches: list[npt.NDArray[np.int_]],
         non_zero_variance_mask: npt.NDArray[np.bool_],
     ) -> npt.NDArray[np.floating]:
-        assert self._smoother is not None
-        assert self._location_mask is not None
-
-        # No located observations; use global assimilation
-        if not self._location_mask.any():
-            X = param_ensemble[non_zero_variance_mask]
-            param_ensemble[non_zero_variance_mask] = self._smoother.assimilate_batch(
-                X=X,
-                overwrite=True,
-            )
-            return param_ensemble
-
         assert self._obs_loc is not None
+        assert self._smoother is not None
 
         xpos, ypos = transform_positions_to_local_field_coordinates(
             (param_config.xori, param_config.yori),
@@ -270,16 +247,14 @@ class DistanceLocalizationUpdate:
             obs_perp_range=self._obs_loc.main_range,
             obs_anisotropy_angle=rotation_angle,
             axis_orientation=AxisOrientation.LEFT_HANDED,
-        )
+        ).astype(np.float32, copy=False)
 
         rho_flat = rho_matrix.reshape(-1, rho_matrix.shape[-1])
         for param_batch_idx in batches:
             update_idx = param_batch_idx[non_zero_variance_mask[param_batch_idx]]
             if update_idx.size == 0:
                 continue
-            rho_batch = self._full_localization_matrix(
-                len(update_idx), rho_flat[update_idx, :]
-            )
+            rho_batch = rho_flat[update_idx, :]
 
             def localization_callback(
                 K: npt.NDArray[np.floating],

--- a/tests/ert/unit_tests/analysis/test_distance_localization.py
+++ b/tests/ert/unit_tests/analysis/test_distance_localization.py
@@ -1,6 +1,4 @@
-import iterative_ensemble_smoother as ies
 import numpy as np
-import pytest
 
 from ert.analysis._update_strategies._distance import DistanceLocalizationUpdate
 from ert.analysis._update_strategies._protocol import (
@@ -159,161 +157,9 @@ def test_that_distance_localization_updates_all_z_layers_at_observation_xy(
         )
 
 
-@pytest.mark.parametrize(
-    ("param_type", "param_config", "n_params"),
-    [
-        (Field, _field_config(3, 3, 1), 9),
-        (SurfaceConfig, _surface_config(3, 3), 9),
-    ],
-)
-def test_that_unlocated_observations_are_assimilated_globally_for_distance_update(
-    param_type,
-    param_config,
-    n_params,
+def test_that_unlocated_observations_are_excluded_from_distance_update(
+    monkeypatch, caplog
 ):
-    n_real = 30
-    rng = np.random.default_rng(123)
-    param_ensemble = rng.standard_normal((n_params, n_real))
-
-    responses = np.vstack(
-        [
-            param_ensemble[0],
-            param_ensemble[-1],
-        ]
-    )
-    obs_values = np.array([3.0, -2.0])
-    obs_errors = np.array([0.2, 0.3])
-    observation_perturbations = (
-        rng.standard_normal(size=responses.shape) * obs_errors[:, np.newaxis]
-    )
-
-    obs_context = ObservationContext(
-        responses=responses,
-        observation_values=obs_values,
-        observation_errors=obs_errors,
-        observation_perturbations=observation_perturbations,
-        observation_locations=None,
-    )
-
-    updater = DistanceLocalizationUpdate(
-        enkf_truncation=0.99,
-        param_type=param_type,
-        progress_callback=_noop_callback,
-    )
-    updater.prepare(obs_context)
-
-    posterior = updater.update(
-        param_ensemble=param_ensemble.copy(),
-        param_config=param_config,
-        non_zero_variance_mask=np.ones(n_params, dtype=bool),
-    )
-
-    smoother = ies.ESMDA(
-        covariance=obs_errors**2,
-        observations=obs_values,
-        alpha=1,
-        seed=None,
-    )
-    smoother.prepare_assimilation(
-        Y=responses,
-        truncation=0.99,
-        overwrite=False,
-        observation_perturbations=observation_perturbations,
-    )
-    expected = smoother.assimilate_batch(X=param_ensemble.copy(), overwrite=True)
-
-    np.testing.assert_allclose(posterior, expected)
-
-
-@pytest.mark.parametrize(
-    ("param_type", "param_config", "n_params"),
-    [
-        (Field, _field_config(3, 3, 1), 9),
-        (SurfaceConfig, _surface_config(3, 3), 9),
-    ],
-)
-def test_that_unlocated_distance_update_respects_non_zero_variance_mask(
-    param_type,
-    param_config,
-    n_params,
-) -> None:
-    n_real = 30
-    rng = np.random.default_rng(124)
-    param_ensemble = rng.standard_normal((n_params, n_real))
-    prior = param_ensemble.copy()
-
-    responses = np.vstack([param_ensemble[0], param_ensemble[-1]])
-    obs_errors = np.array([0.2, 0.3])
-    obs_context = ObservationContext(
-        responses=responses,
-        observation_values=np.array([3.0, -2.0]),
-        observation_errors=obs_errors,
-        observation_perturbations=rng.standard_normal(size=responses.shape)
-        * obs_errors[:, np.newaxis],
-        observation_locations=None,
-    )
-
-    non_zero_variance_mask = np.ones(n_params, dtype=bool)
-    non_zero_variance_mask[0] = False
-
-    updater = DistanceLocalizationUpdate(
-        enkf_truncation=0.99,
-        param_type=param_type,
-        progress_callback=_noop_callback,
-    )
-    updater.prepare(obs_context)
-
-    posterior = updater.update(
-        param_ensemble=param_ensemble,
-        param_config=param_config,
-        non_zero_variance_mask=non_zero_variance_mask,
-    )
-
-    np.testing.assert_allclose(posterior[0, :], prior[0, :])
-    assert not np.allclose(posterior[1:, :], prior[1:, :])
-
-
-def test_that_distance_localization_matrix_uses_float32() -> None:
-    rng = np.random.default_rng(125)
-    updater = DistanceLocalizationUpdate(
-        enkf_truncation=0.99,
-        param_type=Field,
-        progress_callback=_noop_callback,
-    )
-    obs_context = ObservationContext(
-        responses=rng.standard_normal((2, 10)),
-        observation_values=np.ones(2),
-        observation_errors=np.ones(2),
-        observation_perturbations=np.zeros((2, 10)),
-        observation_locations=ObservationLocations(
-            xpos=np.array([0.0]),
-            ypos=np.array([0.0]),
-            main_range=np.array([1.0]),
-            location_mask=np.array([True, False]),
-        ),
-    )
-    updater.prepare(obs_context)
-
-    rho = updater._full_localization_matrix(
-        3,
-        np.array([[0.5], [0.25], [0.0]], dtype=np.float64),
-    )
-
-    assert rho.dtype == np.float32
-    np.testing.assert_allclose(rho[:, 0], np.array([0.5, 0.25, 0.0]))
-    np.testing.assert_allclose(rho[:, 1], np.ones(3))
-
-
-def test_that_mixed_unlocated_observations_update_distant_field_parameters(
-    monkeypatch,
-):
-    """
-    Verifies that unlocated observations (location_mask=False) update all
-    correlated parameters globally, even when mixed with located observations
-    that use distance localization. The distant cell (3, 3) is outside the
-    correlation range of the located observation at (0.5, 0.5), but should
-    still be updated because it correlates with the unlocated observation.
-    """
     nx, ny, nz = 4, 4, 1
     n_params = nx * ny * nz
     n_real = 40
@@ -358,7 +204,12 @@ def test_that_mixed_unlocated_observations_update_distant_field_parameters(
         param_type=Field,
         progress_callback=_noop_callback,
     )
-    updater.prepare(obs_context)
+    with caplog.at_level("INFO", logger="ert.analysis._update_strategies._distance"):
+        updater.prepare(obs_context)
+
+    assert "Distance localization excluded 1 observations without location data" in (
+        caplog.text
+    )
 
     posterior = updater.update(
         param_ensemble=param_ensemble.copy(),
@@ -367,70 +218,10 @@ def test_that_mixed_unlocated_observations_update_distant_field_parameters(
     )
 
     posterior_3d = posterior.reshape(nx, ny, nz, n_real)
-    assert not np.allclose(
+    assert np.allclose(
         posterior_3d[distant_x, distant_y, 0, :], prior_3d[distant_x, distant_y, 0, :]
     )
-
-
-def test_that_mixed_unlocated_observations_update_distant_surface_parameters(
-    monkeypatch,
-):
-    ncol, nrow = 4, 4
-    n_params = ncol * nrow
-    n_real = 40
-    rng = np.random.default_rng(321)
-    param_ensemble = rng.standard_normal((n_params, n_real))
-
-    prior_2d = param_ensemble.reshape(ncol, nrow, n_real)
-    distant_x, distant_y = 3, 3
-    responses = np.vstack(
-        [
-            prior_2d[0, 0, :],
-            prior_2d[distant_x, distant_y, :],
-        ]
-    )
-    obs_values = np.array([2.0, -4.0])
-    obs_errors = np.array([0.1, 0.1])
-    observation_perturbations = (
-        rng.standard_normal(size=responses.shape) * obs_errors[:, np.newaxis]
-    )
-
-    obs_context = ObservationContext(
-        responses=responses,
-        observation_values=obs_values,
-        observation_errors=obs_errors,
-        observation_perturbations=observation_perturbations,
-        observation_locations=ObservationLocations(
-            xpos=np.array([0.5]),
-            ypos=np.array([0.5]),
-            main_range=np.array([1.0]),
-            location_mask=np.array([True, False]),
-        ),
-    )
-
-    forced_batch_size = 5
-    monkeypatch.setattr(
-        "ert.analysis._update_strategies._distance.calculate_localization_batch_size",
-        lambda _num_params, _num_obs: forced_batch_size,
-    )
-
-    updater = DistanceLocalizationUpdate(
-        enkf_truncation=0.99,
-        param_type=SurfaceConfig,
-        progress_callback=_noop_callback,
-    )
-    updater.prepare(obs_context)
-
-    posterior = updater.update(
-        param_ensemble=param_ensemble.copy(),
-        param_config=_surface_config(ncol, nrow),
-        non_zero_variance_mask=np.ones(n_params, dtype=bool),
-    )
-
-    posterior_2d = posterior.reshape(ncol, nrow, n_real)
-    assert not np.allclose(
-        posterior_2d[distant_x, distant_y, :], prior_2d[distant_x, distant_y, :]
-    )
+    assert not np.allclose(posterior_3d[0, 0, 0, :], prior_3d[0, 0, 0, :])
 
 
 def test_that_distance_localization_batch_size_does_not_change_result(


### PR DESCRIPTION
…tion

When using observations without locations, they will get full scaling weights in distance based localization and thus dominate the update step. Therefore this reverts pieces of the commit that includes those observations.
Additionally, this adds logging excluded observations.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
