### PR TITLE
Remove redundant drop statement

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -179,9 +179,7 @@ def perform_ensemble_update(
         std_cutoff=observation_settings.outlier_settings.std_cutoff,
         global_scaling=global_scaling,
     )
-    smoother_snapshot.observations_and_responses = preprocessed_data.drop(
-        [*map(str, iens_active_index), "response_key"]
-    ).select(
+    smoother_snapshot.observations_and_responses = preprocessed_data.select(
         "observation_key",
         "index",
         "observations",


### PR DESCRIPTION
**Approach**
Since the drop is followed by a select with a fixed list of column names, it is redundant.
Verified this with a local hypothesis test and a performance test to exclude that there
might actually be a reason to keep the drop.
The hypothesis test verified that removing the drop yields the same result.
The performance test showed that removing the drop improves performance slightly.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
