### PR TITLE
Avoid blinking cursor in screenshot test

### DIFF
--- a/tests/ert/ui_tests/gui/test_docs_screenshots.py
+++ b/tests/ert/ui_tests/gui/test_docs_screenshots.py
@@ -449,6 +449,7 @@ def test_that_load_results_manually_screenshot_is_up_to_date(
         run_path_edit = get_child(panel, TextBox, name="runpath_edit_lrm")
         current_directory = str(Path.cwd())
         run_path_edit.setText(run_path_edit.get_text.replace(current_directory, "."))
+        run_path_edit.clearFocus()
 
         gui_evaluator.compare_img_with_gui(
             "load_results_manually.png",


### PR DESCRIPTION
By clearing focus, the cursor should not be visible.

**Issue**
Resolves #14306 

**Approach**
🧹 

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [x] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
