### PR TITLE
Update documentation on reservoir simulators

### DIFF
--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -237,26 +237,33 @@ class Eclipse100(ForwardModelStepPlugin):
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:
         return ForwardModelStepDocumentation(
-            description="The Eclipse 100 black-oil reservoir simulator from SLB",
+            description="""The Eclipse 100 black-oil reservoir simulator from SLB.
+
+Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
+correct number of CPUs. If the :code:`PARALLEL` keyword is set up/computed
+during the forward model, then :code:`NUM_CPU` must be set in the Ert config
+for correct configuration of CPU usage.
+            """,
             category="simulators.reservoir",
             examples="""
-The version, number of cpu, and whether or not to ignore errors and whether
-or not to produce `YOUR_CASE_NAME.h5` output files can be configured in the
-configuration file when adding the job, as such:
+The version, whether or not to ignore errors and whether or not to produce
+:code:`YOUR_CASE_NAME.h5` output files can be configured in the configuration
+file when adding the job, as such:
 
 
 .. code-block:: bash
 
-    FORWARD_MODEL ECLIPSE100(<ECLBASE>, <VERSION>=xxxx, \
-        <OPTS>={"--ignore-errors", "--summary-conversion"})
+    FORWARD_MODEL ECLIPSE100(<ECLBASE>, <VERSION>=xxxx, \\
+        <OPTS>="--ignore-errors --summary-conversion")
 
 The :code:`OPTS` argument is optional and can be removed, fully or partially.
 In absence of :code:`--ignore-errors` eclipse will fail on errors.
 Adding the flag :code:`--ignore-errors` will result in eclipse ignoring errors.
 
-And in absence of :code:`--summary-conversions` eclipse will run without producing
-`YOUR_CASE_NAME.h5` output files. Add flag :code:`--summary-conversions` to produce
-`YOUR_CASE_NAME.h5` output files.
+And in absence of :code:`--summary-conversions` eclipse will run without
+producing :code:`YOUR_CASE_NAME.h5` output files. Add flag
+:code:`--summary-conversion` to produce :code:`YOUR_CASE_NAME.h5` output
+files.
 """,
         )
 
@@ -305,18 +312,24 @@ class Eclipse300(ForwardModelStepPlugin):
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:
         return ForwardModelStepDocumentation(
-            description="The Eclipse 300 compositional reservoir simulator from SLB",
+            description="""The Eclipse 300 compositional reservoir simulator from SLB.
+
+Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
+correct number of CPUs. If the :code:`PARALLEL` keyword is set up/computed
+during the forward model, then :code:`NUM_CPU` must be set in the Ert config
+for correct configuration of CPU usage.
+""",
             category="simulators.reservoir",
             examples="""
-The version, number of cpu and whether or not to ignore errors can
-be configured in the configuration file when adding the job, as such:
+The version and whether or not to ignore errors can be configured in the
+configuration file when adding the step, as such:
 
 .. code-block:: bash
 
     FORWARD_MODEL ECLIPSE300(<ECLBASE>, <VERSION>=xxxx, <OPTS>="--ignore-errors")
 
 The :code:`OPTS` argument is optional and can be removed, thus running eclipse
-without ignoring errors
+without ignoring errors.
 """,
         )
 
@@ -368,15 +381,11 @@ class Flow(ForwardModelStepPlugin):
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:
         return ForwardModelStepDocumentation(
-            category="simulators.reservoir",
-            examples="""
-.. code-block:: bash
+            description="""Forward model for OPM Flow simulator.
 
-    FORWARD_MODEL FLOW(<ECLBASE>, <VERSION>=xxx, <OPTS>="--ignore-errors")
-
-The :code:`OPTS` argument is optional and can be skipped. :code:`ECLBASE` can
-also be defaulted. Multiple options in :code:`OPTS` can be supplied by
-separating them with a space.
+Flow will be run with the number of CPUs defined either through
+the keyword :code:`NUM_CPU` or parsed from the :code:`PARALLEL` keyword
+in the DATA file if :code:`NUM_CPU` is not set.
 
 ERT will be able to run the flow simulator if there is an executable named
 :code:`flow` or :code:`flowrun` found in the user's :code:`$PATH` environment
@@ -385,9 +394,22 @@ variable.
 If :code:`flowrun` is found, it will take precedence, and then it will be
 possible to select the version of flow to use by setting :code:`<VERSION>`.
 Available versions are verified towards what :code:`flowrun --report-versions`
-returns.
+returns. An appropriate setting for the threads parameter (per CPU core)
+will automatically be selected if :code:`flowrun` is found.
+
+Any options that should be forwarded to the simulator should be included
+in the :code:`<OPTS>` argument, multiple arguments can be supplied by
+separating them with a space.
 """,
-            description="""Forward model for OPM Flow simulator""",
+            category="simulators.reservoir",
+            examples="""
+.. code-block:: bash
+
+    FORWARD_MODEL FLOW(<ECLBASE>, <VERSION>=rc46, <OPTS>="--ignore-errors")
+
+The :code:`OPTS` argument is optional and can be skipped. :code:`ECLBASE` can
+also be defaulted.
+""",
         )
 
 

--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -239,10 +239,11 @@ class Eclipse100(ForwardModelStepPlugin):
         return ForwardModelStepDocumentation(
             description="""The Eclipse 100 black-oil reservoir simulator from SLB.
 
-:ref:`DATA_FILE <data_file>` Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
-correct number of CPUs. If the :code:`PARALLEL` keyword is set up/computed
-during the forward model, then :code:`NUM_CPU` must be set in the Ert config
-for correct configuration of CPU usage.
+If you have used the :ref:`DATA_FILE <data_file>` keyword Ert will parse the
+DATA-file for the :code:`PARALLEL` keyword and set up the correct number of
+CPUs. If the :code:`PARALLEL` keyword is set up/computed during the forward
+model, then :code:`NUM_CPU` must be set in the Ert config for correct
+configuration of CPU usage.
             """,
             category="simulators.reservoir",
             examples="""
@@ -314,10 +315,11 @@ class Eclipse300(ForwardModelStepPlugin):
         return ForwardModelStepDocumentation(
             description="""The Eclipse 300 compositional reservoir simulator from SLB.
 
-Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
-correct number of CPUs. If the :code:`PARALLEL` keyword is set up/computed
-during the forward model, then :code:`NUM_CPU` must be set in the Ert config
-for correct configuration of CPU usage.
+If you have used the :ref:`DATA_FILE <data_file>` keyword Ert will parse the
+DATA-file for the :code:`PARALLEL` keyword and set up the correct number of
+CPUs. If the :code:`PARALLEL` keyword is set up/computed during the forward
+model, then :code:`NUM_CPU` must be set in the Ert config for correct
+configuration of CPU usage.
 """,
             category="simulators.reservoir",
             examples="""
@@ -383,9 +385,10 @@ class Flow(ForwardModelStepPlugin):
         return ForwardModelStepDocumentation(
             description="""Forward model for OPM Flow simulator.
 
-Flow will be run with the number of CPUs defined either through
-the keyword :code:`NUM_CPU` or parsed from the :code:`PARALLEL` keyword
-in the DATA file if :code:`NUM_CPU` is not set.
+Flow will be run with the number of CPUs defined either through the keyword
+:code:`NUM_CPU` or parsed from the :code:`PARALLEL` keyword in the DATA file
+(requires usage of the :ref:`DATA_FILE <data_file>` keyword) if :code:`NUM_CPU`
+is not set.
 
 ERT will be able to run the flow simulator if there is an executable named
 :code:`flow` or :code:`flowrun` found in the user's :code:`$PATH` environment

--- a/src/ert/plugins/hook_implementations/forward_model_steps.py
+++ b/src/ert/plugins/hook_implementations/forward_model_steps.py
@@ -239,7 +239,7 @@ class Eclipse100(ForwardModelStepPlugin):
         return ForwardModelStepDocumentation(
             description="""The Eclipse 100 black-oil reservoir simulator from SLB.
 
-Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
+:ref:`DATA_FILE <data_file>` Ert will parse the DATA-file for the :code:`PARALLEL` keyword and set up the
 correct number of CPUs. If the :code:`PARALLEL` keyword is set up/computed
 during the forward model, then :code:`NUM_CPU` must be set in the Ert config
 for correct configuration of CPU usage.


### PR DESCRIPTION
Explicitly state how NUM_CPU should be handled for Eclispe and Flow.

Fix backslash rendering bug for multiline Ert config examples

Fix erroneous example on supplying multiple options to Eclipse 100. Curly braces do not work.

**Issue**
Resolves gruff

**Approach**
🧠 ✍🏻 


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [x] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
