### PR TITLE
Log param update strategies

### DIFF
--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import warnings
+from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, TextIO
 
@@ -338,11 +339,25 @@ def build_strategy_map(
     strategy_handlers = _build_strategy_handlers(strategies)
 
     strategy_map = {}
+    clustered_strategy_summary = defaultdict(list)
     for param_name in parameters:
         param_cfg = param_configs[param_name]
         strategy = _resolve_strategy(param_cfg, param_name, strategy_handlers)
         if strategy is not None:
             strategy_map[param_name] = strategy
+
+        strategy_key = (
+            param_cfg.update_strategy.name
+            if param_cfg.update_strategy is not None
+            else "none"
+        )
+        clustered_strategy_summary[strategy_key].append(param_name)
+
+    for strategy_name, params in clustered_strategy_summary.items():
+        logger.info(
+            f"Update strategy '{strategy_name}' for "
+            f"parameters '{', '.join(sorted(params))}'"
+        )
 
     return strategy_map
 

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -329,58 +329,92 @@ def build_strategy_map(
     dict[str, UpdateStrategy]
         Mapping from parameter group names to update strategies.
     """
-    if not progress_callback:
-        progress_callback = noop_progress_callback
+    progress_callback = progress_callback or noop_progress_callback
 
-    strategy_map: dict[str, UpdateStrategy] = {}
-
-    field_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, Field, progress_callback, experiment
+    # Create strategies with shared configuration
+    strategies = _create_strategies(
+        enkf_truncation, correlation_threshold, progress_callback, experiment
     )
+    strategy_handlers = _build_strategy_handlers(strategies)
 
-    surface_distance_strategy = DistanceLocalizationUpdate(
-        enkf_truncation, SurfaceConfig, progress_callback, experiment
-    )
-
-    global_strategy = GlobalESUpdate(
-        enkf_truncation,
-        progress_callback,
-    )
-
-    adaptive_localization_strategy = AdaptiveLocalizationUpdate(
-        correlation_threshold,
-        enkf_truncation,
-        progress_callback,
-    )
-
+    strategy_map = {}
     for param_name in parameters:
         param_cfg = param_configs[param_name]
-        if isinstance(param_cfg, Field):
-            if param_cfg.update_strategy == LocalizationType.DISTANCE:
-                strategy_map[param_name] = field_distance_strategy
-            elif param_cfg.update_strategy == LocalizationType.ADAPTIVE:
-                strategy_map[param_name] = adaptive_localization_strategy
-            elif param_cfg.update_strategy == LocalizationType.GLOBAL:
-                strategy_map[param_name] = global_strategy
-        elif isinstance(param_cfg, SurfaceConfig):
-            if param_cfg.update_strategy == LocalizationType.DISTANCE:
-                strategy_map[param_name] = surface_distance_strategy
-            elif param_cfg.update_strategy == LocalizationType.ADAPTIVE:
-                strategy_map[param_name] = adaptive_localization_strategy
-            elif param_cfg.update_strategy == LocalizationType.GLOBAL:
-                strategy_map[param_name] = global_strategy
-        elif isinstance(param_cfg, GenKwConfig):
-            if param_cfg.update_strategy == LocalizationType.ADAPTIVE:
-                strategy_map[param_name] = adaptive_localization_strategy
-            elif param_cfg.update_strategy == LocalizationType.GLOBAL:
-                strategy_map[param_name] = global_strategy
-        else:
-            logger.warning(
-                f"Parameter '{param_name}' has unrecognized config type "
-                f"'{type(param_cfg).__name__}'. Parameter will not be updated"
-            )
+        strategy = _resolve_strategy(param_cfg, param_name, strategy_handlers)
+        if strategy is not None:
+            strategy_map[param_name] = strategy
 
     return strategy_map
+
+
+def _create_strategies(
+    enkf_truncation: float,
+    correlation_threshold: Callable[[int], float],
+    progress_callback: Callable[[AnalysisEvent], None],
+    experiment: LocalExperiment | None,
+) -> dict[str, UpdateStrategy]:
+    return {
+        "field_distance": DistanceLocalizationUpdate(
+            enkf_truncation, Field, progress_callback, experiment
+        ),
+        "surface_distance": DistanceLocalizationUpdate(
+            enkf_truncation, SurfaceConfig, progress_callback, experiment
+        ),
+        "global": GlobalESUpdate(enkf_truncation, progress_callback),
+        "adaptive": AdaptiveLocalizationUpdate(
+            correlation_threshold, enkf_truncation, progress_callback
+        ),
+    }
+
+
+def _build_strategy_handlers(
+    strategies: dict[str, UpdateStrategy],
+) -> dict[type[ParameterConfig], dict[LocalizationType, UpdateStrategy]]:
+    return {
+        Field: {
+            LocalizationType.DISTANCE: strategies["field_distance"],
+            LocalizationType.ADAPTIVE: strategies["adaptive"],
+            LocalizationType.GLOBAL: strategies["global"],
+        },
+        SurfaceConfig: {
+            LocalizationType.DISTANCE: strategies["surface_distance"],
+            LocalizationType.ADAPTIVE: strategies["adaptive"],
+            LocalizationType.GLOBAL: strategies["global"],
+        },
+        GenKwConfig: {
+            LocalizationType.ADAPTIVE: strategies["adaptive"],
+            LocalizationType.GLOBAL: strategies["global"],
+        },
+    }
+
+
+def _resolve_strategy(
+    param_cfg: ParameterConfig,
+    param_name: str,
+    strategy_handlers: dict[
+        type[ParameterConfig], dict[LocalizationType, UpdateStrategy]
+    ],
+) -> UpdateStrategy | None:
+    if param_cfg.update_strategy is None:
+        return None
+
+    handler = next(
+        (
+            candidate_handler
+            for config_type, candidate_handler in strategy_handlers.items()
+            if isinstance(param_cfg, config_type)
+        ),
+        None,
+    )
+
+    if handler is None:
+        logger.warning(
+            f"Parameter '{param_name}' has unrecognized config type "
+            f"'{type(param_cfg).__name__}'. Parameter will not be updated"
+        )
+        return None
+
+    return strategy_handlers[type(param_cfg)].get(param_cfg.update_strategy)
 
 
 def smoother_update(

--- a/src/ert/analysis/_es_update.py
+++ b/src/ert/analysis/_es_update.py
@@ -414,7 +414,14 @@ def _resolve_strategy(
         )
         return None
 
-    return strategy_handlers[type(param_cfg)].get(param_cfg.update_strategy)
+    strategy = handler.get(param_cfg.update_strategy)
+    if strategy is None:
+        logger.warning(
+            f"Update strategy '{param_cfg.update_strategy.name}' is not supported for "
+            f"parameter '{param_name}' of type '{type(param_cfg).__name__}'. "
+            "Parameter will not be updated"
+        )
+    return strategy
 
 
 def smoother_update(

--- a/tests/ert/unit_tests/analysis/test_es_update.py
+++ b/tests/ert/unit_tests/analysis/test_es_update.py
@@ -1,8 +1,9 @@
 import io
 import logging
+import re
 from contextlib import ExitStack as does_not_raise
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import polars as pl
@@ -525,6 +526,43 @@ def test_that_alpha_can_be_used_for_outlier_detection(
         assert (
             posterior_update.observations_and_responses["status"].to_list() == expected
         )
+
+
+@pytest.mark.parametrize("update_strategy", LocalizationType)
+def test_that_update_strategies_are_logged_in_clusters(caplog, update_strategy):
+    def make_param(strategy):
+        return GenKwConfig(
+            name="KEY",
+            group="GROUP",
+            update_strategy=strategy,
+            distribution={"name": "uniform", "min": 0, "max": 1},
+        )
+
+    param_configs = {
+        "a": make_param(update_strategy),
+        "b": make_param(update_strategy),
+        "c": make_param(None),
+    }
+
+    with caplog.at_level(logging.INFO):
+        build_strategy_map(
+            parameters=["a", "b", "c"],
+            param_configs=param_configs,
+            enkf_truncation=0.5,
+            correlation_threshold=Mock(),
+        )
+
+    strategy_name = update_strategy.name.lower()
+
+    assert any(
+        re.search(rf"update strategy.*?{strategy_name}.*?'a, b'", msg, re.IGNORECASE)
+        for msg in caplog.messages
+    )
+
+    assert any(
+        re.search(r"update strategy.*?none.*?'c'", msg, re.IGNORECASE)
+        for msg in caplog.messages
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue**
Resolves #14260 


**Approach**
Adds the following logs (triggered when running poly):
```
INFO - Update strategy 'GLOBAL' for parameters 'a, b, c' 
```


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)
