### PR TITLE
Add seismic misfit map and observations map

### DIFF
--- a/src/ert/gui/plotting/ert_plots/__init__.py
+++ b/src/ert/gui/plotting/ert_plots/__init__.py
@@ -1,6 +1,7 @@
 from .cesp import CrossEnsembleStatisticsPlot
 from .distribution import DistributionPlot
 from .histogram import HistogramPlot
+from .misfit_map import MisfitMapPlot
 from .misfits import MisfitsPlot
 from .statistics import StatisticsPlot
 from .std_dev import StdDevPlot
@@ -9,6 +10,7 @@ __all__ = [
     "CrossEnsembleStatisticsPlot",
     "DistributionPlot",
     "HistogramPlot",
+    "MisfitMapPlot",
     "MisfitsPlot",
     "StatisticsPlot",
     "StdDevPlot",

--- a/src/ert/gui/plotting/ert_plots/__init__.py
+++ b/src/ert/gui/plotting/ert_plots/__init__.py
@@ -3,6 +3,7 @@ from .distribution import DistributionPlot
 from .histogram import HistogramPlot
 from .misfit_map import MisfitMapPlot
 from .misfits import MisfitsPlot
+from .observations_map import ObservationsMapPlot
 from .statistics import StatisticsPlot
 from .std_dev import StdDevPlot
 
@@ -12,6 +13,7 @@ __all__ = [
     "HistogramPlot",
     "MisfitMapPlot",
     "MisfitsPlot",
+    "ObservationsMapPlot",
     "StatisticsPlot",
     "StdDevPlot",
 ]

--- a/src/ert/gui/plotting/ert_plots/misfit_map.py
+++ b/src/ert/gui/plotting/ert_plots/misfit_map.py
@@ -67,8 +67,17 @@ class MisfitMapPlot:
         misfit_values = mean_misfits["misfit"].to_numpy()
         axes_misfit = figure.add_subplot(111)
 
+        vmin, vmax = (None, None)
+        if plot_context.colorbar_range is not None:
+            vmin, vmax = plot_context.colorbar_range
         misfit_tripcolor = axes_misfit.tripcolor(
-            east, north, misfit_values, shading="flat", cmap="viridis"
+            east,
+            north,
+            misfit_values,
+            shading="flat",
+            cmap="viridis",
+            vmin=vmin,
+            vmax=vmax,
         )
 
         cbar = figure.colorbar(

--- a/src/ert/gui/plotting/ert_plots/misfit_map.py
+++ b/src/ert/gui/plotting/ert_plots/misfit_map.py
@@ -48,6 +48,10 @@ class MisfitMapPlot:
             )
             return
 
+        if observation_data.empty:
+            self._show_no_data(figure, "No observation data available")
+            return
+
         ensemble, ensemble_data = next(iter(ensemble_to_data_map.items()))
         misfits_by_realization = MisfitsPlot._wide_pandas_to_long_polars_with_misfits(
             {(ensemble.name, ensemble.id): ensemble_data},

--- a/src/ert/gui/plotting/ert_plots/misfit_map.py
+++ b/src/ert/gui/plotting/ert_plots/misfit_map.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import polars as pl
+from matplotlib.figure import Figure
+
+from ert.gui.plotting.ert_plots.misfits import MisfitsPlot
+
+if TYPE_CHECKING:
+    from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.plotting.utils import PlotContext
+    from ert.gui.plotting.utils.plot_types import ObservationPlotLocations
+
+
+class MisfitMapPlot:
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = True
+
+    @staticmethod
+    def _show_no_data(figure: Figure, message: str) -> None:
+        axes = figure.add_subplot(111)
+        axes.text(0.5, 0.5, message, ha="center", va="center")
+        axes.set_axis_off()
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: ObservationPlotLocations | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+
+        if not ensemble_to_data_map:
+            self._show_no_data(figure, "No ensemble data available")
+            return
+
+        if len(ensemble_to_data_map) > 1:
+            self._show_no_data(
+                figure, "Multiple ensembles selected; misfit map supports one at a time"
+            )
+            return
+
+        ensemble, ensemble_data = next(iter(ensemble_to_data_map.items()))
+        misfits_by_realization = MisfitsPlot._wide_pandas_to_long_polars_with_misfits(
+            {(ensemble.name, ensemble.id): ensemble_data},
+            observation_data,
+            "seismic",
+        )[ensemble.name, ensemble.id]
+
+        if misfits_by_realization.is_empty():
+            self._show_no_data(figure, "No misfit data available")
+            return
+
+        mean_misfits = misfits_by_realization.group_by(["EAST", "NORTH"]).agg(
+            pl.col("misfit").mean()
+        )
+        east = mean_misfits["EAST"].to_numpy()
+        north = mean_misfits["NORTH"].to_numpy()
+        misfit_values = mean_misfits["misfit"].to_numpy()
+        axes_misfit = figure.add_subplot(111)
+
+        misfit_tripcolor = axes_misfit.tripcolor(
+            east, north, misfit_values, shading="flat", cmap="viridis"
+        )
+
+        cbar = figure.colorbar(
+            misfit_tripcolor,
+            ax=axes_misfit,
+            label="Mean signed χ²",
+            orientation="vertical",
+            pad=0.15,
+            aspect=40,
+        )
+
+        cbar.ax.set_visible(plot_context.plotConfig().is_legend_enabled())
+        cbar.ax.ticklabel_format(useOffset=False, style="plain")
+        config = plot_context.plotConfig()
+        axes_misfit.spines["top"].set_visible(False)
+        axes_misfit.spines["right"].set_visible(False)
+        axes_misfit.spines["left"].set_visible(False)
+        axes_misfit.spines["bottom"].set_visible(False)
+        axes_misfit.set_title(config.title())
+        axes_misfit.ticklabel_format(useOffset=False, style="plain")
+        axes_misfit.set_aspect("equal")
+        axes_misfit.set_xlabel(config.x_label() or "east coordinate")
+        axes_misfit.set_ylabel(config.y_label() or "north coordinate")
+        axes_misfit.grid(config.is_grid_enabled())
+        axes_misfit.set_xlim(east.min(), east.max())
+        axes_misfit.set_ylim(north.min(), north.max())

--- a/src/ert/gui/plotting/ert_plots/observations_map.py
+++ b/src/ert/gui/plotting/ert_plots/observations_map.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import polars as pl
+from matplotlib.figure import Figure
+
+if TYPE_CHECKING:
+    from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
+    from ert.gui.plotting.utils import PlotContext
+    from ert.gui.plotting.utils.plot_types import ObservationPlotLocations
+
+
+class ObservationsMapPlot:
+    def __init__(self) -> None:
+        self.dimensionality = 2
+        self.requires_observations = True
+
+    @staticmethod
+    def _show_no_data(figure: Figure, message: str) -> None:
+        axes = figure.add_subplot(111)
+        axes.text(0.5, 0.5, message, ha="center", va="center")
+        axes.set_axis_off()
+
+    def plot(
+        self,
+        figure: Figure,
+        plot_context: PlotContext,
+        ensemble_to_data_map: dict[EnsembleObject, pd.DataFrame],
+        observation_data: pd.DataFrame,
+        std_dev_images: dict[str, npt.NDArray[np.float32]],
+        obs_loc: ObservationPlotLocations | None,
+        key_def: PlotApiKeyDefinition | None = None,
+    ) -> None:
+        if observation_data.empty:
+            self._show_no_data(figure, "No observation data available")
+            return
+
+        observation = pl.from_pandas(observation_data.T).rename(
+            {"EAST": "EAST", "NORTH": "NORTH", "OBS": "OBS"}
+        )
+
+        east = observation.get_column("EAST").to_numpy()
+        north = observation.get_column("NORTH").to_numpy()
+        observation_values = observation.get_column("OBS").to_numpy()
+
+        axes = figure.add_subplot(111)
+        observation_tripcolor = axes.tripcolor(
+            east, north, observation_values, shading="flat", cmap="viridis"
+        )
+
+        cbar = figure.colorbar(
+            observation_tripcolor,
+            ax=axes,
+            label="Observation value",
+            orientation="vertical",
+            pad=0.15,
+            aspect=40,
+        )
+
+        cbar.ax.set_visible(plot_context.plotConfig().is_legend_enabled())
+        cbar.ax.ticklabel_format(useOffset=False, style="plain")
+        config = plot_context.plotConfig()
+        axes.spines["top"].set_visible(False)
+        axes.spines["right"].set_visible(False)
+        axes.spines["left"].set_visible(False)
+        axes.spines["bottom"].set_visible(False)
+        axes.set_title(config.title())
+        axes.ticklabel_format(useOffset=False, style="plain")
+        axes.set_aspect("equal")
+        axes.set_xlabel(config.x_label() or "east coordinate")
+        axes.set_ylabel(config.y_label() or "north coordinate")
+        axes.set_xlim(east.min(), east.max())
+        axes.grid(config.is_grid_enabled())
+        axes.set_ylim(north.min(), north.max())

--- a/src/ert/gui/plotting/plot_api.py
+++ b/src/ert/gui/plotting/plot_api.py
@@ -457,6 +457,10 @@ class PlotApi:
                             "STD": obs["errors"],
                             "OBS": obs["values"],
                             "key_index": key_index,
+                            "EAST": obs.get("east")
+                            or [float("nan")] * len(obs["values"]),
+                            "NORTH": obs.get("north")
+                            or [float("nan")] * len(obs["values"]),
                         }
                     )
                 )

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -842,8 +842,8 @@ class PlotWindow(QMainWindow):
             and (key_def.observations or not widget._plotter.requires_observations)
             and not is_everest_specific_widget
             and (
-                not is_observed_seismic
-                or widget.name in {MISFITS, MISFIT_MAP, OBSERVATIONS_MAP}
+                (is_observed_seismic and widget.name in {MISFITS, MISFIT_MAP})
+                or (not is_observed_seismic and widget.name != MISFIT_MAP)
             )
         ]
 

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -44,6 +44,7 @@ from ert.gui.plotting.utils.plot_maps import (
     HISTOGRAM,
     MISFIT_MAP,
     MISFITS,
+    OBSERVATIONS_MAP,
     SHARED_PLOT_MAP,
     STATISTICS,
     STD_DEV,
@@ -387,7 +388,7 @@ class PlotWindow(QMainWindow):
         return self._api.api_version
 
     def _apply_ensemble_selection_policy_for_tab(self, tab_name: str) -> None:
-        if tab_name == MISFIT_MAP:
+        if tab_name in {MISFIT_MAP, OBSERVATIONS_MAP}:
             self._ensemble_selection_widget.set_maximum_ensemble_limit(1)
             if len(self._ensemble_selection_widget.get_selected_ensembles()) > 1:
                 self._ensemble_selection_widget.clear_ensemble_selection()
@@ -614,8 +615,9 @@ class PlotWindow(QMainWindow):
                 history_data_available=history_data_available,
                 has_observations=key_def.observations,
                 show_observations=key_def.observations
-                and selected_tab not in {MISFITS, MISFIT_MAP},
-                show_color_palette=key_def.observations and selected_tab != MISFIT_MAP,
+                and selected_tab not in {MISFITS, MISFIT_MAP, OBSERVATIONS_MAP},
+                show_color_palette=key_def.observations
+                and selected_tab not in {MISFIT_MAP, OBSERVATIONS_MAP},
                 log_scale_available=log_scale_valid_values
                 and selected_tab in {HISTOGRAM, DISTRIBUTION, GAUSSIAN_KDE},
             )
@@ -795,7 +797,10 @@ class PlotWindow(QMainWindow):
             if widget._plotter.dimensionality == key_def.dimensionality
             and (key_def.observations or not widget._plotter.requires_observations)
             and not is_everest_specific_widget
-            and (not is_observed_seismic or widget.name in {MISFITS, MISFIT_MAP})
+            and (
+                not is_observed_seismic
+                or widget.name in {MISFITS, MISFIT_MAP, OBSERVATIONS_MAP}
+            )
         ]
 
         def everest_data_origin_check(origin: list[str]) -> bool:

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import numpy as np
 import pandas as pd
+import polars as pl
 from httpx import RequestError
 from pandas import DataFrame
 from PyQt6.QtCore import Qt
@@ -29,6 +30,7 @@ from ert.config import BreakthroughConfig
 from ert.config.field import Field
 from ert.dark_storage.common import get_storage_api_version
 from ert.gui.ertwidgets import CopyButton, showWaitCursorWhileWaiting
+from ert.gui.plotting.ert_plots.misfits import MisfitsPlot
 from ert.gui.plotting.utils.plot_maps import (
     CROSS_ENSEMBLE_STATISTICS,
     DISTRIBUTION,
@@ -609,6 +611,48 @@ class PlotWindow(QMainWindow):
                 key,
                 layer,
             )
+
+            if plot_widget.name == MISFIT_MAP and ensemble_to_data_map:
+                selected = next(iter(ensemble_to_data_map))
+                initial_ensemble = min(
+                    (
+                        e
+                        for e in self._api.get_all_ensembles()
+                        if e.experiment_name == selected.experiment_name
+                    ),
+                    key=lambda e: e.started_at,
+                    default=None,
+                )
+                if initial_ensemble is not None:
+                    try:  # ruff: ignore[too-many-statements-in-try-clause]
+                        if initial_ensemble.id == selected.id:
+                            initial_ensemble_data = ensemble_to_data_map[selected]
+                        else:
+                            initial_ensemble_data = self._api.data_for_response(
+                                ensemble_id=initial_ensemble.id,
+                                response_key=key,
+                                filter_on=key_def.filter_on,
+                            )
+                        misfits = MisfitsPlot._wide_pandas_to_long_polars_with_misfits(
+                            {
+                                (
+                                    initial_ensemble.name,
+                                    initial_ensemble.id,
+                                ): initial_ensemble_data
+                            },
+                            observations,
+                            "seismic",
+                        )[initial_ensemble.name, initial_ensemble.id]
+                        if not misfits.is_empty():
+                            mean = misfits.group_by(["EAST", "NORTH"]).agg(
+                                pl.col("misfit").mean()
+                            )
+                            plot_context.colorbar_range = (
+                                cast(float, mean["misfit"].min()),
+                                cast(float, mean["misfit"].max()),
+                            )
+                    except BaseException as e:
+                        handle_exception(e)
 
             self._general_options.update_plot_context(
                 plot_context,

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -42,6 +42,7 @@ from ert.gui.plotting.utils.plot_maps import (
     EVEREST_PLOT_MAP,
     GAUSSIAN_KDE,
     HISTOGRAM,
+    MISFIT_MAP,
     MISFITS,
     SHARED_PLOT_MAP,
     STATISTICS,
@@ -385,10 +386,30 @@ class PlotWindow(QMainWindow):
     def get_plot_api_version(self) -> str:
         return self._api.api_version
 
+    def _apply_ensemble_selection_policy_for_tab(self, tab_name: str) -> None:
+        if tab_name == MISFIT_MAP:
+            self._ensemble_selection_widget.set_maximum_ensemble_limit(1)
+            if len(self._ensemble_selection_widget.get_selected_ensembles()) > 1:
+                self._ensemble_selection_widget.clear_ensemble_selection()
+        else:
+            self._ensemble_selection_widget.reset_maximum_ensemble_limit_to_default()
+        self._update_ensemble_group_title()
+
+    def _update_ensemble_group_title(self) -> None:
+        max_selected = self._ensemble_selection_widget.get_maximum_ensemble_limit()
+        str_num_of_ens = f" up to {max_selected}" if self.is_everest else ""
+        self._ensemble_group.set_title(
+            f"Select{str_num_of_ens} batches"
+            if self.is_everest
+            else f"Select up to {max_selected} ensemble(s)"
+        )
+
     @Slot(int)
     def current_tab_changed(self, index: int) -> None:
+        tab_name = self._central_tab.tabText(index)
+        self._apply_ensemble_selection_policy_for_tab(tab_name)
         self.update_plot()
-        self.log_plot_tab_usage(self._central_tab.tabText(index))
+        self.log_plot_tab_usage(tab_name)
 
     def log_plot_tab_usage(self, tab_name: str, *, default: bool = False) -> None:
         msg = f"Plotwindow tab used: {tab_name}" + (" (default tab)" if default else "")
@@ -592,7 +613,9 @@ class PlotWindow(QMainWindow):
                 plot_context,
                 history_data_available=history_data_available,
                 has_observations=key_def.observations,
-                show_observations=key_def.observations and selected_tab != MISFITS,
+                show_observations=key_def.observations
+                and selected_tab not in {MISFITS, MISFIT_MAP},
+                show_color_palette=key_def.observations and selected_tab != MISFIT_MAP,
                 log_scale_available=log_scale_valid_values
                 and selected_tab in {HISTOGRAM, DISTRIBUTION, GAUSSIAN_KDE},
             )
@@ -759,13 +782,7 @@ class PlotWindow(QMainWindow):
             else:
                 self._ensemble_selection_widget.reset_maximum_and_minimum_ensemble_limits_to_default()
 
-        max_selected = self._ensemble_selection_widget.get_maximum_ensemble_limit()
-        str_num_of_ens = f" up to {max_selected}" if self.is_everest else ""
-        self._ensemble_group.set_title(
-            f"Select{str_num_of_ens} batches"
-            if self.is_everest
-            else f"Select up to {max_selected} ensembles"
-        )
+        self._update_ensemble_group_title()
 
         is_observed_seismic = (
             key_def.observations
@@ -778,7 +795,7 @@ class PlotWindow(QMainWindow):
             if widget._plotter.dimensionality == key_def.dimensionality
             and (key_def.observations or not widget._plotter.requires_observations)
             and not is_everest_specific_widget
-            and (not is_observed_seismic or widget.name == MISFITS)
+            and (not is_observed_seismic or widget.name in {MISFITS, MISFIT_MAP})
         ]
 
         def everest_data_origin_check(origin: list[str]) -> bool:
@@ -834,6 +851,9 @@ class PlotWindow(QMainWindow):
             current_widget = available_widgets[0]
 
         self._central_tab.setCurrentWidget(current_widget)
+        self._apply_ensemble_selection_policy_for_tab(
+            self._central_tab.tabText(self._central_tab.currentIndex())
+        )
         self._central_tab.currentChanged.connect(self.current_tab_changed)
         self._prev_key_dimensionality = key_def.dimensionality
         self._prev_key = key_def.key

--- a/src/ert/gui/plotting/plot_window.py
+++ b/src/ert/gui/plotting/plot_window.py
@@ -842,8 +842,14 @@ class PlotWindow(QMainWindow):
             and (key_def.observations or not widget._plotter.requires_observations)
             and not is_everest_specific_widget
             and (
-                (is_observed_seismic and widget.name in {MISFITS, MISFIT_MAP})
-                or (not is_observed_seismic and widget.name != MISFIT_MAP)
+                (
+                    is_observed_seismic
+                    and widget.name in {MISFITS, MISFIT_MAP, OBSERVATIONS_MAP}
+                )
+                or (
+                    not is_observed_seismic
+                    and widget.name not in {MISFIT_MAP, OBSERVATIONS_MAP}
+                )
             )
         ]
 

--- a/src/ert/gui/plotting/utils/plot_context.py
+++ b/src/ert/gui/plotting/utils/plot_context.py
@@ -49,6 +49,7 @@ class PlotContext:
         self._plot_config = plot_config
         self.history_data: DataFrame | None = None
         self._layer: int | None = layer
+        self._colorbar_range: tuple[float, float] | None = None
 
         self._date_support_active = True
         self._x_axis: str | None = None
@@ -106,6 +107,14 @@ class PlotContext:
     @property
     def layer(self) -> int | None:
         return self._layer
+
+    @property
+    def colorbar_range(self) -> tuple[float, float] | None:
+        return self._colorbar_range
+
+    @colorbar_range.setter
+    def colorbar_range(self, value: tuple[float, float] | None) -> None:
+        self._colorbar_range = value
 
     @property
     def x_axis(self) -> str | None:

--- a/src/ert/gui/plotting/utils/plot_maps.py
+++ b/src/ert/gui/plotting/utils/plot_maps.py
@@ -4,6 +4,7 @@ from ert.gui.plotting.ert_plots import (
     CrossEnsembleStatisticsPlot,
     DistributionPlot,
     HistogramPlot,
+    MisfitMapPlot,
     MisfitsPlot,
     StatisticsPlot,
     StdDevPlot,
@@ -23,6 +24,7 @@ DISTRIBUTION = "Distribution"
 GAUSSIAN_KDE = "Gaussian KDE"
 ENSEMBLE = "Ensemble"
 HISTOGRAM = "Histogram"
+MISFIT_MAP = "Misfit map"
 STATISTICS = "Statistics"
 STD_DEV = "Std dev"
 MISFITS = "Misfits"
@@ -35,6 +37,7 @@ EVEREST_CONSTRAINT_PLOT = "Constraints"
 ERT_PLOT_MAP: dict[str, Callable[[], Plotter]] = {
     STATISTICS: StatisticsPlot,
     MISFITS: MisfitsPlot,
+    MISFIT_MAP: MisfitMapPlot,
     HISTOGRAM: HistogramPlot,
     DISTRIBUTION: DistributionPlot,
     CROSS_ENSEMBLE_STATISTICS: CrossEnsembleStatisticsPlot,

--- a/src/ert/gui/plotting/utils/plot_maps.py
+++ b/src/ert/gui/plotting/utils/plot_maps.py
@@ -9,6 +9,7 @@ from ert.gui.plotting.ert_plots import (
     StatisticsPlot,
     StdDevPlot,
 )
+from ert.gui.plotting.ert_plots.observations_map import ObservationsMapPlot
 from ert.gui.plotting.everest_plots import (
     EverestBatchObjectiveFunctionPlot,
     EverestConstraintsPlot,
@@ -25,6 +26,7 @@ GAUSSIAN_KDE = "Gaussian KDE"
 ENSEMBLE = "Ensemble"
 HISTOGRAM = "Histogram"
 MISFIT_MAP = "Misfit map"
+OBSERVATIONS_MAP = "Observations map"
 STATISTICS = "Statistics"
 STD_DEV = "Std dev"
 MISFITS = "Misfits"
@@ -38,6 +40,7 @@ ERT_PLOT_MAP: dict[str, Callable[[], Plotter]] = {
     STATISTICS: StatisticsPlot,
     MISFITS: MisfitsPlot,
     MISFIT_MAP: MisfitMapPlot,
+    OBSERVATIONS_MAP: ObservationsMapPlot,
     HISTOGRAM: HistogramPlot,
     DISTRIBUTION: DistributionPlot,
     CROSS_ENSEMBLE_STATISTICS: CrossEnsembleStatisticsPlot,

--- a/src/ert/gui/plotting/widgets/plot_controls/general_options.py
+++ b/src/ert/gui/plotting/widgets/plot_controls/general_options.py
@@ -99,8 +99,8 @@ class GeneralPlotOptions(QObject):
                 ]
             )
 
-        palette_container = QWidget()
-        palette_layout = QVBoxLayout(palette_container)
+        self._palette_container = QWidget()
+        palette_layout = QVBoxLayout(self._palette_container)
         palette_layout.setContentsMargins(0, 0, 0, 0)
         palette_layout.setSpacing(2)
         palette_layout.addWidget(QLabel("Selected color palette:"))
@@ -109,7 +109,7 @@ class GeneralPlotOptions(QObject):
         palette_layout.addWidget(self._color_cycle_selector)
         palette_layout.addWidget(self._color_cycle_selector.get_custom_palette_button())
 
-        widgets.extend([palette_container, edit_buttons])
+        widgets.extend([self._palette_container, edit_buttons])
 
         self._general_options = CollapsibleSection(
             "General options",
@@ -167,6 +167,7 @@ class GeneralPlotOptions(QObject):
         history_data_available: bool,
         has_observations: bool,
         show_observations: bool,
+        show_color_palette: bool = True,
         log_scale_available: bool,
     ) -> None:
         plot_config = plot_context.plotConfig()
@@ -185,6 +186,7 @@ class GeneralPlotOptions(QObject):
         self._observations_color_edit.setVisible(
             show_observations and self.observations_checkbox_state
         )
+        self._palette_container.setVisible(show_color_palette)
         plot_config.set_history_enabled(
             self.history_checkbox_state and history_data_available
         )

--- a/src/ert/gui/plotting/widgets/plot_ensemble_selection_widget.py
+++ b/src/ert/gui/plotting/widgets/plot_ensemble_selection_widget.py
@@ -140,12 +140,7 @@ class EnsembleSelectListWidget(QListWidget):
             it.setData(Qt.ItemDataRole.CheckStateRole, i < cutoff)
             self.addItem(it)
             self._ensemble_count += 1
-            it.setToolTip(
-                f"{item_text}\n"
-                f"Toggle up to {self.get_maximum_ensemble_limit()} plots or reorder by"
-                "drag & drop\n"
-                f"Order determines draw order and color"
-            )
+            self._tooltip_for_ensemble_selection(it)
 
         if (viewport := self.viewport()) is not None:
             viewport.setMouseTracking(True)
@@ -262,23 +257,41 @@ class EnsembleSelectListWidget(QListWidget):
         super().dropEvent(event)
         self.ensembleSelectionListChanged.emit()
 
+    def _uncheck_item(self, item: QListWidgetItem) -> None:
+        self.release_color(item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX))
+        item.setData(Qt.ItemDataRole.CheckStateRole, False)
+
+    def _check_item(self, item: QListWidgetItem) -> None:
+        item.setData(
+            EnsembleSelectListWidgetItemDataRole.COLOR_INDEX,
+            self.assign_available_color(
+                item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX)
+            ),
+        )
+        item.setData(Qt.ItemDataRole.CheckStateRole, True)
+
     def slot_toggle_plot(self, item: QListWidgetItem) -> None:
         count = len(self.get_checked_ensembles())
         selected = item.data(Qt.ItemDataRole.CheckStateRole)
 
+        if not selected and self.get_maximum_ensemble_limit() == 1 and count == 1:
+            for ensemble_index in range(self._ensemble_count):
+                ensemble_item = self.item(ensemble_index)
+                if (
+                    ensemble_item is not None
+                    and ensemble_item is not item
+                    and ensemble_item.data(Qt.ItemDataRole.CheckStateRole)
+                ):
+                    self._uncheck_item(ensemble_item)
+                    break
+            self._check_item(item)
+            self.ensembleSelectionListChanged.emit()
+            return
+
         if selected and count > self.get_minimum_ensemble_limit():
-            self.release_color(
-                item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX)
-            )
-            item.setData(Qt.ItemDataRole.CheckStateRole, False)
+            self._uncheck_item(item)
         elif not selected and count < self.get_maximum_ensemble_limit():
-            item.setData(
-                EnsembleSelectListWidgetItemDataRole.COLOR_INDEX,
-                self.assign_available_color(
-                    item.data(EnsembleSelectListWidgetItemDataRole.COLOR_INDEX)
-                ),
-            )
-            item.setData(Qt.ItemDataRole.CheckStateRole, True)
+            self._check_item(item)
 
         self.ensembleSelectionListChanged.emit()
 
@@ -294,6 +307,18 @@ class EnsembleSelectListWidget(QListWidget):
                 f"Maximum selected ensembles limit ({value}) cannot be less than 1"
             )
         self._maximum_selected = value
+        for i in range(self._ensemble_count):
+            if (item := self.item(i)) is not None:
+                self._tooltip_for_ensemble_selection(item)
+
+    def _tooltip_for_ensemble_selection(self, item: QListWidgetItem) -> None:
+        item_text = item.text()
+        item.setToolTip(
+            f"{item_text}\n"
+            f"Toggle up to {self.get_maximum_ensemble_limit()} plot(s) or reorder "
+            "by drag & drop\n"
+            f"Order determines draw order and color"
+        )
 
     def get_maximum_ensemble_limit(self) -> int:
         return self._maximum_selected

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -354,6 +354,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
             "Histogram",
             "Misfit map",
             "Statistics",
+            "Observations map",
             "Std dev",
             "Misfits",
         }

--- a/tests/ert/ui_tests/gui/test_main_window.py
+++ b/tests/ert/ui_tests/gui/test_main_window.py
@@ -352,6 +352,7 @@ def test_that_the_plot_window_contains_the_expected_elements(
             "Distribution",
             "Ensemble",
             "Histogram",
+            "Misfit map",
             "Statistics",
             "Std dev",
             "Misfits",

--- a/tests/ert/unit_tests/gui/ertwidgets/test_plot_case_selection_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_plot_case_selection_widget.py
@@ -215,3 +215,48 @@ def test_that_ensemble_selection_widget_with_invalid_limits():
         ),
     ):
         widget.set_maximum_ensemble_limit(2)
+
+
+def test_that_single_ensemble_selection_mode_swaps_selection_on_click(qtbot: QtBot):
+    _, list_widget = setup_ensemble_widget_with_ensembles(qtbot, 3)
+    list_widget.set_minimum_ensemble_limit(1)
+    list_widget.set_maximum_ensemble_limit(1)
+
+    target = list_widget.item(2)
+    qtbot.mouseClick(
+        list_widget.viewport(),
+        Qt.MouseButton.LeftButton,
+        pos=list_widget.visualItemRect(target).center(),
+    )
+
+    assert len(list_widget.get_checked_ensembles()) == 1
+
+    item0 = list_widget.item(0)
+    item1 = list_widget.item(1)
+    item2 = list_widget.item(2)
+    assert item0 is not None
+    assert item0.data(Qt.ItemDataRole.CheckStateRole) is False
+    assert item1 is not None
+    assert item1.data(Qt.ItemDataRole.CheckStateRole) is False
+    assert item2 is not None
+    assert item2.data(Qt.ItemDataRole.CheckStateRole) is True
+
+    assert len(list_widget.get_checked_color_indexes()) == 1
+    assert len(list_widget.available_colors) == list_widget._palette_size - 1
+
+
+def test_that_ensemble_item_tooltips_reflect_the_current_maximum_selection_limit(
+    qtbot: QtBot,
+):
+    _, list_widget = setup_ensemble_widget_with_ensembles(qtbot, 5)
+
+    for index in range(list_widget.count()):
+        item = list_widget.item(index)
+        assert item is not None
+        assert "Toggle up to 5 plot(s)" in item.toolTip()
+
+    list_widget.set_maximum_ensemble_limit(1)
+    for index in range(list_widget.count()):
+        item = list_widget.item(index)
+        assert item is not None
+        assert "Toggle up to 1 plot(s)" in item.toolTip()

--- a/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
+++ b/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
@@ -1,0 +1,197 @@
+import pandas as pd
+import pytest
+from matplotlib.figure import Figure
+
+from ert.gui.plotting.ert_plots import MisfitMapPlot
+from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.plotting.utils import PlotConfig, PlotContext
+
+
+@pytest.fixture
+def make_ensemble():
+    def _make(name: str, id_: str | None = None) -> EnsembleObject:
+        return EnsembleObject(
+            name,
+            id_ if id_ is not None else name,
+            False,
+            "experiment",
+            "2026-01-01T00:00:00",
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_plot_context():
+    def _make(
+        ensembles: list[EnsembleObject],
+        *,
+        key: str = "FOPR",
+        plot_config: PlotConfig | None = None,
+    ) -> PlotContext:
+        return PlotContext(
+            plot_config if plot_config is not None else PlotConfig(),
+            ensembles=ensembles,
+            ensembles_color_indexes=list(range(len(ensembles))),
+            key=key,
+            layer=None,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_key_def():
+    def _make(
+        *, key: str = "FOPR", data_origin: str = "seismic"
+    ) -> PlotApiKeyDefinition:
+        return PlotApiKeyDefinition(
+            key,
+            index_type=None,
+            metadata={"data_origin": data_origin},
+            observations=True,
+            dimensionality=2,
+        )
+
+    return _make
+
+
+def test_that_misfit_map_plot_show_no_data_message_when_ensemble_map_is_empty(
+    make_plot_context,
+    make_key_def,
+) -> None:
+    plot_context = make_plot_context([])
+    ensemble_to_data_map = {}
+    figure = Figure()
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map=ensemble_to_data_map,
+        observation_data=pd.DataFrame(),
+        key_def=make_key_def(),
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    assert len(figure.axes) == 1
+    assert figure.axes[0].texts[0].get_text() == "No ensemble data available"
+
+
+def test_that_misfit_map_plot_show_no_misfit_data_message_when_no_misfit_rows_produced(
+    make_plot_context,
+    make_key_def,
+    make_ensemble,
+) -> None:
+    ensemble = make_ensemble("ensemble_1")
+    plot_context = make_plot_context([ensemble], key="SEISMIC_KEY")
+    key_def = make_key_def(key="SEISMIC_KEY")
+    figure = Figure()
+    observation_data = pd.DataFrame(
+        data={0: [1.0, 10.0, "0"], 1: [10.0, 200.0, "5"]},
+        index=["STD", "OBS", "key_index"],
+    )
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map={
+            ensemble: pd.DataFrame(
+                data={"99": [1.0], "100": [2.0]},
+                index=pd.Index([0], name="Realization"),
+            )
+        },
+        observation_data=observation_data,
+        key_def=key_def,
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    assert len(figure.axes) == 1
+    assert figure.axes[0].texts[0].get_text() == "No misfit data available"
+
+
+def test_that_misfit_map_uses_default_title_and_axis_labels_when_plot_config_is_unset(
+    make_plot_context,
+    make_key_def,
+    make_ensemble,
+) -> None:
+    ensemble = make_ensemble("ensemble_1")
+    plot_context = make_plot_context(
+        [ensemble],
+        key="SEISMIC_KEY",
+        plot_config=PlotConfig(title="Costum map title"),
+    )
+    key_def = make_key_def()
+    figure = Figure()
+    observation_data = pd.DataFrame(
+        data={
+            0: [1.0, 10.0, "0", 100.0, 200.0],
+            1: [1.0, 20.0, "5", 150.0, 250.0],
+            2: [1.0, 30.0, "8", 200.0, 100.0],
+        },
+        index=["STD", "OBS", "key_index", "EAST", "NORTH"],
+    )
+
+    ensemble_to_data_map = {
+        ensemble: pd.DataFrame(
+            data={"0": [1.0], "5": [2.0], "8": [3.0]},
+            index=pd.Index([0], name="Realization"),
+        )
+    }
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map=ensemble_to_data_map,
+        observation_data=observation_data,
+        key_def=key_def,
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    assert len(figure.axes) == 2
+    assert figure.axes[0].get_title() == "Costum map title"
+    assert figure.axes[0].get_xlabel() == "east coordinate"
+    assert figure.axes[0].get_ylabel() == "north coordinate"
+
+
+def test_that_misfit_map_shows_message_when_more_than_one_ensemble_is_provided(
+    make_plot_context,
+    make_key_def,
+    make_ensemble,
+) -> None:
+    ensemble_1 = make_ensemble("ensemble_1")
+    ensemble_2 = make_ensemble("ensemble_2")
+    plot_context = make_plot_context([ensemble_1, ensemble_2], key="SEISMIC_KEY")
+    key_def = make_key_def(key="SEISMIC_KEY")
+    figure = Figure()
+    observation_data = pd.DataFrame(
+        data={0: [1.0, 10.0, "0"], 1: [10.0, 200.0, "5"]},
+        index=["STD", "OBS", "key_index"],
+    )
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map={
+            ensemble_1: pd.DataFrame(
+                data={"99": [1.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+            ensemble_2: pd.DataFrame(
+                data={"100": [2.0]},
+                index=pd.Index([0], name="Realization"),
+            ),
+        },
+        observation_data=observation_data,
+        key_def=key_def,
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    assert len(figure.axes) == 1
+    assert (
+        figure.axes[0].texts[0].get_text()
+        == "Multiple ensembles selected; misfit map supports one at a time"
+    )

--- a/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
+++ b/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
@@ -111,6 +111,36 @@ def test_that_misfit_map_plot_show_no_misfit_data_message_when_no_misfit_rows_pr
     assert figure.axes[0].texts[0].get_text() == "No misfit data available"
 
 
+def test_that_misfit_map_plot_show_no_obs_data_message_when_obs_data_is_empty(
+    make_plot_context,
+    make_key_def,
+    make_ensemble,
+) -> None:
+    ensemble = make_ensemble("ensemble_1")
+    plot_context = make_plot_context([ensemble], key="SEISMIC_KEY")
+    key_def = make_key_def(key="SEISMIC_KEY")
+    figure = Figure()
+    observation_data = pd.DataFrame()  # Empty observation data
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map={
+            ensemble: pd.DataFrame(
+                data={"99": [1.0]},
+                index=pd.Index([0], name="Realization"),
+            )
+        },
+        observation_data=observation_data,
+        key_def=key_def,
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    assert len(figure.axes) == 1
+    assert figure.axes[0].texts[0].get_text() == "No observation data available"
+
+
 def test_that_misfit_map_uses_default_title_and_axis_labels_when_plot_config_is_unset(
     make_plot_context,
     make_key_def,

--- a/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
+++ b/tests/ert/unit_tests/gui/plotting/ert_plots/test_misfit_map_plot.py
@@ -195,3 +195,43 @@ def test_that_misfit_map_shows_message_when_more_than_one_ensemble_is_provided(
         figure.axes[0].texts[0].get_text()
         == "Multiple ensembles selected; misfit map supports one at a time"
     )
+
+
+def test_that_misfit_map_pins_colorbar_range_when_plot_context_has_one(
+    make_plot_context,
+    make_key_def,
+    make_ensemble,
+) -> None:
+    ensemble = make_ensemble("ensemble")
+    plot_context = make_plot_context([ensemble], key="SEISMIC_KEY")
+    plot_context.colorbar_range = (-3.0, 7.0)
+
+    observation_data = pd.DataFrame(
+        data={
+            0: [1.0, 10.0, "0", 100.00, 200.00],
+            1: [1.0, 20.0, "5", 150.00, 250.00],
+            2: [1.0, 30.0, "8", 200.00, 100.00],
+        },
+        index=["STD", "OBS", "key_index", "EAST", "NORTH"],
+    )
+
+    ensemble_to_data_map = {
+        ensemble: pd.DataFrame(
+            data={"0": [1.0], "5": [2.0], "8": [3.0]},
+            index=pd.Index([0], name="Realization"),
+        )
+    }
+    figure = Figure()
+
+    MisfitMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map=ensemble_to_data_map,
+        observation_data=observation_data,
+        key_def=make_key_def(key="SEISMIC_KEY"),
+        obs_loc=None,
+        std_dev_images={},
+    )
+
+    tripcolor = figure.axes[0].collections[0]
+    assert tripcolor.get_clim() == (-3.0, 7.0)

--- a/tests/ert/unit_tests/gui/plotting/ert_plots/test_observations_map_plot.py
+++ b/tests/ert/unit_tests/gui/plotting/ert_plots/test_observations_map_plot.py
@@ -1,0 +1,97 @@
+import pandas as pd
+import pytest
+from matplotlib.figure import Figure
+
+from ert.gui.plotting.ert_plots.observations_map import ObservationsMapPlot
+from ert.gui.plotting.plot_api import EnsembleObject, PlotApiKeyDefinition
+from ert.gui.plotting.utils.plot_config import PlotConfig
+from ert.gui.plotting.utils.plot_context import PlotContext
+
+
+@pytest.fixture
+def make_plot_context():
+    def _make(
+        ensembles: list[EnsembleObject],
+        *,
+        key: str = "FOPR",
+        plot_config: PlotConfig | None = None,
+    ) -> PlotContext:
+        return PlotContext(
+            plot_config if plot_config is not None else PlotConfig(),
+            ensembles=ensembles,
+            ensembles_color_indexes=list(range(len(ensembles))),
+            key=key,
+            layer=None,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_key_def():
+    def _make(
+        *, key: str = "FOPR", data_origin: str = "summary"
+    ) -> PlotApiKeyDefinition:
+        return PlotApiKeyDefinition(
+            key,
+            index_type=None,
+            metadata={"data_origin": data_origin},
+            observations=True,
+            dimensionality=2,
+        )
+
+    return _make
+
+
+def test_that_observations_map_shows_no_data_message_when_observation_data_is_empty(
+    make_plot_context, make_key_def
+):
+    figure = Figure()
+    plot_context = make_plot_context([])
+    key_def = make_key_def()
+    ObservationsMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map={},
+        observation_data=pd.DataFrame(),
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    assert len(figure.axes) == 1
+    assert figure.axes[0].texts[0].get_text() == "No observation data available"
+
+
+def test_that_observations_map_renders_tripcolor_with_default_axis_labels_and_title(
+    make_plot_context, make_key_def
+):
+    figure = Figure()
+    plot_context = make_plot_context(
+        [], plot_config=PlotConfig(title="Observation map")
+    )
+    key_def = make_key_def()
+    observation_data = pd.DataFrame(
+        data={
+            0: [100.0, 200.0, 10.0],
+            1: [150.0, 250.0, 20.0],
+            2: [200.0, 100.0, 30.0],
+        },
+        index=["EAST", "NORTH", "OBS"],
+    )
+
+    ObservationsMapPlot().plot(
+        figure=figure,
+        plot_context=plot_context,
+        ensemble_to_data_map={},
+        observation_data=observation_data,
+        std_dev_images={},
+        obs_loc=None,
+        key_def=key_def,
+    )
+
+    assert len(figure.axes) == 2
+    assert len(figure.axes[0].collections) > 0
+    assert figure.axes[0].get_xlabel() == "east coordinate"
+    assert figure.axes[0].get_ylabel() == "north coordinate"
+    assert figure.axes[0].get_title() == "Observation map"

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -33,6 +33,7 @@ def _apply_options_to_plot_context(
     has_observations: bool = False,
     show_observations: bool = False,
     log_scale_available: bool = False,
+    show_color_palette: bool = False,
 ) -> None:
     options.update_plot_context(
         plot_context,
@@ -40,6 +41,7 @@ def _apply_options_to_plot_context(
         has_observations=has_observations,
         show_observations=show_observations,
         log_scale_available=log_scale_available,
+        show_color_palette=show_color_palette,
     )
 
 
@@ -313,3 +315,18 @@ def test_that_palette_selector_child_can_be_found(qtbot):
         type(options._color_cycle_selector), "plot_color_palette_selector"
     )
     assert selector is not None
+
+
+@pytest.mark.parametrize("show_color_palette", [True, False])
+def test_that_color_palette_container_visbility_follows_show_color_palette_flag(
+    qtbot, show_color_palette
+):
+    options = GeneralPlotOptions(Mock())
+    qtbot.addWidget(options.get_widget())
+    options.get_widget().show()
+    _expand(options.get_widget())
+
+    _apply_options_to_plot_context(
+        options, _create_plot_context(), show_color_palette=show_color_palette
+    )
+    assert options._palette_container.isVisible() is show_color_palette

--- a/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
+++ b/tests/ert/unit_tests/gui/plotting/widgets/test_general_options.py
@@ -318,7 +318,7 @@ def test_that_palette_selector_child_can_be_found(qtbot):
 
 
 @pytest.mark.parametrize("show_color_palette", [True, False])
-def test_that_color_palette_container_visbility_follows_show_color_palette_flag(
+def test_that_color_palette_container_visibility_follows_show_color_palette_flag(
     qtbot, show_color_palette
 ):
     options = GeneralPlotOptions(Mock())

--- a/tests/ert/unit_tests/gui/tools/plot/conftest.py
+++ b/tests/ert/unit_tests/gui/tools/plot/conftest.py
@@ -121,6 +121,9 @@ def mocked_requests_get(*args, **kwargs):
                 "errors": [0.05, 0.07],
                 "values": [0.1, 0.7],
                 "x_axis": ["2010-03-31T00:00:00", "2010-12-26T00:00:00"],
+                "east": [None, None],
+                "north": [None, None],
+                "radius": [None, None],
             }
         ],
     }

--- a/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
+++ b/tests/ert/unit_tests/gui/tools/plot/test_plot_api.py
@@ -271,6 +271,8 @@ def test_plot_api_handles_urlescape(api_and_storage):
         STD,1.0
         OBS,1.0
         key_index,2024-10-04 00:00:00
+        EAST,
+        NORTH,
         """
     )
 
@@ -411,7 +413,7 @@ def test_that_multiple_observations_are_parsed_correctly(api_and_storage):
 
     ensemble = next(x for x in api.get_all_ensembles() if x.id == str(ens.id))
     obs_data = api.observations_for_key([ensemble.id], "WOPR:OP1")
-    assert obs_data.shape == (3, 6)
+    assert obs_data.shape == (5, 6)
 
 
 def test_that_observations_for_empty_ensemble_returns_empty_data(api_and_storage):


### PR DESCRIPTION
**Issue**
Resolves #14201 


**Approach**
First three commits are prework towards the two added plots. 
For plotting a heatmap it was necessary to cap the ensemble selection to a single selection.
Additionally the east and north coordinates needed to be exposed through the plot API such that both the observations map and the misfit map can use it in the heatmap plots.
The observations map takes in observation data to plot the observation value for each combination of east and north coordinate, where as the misfit map plots the calculated mean chi squared misfit over all realization for an ensemble and plots the values for each combination of east and north coordinate. 
Furthermore I needed to add some logic in plot window to catch the initial iteration of each experiment to be able to pin the colorbar for the misfit map plot as otherwise one would not be able to tell the difference between the different ensembles of each experiment. (In [this issue](https://github.com/equinor/ert/issues/14411) I describe a better way of defining the range for the colorbar passing the min/max misfit value through to the plots form the dark_storage)

Additionally I've opened [another issue](https://github.com/equinor/ert/issues/14409) for a small bug on the colorbar, that causes the plot to be indented when hovering over the colorbar text. 


**Misfit map plot:** 
<img width="1122" height="783" alt="image" src="https://github.com/user-attachments/assets/1ebdf185-b791-4dae-b72f-ee9492500a9f" />
<img width="1122" height="783" alt="image" src="https://github.com/user-attachments/assets/7087f03c-3210-4cbf-814c-eada11f1695f" />
<img width="1122" height="783" alt="image" src="https://github.com/user-attachments/assets/125443e0-de4c-45f2-ac33-74233d9446a0" />

<img width="1381" height="783" alt="image" src="https://github.com/user-attachments/assets/bc14429d-5c16-4731-aaf1-7029791b276b" />


**Observation map plot**
<img width="1381" height="783" alt="image" src="https://github.com/user-attachments/assets/553e8871-b422-4cd1-9865-6c67eaac0476" />



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
