### PR TITLE
Fix rft_qc_tool screenshot tests

### DIFF
--- a/tests/ert/unit_tests/gui/ertwidgets/test_rft_qc_widget.py
+++ b/tests/ert/unit_tests/gui/ertwidgets/test_rft_qc_widget.py
@@ -219,6 +219,7 @@ def _display_all_points(widget) -> None:
     ):
         list_widget.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         list_widget.selectAll()
+    widget._plot._fit_view_to_displayed_points()
 
 
 @pytest.mark.usefixtures("use_tmpdir")


### PR DESCRIPTION
Make sure all points are visible for the image comparison

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
