### PR TITLE
Remove unused private class function _experiment_type

### DIFF
--- a/src/ert/run_models/everest_run_model.py
+++ b/src/ert/run_models/everest_run_model.py
@@ -55,7 +55,7 @@ from ert.run_models.run_model_configs import EverestRunModelConfig
 from ert.runpaths import Runpaths
 from ert.storage import ExperimentState, ExperimentStatus
 from ert.storage.local_ensemble import EverestRealizationInfo
-from ert.storage.local_experiment import ExperimentType, LocalExperiment
+from ert.storage.local_experiment import LocalExperiment
 from ert.substitutions import Substitutions
 from everest.config import (
     ControlConfig,
@@ -547,10 +547,6 @@ class EverestRunModel(RunModel, EverestRunModelConfig):
     @classmethod
     def description(cls) -> str:
         return "Run batches "
-
-    @classmethod
-    def _experiment_type(cls) -> ExperimentType:
-        return ExperimentType.EVEREST
 
     @property
     def exit_code(self) -> EverestExitCode | None:

--- a/src/ert/run_models/manual_update.py
+++ b/src/ert/run_models/manual_update.py
@@ -10,7 +10,7 @@ from ert.ensemble_evaluator import EvaluatorServerConfig
 from ert.run_models.run_model_configs import ManualUpdateConfig
 from ert.run_models.update_run_model import UpdateRunModel
 from ert.storage import Ensemble
-from ert.storage.local_experiment import ExperimentType, LocalExperiment
+from ert.storage.local_experiment import LocalExperiment
 
 from .run_model import ErtRunError
 
@@ -56,10 +56,6 @@ class ManualUpdate(UpdateRunModel, ManualUpdateConfig):
     @classmethod
     def description(cls) -> str:
         return "Load parameters and responses from existing → update"
-
-    @classmethod
-    def _experiment_type(cls) -> ExperimentType:
-        return ExperimentType.MANUAL_UPDATE
 
     def _create_experiment_storage(self) -> LocalExperiment:
         experiment_config = self.to_experiment_config(

--- a/src/ert/run_models/multiple_data_assimilation.py
+++ b/src/ert/run_models/multiple_data_assimilation.py
@@ -23,7 +23,6 @@ from ert.run_models.update_run_model import UpdateRunModel
 from ert.storage import Ensemble
 from ert.storage.local_experiment import (
     ExperimentConfig,
-    ExperimentType,
     LocalExperiment,
 )
 from ert.trace import tracer
@@ -205,7 +204,3 @@ class MultipleDataAssimilation(
     @classmethod
     def group(cls) -> str | None:
         return MULTIPLE_DATA_ASSIMILATION_GROUP
-
-    @classmethod
-    def _experiment_type(cls) -> ExperimentType:
-        return ExperimentType.ES_MDA

--- a/src/ert/run_models/single_test_run.py
+++ b/src/ert/run_models/single_test_run.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from ert.run_models.ensemble_experiment import EnsembleExperiment
 from ert.run_models.run_model_configs import SingleTestRunConfig
-from ert.storage.local_experiment import ExperimentType
 
 SINGLE_TEST_RUN_GROUP = "Forward model evaluation"
 
@@ -26,7 +25,3 @@ class SingleTestRun(SingleTestRunConfig, EnsembleExperiment):
     @classmethod
     def group(cls) -> str | None:
         return SINGLE_TEST_RUN_GROUP
-
-    @classmethod
-    def _experiment_type(cls) -> ExperimentType:
-        return ExperimentType.SINGLE_TEST_RUN


### PR DESCRIPTION
This was originally introduced in commit e8217781bb and was leftover code after changes in commit 16379f4240.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
