### PR TITLE
Support resdata 6 and 7 GRDECL writers

### DIFF
--- a/tests/ert/ui_tests/cli/test_parameter_passing.py
+++ b/tests/ert/ui_tests/cli/test_parameter_passing.py
@@ -11,20 +11,24 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
+from importlib.metadata import version
 from pathlib import Path
 from typing import Literal
 
-import cwrap
 import hypothesis.strategies as st
 import numpy as np
 import pytest
 import xtgeo
 from hypothesis import given, note, settings
 from hypothesis.extra.numpy import arrays
+from packaging.version import Version
 from resdata import ResDataType
 from resdata.grid import GridGenerator
 from resdata.resfile import ResdataKW
 from resfo_utilities.testing import egrids, summaries
+
+if Version(version("resdata")).major < 7:
+    import cwrap
 
 from ert.field_utils import FieldFileFormat, Shape, read_field, save_field
 from ert.field_utils.field_file_format import ROFF_FORMATS
@@ -188,8 +192,12 @@ class IoProvider:
                 data = values.ravel(order="F")
                 for i in range(self.size):
                     kw[i] = data[i]
-                with cwrap.open(file_name, mode="w") as f:
-                    kw.write_grdecl(f)
+                if Version(version("resdata")).major < 7:
+                    with cwrap.open(file_name, mode="w") as f:
+                        kw.write_grdecl(f)
+                else:
+                    with Path(file_name).open(mode="w", encoding="utf-8") as f:
+                        kw.write_grdecl(f)
             else:
                 # resdata cannot write roff
                 save_field(np.ma.masked_array(values), field_name, file_name, fformat)


### PR DESCRIPTION
Use the legacy cwrap file interface for resdata 6 and a standard text stream for resdata 7 and later.

Tested locally with `resdata@main` (= new resdata API)

**Issue**
Currently no issue. If we are happy with the proposed style of fixes, I will open an issue to track the compatibility fixes introduced to support resdata<7 and resdata>=7 at the same time. Once resdata>=7 is published, we can bump the resdata version required by ert and stick to resdata's new API.



**Approach**
Check available resdata version and use the appropriate resdata API accordingly.

(Screenshot of new behavior in GUI if applicable)


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
