### PR TITLE
Remove leftover debug log statement

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -702,8 +702,6 @@ class RunModel(RunModelConfig, ABC):
             self._max_parallelism_violation, evaluator.max_parallelism_violation
         )
 
-        logger.debug("tasks complete")
-
         if self._end_event.is_set():
             logger.debug("Run model cancelled - post evaluation")
             try:


### PR DESCRIPTION
This statement is too unprecise to be useful.

**Issue**
Resolves log noise


**Approach**
✂️ 

- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
