### PR TITLE
Potential fix for code scanning alert no. 48: Information exposure through an exception

### DIFF
--- a/src/ert/dark_storage/endpoints/experiment_server.py
+++ b/src/ert/dark_storage/endpoints/experiment_server.py
@@ -218,15 +218,14 @@ async def start_experiment(
         experiment_state.storage_path = config.output_dir
         experiment_state.start_time_unix = int(time.time())
         return JSONResponse({"experiment_id": experiment_id})
-    except Exception as e:
+    except Exception:
+        error_message = "Could not start experiment due to an internal error."
         experiment_state.status = ExperimentStatus(
             status=ExperimentState.failed,
-            message=f"Could not start experiment: {e!s}",
+            message=error_message,
         )
-        logging.getLogger(__name__).exception(e)
-        return JSONResponse(
-            {"error": f"Could not start experiment: {e!s}"}, status_code=501
-        )
+        logging.getLogger(__name__).exception("Failed to start experiment")
+        return JSONResponse({"error": error_message}, status_code=501)
 
 
 @router.get(


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/ert/security/code-scanning/48](https://github.com/equinor/ert/security/code-scanning/48)

Use a **generic, non-sensitive error message** for both:
1. `experiment_state.status.message`
2. API response `{"error": ...}`

Keep detailed diagnostics in server logs using `logger.exception(...)` inside the `except` block. This preserves functionality (request still fails and is reported as failed) without exposing internal exception details to clients.

In `src/ert/dark_storage/endpoints/experiment_server.py`, update only the `except Exception as e:` block in `start_experiment`:
- Introduce a constant/local string like `"Could not start experiment due to an internal error."`
- Set `experiment_state.status.message` to that string (instead of interpolating `e`)
- Return `JSONResponse({"error": generic_message}, status_code=501)` (instead of interpolating `e`)
- Keep server-side logging with `.exception(...)` so developers still get stack traces.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
