### PR TITLE
Do not crash on gen_kw with same name as group

### DIFF
--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -609,11 +609,16 @@ class LocalEnsemble(BaseMode):
         otherwise it will return the raw values.
 
         """
-        cfgs = [
-            p
-            for p in self.experiment.parameter_configuration.values()
-            if group in {p.name, p.group_name}
-        ]
+        parameter_config = self.experiment.parameter_configuration.get(group)
+        cfgs = (
+            [parameter_config]
+            if parameter_config is not None
+            else [
+                p
+                for p in self.experiment.parameter_configuration.values()
+                if group == p.group_name
+            ]
+        )
         if not cfgs:
             raise KeyError(f"{group} is not registered to the experiment.")
 

--- a/src/ert/storage/local_ensemble.py
+++ b/src/ert/storage/local_ensemble.py
@@ -598,7 +598,7 @@ class LocalEnsemble(BaseMode):
 
     def load_parameters(
         self,
-        group: str,
+        groupname_or_parametername: str,
         realizations: int | npt.NDArray[np.int_] | None = None,
         *,
         transformed: bool = False,
@@ -609,27 +609,32 @@ class LocalEnsemble(BaseMode):
         otherwise it will return the raw values.
 
         """
-        parameter_config = self.experiment.parameter_configuration.get(group)
+        parameter_config = self.experiment.parameter_configuration.get(
+            groupname_or_parametername
+        )
         cfgs = (
             [parameter_config]
             if parameter_config is not None
             else [
                 p
                 for p in self.experiment.parameter_configuration.values()
-                if group == p.group_name
+                if groupname_or_parametername == p.group_name
             ]
         )
         if not cfgs:
-            raise KeyError(f"{group} is not registered to the experiment.")
+            raise KeyError(
+                f"{groupname_or_parametername} is not registered to the experiment."
+            )
 
-        # if group refers to a group name, we expect the same cardinality
+        # if groupname_or_parametername refers to a group name,
+        # we expect the same cardinality
         cardinality = next(cfg.cardinality for cfg in cfgs)
         if cardinality == ParameterCardinality.multiple_configs_per_ensemble_dataset:
             return self.load_scalar_keys(
                 [cfg.name for cfg in cfgs], realizations, transformed=transformed
             )
         return self._load_dataset(
-            group,
+            groupname_or_parametername,
             (
                 realizations
                 if realizations is not None

--- a/tests/ert/unit_tests/storage/test_save_and_load_parameters.py
+++ b/tests/ert/unit_tests/storage/test_save_and_load_parameters.py
@@ -329,3 +329,58 @@ def test_that_multiple_save_parameters_numpy_calls_overwrite_previous_values(tmp
         gen_kw_parameter.name
     ]
     assert saved_ens.to_list() == [2.2 for _ in range(num_reals)]
+
+
+def test_that_gen_kw_parameter_sharing_group_name_can_be_saved_to_posterior(tmp_path):
+    ensemble_size = 100
+    parameter_group = "GROUP"
+    parameter_names = [
+        parameter_group,
+        *(f"PARAMETER_{index}" for index in range(13)),
+    ]
+    parameter_configs = [
+        GenKwConfig(
+            name=name,
+            group=parameter_group,
+            distribution={"name": "normal", "mean": 0, "std": 1},
+        )
+        for name in parameter_names
+    ]
+    realizations = np.arange(ensemble_size)
+    expected = np.arange(ensemble_size, dtype=float)
+
+    with open_storage(tmp_path, mode="w") as storage:
+        experiment = storage.create_experiment(
+            experiment_config={
+                "parameter_configuration": [
+                    config.model_dump(mode="json") for config in parameter_configs
+                ]
+            }
+        )
+        prior = experiment.create_ensemble(name="prior", ensemble_size=ensemble_size)
+        posterior = experiment.create_ensemble(
+            name="posterior", ensemble_size=ensemble_size
+        )
+        prior.save_parameters(
+            pl.DataFrame(
+                {
+                    "realization": realizations,
+                    **{
+                        name: expected + index
+                        for index, name in enumerate(parameter_names)
+                    },
+                }
+            )
+        )
+
+        parameters = prior.load_parameters_numpy(parameter_group, realizations)
+        posterior.save_parameters_numpy(
+            parameters,
+            parameter_group,
+            realizations,
+        )
+
+        np.testing.assert_array_equal(
+            posterior.load_scalar_keys([parameter_group])[parameter_group],
+            expected,
+        )


### PR DESCRIPTION
**Issue**
Resolves #14367 



- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
