### PR TITLE
Verify runpath does not contain a file

### DIFF
--- a/src/ert/config/model_config.py
+++ b/src/ert/config/model_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os.path
+import re
 import shutil
 from pathlib import Path
 
@@ -24,6 +25,8 @@ DEFAULT_RUNPATH = "simulations/realization-<IENS>/iter-<ITER>"
 DEFAULT_GEN_KW_EXPORT_NAME = "parameters"
 DEFAULT_JOBNAME_FORMAT = "<CONFIG_FILE>-<IENS>"
 DEFAULT_ECLBASE_FORMAT = "ECLBASE<IENS>"
+
+_TOKEN_REGEX = re.compile(r"<[^<>]+>")
 
 FULL_DISK_PERCENTAGE_THRESHOLD = 0.97
 MINIMUM_BYTES_LEFT_ON_DISK_THRESHOLD = 200 * 1000**3  # 200 GB
@@ -74,6 +77,9 @@ class ModelConfig(BaseModel, extra="forbid"):
             )
             ConfigWarning.warn(msg)
             logger.warning(msg)
+
+        cls._validate_static_parts_exists(result)
+
         with contextlib.suppress(Exception):
             mount_dir = get_mount_directory(Path(runpath_format_string))
             total_space, used_space, free_space = shutil.disk_usage(mount_dir)
@@ -126,6 +132,35 @@ class ModelConfig(BaseModel, extra="forbid"):
                 ConfigKeys.GEN_KW_EXPORT_NAME, DEFAULT_GEN_KW_EXPORT_NAME
             ),
         )
+
+    @staticmethod
+    def _validate_static_parts_exists(runpath_format: str) -> None:
+        """
+        Splits the provided runpath format into parts
+        and verifies that the static prefix, if present,
+        consists of directories.
+
+        Static parts after dynamic parts are not validated,
+        as dynamic parts are resolved later in the application.
+        """
+
+        parts = Path(runpath_format).parts
+
+        static_parts = []
+        for part in parts:
+            if _TOKEN_REGEX.search(part):
+                break
+            static_parts.append(part)
+
+        if not static_parts:
+            return
+
+        static_dir = Path(*static_parts)
+        if static_dir.exists() and not static_dir.is_dir():
+            raise ConfigValidationError(
+                f"Invalid runpath format; {static_dir} exists, but is not a directory."
+            )
+        return
 
 
 def _replace_runpath_format(format_string: str) -> str:

--- a/tests/ert/unit_tests/config/test_model_config.py
+++ b/tests/ert/unit_tests/config/test_model_config.py
@@ -57,6 +57,25 @@ def test_model_config_jobname_and_eclbase(extra_config, expected):
     assert ModelConfig.from_dict(config_dict).jobname_format_string == expected
 
 
+def test_that_runpath_validation_raises_error_when_static_prefix_is_not_a_dir(tmp_path):
+    file = tmp_path / "not_a_dir"
+    file.write_text("This is a file")
+
+    with pytest.raises(ValueError, match="not a directory"):
+        ModelConfig(runpath_format_string=str(file / "<IENS>" / "<ITER>"))
+
+
+def test_that_runpath_validation_does_not_raise_error_when_static_prefix_is_a_dir(
+    tmp_path,
+):
+    static_dir = tmp_path / "dir"
+    static_dir.mkdir()
+
+    ModelConfig(
+        runpath_format_string=str(static_dir / "<IENS>" / "static_part" / "<ITER>")
+    )
+
+
 @pytest.mark.parametrize(
     ("total_space", "used_space", "to_warn", "expected_warning"),
     [


### PR DESCRIPTION
**Issue**
Resolves #14265 

**Approach**
If the user provide a runpath, where parts of the runpath contain an existing file,
this is not a valid directory and a config error is thrown.

<img width="1102" height="586" alt="gui" src="https://github.com/user-attachments/assets/c9f01f4b-bb65-42ae-82a8-7d5e0028a73e" />

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
