### PR TITLE
Allow polygon shape to consist of disjoint parts

### DIFF
--- a/src/ert/config/_shapes.py
+++ b/src/ert/config/_shapes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Annotated, ClassVar, Literal, Self
+from typing import Annotated, ClassVar, Literal, Self, cast
 
 import shapely
 import xtgeo
@@ -41,16 +41,16 @@ class CircleShapeConfig(ShapeConfig):
 
 
 class PolygonShapeConfig(ShapeConfig):
-    """Configuration for a polygonal shape.
+    """Configuration for a 2D (multi)polygonal shape.
 
     Attributes:
-        vertices: List of (east, north) tuples defining the polygon vertices. Vertices
-        are expected to be normalized in shapely's sense (first vertex is the lowest,
-        and vertices are ordered clockwise).
+        wkt: Well-Known Text representation of the multipolygon. Vertices are expected
+        to be normalized in shapely's sense (first vertex is the lowest, and vertices
+        are ordered clockwise).
     """
 
     type: Literal["polygon"] = "polygon"
-    vertices: list[tuple[float, float]]
+    wkt: str  # Well-Known Text representation of the multipolygon
 
     TOLERANCE: ClassVar[float] = 0.1
 
@@ -62,37 +62,50 @@ class PolygonShapeConfig(ShapeConfig):
             filepath: Path to a file containing polygon definition. Supported formats
             are the ones supported by xtgeo.polygons_from_file
             https://xtgeo.readthedocs.io/en/latest/api-points-polygons.html#xtgeo.polygons_from_file.
-            Expected to contain exactly one polygon with no holes.
+            Expected to contain one or more polygons with no holes. Multiple polygons
+            (disjoint or overlapping) are preserved; overlapping polygons are merged.
         """
-        xtgeo_polygon = xtgeo.polygons_from_file(filepath)
-
-        if len(set(xtgeo_polygon.dataframe["POLY_ID"])) != 1:
-            raise ValueError(
-                "Multiple polygons found in the file. "
-                "Behavior is defined only for one polygon."
-            )
+        xtgeo_polygons = xtgeo.polygons_from_file(filepath)
+        line_strings = xtgeo_polygons.get_shapely_objects()
 
         try:
-            shapely_polygon = (
-                shapely.Polygon(xtgeo_polygon.get_xyz_arrays())
-                .simplify(tolerance=cls.TOLERANCE)
-                .normalize()
-            )
+            separate_polygons = [shapely.Polygon(poly.coords) for poly in line_strings]
+            polygon_union = shapely.union_all(separate_polygons)
         except Exception as e:
             raise ValueError(f"Failed to create polygon from file {filepath}") from e
 
-        vertices = shapely.get_coordinates(shapely_polygon).tolist()
+        if isinstance(polygon_union, shapely.MultiPolygon):
+            multipolygon = polygon_union
+        elif isinstance(polygon_union, shapely.Polygon):
+            multipolygon = shapely.MultiPolygon([polygon_union])
+        else:
+            raise ValueError(
+                f"Shapes in the file '{filepath}' could not be converted to polygons. "
+                f"Unexpected geometry type {type(polygon_union).__name__}"
+            )
 
-        return cls(vertices=vertices)
+        cleaned_polygons = [
+            cast(
+                shapely.Polygon,
+                geom.simplify(tolerance=cls.TOLERANCE).normalize(),
+            )
+            for geom in multipolygon.geoms
+        ]
+        multipolygon = cast(
+            shapely.MultiPolygon, shapely.MultiPolygon(cleaned_polygons).normalize()
+        )
+
+        return cls(wkt=shapely.force_2d(multipolygon).wkt)
 
     @cached_property
-    def _polygon(self) -> shapely.Polygon:
-        poly = shapely.Polygon(self.vertices)
-        shapely.prepare(poly)
-        return poly
+    def _polygon(self) -> shapely.MultiPolygon:
+        multipolygon = shapely.from_wkt(self.wkt)
+        assert isinstance(multipolygon, shapely.MultiPolygon)
+        shapely.prepare(multipolygon)
+        return multipolygon
 
     def contains(self, east: float, north: float) -> bool:
-        """Check if a point is inside the polygon.
+        """Check if a point is inside any of the internal polygons.
 
         Args:
             east: UTM_X-coordinate of the point

--- a/tests/ert/unit_tests/config/test_observation_declaration.py
+++ b/tests/ert/unit_tests/config/test_observation_declaration.py
@@ -1248,14 +1248,8 @@ def test_that_seismic_observation_reads_boundary_file(file_context_token):
     ]
     boundary = shape_registry.get(0)
     assert isinstance(boundary, PolygonShapeConfig)
-    expected = [
-        (0.0, 0.0),
-        (0.0, 1.0),
-        (1.0, 1.0),
-        (1.0, 0.0),
-        (0.0, 0.0),
-    ]
-    assert boundary.vertices == expected
+    expected = PolygonShapeConfig(wkt="MULTIPOLYGON (((0 0, 0 1, 1 1, 1 0, 0 0)))")
+    assert boundary == expected
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/ert/unit_tests/config/test_observation_quality_control.py
+++ b/tests/ert/unit_tests/config/test_observation_quality_control.py
@@ -174,15 +174,9 @@ def test_that_observation_without_zones_are_not_disabled_by_zone_check():
 
 
 def test_that_observations_within_boundary_stay_while_outside_are_removed():
-    boundary = PolygonShapeConfig(
-        vertices=[
-            (0.0, 0.0),
-            (0.0, 1.0),
-            (1.0, 1.0),
-            (1.0, 0.0),
-            (0.0, 0.0),
-        ]
-    )
+    polygon1 = "((0 0, 0 1, 1 1, 1 0, 0 0))"
+    polygon2 = "((3 3, 3 4, 4 4, 4 3, 3 3))"
+    boundary = PolygonShapeConfig(wkt=f"MULTIPOLYGON ({polygon1}, {polygon2})")
     shape_registry = ShapeRegistry()
     boundary_id = shape_registry.register(boundary)
 
@@ -207,8 +201,13 @@ def test_that_observations_within_boundary_stay_while_outside_are_removed():
                 east=2.5,
                 north=2.5,
             ),
+            create_seismic_observation(
+                east=3.5,
+                north=3.5,
+                boundary_id=boundary_id,
+            ),
         ]
     )
 
     qc = qc_seismic_observations(observations, shape_registry)
-    assert qc["east"].to_list() == [0.5, 2.5]
+    assert qc["east"].to_list() == [0.5, 2.5, 3.5]

--- a/tests/ert/unit_tests/config/test_shapes.py
+++ b/tests/ert/unit_tests/config/test_shapes.py
@@ -1,8 +1,16 @@
 from textwrap import dedent
 
 import pytest
+import shapely
 
 from ert.config._shapes import CircleShapeConfig, PolygonShapeConfig, ShapeRegistry
+
+
+def _polygon_from_coords(coords: list[list[tuple[float, float]]]) -> PolygonShapeConfig:
+    """Create a PolygonShapeConfig from coordinate lists. No holes are considered."""
+    polygons = [shapely.Polygon(ring) for ring in coords]
+    multipolygon = shapely.MultiPolygon(polygons)
+    return PolygonShapeConfig(wkt=multipolygon.wkt)
 
 
 def test_that_shape_registry_reuses_identical_circle_shapes():
@@ -41,14 +49,16 @@ def test_that_polygon_shape_is_read_from_file(mocked_files):
     )
     shape = PolygonShapeConfig.from_file("polygon.pol")
     expected = [
-        (0.5, 4.0),
-        (1.0, 7.0),
-        (2.0, 9.0),
-        (3.0, 6.0),
-        (1.0, 5.0),
-        (0.5, 4.0),
+        [
+            (0.5, 4.0),
+            (1.0, 7.0),
+            (2.0, 9.0),
+            (3.0, 6.0),
+            (1.0, 5.0),
+            (0.5, 4.0),
+        ]
     ]
-    assert shape.vertices == expected
+    assert shape == _polygon_from_coords(expected)
 
 
 def test_that_polygon_shape_is_normalized(mocked_files):
@@ -64,13 +74,15 @@ def test_that_polygon_shape_is_normalized(mocked_files):
     )
     shape = PolygonShapeConfig.from_file("polygon.pol")
     expected = [
-        (1.0, 6.0),
-        (3.0, 9.0),
-        (4.0, 6.0),
-        (2.0, 5.0),
-        (1.0, 6.0),
+        [
+            (1.0, 6.0),
+            (3.0, 9.0),
+            (4.0, 6.0),
+            (2.0, 5.0),
+            (1.0, 6.0),
+        ]
     ]
-    assert shape.vertices == expected
+    assert shape == _polygon_from_coords(expected)
 
 
 def test_that_polygon_shape_is_simplified_within_tolerance(mocked_files):
@@ -90,17 +102,19 @@ def test_that_polygon_shape_is_simplified_within_tolerance(mocked_files):
     )
     shape = PolygonShapeConfig.from_file("polygon.pol")
     expected = [
-        (0.0, 0.0),
-        (0.0, 2.0),
-        (1.0, 2.2),
-        (2.0, 2.0),
-        (2.0, 0.0),
-        (0.0, 0.0),
+        [
+            (0.0, 0.0),
+            (0.0, 2.0),
+            (1.0, 2.2),
+            (2.0, 2.0),
+            (2.0, 0.0),
+            (0.0, 0.0),
+        ]
     ]
-    assert shape.vertices == expected
+    assert shape == _polygon_from_coords(expected)
 
 
-def test_that_polygon_shape_raises_when_multiple_polygons_found(mocked_files):
+def test_that_polygon_shape_keeps_disjoint_polygons(mocked_files):
     mocked_files["polygon.pol"] = dedent(
         """
         0.000000 0.000000 0.000000
@@ -118,7 +132,159 @@ def test_that_polygon_shape_raises_when_multiple_polygons_found(mocked_files):
         999.000000 999.000000 999.000000
         """
     )
-    with pytest.raises(ValueError, match="Multiple polygons found in the file"):
+    shape = PolygonShapeConfig.from_file("polygon.pol")
+    expected = [
+        [
+            (2.0, 2.0),
+            (2.0, 3.0),
+            (3.0, 3.0),
+            (3.0, 2.0),
+            (2.0, 2.0),
+        ],
+        [
+            (0.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+        ],
+    ]
+    assert shape == _polygon_from_coords(expected)
+
+
+def test_that_polygon_shape_merges_overlapping_polygons(mocked_files):
+    mocked_files["polygon.pol"] = dedent(
+        """
+        0.000000 0.000000 0.000000
+        0.000000 2.000000 0.000000
+        2.000000 2.000000 0.000000
+        2.000000 0.000000 0.000000
+        0.000000 0.000000 0.000000
+        999.000000 999.000000 999.000000
+
+        1.000000 1.000000 0.000000
+        1.000000 3.000000 0.000000
+        3.000000 3.000000 0.000000
+        3.000000 1.000000 0.000000
+        1.000000 1.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    shape = PolygonShapeConfig.from_file("polygon.pol")
+    expected = [
+        [
+            (0.0, 0.0),
+            (0.0, 2.0),
+            (1.0, 2.0),
+            (1.0, 3.0),
+            (3.0, 3.0),
+            (3.0, 1.0),
+            (2.0, 1.0),
+            (2.0, 0.0),
+            (0.0, 0.0),
+        ]
+    ]
+    assert shape == _polygon_from_coords(expected)
+
+
+def test_that_polygon_shape_preserves_holes_in_merged_polygon(mocked_files):
+    top = dedent(
+        """
+        0.000000 2.000000 0.000000
+        4.000000 2.000000 0.000000
+        4.000000 3.000000 0.000000
+        0.000000 3.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    bottom = dedent(
+        """
+        0.000000 0.000000 0.000000
+        4.000000 0.000000 0.000000
+        4.000000 1.000000 0.000000
+        0.000000 1.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    left = dedent(
+        """
+        0.000000 1.000000 0.000000
+        1.000000 1.000000 0.000000
+        1.000000 2.000000 0.000000
+        0.000000 2.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    right = dedent(
+        """
+        3.000000 1.000000 0.000000
+        4.000000 1.000000 0.000000
+        4.000000 2.000000 0.000000
+        3.000000 2.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    mocked_files["polygon.pol"] = top + bottom + left + right
+    shape = PolygonShapeConfig.from_file("polygon.pol")
+    assert shape.contains(0.5, 0.5)
+    assert not shape.contains(1.5, 1.5)
+
+
+def test_that_polygon_shape_normalizes_and_simplifies_multipolygons(mocked_files):
+    polygon1 = dedent(
+        """
+        0.000000 0.000000 0.000000
+        2.000000 0.000000 0.000000
+        2.000000 2.000000 0.000000
+        0.000000 2.000000 0.000000
+        0.000000 0.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    polygon2 = dedent(
+        """
+        2.000000 0.000000 0.000000
+        4.000000 0.000000 0.000000
+        4.000000 2.000000 0.000000
+        2.000000 2.000000 0.000000
+        2.000000 0.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    polygon3 = dedent(
+        """
+        4.000000 4.000000 0.000000
+        6.000000 4.000000 0.000000
+        6.000000 6.000000 0.000000
+        4.000000 6.000000 0.000000
+        4.000000 4.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    mocked_files["polygon.pol"] = polygon3 + polygon2 + polygon1
+    shape = PolygonShapeConfig.from_file("polygon.pol")
+    expected = [
+        [
+            (4.0, 4.0),
+            (4.0, 6.0),
+            (6.0, 6.0),
+            (6.0, 4.0),
+            (4.0, 4.0),
+        ],
+        [
+            (0.0, 0.0),
+            (0.0, 2.0),
+            (4.0, 2.0),
+            (4.0, 0.0),
+            (0.0, 0.0),
+        ],
+    ]
+    assert shape == _polygon_from_coords(expected)
+
+
+def test_that_polygon_shape_raises_when_geometry_is_empty(mocked_files):
+    mocked_files["polygon.pol"] = ""
+    with pytest.raises(ValueError, match="could not be converted to polygons"):
         PolygonShapeConfig.from_file("polygon.pol")
 
 
@@ -186,9 +352,39 @@ def test_that_polygons_are_not_equal_outside_tolerance(mocked_files):
     assert shape1 != shape2
 
 
+def test_that_polygons_are_equal_regardless_of_internal_order(mocked_files):
+    polygon1 = dedent(
+        """
+        0.000000 0.000000 0.000000
+        0.000000 1.000000 0.000000
+        1.000000 1.000000 0.000000
+        1.000000 0.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    polygon2 = dedent(
+        """
+        1.000000 1.000000 0.000000
+        1.000000 2.000000 0.000000
+        2.000000 2.000000 0.000000
+        2.000000 1.000000 0.000000
+        999.000000 999.000000 999.000000
+        """
+    )
+    mocked_files["polygon12.pol"] = polygon1 + polygon2
+    shape1 = PolygonShapeConfig.from_file("polygon12.pol")
+
+    mocked_files["polygon21.pol"] = polygon2 + polygon1
+    shape2 = PolygonShapeConfig.from_file("polygon21.pol")
+
+    assert shape1 == shape2
+
+
 def test_that_polygons_are_not_equal_to_circles():
     shape1 = PolygonShapeConfig(
-        vertices=[(0.0, 1.0), (1.0, 2.0), (2.0, 1.0), (1.0, 0.0), (0.0, 1.0)]
+        wkt=_polygon_from_coords(
+            [[(0.0, 1.0), (1.0, 2.0), (2.0, 1.0), (1.0, 0.0), (0.0, 1.0)]]
+        ).wkt
     )
     shape2 = CircleShapeConfig(east=1.0, north=1.0, radius=1.0)
 


### PR DESCRIPTION
**Issue**
Resolves #14297 


**Approach**
Per user's requirement polygon file may contain multiple disjoint polygons. For seismic, we need keep points that are inside one or more polygons.

Polygon shape is for now used only in seismic and seismic is unreleased yet, so we are free to change it.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
