### PR TITLE
Fix fmudesign file handling and plot labels

### DIFF
--- a/src/fmudesign/create_design.py
+++ b/src/fmudesign/create_design.py
@@ -46,6 +46,10 @@ if TYPE_CHECKING:
     CorrelationGroup = tuple[str, pd.DataFrame, list[str]]
 
 
+def _normalize_xlsx_filename(filename: str) -> str:
+    return filename if filename.endswith(".xlsx") else f"{filename}.xlsx"
+
+
 def _derive_rng(base_seed: int, *keys: str) -> np.random.Generator:
     """Return a numpy Generator seeded from ``base_seed`` and ``keys``.
 
@@ -298,12 +302,13 @@ class DesignMatrix:
             defaultsheet (str): name of excel sheet containing default
                 values (optional, defaults to 'DefaultValues')
         """
+        normalized_filename = _normalize_xlsx_filename(filename)
+        if normalized_filename != filename:
+            filename = normalized_filename
+            print(f"Warning: Missing .xlsx suffix. Changed to: {filename}")
+
         # Create folder for output file
         Path(filename).parent.mkdir(exist_ok=True, parents=True)
-
-        if not filename.endswith(".xlsx"):
-            filename += ".xlsx"
-            print(f"Warning: Missing .xlsx suffix. Changed to: {filename}")
 
         with pd.ExcelWriter(filename, engine="openpyxl") as writer:
             self.designvalues.to_excel(

--- a/src/fmudesign/fmudesignrunner.py
+++ b/src/fmudesign/fmudesignrunner.py
@@ -34,7 +34,7 @@ from pydantic import ValidationError
 from ert.shared import __version__ as ert_version
 
 from ._excel_to_dict import excel_to_dict
-from .create_design import DesignMatrix
+from .create_design import DesignMatrix, _normalize_xlsx_filename
 
 
 @dataclasses.dataclass
@@ -252,8 +252,8 @@ def subcommand_run(args: Namespace, parser: ArgumentParser) -> None:
     if not Path(args.config).is_file():
         raise OSError(f"Input file {args.config} does not exist")
 
-    # Check if destination exists
-    if Path(args.config).resolve() == Path(args.destination).resolve():
+    destination = _normalize_xlsx_filename(args.destination)
+    if Path(args.config).resolve() == Path(destination).resolve():
         raise OSError(
             f'Identical name "{args.config}" have been provided for the input'
             "file and the output file"
@@ -270,7 +270,7 @@ def subcommand_run(args: Namespace, parser: ArgumentParser) -> None:
 
     # If destination is 'analysis/generateddesignmatrix.xlsx', then plots
     # will be saved to 'analysis/generateddesignmatrix/<SENSNAME>/<VARNAME>.png'
-    output_dir = Path(args.destination).parent / Path(args.destination).stem
+    output_dir = Path(destination).with_suffix("")
     design = DesignMatrix(verbosity=args.verbose, output_dir=output_dir)
 
     design.generate(config)
@@ -293,21 +293,26 @@ def subcommand_init(args: Namespace, parser: ArgumentParser) -> None:
         sys.exit(0)
 
     filename = args.file.strip()
-    valid_names = {ex.filename for ex in EXAMPLES}
-    if filename not in valid_names:
-        print(f"Error on {filename!r}. Not found among: {valid_names}")
+    examples_by_filename = {example.filename: example for example in EXAMPLES}
+    if filename not in examples_by_filename:
+        print(f"Error on {filename!r}. Not found among: {set(examples_by_filename)}")
         sys.exit(1)
 
-    if Path(filename).exists():
-        print(f"Error on {filename!r}. Already exists.")
+    example = examples_by_filename[filename]
+    destinations = [filename, *example.other_files]
+    existing_destinations = [
+        destination for destination in destinations if Path(destination).exists()
+    ]
+    if existing_destinations:
+        for destination in existing_destinations:
+            print(f"Error on {destination!r}. Already exists.")
         sys.exit(1)
 
     with as_file(EXAMPLES_DIR / filename) as source_path:
         shutil.copy(source_path, filename)
         print(f"Created file {filename!r}.")
 
-    examples_by_filename = {example.filename: example for example in EXAMPLES}
-    for other_file in examples_by_filename[filename].other_files:
+    for other_file in example.other_files:
         with as_file(EXAMPLES_DIR / other_file) as source_path:
             shutil.copy(source_path, other_file)
             print(f"  Created auxiliary file {other_file!r}.")

--- a/src/fmudesign/quality_report.py
+++ b/src/fmudesign/quality_report.py
@@ -240,17 +240,9 @@ class QualityReporter:
         """
         fig, ax = plt.subplots(figsize=(6, 4))
 
-        # Calculate normalized proportions
-        proportions = series.value_counts(normalize=True)
-        value_counts = series.value_counts(normalize=False)
-
-        # Create DataFrame for seaborn
-        plot_data = pd.DataFrame(
-            {var_name: proportions.index, "proportion": proportions.to_numpy()}
-        ).sort_values(by=var_name)
-
-        # Use seaborn barplot with normalized values
-        sns.barplot(data=plot_data, x=var_name, y="proportion", ax=ax)
+        value_counts = series.value_counts().sort_index()
+        proportions = value_counts / value_counts.sum()
+        sns.barplot(x=value_counts.index, y=proportions.to_numpy(), ax=ax)
 
         # Create string to describe distribution
         var_string = (
@@ -262,14 +254,12 @@ class QualityReporter:
         )
 
         ax.set_title(f"{var_name}\n{var_string}", fontsize=7)
+        ax.set_xlabel(var_name)
         ax.set_ylabel("Proportion")
 
         # Add percentage labels on bars
-        for _proportion, count, p in zip(
-            proportions, value_counts, ax.patches, strict=False
-        ):
+        for count, p in zip(value_counts, ax.patches, strict=False):
             rect = cast("Rectangle", p)
-            # assert math.isclose(_proportion, rect.get_height())
             percentage = f"{rect.get_height():.1%} (n={count:.0f})"
             ax.annotate(
                 percentage,

--- a/tests/fmudesign/test_create_design.py
+++ b/tests/fmudesign/test_create_design.py
@@ -223,7 +223,10 @@ def test_that_generated_distributions_match_configured_statistics(
         assert np.sqrt(np.mean((obs_corr - corr_values) ** 2)) < 0.02
 
 
-def test_that_onebyone_design_contains_configured_cases_and_values(tmp_path):
+@pytest.mark.parametrize("output_filename", ["designmatrix.xlsx", "designmatrix"])
+def test_that_onebyone_design_contains_configured_cases_and_values(
+    tmp_path, capsys, output_filename
+):
     input_dict = onebyone_configuration()
 
     # Note that repeats are set to 10 in general_input sheet.
@@ -237,7 +240,16 @@ def test_that_onebyone_design_contains_configured_cases_and_values(tmp_path):
     assert design.designvalues.shape == (rows_in_design_matrix, 10)
 
     output_path = tmp_path / "designmatrix.xlsx"
-    design.to_xlsx(str(output_path))
+    capsys.readouterr()
+    design.to_xlsx(str(tmp_path / output_filename))
+    stdout = capsys.readouterr().out
+    warning = "Warning: Missing .xlsx suffix."
+    if output_filename.endswith(".xlsx"):
+        assert warning not in stdout
+    else:
+        assert stdout.count(warning) == 1
+        assert f"{warning} Changed to: {output_path}" in stdout
+
     diskdesign = pd.read_excel(output_path, engine="openpyxl")
 
     assert (

--- a/tests/fmudesign/test_fmudesignrunner.py
+++ b/tests/fmudesign/test_fmudesignrunner.py
@@ -160,7 +160,7 @@ def test_that_subcommand_run_raises_when_config_does_not_exist(use_tmpdir):
 def test_that_subcommand_run_raises_when_config_is_equal_to_destination(use_tmpdir):
     _, subparsers = get_parser()
     parser_run = subparsers.choices["run"]
-    duplicate_name = "duplicate_name"
+    duplicate_name = "duplicate_name.xlsx"
     Path(duplicate_name).touch()
     args = _create_run_args(
         config_file_name=duplicate_name, destination_file_name=duplicate_name
@@ -252,3 +252,43 @@ def test_that_subcommand_init_creates_auxiliary_files(use_tmpdir, capsys):
     assert Path(auxiliary_file).is_file()
     assert f"Created file {example_file!r}." in stdout
     assert f"Created auxiliary file {auxiliary_file!r}." in stdout
+
+
+def test_that_run_rejects_output_matching_input_after_adding_xlsx_suffix(
+    tmp_path, monkeypatch
+):
+    input_path = tmp_path / "config.xlsx"
+    original_content = b"original workbook"
+    input_path.write_bytes(original_content)
+
+    parser, _ = fmudesignrunner.get_parser()
+    args = parser.parse_args(["run", str(input_path), str(input_path.with_suffix(""))])
+    monkeypatch.setattr(
+        fmudesignrunner,
+        "excel_to_dict",
+        lambda *args, **kwargs: pytest.fail("Input workbook was parsed"),
+    )
+
+    with pytest.raises(OSError, match="Identical name"):
+        args.func(args)
+
+    assert input_path.read_bytes() == original_content
+
+
+def test_that_init_copies_nothing_when_auxiliary_destination_exists(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    auxiliary_path = Path("ex2_doe1.xlsx")
+    original_content = b"existing auxiliary workbook"
+    auxiliary_path.write_bytes(original_content)
+
+    parser, _ = fmudesignrunner.get_parser()
+    args = parser.parse_args(["init", "ex2_correlations.xlsx"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        args.func(args)
+
+    assert exc_info.value.code == 1
+    assert not Path("ex2_correlations.xlsx").exists()
+    assert auxiliary_path.read_bytes() == original_content

--- a/tests/fmudesign/test_general_input.py
+++ b/tests/fmudesign/test_general_input.py
@@ -45,7 +45,7 @@ TEXT_STRIPPED_OR_NONE = st.one_of(TEXT_STRIPPED_NOT_NUMERIC, st.none())
 
 @pytest.mark.parametrize(
     "required_key",
-    (key for key, info in GeneralInput.model_fields.items() if info.is_required()),
+    [key for key, info in GeneralInput.model_fields.items() if info.is_required()],
 )
 def test_that_missing_required_key_raises_validation_error(required_key):
     general_input_dict = base_general_input_dict()
@@ -56,7 +56,7 @@ def test_that_missing_required_key_raises_validation_error(required_key):
 
 @pytest.mark.parametrize(
     "optional_key",
-    (key for key, info in GeneralInput.model_fields.items() if not info.is_required()),
+    [key for key, info in GeneralInput.model_fields.items() if not info.is_required()],
 )
 def test_that_missing_optional_key_does_not_raise_validation_error(optional_key):
     general_input_dict = base_general_input_dict()

--- a/tests/fmudesign/test_quality_report.py
+++ b/tests/fmudesign/test_quality_report.py
@@ -1,0 +1,26 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from fmudesign.quality_report import QualityReporter
+
+
+@pytest.mark.parametrize("var_name", ["category", "count", "proportion"])
+def test_that_discrete_plot_counts_match_sorted_categories(var_name):
+    series = pd.Series(["beta", "beta", "beta", "alpha"])
+
+    fig, ax = QualityReporter.plot_discrete(
+        series=series,
+        var_name=var_name,
+        var_description=["Discrete", []],
+    )
+
+    assert ax.get_xlabel() == var_name
+    categories = [label.get_text() for label in ax.get_xticklabels()]
+    annotations = [annotation.get_text() for annotation in ax.texts]
+    assert dict(zip(categories, annotations, strict=True)) == {
+        "alpha": "25.0% (n=1)",
+        "beta": "75.0% (n=3)",
+    }
+
+    plt.close(fig)

--- a/tests/fmudesign/test_use_cases.py
+++ b/tests/fmudesign/test_use_cases.py
@@ -140,13 +140,15 @@ def test_that_cli_verbosity_controls_sensitivity_plot_generation(
     monkeypatch.chdir(tmp_path)
     designfile = "ex4_background_parameters.xlsx"
     _run_cli("init", designfile)
-    result = _run_cli("run", designfile, *(["--verbose"] * verbosity))
+    result = _run_cli(
+        "run", designfile, "analysis/design.v2", *(["--verbose"] * verbosity)
+    )
 
-    assert (tmp_path / "generateddesignmatrix.xlsx").is_file()
+    assert (tmp_path / "analysis/design.v2.xlsx").is_file()
     assert "CONTINUOUS PARAMETERS" in result.stdout
     assert "CORRELATION_GROUP 'corr1'" in result.stdout
-    assert (tmp_path / "generateddesignmatrix/background/PARAM17.png").is_file()
-    sensitivity_plot = tmp_path / "generateddesignmatrix/sens7/PARAM9.png"
+    assert (tmp_path / "analysis/design.v2/background/PARAM17.png").is_file()
+    sensitivity_plot = tmp_path / "analysis/design.v2/sens7/PARAM9.png"
     if verbosity == 2:
         assert sensitivity_plot.is_file()
     else:


### PR DESCRIPTION
Fix fmudesign edge cases that could overwrite files or produce misleading QC plots.
 
 - Normalize output filenames before checking for input/output collisions and deriving plot directories. This prevents `fmudesign run config.xlsx config` from overwriting the input and keeps plots alongside the intended workbook when output names contain dots, such as `design.v2`.
 - Check all example destinations before copying anything. If an auxiliary workbook already exists, `init` now refuses to proceed instead of overwriting it or leaving a newly created main workbook behind.
 - Derive discrete plot proportions and annotations from the same category-ordered counts. This fixes mismatched `n=` labels and avoids collisions with parameter names such as `count` and `proportion`.
 
 Also replace generator-based pytest parameters with lists to remove deprecation warnings.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
