### PR TITLE
Ensure workflows run in their declared order

### DIFF
--- a/docs/ert/reference/configuration/keywords.rst
+++ b/docs/ert/reference/configuration/keywords.rst
@@ -2040,6 +2040,10 @@ The last argument must be one of the supported runtime step values:
 
    HOOK_WORKFLOW_JOB export_rft EXPORT_RFT some_path/rft.csv POST_SIMULATION
 
+Hooks declared with :code:`HOOK_WORKFLOW_JOB` and :code:`HOOK_WORKFLOW` share the
+same execution order at a given runtime step, which follows the order of
+declaration in the config file. See :ref:`automatically-run-workflows`.
+
 .. _load_workflow:
 
 LOAD_WORKFLOW

--- a/docs/ert/reference/workflows/complete_workflows.rst
+++ b/docs/ert/reference/workflows/complete_workflows.rst
@@ -86,6 +86,42 @@ Observe that the workflows being 'hooked in' with the
 :code:`HOOK_WORKFLOW` must be loaded with the :code:`LOAD_WORKFLOW`
 keyword.
 
+Workflows hooked to the same point run in the order they are declared in the
+config file. This also holds when :code:`HOOK_WORKFLOW` and
+:code:`HOOK_WORKFLOW_JOB` are mixed, so a workflow that depends on the output
+of another one only needs to be declared after it::
+
+   HOOK_WORKFLOW_JOB first_workflow MY_JOB PRE_SIMULATION
+   LOAD_WORKFLOW second_workflow
+   HOOK_WORKFLOW second_workflow PRE_SIMULATION
+
+Here :code:`first_workflow` runs before :code:`second_workflow`.
+
+Workflow output
+---------------
+
+Output from workflow jobs is written to the ERT log.
+Every job invocation gets an output that the job wrote to stdout and stderr::
+
+    2026-07-30 10:19:33,041 - ert.workflow_runner - MainThread - INFO - Workflow job starting; hook=PRE_SIMULATION workflow=my_workflow job=MY_JOB#0
+    2026-07-30 10:19:33,052 - ert.workflow_runner - MainThread - INFO - Workflow job result; hook=PRE_SIMULATION workflow=my_workflow job=MY_JOB#0 status=success
+    --- arguments ---
+    first_argument second_argument
+    --- stdout ---
+    Hello from the workflow
+
+This covers every way a workflow can be started: hooked in with
+:code:`HOOK_WORKFLOW`, run with :code:`ert workflow`, or started from the *Run
+workflow* tool in the GUI. Workflows that were not started from a hook, such as
+a manual run, are logged with :code:`hook=None`.
+
+The :code:`status` field is one of :code:`success`, :code:`failed` or
+:code:`cancelled`. Only :code:`failed` is logged at :code:`ERROR` level;
+jobs that were stopped because the workflow was cancelled are logged at
+:code:`INFO` level.
+
+.. _runpath-file-workflows:
+
 Locating the realisations: <RUNPATH_FILE>
 -----------------------------------------
 

--- a/src/ert/config/ert_config.py
+++ b/src/ert/config/ert_config.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from os import path
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Self, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Self, cast, overload
 
 from numpy.random import SeedSequence
 from pydantic import BaseModel, Field, model_validator
@@ -62,6 +62,7 @@ from .parsing import (
     parse_contents,
     read_file,
 )
+from .parsing.file_context_token import FileContextToken
 from .parsing.observations_parser import ObservationDict
 from .queue_config import KnownQueueOptions, QueueConfig
 from .rft_config import RFTConfig
@@ -465,6 +466,25 @@ def _validate_fixtures(
     return errors
 
 
+class _DeclaredHook(NamedTuple):
+    declaration_order: int
+    workflow: Workflow
+
+
+def _declaration_order_of(workflow_name: str) -> int:
+    """Position of the hook among all instructions in the fully resolved
+    config (after INCLUDE files are spliced in), used to order hooks by
+    where they were declared.
+    """
+    if (
+        isinstance(workflow_name, FileContextToken)
+        and workflow_name.declaration_order is not None
+    ):
+        return workflow_name.declaration_order
+    # return 0 for jobs not declared in the config file, e.g. site-installed jobs
+    return 0
+
+
 def create_and_hook_workflows(
     hook_workflow_info: list[tuple[str, HookRuntime]],
     hook_workflow_job_info: list[list[str]],
@@ -474,7 +494,7 @@ def create_and_hook_workflows(
     substitutions: dict[str, str],
 ) -> tuple[dict[str, Workflow], defaultdict[HookRuntime, list[Workflow]]]:
     workflows = {}
-    hooked_workflows = defaultdict(list)
+    declared_hooks: defaultdict[HookRuntime, list[_DeclaredHook]] = defaultdict(list)
 
     errors: list[ErrorInfo | ConfigValidationError] = []
 
@@ -542,7 +562,9 @@ def create_and_hook_workflows(
         workflow = workflows[hook_name]
         errors.extend(_validate_fixtures(hook_name, workflow, mode))
 
-        hooked_workflows[mode].append(workflow)
+        declared_hooks[mode].append(
+            _DeclaredHook(_declaration_order_of(hook_name), workflow)
+        )
 
     for inline_workflow_hook in hook_workflow_job_info:
         inline_workflow = inline_workflow_hook[:-1]
@@ -561,12 +583,21 @@ def create_and_hook_workflows(
             wf_name, wf = _create_workflow_from_job(inline_workflow)
             _register_workflow(inline_workflow, wf_name, wf)
             errors.extend(_validate_fixtures(wf_name, wf, mode))
-            hooked_workflows[mode].append(wf)
+            declared_hooks[mode].append(
+                _DeclaredHook(_declaration_order_of(wf_name), wf)
+            )
         except ConfigValidationError as err:
             errors.append(err)
 
     if errors:
         raise ConfigValidationError.from_collected(errors)
+
+    hooked_workflows: defaultdict[HookRuntime, list[Workflow]] = defaultdict(list)
+    for mode, hooks in declared_hooks.items():
+        hooks_in_declaration_order = sorted(
+            hooks, key=lambda hook: hook.declaration_order
+        )
+        hooked_workflows[mode] = [hook.workflow for hook in hooks_in_declaration_order]
 
     return workflows, hooked_workflows
 

--- a/src/ert/config/parsing/file_context_token.py
+++ b/src/ert/config/parsing/file_context_token.py
@@ -13,7 +13,12 @@ class FileContextToken(Token):
 
     filename: str
 
-    def __new__(cls, token: Token, filename: str) -> FileContextToken:  # noqa: PYI034
+    # Position of this token among all instructions in the fully resolved
+    # config, i.e. after INCLUDE files have been spliced into place.
+    # defaults to None for tokens created outside of config file parsing.
+    declaration_order: int | None = None
+
+    def __new__(cls, token: Token, filename: str) -> FileContextToken:  # ruff: ignore[non-self-return-type]
         inst = super().__new__(
             cls,
             token.type,
@@ -28,6 +33,10 @@ class FileContextToken(Token):
 
         inst_fct = cast(FileContextToken, inst)
         inst_fct.filename = filename
+        if isinstance(token, FileContextToken):
+            # Re-wrapping an already-tagged token (e.g. in replace_value())
+            # must not silently lose its declaration_order.
+            inst_fct.declaration_order = token.declaration_order
         return inst_fct
 
     def __repr__(self) -> str:
@@ -47,7 +56,9 @@ class FileContextToken(Token):
         return hash(self.value)
 
     def update(self, value: Any = None) -> FileContextToken:  # type: ignore[override]
-        return FileContextToken(super().update(value=value), self.filename)
+        updated = FileContextToken(super().update(value=value), self.filename)
+        updated.declaration_order = self.declaration_order
+        return updated
 
     @classmethod
     def join_tokens(
@@ -67,7 +78,10 @@ class FileContextToken(Token):
             if x.line == max_end_line
             if x.end_column is not None
         )
-        return FileContextToken(
+        declaration_orders = [
+            x.declaration_order for x in tokens if x.declaration_order is not None
+        ]
+        joined = FileContextToken(
             Token(
                 type=first.type,
                 value=separator.join(tokens) if tokens else None,
@@ -80,6 +94,9 @@ class FileContextToken(Token):
             ),
             filename=first.filename,
         )
+        if declaration_orders:
+            joined.declaration_order = min(declaration_orders)
+        return joined
 
     def replace_value(self, old: str, new: str, count: int = -1) -> FileContextToken:
         if old in self.value:

--- a/src/ert/config/parsing/lark_parser.py
+++ b/src/ert/config/parsing/lark_parser.py
@@ -192,13 +192,18 @@ def _tree_to_dict(
     errors = []
     cwd = os.path.dirname(os.path.abspath(config_file))
 
-    for node in tree.children:
+    for declaration_order, node in enumerate(tree.children):
         args: list[FileContextToken]
         kw: FileContextToken
         kw, *args = node  # type: ignore
         if kw not in schema:
             ConfigWarning.warn(f"Unknown keyword {kw!r}", kw)
             continue
+
+        kw.declaration_order = declaration_order
+        for arg in args:
+            if isinstance(arg, FileContextToken):
+                arg.declaration_order = declaration_order
 
         constraints = schema[kw]
         if kw != constraints.kw:  # is an alias

--- a/tests/ert/unit_tests/config/test_ert_config.py
+++ b/tests/ert/unit_tests/config/test_ert_config.py
@@ -2973,6 +2973,103 @@ def test_that_hook_workflow_job_registers_and_hooks_workflow(ert_config_with_job
     assert ert_config.workflows["my_wf"] in ert_config.hooked_workflows[mode]
 
 
+@pytest.mark.parametrize(
+    ("hook_lines_in_config_order", "expected_hook_order"),
+    [
+        pytest.param(
+            [
+                "HOOK_WORKFLOW_JOB inline_wf MY_JOB PRE_SIMULATION",
+                "HOOK_WORKFLOW loaded_wf PRE_SIMULATION",
+            ],
+            ["inline_wf", "loaded_wf"],
+            id="hook_workflow_job_declared_before_hook_workflow",
+        ),
+        pytest.param(
+            [
+                "HOOK_WORKFLOW loaded_wf PRE_SIMULATION",
+                "HOOK_WORKFLOW_JOB inline_wf MY_JOB PRE_SIMULATION",
+            ],
+            ["loaded_wf", "inline_wf"],
+            id="hook_workflow_declared_before_hook_workflow_job",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_hooked_workflows_are_ordered_by_position_in_config_file(
+    ert_config_with_job, hook_lines_in_config_order, expected_hook_order
+):
+    Path("loaded_wf").write_text("MY_JOB\n", encoding="utf-8")
+    hook_lines = "\n".join(hook_lines_in_config_order)
+    ert_config = ert_config_with_job.from_file_contents(
+        dedent(f"""
+        NUM_REALIZATIONS 1
+        LOAD_WORKFLOW loaded_wf
+        {hook_lines}
+        """)
+    )
+
+    hooked_workflows = ert_config.hooked_workflows[HookRuntime.PRE_SIMULATION]
+    actual_hook_order = [Path(wf.src_file).name for wf in hooked_workflows]
+    assert actual_hook_order == expected_hook_order
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_hooked_workflows_across_include_are_ordered_by_declaration(
+    ert_config_with_job,
+):
+    """A hook declared in an INCLUDE'd file must keep its position relative to
+    hooks declared directly in the including config file, not be reordered to
+    the position of the INCLUDE line itself or grouped by keyword.
+    """
+    Path("included.ert").write_text(
+        dedent("""
+        LOAD_WORKFLOW loaded_wf
+        HOOK_WORKFLOW loaded_wf PRE_SIMULATION
+        """),
+        encoding="utf-8",
+    )
+    Path("loaded_wf").write_text("MY_JOB\n", encoding="utf-8")
+    ert_config = ert_config_with_job.from_file_contents(
+        dedent("""
+        NUM_REALIZATIONS 1
+        HOOK_WORKFLOW_JOB inline_wf_before MY_JOB PRE_SIMULATION
+        INCLUDE included.ert
+        HOOK_WORKFLOW_JOB inline_wf_after MY_JOB PRE_SIMULATION
+        """)
+    )
+
+    hooked_workflows = ert_config.hooked_workflows[HookRuntime.PRE_SIMULATION]
+    actual_hook_order = [Path(wf.src_file).name for wf in hooked_workflows]
+    assert actual_hook_order == ["inline_wf_before", "loaded_wf", "inline_wf_after"]
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_hooked_workflows_are_ordered_when_name_uses_a_define(
+    ert_config_with_job,
+):
+    """A hook whose name is built from a DEFINE must keep its declared
+    position, not fall back to the front because the substitution replaced
+    its underlying token with a new one.
+    """
+    ert_config = ert_config_with_job.from_file_contents(
+        dedent("""
+        DEFINE <WF_SUFFIX> substituted
+        NUM_REALIZATIONS 1
+        HOOK_WORKFLOW_JOB before_wf MY_JOB PRE_SIMULATION
+        HOOK_WORKFLOW_JOB inline_wf_<WF_SUFFIX> MY_JOB PRE_SIMULATION
+        HOOK_WORKFLOW_JOB after_wf MY_JOB PRE_SIMULATION
+        """)
+    )
+
+    hooked_workflows = ert_config.hooked_workflows[HookRuntime.PRE_SIMULATION]
+    actual_hook_order = [Path(wf.src_file).name for wf in hooked_workflows]
+    assert actual_hook_order == [
+        "before_wf",
+        "inline_wf_substituted",
+        "after_wf",
+    ]
+
+
 def test_that_create_workflow_from_job_with_unknown_job_name_raises_error():
     with pytest.raises(
         ConfigValidationError,


### PR DESCRIPTION
* Ensure workflows run in their declared order

* Refactor ordering of workflows to also account for INCLUDE keyword

* Preserve declaration_order when re-wrapping FileContextToken

(cherry picked from commit 79e5551ee50d2286601aa1fbc7a100acf4013729)

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
