### PR TITLE
Solve crash when queue system is down

### DIFF
--- a/src/ert/run_models/run_model.py
+++ b/src/ert/run_models/run_model.py
@@ -59,6 +59,7 @@ from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
 from ert.ensemble_evaluator.state import (
     REALIZATION_STATE_FAILED,
     REALIZATION_STATE_FINISHED,
+    REALIZATION_STATE_UNKNOWN,
 )
 from ert.mode_definitions import MODULE_MODE
 from ert.run_arg import RunArg
@@ -484,7 +485,7 @@ class RunModel(RunModelConfig, ABC):
 
             if all_realizations:
                 for real in all_realizations.values():
-                    status[str(real["status"])] += 1
+                    status[str(real.get("status", REALIZATION_STATE_UNKNOWN))] += 1
 
         if self._is_rerunning_failed_realizations:
             status["Finished"] += (

--- a/tests/ert/unit_tests/run_models/test_base_run_model.py
+++ b/tests/ert/unit_tests/run_models/test_base_run_model.py
@@ -28,6 +28,10 @@ from ert.ensemble_evaluator import EndEvent, EvaluatorServerConfig, StartEvent
 from ert.ensemble_evaluator.evaluator import ParallelismViolation
 from ert.ensemble_evaluator.event import FullSnapshotEvent
 from ert.ensemble_evaluator.snapshot import EnsembleSnapshot
+from ert.ensemble_evaluator.state import (
+    REALIZATION_STATE_RUNNING,
+    REALIZATION_STATE_UNKNOWN,
+)
 from ert.mode_definitions import TEST_RUN_MODE
 from ert.plugins import ErtRuntimePlugins
 from ert.run_models import create_model
@@ -300,6 +304,38 @@ def test_get_current_status(
     brm._iter_snapshot[0] = iter_snapshot
     brm.active_realizations = new_active_realizations
     assert dict(brm.get_current_status()) == expected_result
+
+
+def test_that_get_current_status_handles_realizations_missing_status(
+    use_tmpdir,
+):
+    """If the scheduler is unable to get any information from the queue system
+    on realization statuses but are receiving updates from fm_dispatch (or if
+    the messages from queue system and fm_dispatch are out of order), the
+    realization status should be regarded as Unknown
+    """
+    config = ErtConfig.from_file_contents("NUM_REALIZATIONS 2")
+    active_realizations = [True] * 2
+
+    brm = create_run_model(
+        queue_config=config.queue_config,
+        substitutions=config.substitutions,
+        active_realizations=active_realizations,
+    )
+
+    iter_snapshot = EnsembleSnapshot.from_nested_dict(
+        {"reals": {"0": {"status": REALIZATION_STATE_RUNNING}}}
+    )
+    # Simulate a realization entry that only received forward-model-step
+    # updates and never had its "status" field populated.
+    iter_snapshot.add_realization("1", {"fm_steps": {}})
+    brm._iter_snapshot[0] = iter_snapshot
+    brm.active_realizations = active_realizations
+
+    assert dict(brm.get_current_status()) == {
+        REALIZATION_STATE_RUNNING: 1,
+        REALIZATION_STATE_UNKNOWN: 1,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fm_dispatch messages can still arrive while there is no message from the queue system.

**Issue**
Resolves #14391


**Approach**
Add fallback status.


- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
