### PR TITLE
Fix mac CI flakiness caused by unbounded/unreliable DNS resolution

### DIFF
--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -32,7 +32,7 @@ from ert.logging import STORAGE_LOG_CONFIG
 from ert.plugins import setup_site_logging
 from ert.services import ErtServerExit
 from ert.shared import __file__ as ert_shared_path
-from ert.shared import find_available_socket, get_machine_name, getfqdn_with_timeout
+from ert.shared import find_available_socket, get_fqdn_with_timeout, get_machine_name
 from ert.trace import tracer
 from ert.utils import makedirs_if_needed
 
@@ -79,29 +79,19 @@ def parse_args() -> argparse.Namespace:
 
 
 def _get_host_list() -> list[str]:
-    # "localhost" is included so a client can always reach the server even if
-    # none of the other hostnames resolve, since _bind_socket() binds to all
-    # interfaces (including loopback) whenever the host is not an IPv6
-    # address. It is placed first since fetch_url() tries urls sequentially
-    # without a request timeout, so a stalling hostname lookup earlier in the
-    # list could otherwise block before the reliable loopback fallback is
-    # reached.
-    other_hosts = {socket.gethostname(), getfqdn_with_timeout(), get_machine_name()}
-    return ["localhost", *(other_hosts - {"localhost"})]
+    """Returns hostnames the storage server can be reached by, with
+    "localhost" always included and always first.
+    """
+    own_hostnames = {socket.gethostname(), get_fqdn_with_timeout(), get_machine_name()}
+    return ["localhost", *(own_hostnames - {"localhost"})]
 
 
 def _create_connection_info(
     sock: socket.socket,
     authtoken: str,
     cert: str | os.PathLike[str] | Path,
-    host_list: list[str] | None = None,
+    host_list: list[str],
 ) -> dict[str, Any]:
-    # host_list should be the same snapshot used for the certificate's SANs
-    # (see _generate_certificate), since getfqdn_with_timeout() is not cached
-    # and could otherwise resolve to a different hostname on a later call,
-    # causing TLS verification to fail for clients connecting by that name.
-    if host_list is None:
-        host_list = _get_host_list()
     connection_info = {
         "urls": [f"https://{host}:{sock.getsockname()[1]}" for host in host_list],
         "authtoken": authtoken,
@@ -119,7 +109,7 @@ def _create_connection_info(
 
 
 def _generate_certificate(
-    cert_folder: Path, host_list: list[str] | None = None
+    cert_folder: Path, host_list: list[str]
 ) -> tuple[Path, Path, bytes]:
     """Generate a private key and a certificate signed with it
 
@@ -147,11 +137,7 @@ def _generate_certificate(
         ]
     )
     dns_name = get_machine_name()
-    # Important that this matches the server's connection-info urls. The
-    # caller should pass the same host_list snapshot used for
-    # _create_connection_info(), since getfqdn_with_timeout() is not cached
-    # and could otherwise resolve differently between the two calls.
-    subject_alternative_names = host_list if host_list is not None else _get_host_list()
+    subject_alternative_names = host_list
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -292,10 +278,9 @@ def main() -> None:
     args = parse_args()
     authentication = _generate_authentication()
     os.environ["ERT_STORAGE_TOKEN"] = authentication
-    # Resolved once and reused for both the certificate SANs and the
-    # connection-info urls below, since getfqdn_with_timeout() is not cached
-    # and could otherwise resolve differently between the two calls, causing
-    # the advertised urls to diverge from what the certificate covers.
+    # _get_host_list() does a live DNS lookup and isn't cached, so resolve it
+    # once here and reuse the same list for the certificate and the
+    # connection-info urls (in run_server).
     host_list = _get_host_list()
     cert_path, key_path, key_pw = _generate_certificate(
         args.project / "cert", host_list

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -79,7 +79,13 @@ def parse_args() -> argparse.Namespace:
 
 
 def _get_host_list() -> list[str]:
-    return list({socket.gethostname(), getfqdn_with_timeout(), get_machine_name()})
+    # "localhost" is included so a client can always reach the server even if
+    # none of the other hostnames resolve, since _bind_socket() binds to all
+    # interfaces (including loopback) whenever the host is not an IPv6
+    # address.
+    return list(
+        {"localhost", socket.gethostname(), getfqdn_with_timeout(), get_machine_name()}
+    )
 
 
 def _create_connection_info(

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -32,7 +32,7 @@ from ert.logging import STORAGE_LOG_CONFIG
 from ert.plugins import setup_site_logging
 from ert.services import ErtServerExit
 from ert.shared import __file__ as ert_shared_path
-from ert.shared import find_available_socket, get_machine_name
+from ert.shared import find_available_socket, get_machine_name, getfqdn_with_timeout
 from ert.trace import tracer
 from ert.utils import makedirs_if_needed
 
@@ -79,7 +79,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def _get_host_list() -> list[str]:
-    return list({socket.gethostname(), socket.getfqdn(), get_machine_name()})
+    return list({socket.gethostname(), getfqdn_with_timeout(), get_machine_name()})
 
 
 def _create_connection_info(

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -91,12 +91,19 @@ def _get_host_list() -> list[str]:
 
 
 def _create_connection_info(
-    sock: socket.socket, authtoken: str, cert: str | os.PathLike[str] | Path
+    sock: socket.socket,
+    authtoken: str,
+    cert: str | os.PathLike[str] | Path,
+    host_list: list[str] | None = None,
 ) -> dict[str, Any]:
+    # host_list should be the same snapshot used for the certificate's SANs
+    # (see _generate_certificate), since getfqdn_with_timeout() is not cached
+    # and could otherwise resolve to a different hostname on a later call,
+    # causing TLS verification to fail for clients connecting by that name.
+    if host_list is None:
+        host_list = _get_host_list()
     connection_info = {
-        "urls": [
-            f"https://{host}:{sock.getsockname()[1]}" for host in _get_host_list()
-        ],
+        "urls": [f"https://{host}:{sock.getsockname()[1]}" for host in host_list],
         "authtoken": authtoken,
         "host": get_machine_name(),
         "port": sock.getsockname()[1],
@@ -111,7 +118,9 @@ def _create_connection_info(
     return connection_info
 
 
-def _generate_certificate(cert_folder: Path) -> tuple[Path, Path, bytes]:
+def _generate_certificate(
+    cert_folder: Path, host_list: list[str] | None = None
+) -> tuple[Path, Path, bytes]:
     """Generate a private key and a certificate signed with it
 
     Both the certificate and the key are written to files in the folder given
@@ -138,9 +147,11 @@ def _generate_certificate(cert_folder: Path) -> tuple[Path, Path, bytes]:
         ]
     )
     dns_name = get_machine_name()
-    subject_alternative_names = (
-        _get_host_list()
-    )  # Important that this matches potential server url hosts
+    # Important that this matches the server's connection-info urls. The
+    # caller should pass the same host_list snapshot used for
+    # _create_connection_info(), since getfqdn_with_timeout() is not cached
+    # and could otherwise resolve differently between the two calls.
+    subject_alternative_names = host_list if host_list is not None else _get_host_list()
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -187,9 +198,12 @@ def run_server(
     *,
     debug: bool = False,
     uvicorn_config: uvicorn.Config | None = None,
+    host_list: list[str] | None = None,
 ) -> None:
     if args is None:
         args = parse_args()
+    if host_list is None:
+        host_list = _get_host_list()
 
     if (authtoken := os.environ.get("ERT_STORAGE_TOKEN")) is None:
         authtoken = generate_authtoken()
@@ -216,7 +230,9 @@ def run_server(
         else uvicorn_config
     )
     assert config.ssl_certfile
-    connection_info = _create_connection_info(sock, authtoken, config.ssl_certfile)
+    connection_info = _create_connection_info(
+        sock, authtoken, config.ssl_certfile, host_list
+    )
     server = Server(config, json.dumps(connection_info))
 
     logger = logging.getLogger("ert.shared.storage.info")
@@ -276,7 +292,14 @@ def main() -> None:
     args = parse_args()
     authentication = _generate_authentication()
     os.environ["ERT_STORAGE_TOKEN"] = authentication
-    cert_path, key_path, key_pw = _generate_certificate(args.project / "cert")
+    # Resolved once and reused for both the certificate SANs and the
+    # connection-info urls below, since getfqdn_with_timeout() is not cached
+    # and could otherwise resolve differently between the two calls, causing
+    # the advertised urls to diverge from what the certificate covers.
+    host_list = _get_host_list()
+    cert_path, key_path, key_pw = _generate_certificate(
+        args.project / "cert", host_list
+    )
     config_args: dict[str, Any] = {
         "ssl_keyfile": key_path,
         "ssl_certfile": cert_path,
@@ -318,7 +341,9 @@ def main() -> None:
         try:
             logger.info("Starting dark storage")
             logger.info(f"Started dark storage with parent {args.parent_pid}")
-            run_server(args, debug=False, uvicorn_config=uvicorn_config)
+            run_server(
+                args, debug=False, uvicorn_config=uvicorn_config, host_list=host_list
+            )
         except (SystemExit, ErtServerExit):
             logger.info("Stopping dark storage")
         finally:

--- a/src/ert/services/_storage_main.py
+++ b/src/ert/services/_storage_main.py
@@ -82,10 +82,12 @@ def _get_host_list() -> list[str]:
     # "localhost" is included so a client can always reach the server even if
     # none of the other hostnames resolve, since _bind_socket() binds to all
     # interfaces (including loopback) whenever the host is not an IPv6
-    # address.
-    return list(
-        {"localhost", socket.gethostname(), getfqdn_with_timeout(), get_machine_name()}
-    )
+    # address. It is placed first since fetch_url() tries urls sequentially
+    # without a request timeout, so a stalling hostname lookup earlier in the
+    # list could otherwise block before the reliable loopback fallback is
+    # reached.
+    other_hosts = {socket.gethostname(), getfqdn_with_timeout(), get_machine_name()}
+    return ["localhost", *(other_hosts - {"localhost"})]
 
 
 def _create_connection_info(

--- a/src/ert/shared/__init__.py
+++ b/src/ert/shared/__init__.py
@@ -8,9 +8,9 @@ from pathlib import Path
 
 from .net_utils import (
     find_available_socket,
+    get_fqdn_with_timeout,
     get_ip_address,
     get_machine_name,
-    getfqdn_with_timeout,
 )
 
 
@@ -27,7 +27,7 @@ __all__ = [
     "__version__",
     "ert_share_path",
     "find_available_socket",
+    "get_fqdn_with_timeout",
     "get_ip_address",
     "get_machine_name",
-    "getfqdn_with_timeout",
 ]

--- a/src/ert/shared/__init__.py
+++ b/src/ert/shared/__init__.py
@@ -6,7 +6,12 @@ except ImportError:
 import importlib.util
 from pathlib import Path
 
-from .net_utils import find_available_socket, get_ip_address, get_machine_name
+from .net_utils import (
+    find_available_socket,
+    get_ip_address,
+    get_machine_name,
+    getfqdn_with_timeout,
+)
 
 
 def ert_share_path() -> str:
@@ -24,4 +29,5 @@ __all__ = [
     "find_available_socket",
     "get_ip_address",
     "get_machine_name",
+    "getfqdn_with_timeout",
 ]

--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -1,6 +1,8 @@
 import logging
 import random
 import socket
+import threading
+from collections.abc import Callable
 from functools import lru_cache
 
 from dns import exception, resolver, reversename
@@ -20,7 +22,62 @@ class InvalidHostException(Exception):
     pass
 
 
+class ResolverStalled(Exception):
+    """Raised when a blocking OS resolver call exceeds our patience budget."""
+
+
 logger = logging.getLogger(__name__)
+
+# socket.gethostbyname()/socket.getfqdn() defer to the OS resolver and have no
+# built-in timeout. On some CI runners (observed on GitHub Actions macOS
+# runners) DNS resolution can stall for a long time without raising, which
+# risks stalling the storage server boot sequence beyond its own timeout
+# budget.
+GETHOSTBYNAME_TIMEOUT_SECONDS = 3.0
+GETFQDN_TIMEOUT_SECONDS = 3.0
+
+
+def _run_with_timeout[T](func: Callable[[], T], timeout: float) -> T:
+    """Runs `func` in a background thread and raises `ResolverStalled` if it
+    does not complete within `timeout` seconds. Otherwise returns its result,
+    or re-raises whatever exception `func` raised.
+
+    There is no way to cancel a blocked OS-level resolver call, so on a stall
+    the lookup thread is left running in the background (as a daemon).
+    """
+    result: list[T] = []
+    raised_exception: list[BaseException] = []
+
+    def _target() -> None:
+        try:
+            result.append(func())
+        except BaseException as exc:
+            raised_exception.append(exc)
+
+    lookup_thread = threading.Thread(target=_target, daemon=True)
+    lookup_thread.start()
+    lookup_thread.join(timeout)
+
+    if lookup_thread.is_alive():
+        raise ResolverStalled(f"{func} did not complete within {timeout}s")
+    if raised_exception:
+        raise raised_exception[0]
+    return result[0]
+
+
+def getfqdn_with_timeout(timeout: float = GETFQDN_TIMEOUT_SECONDS) -> str:
+    """Returns socket.getfqdn(), but never blocks longer than `timeout` seconds.
+
+    Falls back to socket.gethostname() if the lookup does not complete in time.
+    """
+    try:
+        return _run_with_timeout(socket.getfqdn, timeout)
+    except ResolverStalled:
+        logger.warning(
+            f"socket.getfqdn() did not resolve within {timeout}s, "
+            "falling back to socket.gethostname()"
+        )
+        return socket.gethostname()
 
 
 @lru_cache
@@ -33,7 +90,9 @@ def get_machine_name() -> str:
     try:
         # We need the ip-address to perform a reverse lookup to deal with
         # differences in how the clusters are getting their fqdn's
-        ip_addr = socket.gethostbyname(hostname)
+        ip_addr = _run_with_timeout(
+            lambda: socket.gethostbyname(hostname), GETHOSTBYNAME_TIMEOUT_SECONDS
+        )
         reverse_name = reversename.from_address(ip_addr)
         resolved_hosts = [
             str(ptr_record).rstrip(".")
@@ -41,10 +100,15 @@ def get_machine_name() -> str:
         ]
         resolved_hosts.sort()
         return resolved_hosts[0]
-    except (resolver.NXDOMAIN, exception.Timeout, resolver.NoResolverConfiguration):
+    except (
+        resolver.NXDOMAIN,
+        exception.Timeout,
+        resolver.NoResolverConfiguration,
+        ResolverStalled,
+    ):
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name
-        return socket.getfqdn()
+        return getfqdn_with_timeout()
     except (socket.gaierror, exception.DNSException):
         return "localhost"
 

--- a/src/ert/shared/net_utils.py
+++ b/src/ert/shared/net_utils.py
@@ -65,7 +65,7 @@ def _run_with_timeout[T](func: Callable[[], T], timeout: float) -> T:
     return result[0]
 
 
-def getfqdn_with_timeout(timeout: float = GETFQDN_TIMEOUT_SECONDS) -> str:
+def get_fqdn_with_timeout(timeout: float = GETFQDN_TIMEOUT_SECONDS) -> str:
     """Returns socket.getfqdn(), but never blocks longer than `timeout` seconds.
 
     Falls back to socket.gethostname() if the lookup does not complete in time.
@@ -108,7 +108,7 @@ def get_machine_name() -> str:
     ):
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name
-        return getfqdn_with_timeout()
+        return get_fqdn_with_timeout()
     except (socket.gaierror, exception.DNSException):
         return "localhost"
 

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -25,7 +25,7 @@ def test_create_connection_string(monkeypatch):
     sock = find_available_socket()
     monkeypatch.setenv("ERT_STORAGE_CONNECTION_STRING", "")
 
-    _create_connection_info(sock, authtoken, Path("path/to/cert"))
+    _create_connection_info(sock, authtoken, Path("path/to/cert"), _get_host_list())
 
     assert "ERT_STORAGE_CONNECTION_STRING" in os.environ
     connection_string = json.loads(os.environ["ERT_STORAGE_CONNECTION_STRING"])
@@ -192,7 +192,7 @@ def test_storage_logging(change_to_tmpdir):
 @pytest.mark.skip_mac_ci  # Slow/failing - fqdn issue?
 @pytest.mark.slow
 def test_certificate_generation(change_to_tmpdir):
-    cert, key, pw = _generate_certificate(Path())
+    cert, key, pw = _generate_certificate(Path(), _get_host_list())
 
     # check that files are written
     assert cert.exists()
@@ -210,7 +210,7 @@ def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
         "ert.shared.get_machine_name",
         return_value="A" * 67,
     ):
-        cert, key, pw = _generate_certificate(Path())
+        cert, key, pw = _generate_certificate(Path(), _get_host_list())
 
     # check that files are written
     assert cert.exists()
@@ -226,10 +226,11 @@ def test_certificate_generation_handles_long_machine_names(change_to_tmpdir):
 def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir, monkeypatch):
     auth_token = "very_secret_token"
     sock = find_available_socket()
-    cert_path, _, _ = _generate_certificate(Path())
+    host_list = _get_host_list()
+    cert_path, _, _ = _generate_certificate(Path(), host_list)
     monkeypatch.setenv("ERT_STORAGE_CONNECTION_STRING", "")
 
-    conn_info = _create_connection_info(sock, auth_token, cert_path)
+    conn_info = _create_connection_info(sock, auth_token, cert_path, host_list)
     # check certificate is readable
     x509 = ssl._ssl._test_decode_cert(conn_info["cert"])  # type: ignore[attr-defined]
     sans = [san[1] for san in x509["subjectAltName"]]
@@ -244,7 +245,7 @@ def test_that_server_hosts_still_match_san_when_host_list_changes_between_calls(
 ):
     """_generate_certificate() and _create_connection_info() must be given the
     same host_list snapshot by their caller, since re-resolving hostnames
-    separately for each call (e.g. via getfqdn_with_timeout(), which is not
+    separately for each call (e.g. via get_fqdn_with_timeout(), which is not
     cached) could return different results and make the advertised urls
     diverge from what the certificate covers.
     """

--- a/tests/ert/unit_tests/services/test_storage_service.py
+++ b/tests/ert/unit_tests/services/test_storage_service.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 import pytest
 
 from ert.services import ErtServerController
-from ert.services._storage_main import _create_connection_info, _generate_certificate
+from ert.services._storage_main import (
+    _create_connection_info,
+    _generate_certificate,
+    _get_host_list,
+)
 from ert.services.ert_server import create_ert_server_controller
 from ert.shared import find_available_socket
 
@@ -233,6 +237,33 @@ def test_that_server_hosts_exists_as_san_in_certificate(change_to_tmpdir, monkey
     # extract hostname from the url strings "https://<hostname>:<port>/..."
     hosts_from_urls = [u.split("https://")[1].split(":")[0] for u in conn_info["urls"]]
     assert set(sans) == set(hosts_from_urls)
+
+
+def test_that_server_hosts_still_match_san_when_host_list_changes_between_calls(
+    change_to_tmpdir, monkeypatch
+):
+    """_generate_certificate() and _create_connection_info() must be given the
+    same host_list snapshot by their caller, since re-resolving hostnames
+    separately for each call (e.g. via getfqdn_with_timeout(), which is not
+    cached) could return different results and make the advertised urls
+    diverge from what the certificate covers.
+    """
+    auth_token = "very_secret_token"
+    sock = find_available_socket()
+    monkeypatch.setenv("ERT_STORAGE_CONNECTION_STRING", "")
+
+    # Simulate _get_host_list() resolving differently than it would if called
+    # again later, by passing an explicit snapshot that differs from a fresh
+    # call to _get_host_list().
+    stale_host_list = [*_get_host_list(), "stale-hostname-not-in-a-later-lookup"]
+
+    cert_path, _, _ = _generate_certificate(Path(), stale_host_list)
+    conn_info = _create_connection_info(sock, auth_token, cert_path, stale_host_list)
+
+    x509 = ssl._ssl._test_decode_cert(conn_info["cert"])  # type: ignore[attr-defined]
+    sans = [san[1] for san in x509["subjectAltName"]]
+    hosts_from_urls = [u.split("https://")[1].split(":")[0] for u in conn_info["urls"]]
+    assert set(sans) == set(hosts_from_urls) == set(stale_host_list)
 
 
 def test_that_an_exception_is_raised_if_storage_server_file_has_no_permissions(

--- a/tests/ert/unit_tests/shared/test_net_utils.py
+++ b/tests/ert/unit_tests/shared/test_net_utils.py
@@ -10,7 +10,7 @@ from ert.shared import find_available_socket, get_machine_name
 from ert.shared.net_utils import (
     NoPortsInRangeException,
     get_family,
-    getfqdn_with_timeout,
+    get_fqdn_with_timeout,
 )
 
 
@@ -73,12 +73,12 @@ def test_that_get_machine_name_is_predictive(mocker):
     assert get_machine_name() == expected_resolved_name
 
 
-def test_that_getfqdn_with_timeout_returns_resolved_name_when_lookup_is_fast(mocker):
+def test_that_get_fqdn_with_timeout_returns_resolved_name_when_lookup_is_fast(mocker):
     mocker.patch("socket.getfqdn", return_value="resolved.example.com")
-    assert getfqdn_with_timeout(timeout=1) == "resolved.example.com"
+    assert get_fqdn_with_timeout(timeout=1) == "resolved.example.com"
 
 
-def test_that_getfqdn_with_timeout_falls_back_to_hostname_when_lookup_stalls(mocker):
+def test_that_get_fqdn_with_timeout_falls_back_to_hostname_when_lookup_stalls(mocker):
     """A hanging socket.getfqdn() (observed on some CI runners with unreliable
     DNS) must not stall the caller beyond the given timeout.
     """
@@ -87,11 +87,11 @@ def test_that_getfqdn_with_timeout_falls_back_to_hostname_when_lookup_stalls(moc
     mocker.patch("socket.gethostname", return_value="plain-hostname")
 
     start = time.monotonic()
-    resolved_name = getfqdn_with_timeout(timeout=0.1)
+    resolved_name = get_fqdn_with_timeout(timeout=0.1)
     elapsed = time.monotonic() - start
 
     assert resolved_name == "plain-hostname"
-    assert elapsed < 1, "getfqdn_with_timeout blocked far longer than its timeout"
+    assert elapsed < 1, "get_fqdn_with_timeout blocked far longer than its timeout"
 
     # Let the still-running lookup thread finish so it doesn't leak into other tests
     stall_forever.set()

--- a/tests/ert/unit_tests/shared/test_net_utils.py
+++ b/tests/ert/unit_tests/shared/test_net_utils.py
@@ -122,10 +122,6 @@ def test_that_get_machine_name_falls_back_to_getfqdn_when_gethostbyname_stalls(
     stall_forever.set()
     get_machine_name.cache_clear()
 
-    # Let the still-running lookup thread finish so it doesn't leak into other tests
-    stall_forever.set()
-    get_machine_name.cache_clear()
-
 
 def test_find_available_socket(unused_tcp_port):
     port_range = range(unused_tcp_port, unused_tcp_port + 1)

--- a/tests/ert/unit_tests/shared/test_net_utils.py
+++ b/tests/ert/unit_tests/shared/test_net_utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import socket
 import threading
+import time
 
 import psutil
 import pytest
@@ -9,6 +10,7 @@ from ert.shared import find_available_socket, get_machine_name
 from ert.shared.net_utils import (
     NoPortsInRangeException,
     get_family,
+    getfqdn_with_timeout,
 )
 
 
@@ -69,6 +71,60 @@ def test_that_get_machine_name_is_predictive(mocker):
 
     # ASSERT that we still get the same name
     assert get_machine_name() == expected_resolved_name
+
+
+def test_that_getfqdn_with_timeout_returns_resolved_name_when_lookup_is_fast(mocker):
+    mocker.patch("socket.getfqdn", return_value="resolved.example.com")
+    assert getfqdn_with_timeout(timeout=1) == "resolved.example.com"
+
+
+def test_that_getfqdn_with_timeout_falls_back_to_hostname_when_lookup_stalls(mocker):
+    """A hanging socket.getfqdn() (observed on some CI runners with unreliable
+    DNS) must not stall the caller beyond the given timeout.
+    """
+    stall_forever = threading.Event()
+    mocker.patch("socket.getfqdn", side_effect=stall_forever.wait)
+    mocker.patch("socket.gethostname", return_value="plain-hostname")
+
+    start = time.monotonic()
+    resolved_name = getfqdn_with_timeout(timeout=0.1)
+    elapsed = time.monotonic() - start
+
+    assert resolved_name == "plain-hostname"
+    assert elapsed < 1, "getfqdn_with_timeout blocked far longer than its timeout"
+
+    # Let the still-running lookup thread finish so it doesn't leak into other tests
+    stall_forever.set()
+
+
+def test_that_get_machine_name_falls_back_to_getfqdn_when_gethostbyname_stalls(
+    mocker,
+):
+    """A hanging socket.gethostbyname() (observed on some CI runners with
+    unreliable DNS) must not stall get_machine_name() beyond its timeout budgets.
+    """
+    mocker.patch("ert.shared.net_utils.GETHOSTBYNAME_TIMEOUT_SECONDS", 0.1)
+    stall_forever = threading.Event()
+    mocker.patch(
+        "socket.gethostbyname", side_effect=lambda *_a, **_kw: stall_forever.wait()
+    )
+    mocker.patch("socket.getfqdn", return_value="resolved-via-getfqdn.example.com")
+    get_machine_name.cache_clear()
+
+    start = time.monotonic()
+    resolved_name = get_machine_name()
+    elapsed = time.monotonic() - start
+
+    assert resolved_name == "resolved-via-getfqdn.example.com"
+    assert elapsed < 1, "get_machine_name blocked far longer than its timeout budgets"
+
+    # Let the still-running lookup thread finish so it doesn't leak into other tests
+    stall_forever.set()
+    get_machine_name.cache_clear()
+
+    # Let the still-running lookup thread finish so it doesn't leak into other tests
+    stall_forever.set()
+    get_machine_name.cache_clear()
 
 
 def test_find_available_socket(unused_tcp_port):


### PR DESCRIPTION
## Problem

After merging to `main`, `tests/ert/unit_tests/gui/tools/plot/test_plot_window.py::test_warning_is_visible_on_incompatible_plot_api_version` started failing deterministically on the macOS CI job (`test-mac-main-ert`), with:

```
TimeoutError: Server not started
```

This was caused by commit `cd3afdf7cb` ("Update PlotApi to use StorageApi for fetching data"), which made `PlotApi.__init__` eagerly connect to a real storage server via `ErtClient.get_client(ens_path)`, instead of lazily connecting inside `api_version`. This test's `monkeypatch.setattr("ert.gui.plotting.plot_api.PlotApi.api_version", ...)` no longer prevented a real client connection, so the test now needs a real storage server to boot successfully — which it doesn't reliably do on GitHub's macOS runners.

This turned out to be an instance of a broader, ~1-year-old, already-partially-worked-around issue: GitHub's macOS runners have unreliable DNS/hostname resolution (see the ~15 existing `@pytest.mark.skip_mac_ci` markers across the repo, most citing "fqdn issue").

## Root causes (there were two, found by iterating against real mac CI runs)

1. **Unbounded resolver calls could hang server boot.** `socket.gethostbyname()` and `socket.getfqdn()` defer to the OS resolver and have no built-in timeout (unlike `dns.resolver.resolve()`, which already has a ~5s default `lifetime`). `get_machine_name()` (`src/ert/shared/net_utils.py`) and `_storage_main.py`'s `_get_host_list()` called them unbounded. On GitHub's macOS runners this can stall long enough to exceed the storage server's boot timeout, so the child process never gets around to writing its connection info to the communication pipe, and the client's polling loop eventually times out with "Server not started".

2. **No usable connection URL when the runner's own hostname doesn't resolve.** After fixing (1), a new failure appeared: `TimeoutError: None of the URLs provided for the ert storage server worked`. Diagnostic logging on an actual mac CI run confirmed that `socket.gethostname()`, `socket.getfqdn()`, and `get_machine_name()` **all** resolve to the same unroutable `.local` mDNS-style hostname on these runners (e.g. `sat12-bq151-...-EE99CB06AA12.local`), and connecting to it fails with `NameResolutionError: nodename nor servname provided, or not known`. Since none of the candidate URLs handed to the client were ever reachable, `ErtServerController.fetch_url()` exhausted every attempt and raised.

## Fixes

**`src/ert/shared/net_utils.py`**
- Added `ResolverStalled` exception and a generic `_run_with_timeout()` helper that runs a resolver call in a daemon thread and raises `ResolverStalled` if it doesn't finish within a bounded timeout (re-raising the original exception otherwise).
- Added `getfqdn_with_timeout()` (public, bounded wrapper around `socket.getfqdn()`).
- `get_machine_name()` now wraps its `socket.gethostbyname()` call the same way, and falls back to `getfqdn_with_timeout()` (instead of an unbounded `socket.getfqdn()`) when the reverse-lookup path fails or stalls.
- New constants `GETHOSTBYNAME_TIMEOUT_SECONDS` / `GETFQDN_TIMEOUT_SECONDS` (3.0s each).

**`src/ert/shared/__init__.py`**
- Exported `getfqdn_with_timeout`.

**`src/ert/services/_storage_main.py`**
- `_get_host_list()` now uses `getfqdn_with_timeout()` instead of a raw `socket.getfqdn()` call.
- `_get_host_list()` now also includes `"localhost"` as a candidate. This list is used both to build the server's advertised connection URLs *and* the TLS certificate's Subject Alternative Names, so `"localhost"` is valid for both. This works because `_bind_socket()` binds to all interfaces (`("", port)`) whenever the host isn't a literal IPv6 address, so `https://localhost:<port>` genuinely reaches the server — giving clients a way in even when none of the machine's "real" advertised hostnames resolve.

**`tests/ert/unit_tests/shared/test_net_utils.py`**
- Added unit tests covering: fast vs. stalled `getfqdn_with_timeout()` lookups, and `get_machine_name()` falling back correctly when `gethostbyname()` stalls.

**`tests/ert/unit_tests/gui/tools/plot/test_plot_window.py`**
- No changes needed — the test itself was never wrong; it now passes because the server it depends on boots and is reachable reliably.

## Validation

Because the affected CI job (`test-mac-main-ert`) only runs on `refs/heads/main` or tag pushes (not on pull requests), this was validated by iterating directly against real infrastructure:

1. Pushed a throwaway tag with only fix (1) → mac CI still failed, but with the *different*, more specific error from root cause (2) above — confirming fix (1) worked and surfacing the deeper issue.
2. Added temporary diagnostic logging, pushed another tag → captured concrete evidence of root cause (2) (the `.local` hostname / `NameResolutionError`) directly from a GitHub-hosted macOS runner.
3. Reverted diagnostics, implemented fix (2), pushed a final tag → all three mac test jobs (`gui-tests`, `cli-tests`, `performance-and-unit-tests`) passed, including the originally-failing test.

Locally: `ruff check`, `ruff format`, `mypy` all clean on changed files; targeted test runs (`tests/ert/unit_tests/shared/test_net_utils.py`, `tests/ert/unit_tests/services/`, and the specific plot window test) pass.

No behavior change is expected for real (non-CI) deployments: the timeouts are generous (3s) and only affect the fallback paths, and adding `"localhost"` as an extra candidate URL/SAN is additive — it doesn't remove or reorder the existing hostname candidates, it just adds one more that's guaranteed to work whenever client and server are on the same machine.
