### PR TITLE
Move backend selection before importing .main

### DIFF
--- a/src/ert/gui/__init__.py
+++ b/src/ert/gui/__init__.py
@@ -22,17 +22,13 @@ import os
 
 import matplotlib as mpl
 
-from .main import run_gui
-
 
 def headless() -> bool:
     return "DISPLAY" not in os.environ
 
 
-if headless():
-    mpl.use("Agg")
-else:
-    mpl.use("QtAgg")
+mpl.use("Agg" if headless() else "QtAgg")
 
+from .main import run_gui  # ruff: ignore[module-import-not-at-top-of-file]
 
 __all__ = ["run_gui"]


### PR DESCRIPTION
This ensures PlotWindow and backend_qtagg are imported only after Matplotlib’s backend is fixed for that worker process.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
