### PR TITLE
Keep cyclic GC off while Qt tests dispatch events

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import os
 from unittest.mock import patch
 
@@ -87,6 +88,20 @@ def print_system_load_on_test_failure(request):
             "System load after test failure (1/5/15min): "
             f"{load1:.2f}, {load5:.2f}, {load15:.2f}, cpu_count={os.cpu_count()}"
         )
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    if not item.get_closest_marker("requires_window_manager"):
+        return (yield)
+    # Reclaiming a Qt widget while Qt is dispatching events to it segfaults the
+    # worker, so the test's cycles are collected between tests instead.
+    gc.disable()
+    try:
+        return (yield)
+    finally:
+        gc.enable()
+        gc.collect(0)
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
**Issue**
Resolves #14368

**Approach**

The segfaults are not caused by the plotting code itself, and still reproduce on `main` after #14408.

Qt widgets built in a test are kept alive by reference cycles — child widgets hold slots capturing the object that owns the widget tree, and pytest-qt's `addWidget` only stores a `weakref`. They are therefore reclaimed by the *cyclic* collector rather than by refcounting, and the collector fires on its own schedule — including from inside the `QApplication.processEvents()` call pytest-qt makes after every test body. Destroying a visible top-level widget while Qt is dispatching events to it crashes the worker.

That matches the evidence: every crash traceback points at `pytestqt/plugin.py:220 _process_events`, always in a test that calls `widget.show()`; a `gc.DEBUG_SAVEALL` probe shows `CollapsibleSection`, `GeneralPlotOptions`, `ObservationColorEdit`, 5 `QCheckBox` and 4 `QPushButton` all being collected as cyclic garbage; and `gc.disable()` alone makes the crash disappear. It also explains the reported behaviour — non-deterministic, deterministic under CPU load, and scaling with the number of plotting tests.

This disables the cyclic collector for the duration of each `requires_window_manager` test and collects once the protocol is over, confining reclamation to the gap between tests where no Qt event dispatch is in progress.

Only generation 0 is collected. Nothing is promoted out of it while the collector is off, so it holds everything the test allocated, and collecting just that generation avoids rescanning the rest of the heap once per test. A full `gc.collect()` is expensive enough to matter: `gui/plotting` + `gui/plottery` go from 1.94s to 12.4s, and the whole `unit_tests/gui` suite from ~47s to ~70s. With `gc.collect(0)` both are back at baseline speed, and the stress runs below are unchanged (0 segfaults across 6 runs on plotting, 6 on experiments).

Note on an approach that was tried and rejected: calling `gc.collect()` straight after the test body fixes `tests/ert/unit_tests/gui/plotting`, but introduced crashes in `tests/ert/unit_tests/gui/experiments`, whose run dialog tests spin the event loop with worker threads still live (2 segfaults across 6 paired stress runs, vs 0 for baseline). Collection has to be deferred past teardown rather than merely moved earlier.

**Verification**

All runs on macOS/arm64 with 12 busy-loop stressors applied, since load makes the crash reliable.

| Suite | Baseline | This PR |
|---|---|---|
| `tests/ert/unit_tests/gui/plotting` + `plottery`, 6 paired runs | 8 segfaults | 0 |
| `tests/ert/unit_tests/gui/experiments`, 8 paired runs | 0 | 0 |
| `tests/ert/unit_tests/gui`, 6 consecutive runs | crashed in 3/6 | 0 (`471 passed, 2 skipped`) |

```
uv run pytest -n 12 --dist loadgroup tests/ert/unit_tests/gui -q
```

`tests/ert/unit_tests/config` (`1279 passed`) was run as a sanity check that the non-GUI path is untouched, and `just rapid-tests` passed via the pre-push hook.

No regression test accompanies this. The failure is a race between the collector and Qt's event dispatch and cannot be triggered reliably from a test; it is verified by repeated stressed xdist runs instead.

- [x] PR title captures the intent of the changes, and is fitting for release notes.
- [x] Added appropriate release note label
- [x] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [x] Make sure unit tests pass locally after every commit (`git rebase -i main --exec 'just rapid-tests'`)

