### PR TITLE
Prevent hung/killed workers in fm_dispatch test

### DIFF
--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -111,6 +111,8 @@ def _reap_zombies(timeout: float) -> None:
             return
         if pid == 0:
             time.sleep(0.01)
+        else:
+            return
 
 
 @pytest.mark.slow

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -110,7 +110,7 @@ def _reap_zombies(timeout: float) -> None:
         except ChildProcessError:
             return
         if pid == 0:
-            return
+            time.sleep(0.01)
 
 
 @pytest.mark.slow

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import glob
 import json
 import os
 import signal
 import stat
 import sys
+import time
 from pathlib import Path
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from textwrap import dedent
 from threading import Lock
 from typing import Any
@@ -89,6 +91,28 @@ def job_dict(
     }
 
 
+def _kill_process_tree(proc: psutil.Process) -> None:
+    """Best-effort SIGKILL of a process and any still-living descendants."""
+    with contextlib.suppress(psutil.NoSuchProcess):
+        for child in proc.children(recursive=True):
+            with contextlib.suppress(psutil.NoSuchProcess):
+                child.kill()
+    with contextlib.suppress(psutil.NoSuchProcess):
+        proc.kill()
+
+
+def _reap_zombies(timeout: float) -> None:
+    # Non-blocking, time-bounded reap of children possibly reparented to us.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if pid == 0:
+            return
+
+
 @pytest.mark.slow
 @pytest.mark.usefixtures("use_custom_setsid")
 def test_that_all_subprocesses_of_a_job_are_cleaned_up_on_fm_dispatch_termination(
@@ -120,19 +144,28 @@ def test_that_all_subprocesses_of_a_job_are_cleaned_up_on_fm_dispatch_terminatio
         }
     )
 
-    # (we wait for the process below)
     fm_dispatch_process = Popen([Path.cwd() / "setsid", "fm_dispatch.py", Path.cwd()])
-
     p = psutil.Process(fm_dispatch_process.pid)
 
-    # Three levels of processes should spawn 8 children in total
-    wait_until(lambda: len(p.children(recursive=True)) == 8)
+    try:
+        # Three levels of processes should spawn 8 children in total
+        wait_until(lambda: len(p.children(recursive=True)) == 8, timeout=30)
 
-    p.terminate()
+        p.terminate()
 
-    wait_until(lambda: len(p.children(recursive=True)) == 0)
+        wait_until(lambda: len(p.children(recursive=True)) == 0, timeout=30)
 
-    os.wait()  # allow os to clean up zombie processes
+        fm_dispatch_process.wait(timeout=10)
+    finally:
+        # A hung cleanup here would otherwise leave 100s-sleeping descendants
+        # behind, which can pile up and crash the test worker under load.
+        _kill_process_tree(p)
+        with contextlib.suppress(TimeoutExpired):
+            fm_dispatch_process.wait(timeout=10)
+        if fm_dispatch_process.poll() is None:
+            fm_dispatch_process.kill()
+            fm_dispatch_process.wait(timeout=10)
+        _reap_zombies(timeout=10)
 
 
 @pytest.mark.slow

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -35,6 +35,10 @@ from _ert.forward_model_runner.reporting.message import Finish, Init, Message
 from _ert.threading import ErtThread
 from tests.ert.utils import MockZMQServer, wait_until
 
+# Keeps these tests off other workers while the heavy subprocess-forking
+# test below runs, since it has crashed unrelated workers under load.
+pytestmark = pytest.mark.xdist_group("fm_dispatch")
+
 
 @pytest.fixture
 def use_custom_setsid(use_tmpdir):

--- a/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
+++ b/tests/ert/unit_tests/forward_model_runner/test_fm_dispatch.py
@@ -106,10 +106,10 @@ def _kill_process_tree(proc: psutil.Process) -> None:
 
 
 def _reap_zombies(timeout: float) -> None:
-    # Non-blocking, time-bounded reap of children possibly reparented to us.
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
+            # -1: any child of ours; WNOHANG: return immediately, don't block
             pid, _ = os.waitpid(-1, os.WNOHANG)
         except ChildProcessError:
             return


### PR DESCRIPTION
test_that_all_subprocesses_of_a_job_are_cleaned_up_on_fm_dispatch_termination relied on an unbounded os.wait() after confirming the process tree had exited. If cleanup ever stalled, the 100s-sleeping child processes were left running and os.wait() would block on them, which could hang or crash the pytest-xdist worker under high load.

Wrap the process termination and verification in a try/finally that always force-kills the dispatcher and any remaining descendants and reaps zombies with a bounded, non-blocking loop, so the test fails fast instead of hanging the worker when cleanup doesn't behave as expected.

**Issue**
Resolves #my_issue


**Approach**
_Short description of the approach_

(Screenshot of new behavior in GUI if applicable)


- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md).
- [ ] Make sure unit tests pass locally after every commit (`git rebase -i main
      --exec 'just rapid-tests'`)

## When applicable
- [ ] **When screenshots are changed**: Review screenshot-PR in ert-testdata,
      merge screenshot-PR in ert-testdata **before** merging this PR.
- [ ] **When there are user facing changes**: Updated documentation
- [ ] **New behavior or changes to existing untested code**: Ensured that unit tests are added (See [Ground Rules](https://github.com/equinor/ert/blob/main/CONTRIBUTING.md#ground-rules)).
- [ ] **Large PR**: Prepare changes in small commits for more convenient review
- [ ] **Bug fix**: Add regression test for the bug
- [ ] **Bug fix**: Add backport label to latest release (format: 'backport release-branch-name')

<!--
Adding labels helps the maintainers when writing release notes. This is the [list of release note labels](https://github.com/equinor/ert/labels?q=release-notes).
-->
